### PR TITLE
fix(runt-mcp): create_notebook(package_manager='pixi') now persists correctly

### DIFF
--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -91,26 +91,32 @@ pub(crate) fn ensure_package_manager_metadata(
     manager: &str,
 ) -> bool {
     let current = handle.get_notebook_metadata();
+
+    // Check if the metadata already has the right exclusive section.
+    // needs_fix is true when: (a) the requested section is missing, OR
+    // (b) competing sections exist (e.g. pixi requested but uv section present).
     let needs_fix = match manager {
-        "pixi" => current.as_ref().is_none_or(|m| m.runt.pixi.is_none()),
-        "conda" => current.as_ref().is_none_or(|m| m.runt.conda.is_none()),
-        // uv: fix if metadata has pixi/conda but not uv (daemon default was
-        // pixi/conda but user explicitly requested uv)
-        _ => current.as_ref().is_some_and(|m| {
-            m.runt.uv.is_none() && (m.runt.pixi.is_some() || m.runt.conda.is_some())
+        "pixi" => current
+            .as_ref()
+            .is_none_or(|m| m.runt.pixi.is_none() || m.runt.uv.is_some() || m.runt.conda.is_some()),
+        "conda" => current
+            .as_ref()
+            .is_none_or(|m| m.runt.conda.is_none() || m.runt.uv.is_some() || m.runt.pixi.is_some()),
+        "uv" => current.as_ref().is_some_and(|m| {
+            m.runt.uv.is_none() || m.runt.pixi.is_some() || m.runt.conda.is_some()
         }),
+        _ => return false, // Unknown manager — no-op
     };
 
     if !needs_fix {
         return false;
     }
 
-    // Update the metadata snapshot to have the right package manager
+    // Update the metadata snapshot to have exactly one package manager section.
+    // Clear competing sections so detect_package_manager picks the right one.
     let mut snapshot = current.unwrap_or_default();
     match manager {
         "pixi" => {
-            // Create pixi section, clear uv/conda so detect_package_manager
-            // picks pixi
             if snapshot.runt.pixi.is_none() {
                 snapshot.runt.pixi = Some(notebook_doc::metadata::PixiInlineMetadata {
                     dependencies: Vec::new(),
@@ -134,9 +140,7 @@ pub(crate) fn ensure_package_manager_metadata(
             snapshot.runt.pixi = None;
         }
         _ => {
-            // uv: clear pixi/conda, ensure uv section exists
-            snapshot.runt.pixi = None;
-            snapshot.runt.conda = None;
+            // uv
             if snapshot.runt.uv.is_none() {
                 snapshot.runt.uv = Some(notebook_doc::metadata::UvInlineMetadata {
                     dependencies: Vec::new(),

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -37,10 +37,31 @@ pub struct GetDependenciesParams {}
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SyncEnvironmentParams {}
 
-/// Detect the active package manager for a notebook from its env_source or metadata.
+/// Detect the active package manager for a notebook from its metadata or env_source.
 /// Each notebook has exactly one env manager type.
+///
+/// Priority: metadata section existence (authoritative) → env_source (runtime) → default.
+/// Metadata wins because the user explicitly chose the package manager (via
+/// `create_notebook(package_manager=...)` or the UI), while env_source reflects
+/// what the daemon happened to auto-launch with (which may be the system default,
+/// not the notebook's intent).
 pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) -> String {
-    // Priority 1: env_source from running kernel
+    // Priority 1: metadata declares which package manager section exists.
+    // Check section existence, not just non-empty deps — an empty pixi section
+    // means "this is a pixi notebook with no deps yet".
+    if let Some(meta) = handle.get_notebook_metadata() {
+        if meta.runt.pixi.is_some() {
+            return "pixi".to_string();
+        }
+        if meta.runt.conda.is_some() {
+            return "conda".to_string();
+        }
+        if meta.runt.uv.is_some() {
+            return "uv".to_string();
+        }
+    }
+    // Priority 2: env_source from running kernel (fallback for notebooks
+    // with no runt metadata yet)
     if let Ok(state) = handle.get_runtime_state() {
         let src = &state.kernel.env_source;
         if src.starts_with("conda:") {
@@ -53,17 +74,83 @@ pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) 
             return "uv".to_string();
         }
     }
-    // Priority 2: existing metadata deps
-    if let Some(meta) = handle.get_notebook_metadata() {
-        if !meta.pixi_dependencies().is_empty() {
-            return "pixi".to_string();
-        }
-        if !meta.conda_dependencies().is_empty() {
-            return "conda".to_string();
-        }
-    }
     // Default
     "uv".to_string()
+}
+
+/// Ensure the notebook metadata has the correct package manager section.
+///
+/// The daemon creates metadata based on `default_python_env`, which may
+/// differ from the MCP client's requested `package_manager`. This function
+/// reads the current metadata, and if the requested manager's section is
+/// missing, creates it (and clears competing sections so
+/// `detect_package_manager` picks the right one).
+/// Returns `true` if the metadata was changed.
+pub(crate) fn ensure_package_manager_metadata(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: &str,
+) -> bool {
+    let current = handle.get_notebook_metadata();
+    let needs_fix = match manager {
+        "pixi" => current.as_ref().is_none_or(|m| m.runt.pixi.is_none()),
+        "conda" => current.as_ref().is_none_or(|m| m.runt.conda.is_none()),
+        // uv: fix if metadata has pixi/conda but not uv (daemon default was
+        // pixi/conda but user explicitly requested uv)
+        _ => current.as_ref().is_some_and(|m| {
+            m.runt.uv.is_none() && (m.runt.pixi.is_some() || m.runt.conda.is_some())
+        }),
+    };
+
+    if !needs_fix {
+        return false;
+    }
+
+    // Update the metadata snapshot to have the right package manager
+    let mut snapshot = current.unwrap_or_default();
+    match manager {
+        "pixi" => {
+            // Create pixi section, clear uv/conda so detect_package_manager
+            // picks pixi
+            if snapshot.runt.pixi.is_none() {
+                snapshot.runt.pixi = Some(notebook_doc::metadata::PixiInlineMetadata {
+                    dependencies: Vec::new(),
+                    pypi_dependencies: Vec::new(),
+                    channels: vec!["conda-forge".to_string()],
+                    python: None,
+                });
+            }
+            snapshot.runt.uv = None;
+            snapshot.runt.conda = None;
+        }
+        "conda" => {
+            if snapshot.runt.conda.is_none() {
+                snapshot.runt.conda = Some(notebook_doc::metadata::CondaInlineMetadata {
+                    dependencies: Vec::new(),
+                    channels: vec!["conda-forge".to_string()],
+                    python: None,
+                });
+            }
+            snapshot.runt.uv = None;
+            snapshot.runt.pixi = None;
+        }
+        _ => {
+            // uv: clear pixi/conda, ensure uv section exists
+            snapshot.runt.pixi = None;
+            snapshot.runt.conda = None;
+            if snapshot.runt.uv.is_none() {
+                snapshot.runt.uv = Some(notebook_doc::metadata::UvInlineMetadata {
+                    dependencies: Vec::new(),
+                    requires_python: None,
+                    prerelease: None,
+                });
+            }
+        }
+    }
+    if let Err(e) = handle.set_metadata_snapshot(&snapshot) {
+        tracing::warn!("Failed to fix package manager metadata: {e}");
+        return false;
+    }
+    true
 }
 
 /// Add a dependency using the appropriate package manager, return error string on failure.

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -405,6 +405,14 @@ pub async fn create_notebook(
 
             let pkg_manager = arg_str(request, "package_manager").unwrap_or("uv");
 
+            // Validate package_manager
+            if !matches!(pkg_manager, "uv" | "conda" | "pixi") {
+                return tool_error(&format!(
+                    "Invalid package_manager '{}'. Must be 'uv', 'conda', or 'pixi'.",
+                    pkg_manager
+                ));
+            }
+
             // Ensure the daemon's doc structure is fully received before
             // any metadata writes.
             let mut metadata_changed = false;

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -405,14 +405,19 @@ pub async fn create_notebook(
 
             let pkg_manager = arg_str(request, "package_manager").unwrap_or("uv");
 
-            if runtime != "deno" && !deps.is_empty() {
-                // Flush any pending sync frames from the daemon so we have
-                // the full document structure (metadata map, runt map) before
-                // writing deps.  Without this, a concurrent daemon sync can
-                // race with the client-side put_object and shadow our writes.
+            // Ensure the daemon's doc structure is fully received before
+            // any metadata writes.
+            let mut metadata_changed = false;
+            if runtime != "deno" {
                 if let Err(e) = result.handle.confirm_sync().await {
-                    tracing::warn!("confirm_sync before create_notebook deps failed: {e}");
+                    tracing::warn!("confirm_sync before create_notebook metadata fix: {e}");
                 }
+
+                // The daemon creates metadata based on default_python_env,
+                // which may not match the requested package_manager. Fix the
+                // metadata to have the correct package manager section.
+                metadata_changed =
+                    super::deps::ensure_package_manager_metadata(&result.handle, pkg_manager);
 
                 for dep in &deps {
                     let _ = super::deps::add_dep_for_manager(&result.handle, dep, pkg_manager);
@@ -426,8 +431,12 @@ pub async fn create_notebook(
             };
             *server.session.write().await = Some(session);
 
-            // If dependencies were added, ensure daemon has them and restart kernel
-            if !deps.is_empty() && runtime != "deno" {
+            // Restart kernel if deps were added or package manager metadata
+            // was changed from the daemon's default (so the kernel picks up
+            // the right env). Skip for deno — deno doesn't use Python
+            // package managers.
+            let needs_restart = runtime != "deno" && (!deps.is_empty() || metadata_changed);
+            if needs_restart {
                 let session = server.session.read().await;
                 if let Some(s) = session.as_ref() {
                     // Ensure daemon has the dep metadata before restarting


### PR DESCRIPTION
## Summary

`create_notebook(package_manager="pixi")` reported pixi in the response but all subsequent operations (`add_dependency`, `get_dependencies`, `restart_kernel`) silently used uv instead.

**Root causes:**

1. The daemon creates notebook metadata based on `default_python_env` (system setting), ignoring the MCP client's `package_manager` param. If the user's default is uv, a pixi notebook gets uv metadata.

2. `detect_package_manager` checked `env_source` first (from the running kernel), which reflected the daemon's auto-launch default (uv), not the notebook's intent. It also required non-empty deps to detect pixi — an empty pixi section was invisible.

**Fixes:**

- `ensure_package_manager_metadata`: After `connect_create`, swaps the metadata section to match the requested package_manager (clears competing sections so detection works)
- `detect_package_manager`: Checks metadata section **existence** first (pixi section present = pixi notebook), falls back to env_source
- Kernel restart on metadata change (even without deps) so `env_source` updates

## Test plan

- [x] `create_notebook(package_manager="pixi")` → `add_dependency` returns `package_manager: "pixi"`
- [x] `get_dependencies` returns `package_manager: "pixi"`
- [x] Default `create_notebook()` → still uses uv correctly
- [x] `create_notebook(runtime="deno")` → no Python kernel launched
- [x] Clippy clean, all tests pass

Closes #1597