### PR TITLE
fix(runtimed): show 'awaiting approval' instead of 'initializing' when blocked on trust

### DIFF
--- a/apps/notebook/src/lib/__tests__/kernel-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/kernel-status.test.ts
@@ -38,8 +38,8 @@ describe("getKernelStatusLabel", () => {
 });
 
 describe("KERNEL_STATUS", () => {
-  it("contains exactly six statuses", () => {
-    expect(Object.keys(KERNEL_STATUS)).toHaveLength(6);
+  it("contains exactly seven statuses", () => {
+    expect(Object.keys(KERNEL_STATUS)).toHaveLength(7);
   });
 
   it("has expected values", () => {
@@ -49,6 +49,7 @@ describe("KERNEL_STATUS", () => {
     expect(KERNEL_STATUS.BUSY).toBe("busy");
     expect(KERNEL_STATUS.ERROR).toBe("error");
     expect(KERNEL_STATUS.SHUTDOWN).toBe("shutdown");
+    expect(KERNEL_STATUS.AWAITING_TRUST).toBe("awaiting_trust");
   });
 });
 

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -15,6 +15,7 @@ export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.BUSY]: "busy",
   [KERNEL_STATUS.ERROR]: "error",
   [KERNEL_STATUS.SHUTDOWN]: "shutdown",
+  [KERNEL_STATUS.AWAITING_TRUST]: "awaiting approval",
 };
 
 const STARTING_PHASE_LABELS: Record<string, string> = {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1921,6 +1921,25 @@ where
                 )
                 .await;
             });
+        } else if !has_kernel
+            && matches!(
+                trust_status,
+                runt_trust::TrustStatus::Untrusted | runt_trust::TrustStatus::SignatureInvalid
+            )
+        {
+            // Kernel blocked on trust approval — write this to RuntimeStateDoc
+            // so the frontend shows "Awaiting Trust Approval" instead of "Initializing"
+            info!(
+                "[notebook-sync] Kernel blocked on trust approval for {} (trust: {:?})",
+                notebook_id, trust_status
+            );
+            let mut sd = room.state_doc.write().await;
+            let mut changed = false;
+            changed |= sd.set_kernel_status("awaiting_trust");
+            changed |= sd.set_starting_phase("");
+            if changed {
+                let _ = room.state_changed_tx.send(());
+            }
         } else {
             info!(
                 "[notebook-sync] Auto-launch skipped for {} (trust: {:?}, has_kernel: {}, path_exists: {}, is_new: {}, created_at_path: {})",

--- a/packages/runtimed/src/derived-state.ts
+++ b/packages/runtimed/src/derived-state.ts
@@ -26,6 +26,7 @@ export const KERNEL_STATUS = {
   BUSY: "busy",
   ERROR: "error",
   SHUTDOWN: "shutdown",
+  AWAITING_TRUST: "awaiting_trust",
 } as const;
 
 export type KernelStatus = (typeof KERNEL_STATUS)[keyof typeof KERNEL_STATUS];
@@ -92,7 +93,8 @@ export function deriveEnvSyncState(
   if (
     (state.kernel.status === "not_started" && !state.kernel.env_source) ||
     state.kernel.status === "shutdown" ||
-    state.kernel.status === "error"
+    state.kernel.status === "error" ||
+    state.kernel.status === "awaiting_trust"
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary

When a notebook has dependencies needing trust approval, the kernel status showed "Initializing" indefinitely. The daemon silently skipped auto-launch but didn't tell the RuntimeStateDoc why.

**Fix**: When auto-launch is blocked by untrusted dependencies, write `"awaiting_trust"` to the RuntimeStateDoc kernel status. The frontend renders this as "Awaiting Approval" — matching the trust banner.

## Changes

| File | Change |
|------|--------|
| `crates/runtimed/src/notebook_sync_server.rs` | Write `awaiting_trust` status when trust blocks auto-launch |
| `packages/runtimed/src/derived-state.ts` | Add `AWAITING_TRUST` to `KERNEL_STATUS` enum |
| `apps/notebook/src/lib/kernel-status.ts` | Add "awaiting approval" label |
| `apps/notebook/src/lib/__tests__/kernel-status.test.ts` | Update test for new status |

## Test plan

- [x] Clippy clean, notebook-doc tests pass, vitest kernel-status tests pass (19)
- [ ] Open a notebook with untrusted deps → status shows "Awaiting Approval" instead of "Initializing"
- [ ] Approve trust → kernel launches normally (status transitions to starting → idle)

**Note**: Auto-launch after trust approval requires a manual "Start Kernel" click — this is existing behavior, not a regression.

Closes #1601