### PR TITLE
fix(runt-mcp): route conda/pixi notebooks to correct kernel pool

### DIFF
--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -63,10 +63,11 @@ pub async fn restart_kernel(
         tracing::warn!("confirm_sync failed before restart_kernel launch: {e}");
     }
 
-    // Step 2: Determine kernel type and env_source from RuntimeState.
-    // Use scoped auto-detect (auto:uv, auto:conda, auto:pixi) to stay within
-    // the original package manager family while re-checking metadata for new deps.
-    // This matches the Python bindings' restart logic in session_core.rs.
+    // Step 2: Determine kernel type and env_source.
+    // Use metadata-based detection (not RuntimeState env_source) to scope the
+    // auto-detect. This ensures the correct package manager pool is used even
+    // if the previous kernel was launched with a different env (e.g., UV default
+    // when the notebook metadata says pixi). See #1605.
     let (kernel_type, env_source) = {
         let state = handle.get_runtime_state().ok();
         let kernel_type = state
@@ -80,12 +81,12 @@ pub async fn restart_kernel(
                 }
             })
             .unwrap_or_else(|| "python".to_string());
-        let env_source = match state.as_ref().map(|s| s.kernel.env_source.as_str()) {
-            Some("uv:prewarmed") => "auto:uv".to_string(),
-            Some("conda:prewarmed") => "auto:conda".to_string(),
-            Some("pixi:prewarmed") => "auto:pixi".to_string(),
-            Some("") | None => "auto".to_string(),
-            Some(s) => s.to_string(),
+        // Scope auto-detect based on notebook metadata, not stale env_source
+        let detected_manager = super::deps::detect_package_manager(&handle);
+        let env_source = match detected_manager.as_str() {
+            "pixi" => "auto:pixi".to_string(),
+            "conda" => "auto:conda".to_string(),
+            _ => "auto:uv".to_string(),
         };
         (kernel_type, env_source)
     };

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -452,7 +452,15 @@ pub async fn create_notebook(
                         tracing::warn!("confirm_sync failed before create_notebook relaunch: {e}");
                     }
 
-                    // Shutdown and relaunch with auto-detect (daemon reads deps from metadata)
+                    // Shutdown and relaunch with scoped auto-detect so the daemon
+                    // uses the correct package manager pool (not the system default).
+                    // "auto:pixi" → pixi pool/inline, "auto:conda" → conda pool/inline,
+                    // "auto" → follows default_python_env (which may differ from requested).
+                    let scoped_env_source = match pkg_manager {
+                        "pixi" => "auto:pixi",
+                        "conda" => "auto:conda",
+                        _ => "auto:uv",
+                    };
                     let _ = s
                         .handle
                         .send_request(NotebookRequest::ShutdownKernel {})
@@ -462,7 +470,7 @@ pub async fn create_notebook(
                         .handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: runtime.to_string(),
-                            env_source: "auto".to_string(),
+                            env_source: scoped_env_source.to_string(),
                             notebook_path: None,
                         })
                         .await;


### PR DESCRIPTION
## Summary

Conda and pixi notebooks silently fell back to UV pooled kernels because the MCP tools sent `env_source: "auto"` (unscoped), which the daemon resolved using the system default (`uv`).

**Fixes:**
- `create_notebook`: sends `"auto:pixi"` / `"auto:conda"` / `"auto:uv"` based on `package_manager` param
- `restart_kernel`: uses `detect_package_manager()` (metadata-based) instead of stale `RuntimeState.env_source` to scope the auto-detect

The daemon's scoped auto-detect already handles these correctly — `auto:pixi` routes to `pixi:inline` (with deps) or `pixi:prewarmed` (without).

## Test plan

- [ ] `create_notebook(package_manager="pixi")` + `create_cell("import numpy; print(numpy.__file__)")` → path contains `runtimed-pixi-*`
- [ ] `create_notebook(package_manager="conda")` + execute → path contains `runtimed-conda-*`
- [ ] Default `create_notebook()` → still uses UV
- [ ] `add_dependency(after="restart")` on pixi notebook → `env_source: "pixi:*"`

Closes #1605