### PR TITLE
chore: bump to 2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "kernel-env",
  "log",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.1.1"
+version = "2.1.2"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.1.1"
+version = "2.1.2"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Version bump for patch release. Bug fixes since 2.1.1:

- **#1589** — replace_match context matching + create_notebook dep sync
- **#1595** — Plotly 6 bdata, GeoJSON text parsing, structured viz synthesis
- **#1599** — create_notebook(package_manager='pixi') persists correctly
- **#1600** — `runt config` CLI subcommand
- **#1602** — Safe CRDT writes via update_json_at_key
- **#1603** — Show 'awaiting approval' when blocked on trust
- **#1604** — Trust banner for awaiting_trust status
- **#1606** — Route conda/pixi notebooks to correct kernel pool