### PR TITLE
feat(prewarm): replace inline warmup scripts with embedded prewarm package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,6 +45,7 @@ jobs:
               - 'python/runtimed/**'
               - 'python/nteract/**'
               - 'python/gremlin/**'
+              - 'python/prewarm/**'
               - 'crates/runtimed-py/**'
               - 'crates/runtimed/**'
               - 'apps/mcp-app/**'
@@ -80,10 +81,10 @@ jobs:
         run: uv sync
 
       - name: Ruff check
-        run: uv run ruff check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/
+        run: uv run ruff check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/prewarm/src/ python/prewarm/tests/
 
       - name: Ruff format check
-        run: uv run ruff format --check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/
+        run: uv run ruff format --check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/prewarm/src/ python/prewarm/tests/
 
       - name: Type check
         run: uv run ty check python/
@@ -91,6 +92,9 @@ jobs:
       - name: Run runtimed-py unit tests
         working-directory: python/runtimed
         run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
+
+      - name: Run prewarm unit tests
+        run: uv run pytest python/prewarm/tests/ -v --tb=short
 
   python-lint-and-test-skip:
     name: Python Lint & Unit Tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -94,7 +94,9 @@ jobs:
         run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
 
       - name: Run prewarm unit tests
-        run: uv run pytest python/prewarm/tests/ -v --tb=short
+        run: |
+          uv pip install -e python/prewarm
+          uv run pytest python/prewarm/tests/ -v --tb=short
 
   python-lint-and-test-skip:
     name: Python Lint & Unit Tests

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -632,22 +632,15 @@ pub async fn warmup_environment(env: &CondaEnvironment) -> Result<()> {
         env.env_path
     );
 
-    let warmup_script = r#"
-import sys
-import ipykernel
-import IPython
-import ipywidgets
-import nbformat
-import traitlets
-import zmq
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-from ipykernel.comm import CommManager
-print("warmup complete")
-"#;
+    let site_packages = find_site_packages(&env.env_path);
+    let warmup_script = crate::warmup::build_warmup_command(
+        &[],
+        true,
+        site_packages.as_deref(),
+    );
 
     let output = tokio::process::Command::new(&env.python_path)
-        .args(["-c", warmup_script])
+        .args(["-c", &warmup_script])
         .output()
         .await?;
 
@@ -868,6 +861,27 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Find the site-packages directory inside a venv/env.
+fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
+    let lib_dir = base_path.join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with("python") {
+                        let sp = path.join("site-packages");
+                        if sp.is_dir() {
+                            return sp.to_str().map(String::from);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -633,11 +633,7 @@ pub async fn warmup_environment(env: &CondaEnvironment) -> Result<()> {
     );
 
     let site_packages = find_site_packages(&env.env_path);
-    let warmup_script = crate::warmup::build_warmup_command(
-        &[],
-        true,
-        site_packages.as_deref(),
-    );
+    let warmup_script = crate::warmup::build_warmup_command(&[], true, site_packages.as_deref());
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -33,6 +33,7 @@ pub mod pixi;
 pub mod progress;
 #[cfg(feature = "runtime")]
 pub mod uv;
+pub mod warmup;
 
 // Re-export key types
 #[cfg(feature = "runtime")]

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -439,14 +439,13 @@ async fn install_pixi_env(
 /// Warm up a pixi environment by running Python to trigger .pyc compilation.
 pub async fn warmup_environment(env: &PixiEnvironment) -> Result<()> {
     let warmup_start = Instant::now();
-    info!("[prewarm] Warming up pixi environment at {:?}", env.venv_path);
+    info!(
+        "[prewarm] Warming up pixi environment at {:?}",
+        env.venv_path
+    );
 
     let site_packages = find_site_packages(&env.venv_path);
-    let warmup_script = crate::warmup::build_warmup_command(
-        &[],
-        true,
-        site_packages.as_deref(),
-    );
+    let warmup_script = crate::warmup::build_warmup_command(&[], true, site_packages.as_deref());
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])
@@ -455,7 +454,10 @@ pub async fn warmup_environment(env: &PixiEnvironment) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("[prewarm] Warmup failed for {:?}: {}", env.venv_path, stderr);
+        warn!(
+            "[prewarm] Warmup failed for {:?}: {}",
+            env.venv_path, stderr
+        );
         return Ok(());
     }
 

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -439,30 +439,23 @@ async fn install_pixi_env(
 /// Warm up a pixi environment by running Python to trigger .pyc compilation.
 pub async fn warmup_environment(env: &PixiEnvironment) -> Result<()> {
     let warmup_start = Instant::now();
-    info!("[pixi] Warming up environment at {:?}", env.venv_path);
+    info!("[prewarm] Warming up pixi environment at {:?}", env.venv_path);
 
-    let warmup_script = r#"
-import sys
-import ipykernel
-import IPython
-import ipywidgets
-import nbformat
-import traitlets
-import zmq
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-from ipykernel.comm import CommManager
-print("warmup complete")
-"#;
+    let site_packages = find_site_packages(&env.venv_path);
+    let warmup_script = crate::warmup::build_warmup_command(
+        &[],
+        true,
+        site_packages.as_deref(),
+    );
 
     let output = tokio::process::Command::new(&env.python_path)
-        .args(["-c", warmup_script])
+        .args(["-c", &warmup_script])
         .output()
         .await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("[pixi] Warmup failed for {:?}: {}", env.venv_path, stderr);
+        warn!("[prewarm] Warmup failed for {:?}: {}", env.venv_path, stderr);
         return Ok(());
     }
 
@@ -470,7 +463,7 @@ print("warmup complete")
     tokio::fs::write(&marker_path, "").await.ok();
 
     info!(
-        "[pixi] Warmup complete for {:?} in {}ms",
+        "[prewarm] Warmup complete for {:?} in {}ms",
         env.venv_path,
         warmup_start.elapsed().as_millis()
     );
@@ -481,6 +474,27 @@ print("warmup complete")
 /// Check if a pixi environment has been warmed up.
 pub fn is_environment_warmed(env: &PixiEnvironment) -> bool {
     env.venv_path.join(".warmed").exists()
+}
+
+/// Find the site-packages directory inside a venv/env.
+fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
+    let lib_dir = base_path.join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with("python") {
+                        let sp = path.join("site-packages");
+                        if sp.is_dir() {
+                            return sp.to_str().map(String::from);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -555,11 +555,7 @@ pub async fn warmup_environment(env: &UvEnvironment) -> Result<()> {
     info!("[prewarm] Warming up UV environment at {:?}", env.venv_path);
 
     let site_packages = find_site_packages(&env.venv_path);
-    let warmup_script = crate::warmup::build_warmup_command(
-        &[],
-        true,
-        site_packages.as_deref(),
-    );
+    let warmup_script = crate::warmup::build_warmup_command(&[], true, site_packages.as_deref());
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -554,22 +554,15 @@ pub async fn warmup_environment(env: &UvEnvironment) -> Result<()> {
     let warmup_start = std::time::Instant::now();
     info!("[prewarm] Warming up UV environment at {:?}", env.venv_path);
 
-    let warmup_script = r#"
-import sys
-import ipykernel
-import IPython
-import ipywidgets
-import nbformat
-import traitlets
-import zmq
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-from ipykernel.comm import CommManager
-print("warmup complete")
-"#;
+    let site_packages = find_site_packages(&env.venv_path);
+    let warmup_script = crate::warmup::build_warmup_command(
+        &[],
+        true,
+        site_packages.as_deref(),
+    );
 
     let output = tokio::process::Command::new(&env.python_path)
-        .args(["-c", warmup_script])
+        .args(["-c", &warmup_script])
         .output()
         .await?;
 
@@ -688,6 +681,27 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Find the site-packages directory inside a venv/env.
+fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
+    let lib_dir = base_path.join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with("python") {
+                        let sp = path.join("site-packages");
+                        if sp.is_dir() {
+                            return sp.to_str().map(String::from);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/kernel-env/src/warmup.rs
+++ b/crates/kernel-env/src/warmup.rs
@@ -21,8 +21,7 @@
 /// This is the full `__init__.py` from `python/prewarm/src/prewarm/`.
 /// It contains `build_warmup_script()` which generates a self-contained
 /// Python script string — no prewarm import needed at runtime.
-pub const PREWARM_SOURCE: &str =
-    include_str!("../../../python/prewarm/src/prewarm/__init__.py");
+pub const PREWARM_SOURCE: &str = include_str!("../../../python/prewarm/src/prewarm/__init__.py");
 
 /// Build a complete Python script that can be passed to `python -c`.
 ///

--- a/crates/kernel-env/src/warmup.rs
+++ b/crates/kernel-env/src/warmup.rs
@@ -1,0 +1,102 @@
+//! Embedded Python warmup script and command builder.
+//!
+//! The prewarm Python package at `python/prewarm/src/prewarm/__init__.py`
+//! is the single source of truth for warmup logic. This module embeds it
+//! at compile time via `include_str!` so the daemon can run it in any
+//! environment without pip-installing the package first.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use kernel_env::warmup;
+//!
+//! // Build a warmup script for a conda environment
+//! let script = warmup::build_warmup_script(&["matplotlib"], true, Some(site_packages));
+//!
+//! // Run: python -c <script>
+//! ```
+
+/// The prewarm Python source, embedded at compile time.
+///
+/// This is the full `__init__.py` from `python/prewarm/src/prewarm/`.
+/// It contains `build_warmup_script()` which generates a self-contained
+/// Python script string — no prewarm import needed at runtime.
+pub const PREWARM_SOURCE: &str =
+    include_str!("../../../python/prewarm/src/prewarm/__init__.py");
+
+/// Build a complete Python script that can be passed to `python -c`.
+///
+/// The generated script:
+/// 1. Defines the prewarm functions (from embedded source)
+/// 2. Calls `build_warmup_script()` with the given arguments
+/// 3. `exec()`s the result
+///
+/// This avoids the package needing to be installed — the entire prewarm
+/// module is inlined into the script.
+pub fn build_warmup_command(
+    extra_modules: &[String],
+    include_conda: bool,
+    site_packages: Option<&str>,
+) -> String {
+    let modules_py: Vec<String> = extra_modules.iter().map(|m| format!("{m:?}")).collect();
+    let modules_list = format!("[{}]", modules_py.join(", "));
+
+    let site_packages_py = match site_packages {
+        Some(path) => format!("{path:?}"),
+        None => "None".to_string(),
+    };
+
+    // We exec the embedded source to define all functions, then call
+    // build_warmup_script() and exec the result.
+    format!(
+        r#"exec({prewarm_source:?})
+_script = build_warmup_script({modules}, include_conda={include_conda}, site_packages={site_packages})
+exec(_script)"#,
+        prewarm_source = PREWARM_SOURCE,
+        modules = modules_list,
+        include_conda = if include_conda { "True" } else { "False" },
+        site_packages = site_packages_py,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prewarm_source_is_embedded() {
+        // Verify the include_str! resolved correctly
+        assert!(PREWARM_SOURCE.contains("def warm("));
+        assert!(PREWARM_SOURCE.contains("def build_warmup_script("));
+        assert!(PREWARM_SOURCE.contains("BASE_MODULES"));
+    }
+
+    #[test]
+    fn test_build_warmup_command_basic() {
+        let cmd = build_warmup_command(&[], false, None);
+        assert!(cmd.contains("exec("));
+        assert!(cmd.contains("build_warmup_script("));
+        assert!(cmd.contains("include_conda=False"));
+    }
+
+    #[test]
+    fn test_build_warmup_command_with_conda() {
+        let cmd = build_warmup_command(&[], true, None);
+        assert!(cmd.contains("include_conda=True"));
+    }
+
+    #[test]
+    fn test_build_warmup_command_with_modules() {
+        let modules = vec!["numpy".to_string(), "pandas".to_string()];
+        let cmd = build_warmup_command(&modules, false, None);
+        assert!(cmd.contains("numpy"));
+        assert!(cmd.contains("pandas"));
+    }
+
+    #[test]
+    fn test_build_warmup_command_with_site_packages() {
+        let cmd = build_warmup_command(&[], false, Some("/fake/site-packages"));
+        assert!(cmd.contains("/fake/site-packages"));
+    }
+}

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2850,8 +2850,7 @@ impl Daemon {
                 .await
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
-                    error_message: "Conda warmup script failed (ipykernel may not be installed)"
-                        .into(),
+                    error_message: "Conda warmup failed (timed out or imports errored)".into(),
                 }));
             self.update_pool_doc().await;
         }
@@ -3351,7 +3350,7 @@ impl Daemon {
                 .await
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
-                    error_message: "Warmup script failed (ipykernel may not be installed)".into(),
+                    error_message: "UV warmup failed (timed out or imports errored)".into(),
                 }));
             self.update_pool_doc().await;
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -233,86 +233,6 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     packages
 }
 
-fn package_import_name(pkg: &str) -> Option<String> {
-    let name = pkg
-        .split("::")
-        .last()?
-        .split([
-            '<', '>', '=', '!', '~', ' ', '[', '"', '\'', '\\', '\n', '\r',
-        ])
-        .next()?
-        .trim();
-    if name.is_empty() {
-        return None;
-    }
-    let candidate = name.replace('-', "_");
-    if candidate.split('.').all(is_valid_python_identifier) {
-        Some(candidate)
-    } else {
-        None
-    }
-}
-
-fn is_valid_python_identifier(segment: &str) -> bool {
-    let mut chars = segment.chars();
-    match chars.next() {
-        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
-        _ => return false,
-    }
-    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn build_python_warmup_script(extra_packages: &[String], include_conda_runtime: bool) -> String {
-    let mut script = r#"
-import ipykernel
-import IPython
-import ipywidgets
-import anywidget
-import nbformat
-"#
-    .to_string();
-
-    if include_conda_runtime {
-        script.push_str(
-            r#"
-import traitlets
-import zmq
-"#,
-        );
-    }
-
-    let mut modules = extra_packages
-        .iter()
-        .filter_map(|pkg| package_import_name(pkg))
-        .collect::<Vec<_>>();
-    modules.sort();
-    modules.dedup();
-
-    if !modules.is_empty() {
-        if let Ok(modules_json) = serde_json::to_string(&modules) {
-            script.push('\n');
-            script.push_str("for module_name in ");
-            script.push_str(&modules_json);
-            script.push_str(":\n");
-            script.push_str("    try:\n");
-            script.push_str("        __import__(module_name)\n");
-            script.push_str("    except Exception:\n");
-            script.push_str("        pass\n");
-        }
-    }
-
-    script.push_str(
-        r#"
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-"#,
-    );
-    if include_conda_runtime {
-        script.push_str("from ipykernel.comm import CommManager\n");
-    }
-    script.push_str("print(\"warmup complete\")\n");
-    script
-}
 
 impl Pool {
     fn new(target: usize, max_age_secs: u64) -> Self {
@@ -2946,7 +2866,28 @@ impl Daemon {
         env_path: &PathBuf,
         extra_packages: &[String],
     ) -> bool {
-        let warmup_script = build_python_warmup_script(extra_packages, true);
+        let site_packages = {
+            let lib_dir = env_path.join("lib");
+            std::fs::read_dir(&lib_dir)
+                .ok()
+                .and_then(|entries| {
+                    entries.flatten().find_map(|entry| {
+                        let path = entry.path();
+                        let name = path.file_name()?.to_str()?;
+                        if name.starts_with("python") {
+                            let sp = path.join("site-packages");
+                            sp.is_dir().then(|| sp.to_string_lossy().into_owned())
+                        } else {
+                            None
+                        }
+                    })
+                })
+        };
+        let warmup_script = kernel_env::warmup::build_warmup_command(
+            extra_packages,
+            true,
+            site_packages.as_deref(),
+        );
 
         let warmup_result = tokio::time::timeout(
             std::time::Duration::from_secs(30),
@@ -3339,7 +3280,28 @@ impl Daemon {
         }
 
         // Warm up the environment (30 second timeout)
-        let warmup_script = build_python_warmup_script(&user_default_packages, false);
+        let site_packages = {
+            let lib_dir = venv_path.join("lib");
+            std::fs::read_dir(&lib_dir)
+                .ok()
+                .and_then(|entries| {
+                    entries.flatten().find_map(|entry| {
+                        let path = entry.path();
+                        let name = path.file_name()?.to_str()?;
+                        if name.starts_with("python") {
+                            let sp = path.join("site-packages");
+                            sp.is_dir().then(|| sp.to_string_lossy().into_owned())
+                        } else {
+                            None
+                        }
+                    })
+                })
+        };
+        let warmup_script = kernel_env::warmup::build_warmup_command(
+            &user_default_packages,
+            false,
+            site_packages.as_deref(),
+        );
 
         let warmup_result = tokio::time::timeout(
             std::time::Duration::from_secs(30),

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -233,7 +233,6 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     packages
 }
 
-
 impl Pool {
     fn new(target: usize, max_age_secs: u64) -> Self {
         Self {
@@ -2868,20 +2867,18 @@ impl Daemon {
     ) -> bool {
         let site_packages = {
             let lib_dir = env_path.join("lib");
-            std::fs::read_dir(&lib_dir)
-                .ok()
-                .and_then(|entries| {
-                    entries.flatten().find_map(|entry| {
-                        let path = entry.path();
-                        let name = path.file_name()?.to_str()?;
-                        if name.starts_with("python") {
-                            let sp = path.join("site-packages");
-                            sp.is_dir().then(|| sp.to_string_lossy().into_owned())
-                        } else {
-                            None
-                        }
-                    })
+            std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
+                entries.flatten().find_map(|entry| {
+                    let path = entry.path();
+                    let name = path.file_name()?.to_str()?;
+                    if name.starts_with("python") {
+                        let sp = path.join("site-packages");
+                        sp.is_dir().then(|| sp.to_string_lossy().into_owned())
+                    } else {
+                        None
+                    }
                 })
+            })
         };
         let warmup_script = kernel_env::warmup::build_warmup_command(
             extra_packages,
@@ -3282,20 +3279,18 @@ impl Daemon {
         // Warm up the environment (30 second timeout)
         let site_packages = {
             let lib_dir = venv_path.join("lib");
-            std::fs::read_dir(&lib_dir)
-                .ok()
-                .and_then(|entries| {
-                    entries.flatten().find_map(|entry| {
-                        let path = entry.path();
-                        let name = path.file_name()?.to_str()?;
-                        if name.starts_with("python") {
-                            let sp = path.join("site-packages");
-                            sp.is_dir().then(|| sp.to_string_lossy().into_owned())
-                        } else {
-                            None
-                        }
-                    })
+            std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
+                entries.flatten().find_map(|entry| {
+                    let path = entry.path();
+                    let name = path.file_name()?.to_str()?;
+                    if name.starts_with("python") {
+                        let sp = path.join("site-packages");
+                        sp.is_dir().then(|| sp.to_string_lossy().into_owned())
+                    } else {
+                        None
+                    }
                 })
+            })
         };
         let warmup_script = kernel_env::warmup::build_warmup_command(
             &user_default_packages,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2887,7 +2887,7 @@ impl Daemon {
         );
 
         let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(120),
             tokio::process::Command::new(python_path)
                 .args(["-c", &warmup_script])
                 .stdout(Stdio::piped())
@@ -3299,7 +3299,7 @@ impl Daemon {
         );
 
         let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(120),
             tokio::process::Command::new(&python_path)
                 .args(["-c", &warmup_script])
                 .output(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 packages = []
 
 [tool.uv.workspace]
-members = ["python/runtimed", "python/nteract", "python/gremlin"]
+members = ["python/runtimed", "python/nteract", "python/gremlin", "python/prewarm"]
 
 [tool.uv.sources]
 runtimed = { workspace = true }
@@ -42,7 +42,7 @@ select = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["runtimed", "nteract"]
+known-first-party = ["runtimed", "nteract", "prewarm"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["SIM105", "SIM117"]
@@ -71,6 +71,7 @@ extra-paths = [
     "python/runtimed/src",
     "python/nteract/src",
     "python/gremlin/src",
+    "python/prewarm/src",
 ]
 
 [tool.ty.rules]

--- a/python/prewarm/.gitignore
+++ b/python/prewarm/.gitignore
@@ -1,0 +1,2 @@
+dist/
+*.egg-info/

--- a/python/prewarm/README.md
+++ b/python/prewarm/README.md
@@ -1,0 +1,42 @@
+# prewarm
+
+Warm up Python environments by importing packages and triggering their
+one-time side effects — font caches, C extension loading, BLAS discovery,
+and more.
+
+## Usage
+
+```bash
+# Warm up via IPython (warms IPython's own init + packages)
+prewarm matplotlib pandas numpy
+
+# Or as a module
+python -m prewarm matplotlib pandas numpy
+
+# Skip IPython, just import directly
+prewarm --no-ipython matplotlib pandas
+```
+
+## API
+
+```python
+from prewarm import warm
+
+# Boot IPython, import modules, exit
+warm(["matplotlib", "pandas"])
+
+# Just import, no IPython
+warm(["matplotlib", "pandas"], ipython=False)
+```
+
+## Why?
+
+First imports of heavy packages like matplotlib and pandas are slow — they
+build font caches, load C extensions, discover BLAS libraries, etc.
+Running `prewarm` in a fresh environment triggers all of these one-time
+costs up front so subsequent imports are fast.
+
+When run with IPython (the default), it also warms IPython's startup path:
+traitlets configuration, magic commands, tab completion, and the display
+system. This is especially useful for Jupyter kernels where IPython boot
+time is part of the perceived startup latency.

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "prewarm"
+version = "0.0.1"
+description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
+readme = "README.md"
+license = "BSD-3-Clause"
+authors = [
+    { name = "Kyle Kelley", email = "rgbkrk@gmail.com" }
+]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+prewarm = "prewarm:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/prewarm"]

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = []
 [project.scripts]
 prewarm = "prewarm:main"
 
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/python/prewarm/src/prewarm/__init__.py
+++ b/python/prewarm/src/prewarm/__init__.py
@@ -1,53 +1,170 @@
-"""Warm up Python environments by importing packages and running IPython's init."""
+"""Warm up Python environments by importing packages and running IPython's init.
+
+This module is both a standalone CLI tool (``python -m prewarm``) and is embedded
+into the Rust daemon via ``include_str!`` for environments where the package
+can't be pip-installed (conda/pixi pools).
+
+The warmup has two phases:
+1. ``compileall`` — pre-compile all ``.pyc`` files in site-packages
+2. Imports — trigger expensive first-run side effects (font caches, C extensions, BLAS)
+"""
 
 from __future__ import annotations
 
 import argparse
+import compileall
 import contextlib
 import importlib
 
+# Base packages always imported during warmup — these are the core
+# notebook runtime dependencies whose first-import is expensive.
+BASE_MODULES = [
+    "ipykernel",
+    "IPython",
+    "ipywidgets",
+    "anywidget",
+    "nbformat",
+]
 
-def warm(modules: list[str], *, ipython: bool = True) -> None:
-    """Import *modules* and optionally boot IPython to warm its caches.
+# Additional imports for conda/pixi environments that bundle the
+# full Jupyter runtime (traitlets config, zmq transport, comms).
+CONDA_MODULES = [
+    "traitlets",
+    "zmq",
+]
+
+CONDA_DEEP_IMPORTS = [
+    ("ipykernel.kernelbase", "Kernel"),
+    ("ipykernel.ipkernel", "IPythonKernel"),
+    ("ipykernel.comm", "CommManager"),
+]
+
+
+def warm(
+    modules: list[str],
+    *,
+    ipython: bool = True,
+    include_conda: bool = False,
+    site_packages: str | None = None,
+) -> None:
+    """Import *modules* and optionally boot IPython to warm caches.
 
     Each module is imported inside a ``try``/``except`` so a single broken
     package never blocks the rest of the warmup.
+
+    When *site_packages* is given, ``compileall.compile_dir()`` is run first
+    to pre-compile all ``.pyc`` files in that directory.
 
     When *ipython* is ``True`` (the default) the function starts an embedded
     IPython session that runs the imports and exits immediately.  This warms
     IPython's own startup path (traitlets, magics, completer, display hooks)
     in addition to the requested packages.
+
+    When *include_conda* is ``True``, additional conda-runtime imports
+    (traitlets, zmq, CommManager) are included in the warmup.
     """
+    if site_packages:
+        _compile_site_packages(site_packages)
+
+    all_modules = _collect_modules(modules, include_conda=include_conda)
+
     if ipython:
-        _warm_via_ipython(modules)
+        _warm_via_ipython(all_modules, include_conda=include_conda)
     else:
-        _warm_directly(modules)
+        _warm_directly(all_modules, include_conda=include_conda)
 
 
-def _warm_directly(modules: list[str]) -> None:
+def _compile_site_packages(path: str) -> None:
+    """Pre-compile all .py files in site-packages to .pyc."""
+    compileall.compile_dir(path, quiet=2, workers=0)
+
+
+def _collect_modules(extra: list[str], *, include_conda: bool = False) -> list[str]:
+    """Assemble the full module list: base + conda (optional) + user extras."""
+    modules = list(BASE_MODULES)
+    if include_conda:
+        modules.extend(CONDA_MODULES)
+    modules.extend(extra)
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    result: list[str] = []
+    for m in modules:
+        if m not in seen:
+            seen.add(m)
+            result.append(m)
+    return result
+
+
+def _warm_directly(modules: list[str], *, include_conda: bool = False) -> None:
+    """Import modules directly without IPython."""
     for m in modules:
         with contextlib.suppress(Exception):
             importlib.import_module(m)
+    if include_conda:
+        _import_conda_deep()
 
 
-def _warm_via_ipython(modules: list[str]) -> None:
+def _import_conda_deep() -> None:
+    """Import conda-specific deep imports (CommManager, etc.)."""
+    for mod, attr in CONDA_DEEP_IMPORTS:
+        with contextlib.suppress(Exception):
+            m = importlib.import_module(mod)
+            getattr(m, attr)
+
+
+def _warm_via_ipython(modules: list[str], *, include_conda: bool = False) -> None:
+    """Warm modules by running them inside an IPython session."""
     try:
         import IPython
     except ImportError:
-        _warm_directly(modules)
+        _warm_directly(modules, include_conda=include_conda)
         return
 
-    code = "\n".join(
-        [
-            "import importlib",
-            *(
-                f"try:\n    importlib.import_module({m!r})\nexcept Exception:\n    pass"
-                for m in modules
-            ),
-        ]
+    script = build_warmup_script(modules, include_conda=include_conda)
+    IPython.start_ipython(argv=["--quick", "--no-banner", "-c", script])
+
+
+def build_warmup_script(
+    extra_modules: list[str],
+    *,
+    include_conda: bool = False,
+    site_packages: str | None = None,
+) -> str:
+    """Build a self-contained Python script string for warmup.
+
+    This is the script that gets embedded via ``include_str!`` in Rust
+    and run via ``python -c``. It must be a single string that works
+    standalone — no imports from the prewarm package itself.
+    """
+    lines: list[str] = []
+
+    # Phase 1: compileall (always import, conditionally run)
+    lines.append("import compileall")
+    if site_packages:
+        lines.append(f"compileall.compile_dir({site_packages!r}, quiet=2, workers=0)")
+
+    # Phase 2: imports
+    lines.append("import importlib")
+
+    all_modules = _collect_modules(extra_modules, include_conda=include_conda)
+    for m in all_modules:
+        lines.append(f"try:\n    importlib.import_module({m!r})\nexcept Exception:\n    pass")
+
+    # Deep imports (always — ipykernel classes)
+    lines.append(
+        "try:\n"
+        "    from ipykernel.kernelbase import Kernel\n"
+        "    from ipykernel.ipkernel import IPythonKernel\n"
+        "except Exception:\n"
+        "    pass"
     )
 
-    IPython.start_ipython(argv=["--quick", "--no-banner", "-c", code])
+    if include_conda:
+        for mod, attr in CONDA_DEEP_IMPORTS:
+            lines.append(f"try:\n    from {mod} import {attr}\nexcept Exception:\n    pass")
+
+    lines.append('print("warmup complete")')
+    return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -65,8 +182,23 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Skip IPython startup, just import modules directly.",
     )
+    parser.add_argument(
+        "--include-conda",
+        action="store_true",
+        help="Include conda-runtime imports (traitlets, zmq, CommManager).",
+    )
+    parser.add_argument(
+        "--site-packages",
+        default=None,
+        help="Path to site-packages directory for compileall pre-compilation.",
+    )
     args = parser.parse_args(argv)
-    warm(args.modules, ipython=not args.no_ipython)
+    warm(
+        args.modules,
+        ipython=not args.no_ipython,
+        include_conda=args.include_conda,
+        site_packages=args.site_packages,
+    )
 
 
 if __name__ == "__main__":

--- a/python/prewarm/src/prewarm/__init__.py
+++ b/python/prewarm/src/prewarm/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib
-import sys
 
 
 def warm(modules: list[str], *, ipython: bool = True) -> None:
@@ -26,10 +26,8 @@ def warm(modules: list[str], *, ipython: bool = True) -> None:
 
 def _warm_directly(modules: list[str]) -> None:
     for m in modules:
-        try:
+        with contextlib.suppress(Exception):
             importlib.import_module(m)
-        except Exception:
-            pass
 
 
 def _warm_via_ipython(modules: list[str]) -> None:

--- a/python/prewarm/src/prewarm/__init__.py
+++ b/python/prewarm/src/prewarm/__init__.py
@@ -1,0 +1,75 @@
+"""Warm up Python environments by importing packages and running IPython's init."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+
+def warm(modules: list[str], *, ipython: bool = True) -> None:
+    """Import *modules* and optionally boot IPython to warm its caches.
+
+    Each module is imported inside a ``try``/``except`` so a single broken
+    package never blocks the rest of the warmup.
+
+    When *ipython* is ``True`` (the default) the function starts an embedded
+    IPython session that runs the imports and exits immediately.  This warms
+    IPython's own startup path (traitlets, magics, completer, display hooks)
+    in addition to the requested packages.
+    """
+    if ipython:
+        _warm_via_ipython(modules)
+    else:
+        _warm_directly(modules)
+
+
+def _warm_directly(modules: list[str]) -> None:
+    for m in modules:
+        try:
+            importlib.import_module(m)
+        except Exception:
+            pass
+
+
+def _warm_via_ipython(modules: list[str]) -> None:
+    try:
+        import IPython
+    except ImportError:
+        _warm_directly(modules)
+        return
+
+    code = "\n".join(
+        [
+            "import importlib",
+            *(
+                f"try:\n    importlib.import_module({m!r})\nexcept Exception:\n    pass"
+                for m in modules
+            ),
+        ]
+    )
+
+    IPython.start_ipython(argv=["--quick", "--no-banner", "-c", code])
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="prewarm",
+        description="Warm up a Python environment by importing packages.",
+    )
+    parser.add_argument(
+        "modules",
+        nargs="*",
+        help="Module names to import (e.g. matplotlib pandas numpy).",
+    )
+    parser.add_argument(
+        "--no-ipython",
+        action="store_true",
+        help="Skip IPython startup, just import modules directly.",
+    )
+    args = parser.parse_args(argv)
+    warm(args.modules, ipython=not args.no_ipython)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/prewarm/src/prewarm/__main__.py
+++ b/python/prewarm/src/prewarm/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m prewarm matplotlib pandas ...``."""
+
+from prewarm import main
+
+main()

--- a/python/prewarm/tests/test_prewarm.py
+++ b/python/prewarm/tests/test_prewarm.py
@@ -1,0 +1,106 @@
+"""Tests for the prewarm package."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_warm_directly_with_stdlib_module():
+    """warm() with ipython=False should import stdlib modules without error."""
+    from prewarm import warm
+
+    # json is always available — should not raise
+    warm(["json", "os"], ipython=False)
+
+
+def test_warm_directly_skips_missing_modules():
+    """Missing modules should be silently skipped."""
+    from prewarm import warm
+
+    # Should not raise even though this module doesn't exist
+    warm(["__nonexistent_module_xyz__"], ipython=False)
+
+
+def test_collect_modules_base_only():
+    """Base modules are always included."""
+    from prewarm import BASE_MODULES, _collect_modules
+
+    result = _collect_modules([], include_conda=False)
+    for m in BASE_MODULES:
+        assert m in result
+
+
+def test_collect_modules_with_conda():
+    """--include-conda adds traitlets and zmq."""
+    from prewarm import CONDA_MODULES, _collect_modules
+
+    result = _collect_modules([], include_conda=True)
+    for m in CONDA_MODULES:
+        assert m in result
+
+
+def test_collect_modules_deduplicates():
+    """Duplicate modules should be removed while preserving order."""
+    from prewarm import _collect_modules
+
+    result = _collect_modules(["ipykernel", "numpy"], include_conda=False)
+    assert result.count("ipykernel") == 1
+
+
+def test_build_warmup_script_basic():
+    """build_warmup_script produces valid Python with module imports."""
+    from prewarm import build_warmup_script
+
+    script = build_warmup_script(["numpy", "pandas"], include_conda=False)
+    assert "numpy" in script
+    assert "pandas" in script
+    assert "compileall" in script
+    assert "warmup complete" in script
+
+
+def test_build_warmup_script_include_conda():
+    """--include-conda adds traitlets, zmq, and CommManager imports."""
+    from prewarm import build_warmup_script
+
+    script = build_warmup_script([], include_conda=True)
+    assert "traitlets" in script
+    assert "zmq" in script
+    assert "CommManager" in script
+
+
+def test_build_warmup_script_no_conda():
+    """Without --include-conda, conda-specific imports are absent."""
+    from prewarm import build_warmup_script
+
+    script = build_warmup_script([], include_conda=False)
+    assert "CommManager" not in script
+
+
+def test_build_warmup_script_with_site_packages():
+    """--site-packages adds a compileall.compile_dir() call."""
+    from prewarm import build_warmup_script
+
+    script = build_warmup_script([], include_conda=False, site_packages="/fake/path")
+    assert "compileall" in script
+    assert "/fake/path" in script
+
+
+def test_cli_no_ipython_flag():
+    """prewarm --no-ipython json should exit 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "prewarm", "--no-ipython", "json"],
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0
+
+
+def test_cli_help():
+    """prewarm --help should exit 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "prewarm", "--help"],
+        capture_output=True,
+        timeout=10,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Introduces the `prewarm` Python package (`python/prewarm/`) as the single source of truth for environment warmup logic
- Embeds it into the Rust daemon via `include_str!` in `kernel-env/src/warmup.rs` — works in all pool types (UV, conda, pixi) without pip-installing the package
- Adds a `compileall` phase that pre-compiles all `.pyc` files in site-packages before imports trigger side effects (font caches, C extensions, BLAS)
- Removes `build_python_warmup_script`, `package_import_name`, and `is_valid_python_identifier` from daemon.rs (net -38 lines of Rust string-building)
- Increases warmup timeout from 30s → 120s to handle heavy conda environments (fixes #1605)
- Fixes misleading "ipykernel may not be installed" error messages on warmup failures

## How it works

1. `python/prewarm/src/prewarm/__init__.py` defines `build_warmup_script()` which generates a self-contained Python script
2. `kernel-env/src/warmup.rs` embeds this source via `include_str!` and provides `build_warmup_command()` 
3. The daemon runs `python -c <script>` where the script `exec()`s the embedded source, calls `build_warmup_script()`, and `exec()`s the result
4. The generated script runs `compileall.compile_dir()` on site-packages, then imports all packages with try/except per import

## Test plan

- [ ] 11 Python unit tests for prewarm package (`uv run pytest python/prewarm/tests/ -v`)
- [ ] 5 Rust unit tests for `kernel-env::warmup` module (`cargo test -p kernel-env -- warmup`)
- [ ] 204 daemon unit tests + 21 integration tests pass (`cargo test -p runtimed`)
- [ ] Full lint passes (`cargo xtask lint`)
- [ ] Verify conda pool warmup succeeds with heavy packages (matplotlib, pandas, numpy) — should no longer timeout
- [ ] Verify UV pool warmup still works