### PR TITLE
fix(runtimed): avoid holding notebook_rooms lock across .await points

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2129,26 +2129,27 @@ impl Daemon {
             Request::ShutdownNotebook { notebook_id } => {
                 // Remove the room from the map and drop the lock before any .await
                 // to avoid holding notebook_rooms across async teardown calls.
-                // Teardown is spawned into a background task so a concurrent
-                // reconnect won't race against the in-progress shutdown.
+                //
+                // Note: the room is already removed from the map so concurrent
+                // get_or_create_room() calls will create a fresh room. This is
+                // identical to the original behavior (remove() was always called
+                // before teardown), but now the lock isn't held during the async
+                // teardown that follows.
                 let maybe_room = {
                     let mut rooms = self.notebook_rooms.lock().await;
                     rooms.remove(&notebook_id)
                 };
                 if let Some(room) = maybe_room {
-                    // Spawn teardown so we don't hold the caller while the
-                    // runtime agent shuts down (which may take a few seconds).
-                    let nb_id = notebook_id.clone();
-                    tokio::spawn(async move {
-                        // Shut down runtime agent via RPC before dropping handle.
-                        // RuntimeAgentHandle doesn't own the Child (it's in a background
-                        // task), so dropping the handle alone doesn't kill it.
+                    // Shut down runtime agent via RPC before dropping handle.
+                    // RuntimeAgentHandle doesn't own the Child (it's in a background
+                    // task), so dropping the handle alone doesn't kill it.
+                    {
                         let has_runtime_agent =
                             room.runtime_agent_request_tx.lock().await.is_some();
                         if has_runtime_agent {
                             info!(
                                 "[runtimed] Shutting down runtime agent for notebook: {}",
-                                nb_id
+                                notebook_id
                             );
                             let _ = crate::notebook_sync_server::send_runtime_agent_request(
                                 &room,
@@ -2160,8 +2161,8 @@ impl Daemon {
                         *ra_guard = None;
                         let mut tx = room.runtime_agent_request_tx.lock().await;
                         *tx = None;
-                        info!("[runtimed] Evicted room for notebook: {}", nb_id);
-                    });
+                    }
+                    info!("[runtimed] Evicted room for notebook: {}", notebook_id);
                     Response::NotebookShutdown { found: true }
                 } else {
                     Response::NotebookShutdown { found: false }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2129,21 +2129,26 @@ impl Daemon {
             Request::ShutdownNotebook { notebook_id } => {
                 // Remove the room from the map and drop the lock before any .await
                 // to avoid holding notebook_rooms across async teardown calls.
+                // Teardown is spawned into a background task so a concurrent
+                // reconnect won't race against the in-progress shutdown.
                 let maybe_room = {
                     let mut rooms = self.notebook_rooms.lock().await;
                     rooms.remove(&notebook_id)
                 };
                 if let Some(room) = maybe_room {
-                    // Shut down runtime agent via RPC before dropping handle.
-                    // RuntimeAgentHandle doesn't own the Child (it's in a background
-                    // task), so dropping the handle alone doesn't kill it.
-                    {
+                    // Spawn teardown so we don't hold the caller while the
+                    // runtime agent shuts down (which may take a few seconds).
+                    let nb_id = notebook_id.clone();
+                    tokio::spawn(async move {
+                        // Shut down runtime agent via RPC before dropping handle.
+                        // RuntimeAgentHandle doesn't own the Child (it's in a background
+                        // task), so dropping the handle alone doesn't kill it.
                         let has_runtime_agent =
                             room.runtime_agent_request_tx.lock().await.is_some();
                         if has_runtime_agent {
                             info!(
                                 "[runtimed] Shutting down runtime agent for notebook: {}",
-                                notebook_id
+                                nb_id
                             );
                             let _ = crate::notebook_sync_server::send_runtime_agent_request(
                                 &room,
@@ -2155,8 +2160,8 @@ impl Daemon {
                         *ra_guard = None;
                         let mut tx = room.runtime_agent_request_tx.lock().await;
                         *tx = None;
-                    }
-                    info!("[runtimed] Evicted room for notebook: {}", notebook_id);
+                        info!("[runtimed] Evicted room for notebook: {}", nb_id);
+                    });
                     Response::NotebookShutdown { found: true }
                 } else {
                     Response::NotebookShutdown { found: false }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2036,9 +2036,14 @@ impl Daemon {
             Request::InspectNotebook { notebook_id } => {
                 info!("[runtimed] Inspecting notebook: {}", notebook_id);
 
-                // First try to get from an active room
-                let rooms = self.notebook_rooms.lock().await;
-                if let Some(room) = rooms.get(&notebook_id) {
+                // First try to get from an active room.
+                // Clone the Arc and drop the lock before any .await to avoid
+                // holding notebook_rooms across async calls.
+                let maybe_room = {
+                    let rooms = self.notebook_rooms.lock().await;
+                    rooms.get(&notebook_id).cloned()
+                };
+                if let Some(room) = maybe_room {
                     let doc = room.doc.read().await;
                     let cells = doc.get_cells();
                     let kernel_info = room.kernel_info().await.map(|(kt, es, status)| {
@@ -2056,7 +2061,6 @@ impl Daemon {
                     }
                 } else {
                     // No active room - try to load from persisted file
-                    drop(rooms); // Release lock before disk I/O
                     let filename = crate::notebook_doc::notebook_doc_filename(&notebook_id);
                     let persist_path = self.config.notebook_docs_dir.join(filename);
                     if persist_path.exists() {
@@ -2091,9 +2095,17 @@ impl Daemon {
             }
 
             Request::ListRooms => {
-                let rooms = self.notebook_rooms.lock().await;
+                // Snapshot room references and drop the lock before any .await
+                // to avoid holding notebook_rooms across async calls (convoy deadlock).
+                let snapshot: Vec<_> = {
+                    let rooms = self.notebook_rooms.lock().await;
+                    rooms
+                        .iter()
+                        .map(|(id, room)| (id.clone(), room.clone()))
+                        .collect()
+                };
                 let mut room_infos = Vec::new();
-                for (notebook_id, room) in rooms.iter() {
+                for (notebook_id, room) in &snapshot {
                     // Get kernel info if available
                     let (kernel_type, env_source, kernel_status) = room
                         .kernel_info()
@@ -2115,8 +2127,13 @@ impl Daemon {
             }
 
             Request::ShutdownNotebook { notebook_id } => {
-                let mut rooms = self.notebook_rooms.lock().await;
-                if let Some(room) = rooms.remove(&notebook_id) {
+                // Remove the room from the map and drop the lock before any .await
+                // to avoid holding notebook_rooms across async teardown calls.
+                let maybe_room = {
+                    let mut rooms = self.notebook_rooms.lock().await;
+                    rooms.remove(&notebook_id)
+                };
+                if let Some(room) = maybe_room {
                     // Shut down runtime agent via RPC before dropping handle.
                     // RuntimeAgentHandle doesn't own the Child (it's in a background
                     // task), so dropping the handle alone doesn't kill it.
@@ -2156,9 +2173,14 @@ impl Daemon {
 
     /// Collect env paths from all running kernels to protect from GC eviction.
     async fn collect_active_env_paths(&self) -> std::collections::HashSet<PathBuf> {
+        // Snapshot room references and drop the lock before any .await
+        // to avoid holding notebook_rooms across async calls.
+        let snapshot: Vec<_> = {
+            let rooms = self.notebook_rooms.lock().await;
+            rooms.values().cloned().collect()
+        };
         let mut paths = std::collections::HashSet::new();
-        let rooms = self.notebook_rooms.lock().await;
-        for room in rooms.values() {
+        for room in &snapshot {
             // Check runtime-agent-backed kernel
             if let Some(ref env_path) = *room.runtime_agent_env_path.read().await {
                 paths.insert(env_path.clone());


### PR DESCRIPTION
## Summary
- Fix deadlock caused by holding `notebook_rooms` tokio Mutex across `.await` points in 4 handlers
- Apply the same snapshot-and-drop pattern already used by the shutdown handler
- Affected handlers: `InspectNotebook`, `ListRooms`, `ShutdownNotebook`, `collect_active_env_paths`

## Problem
Under load (e.g., RunAllCells on 15+ cells), `ListRooms` holds `notebook_rooms` while awaiting `kernel_info()` and `has_kernel()`, which acquire `runtime_agent_handle`. This creates a convoy — everything needing `notebook_rooms` queues behind the stalled handler, making the daemon unresponsive while `Ping` still succeeds.

## Fix
Clone room `Arc`s in a scoped block, drop the `notebook_rooms` lock, then perform async operations on the owned references. This is the same pattern the shutdown handler (line 675) already uses with an explicit comment explaining why.

## Test plan
- [x] `cargo build -p runtimed` compiles cleanly
- [x] `cargo xtask lint` passes
- [ ] Manual: open 15+ cell notebook, RunAllCells, call ListRooms mid-execution — daemon stays responsive