### PR TITLE
fix(mcp-app): address code review — rehypeRaw, blob fetch fallbacks

### DIFF
--- a/apps/mcp-app/src/components/error-output.tsx
+++ b/apps/mcp-app/src/components/error-output.tsx
@@ -9,6 +9,7 @@ interface ErrorOutputProps {
 
 export function ErrorOutput({ output }: ErrorOutputProps) {
   const [tracebackLines, setTracebackLines] = useState<string[]>([]);
+  const [fetchFailed, setFetchFailed] = useState(false);
 
   const header = output.ename
     ? `${output.ename}: ${output.evalue || ""}`
@@ -24,7 +25,7 @@ export function ErrorOutput({ output }: ErrorOutputProps) {
         .then((lines: string[]) => {
           if (Array.isArray(lines)) setTracebackLines(lines);
         })
-        .catch(() => { /* show header only */ });
+        .catch(() => setFetchFailed(true));
     }
   }, [output.traceback]);
 
@@ -33,6 +34,11 @@ export function ErrorOutput({ output }: ErrorOutputProps) {
       {header && <AnsiText text={header} />}
       {tracebackLines.length > 0 && (
         <AnsiText text={tracebackLines.join("\n")} />
+      )}
+      {fetchFailed && tracebackLines.length === 0 && (
+        <div style={{ opacity: 0.6, fontSize: "12px", marginTop: "4px" }}>
+          (traceback could not be loaded)
+        </div>
       )}
     </div>
   );

--- a/apps/mcp-app/src/components/markdown-output.tsx
+++ b/apps/mcp-app/src/components/markdown-output.tsx
@@ -1,6 +1,5 @@
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { CodeBlock } from "./code-block";
@@ -15,7 +14,7 @@ export function MarkdownOutput({ content }: MarkdownOutputProps) {
     <div className="markdown-output">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeKatex, rehypeRaw]}
+        rehypePlugins={[rehypeKatex]}
         components={{
           code({ className, children }) {
             const codeContent = String(children).replace(/\n$/, "");

--- a/apps/mcp-app/src/components/mime-renderer.tsx
+++ b/apps/mcp-app/src/components/mime-renderer.tsx
@@ -43,19 +43,31 @@ export function MimeRenderer({ data }: MimeRendererProps) {
     return <ImageOutput data={String(raw)} mediaType={mime} alt={data["text/plain"] || undefined} />;
   }
 
-  return <FetchAndRender mime={mime} raw={String(raw)} />;
+  // text/plain fallback for when blob fetch fails
+  const plainFallback = data["text/plain"] ? String(data["text/plain"]) : undefined;
+
+  return <FetchAndRender mime={mime} raw={String(raw)} plainFallback={plainFallback} />;
 }
 
-function FetchAndRender({ mime, raw }: { mime: string; raw: string }) {
+function FetchAndRender({ mime, raw, plainFallback }: { mime: string; raw: string; plainFallback?: string }) {
   const [content, setContent] = useState<string | null>(
     isBlobUrl(raw) ? null : raw,
   );
+  const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     if (isBlobUrl(raw)) {
-      fetchBlobText(raw).then(setContent).catch(() => setContent(null));
+      fetchBlobText(raw)
+        .then(setContent)
+        .catch(() => setFailed(true));
     }
   }, [raw]);
+
+  // Blob fetch failed — show text/plain fallback if available
+  if (failed) {
+    if (plainFallback) return <AnsiText text={plainFallback} />;
+    return null;
+  }
 
   if (content === null) return null;
 

--- a/apps/mcp-app/src/lib/blob-fetch.ts
+++ b/apps/mcp-app/src/lib/blob-fetch.ts
@@ -12,6 +12,7 @@ export function isBlobUrl(value: unknown): value is string {
 /**
  * Fetch text content from a blob URL, with caching.
  * Returns the original value if it's not a blob URL.
+ * Evicts failed promises from cache so retries are possible.
  */
 export async function fetchBlobText(value: string): Promise<string> {
   if (!isBlobUrl(value)) return value;
@@ -25,6 +26,10 @@ export async function fetchBlobText(value: string): Promise<string> {
   });
 
   cache.set(value, promise);
+
+  // Evict on failure so future attempts can retry
+  promise.catch(() => cache.delete(value));
+
   return promise;
 }
 


### PR DESCRIPTION
## Summary

Follow-up fixes from Codex code review on #1615:

- Remove `rehypeRaw` from markdown renderer — prevents raw HTML injection into the widget DOM (isolation parity with the `text/html` iframe path)
- Evict failed blob fetch promises from cache so retries are possible on transient failures
- Show `text/plain` fallback when blob fetch fails for rich MIME types instead of empty widget
- Show "(traceback could not be loaded)" on error traceback fetch failure instead of silently dropping it

## Test plan

- [ ] Build: `cd apps/mcp-app && pnpm build`
- [ ] Verify markdown with raw HTML tags renders the tags as text (not injected into DOM)
- [ ] Verify blob fetch failure shows text/plain fallback