### PR TITLE
feat(plugins): add async-rust-lsp plugin for tokio mutex diagnostics

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -12,6 +12,12 @@
       "source": "./biome-lsp",
       "description": "Biome language server for JavaScript/TypeScript code intelligence",
       "version": "1.0.0"
+    },
+    {
+      "name": "async-rust-lsp",
+      "source": "./async-rust-lsp",
+      "description": "Detects tokio::sync::Mutex guards held across .await points",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude/plugins/async-rust-lsp/.claude-plugin/plugin.json
+++ b/.claude/plugins/async-rust-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "async-rust-lsp",
+  "description": "Detects tokio::sync::Mutex guards held across .await points",
+  "version": "0.1.0"
+}

--- a/.claude/plugins/async-rust-lsp/.lsp.json
+++ b/.claude/plugins/async-rust-lsp/.lsp.json
@@ -1,6 +1,6 @@
 {
   "async-rust-lsp": {
-    "command": "/Users/kylekelley/code/src/github.com/rgbkrk/async-rust-lsp/target/release/async-rust-lsp",
+    "command": "async-rust-lsp",
     "extensionToLanguage": {
       ".rs": "rust"
     }

--- a/.claude/plugins/async-rust-lsp/.lsp.json
+++ b/.claude/plugins/async-rust-lsp/.lsp.json
@@ -1,0 +1,8 @@
+{
+  "async-rust-lsp": {
+    "command": "/Users/kylekelley/code/src/github.com/rgbkrk/async-rust-lsp/target/release/async-rust-lsp",
+    "extensionToLanguage": {
+      ".rs": "rust"
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
-    "biome-lsp@nteract-plugins": true
+    "biome-lsp@nteract-plugins": true,
+    "async-rust-lsp@nteract-plugins": true
   },
   "extraKnownMarketplaces": {
     "nteract-plugins": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
+name = "async-rust-lsp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c203dee015a29874d864dc5973c7b182ab4dab593707287a5958a4bec3cbd9a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-rust",
+]
+
+[[package]]
 name = "async-spooled-tempfile"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +364,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,7 +454,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -933,7 +961,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
 dependencies = [
- "dashmap",
+ "dashmap 6.1.0",
  "tokio",
 ]
 
@@ -1293,6 +1321,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3504,6 +3545,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,7 +5499,7 @@ checksum = "f380851c13b9c14811d0281ce72ddd608b7dd98bc0a3e669247aa75dbac5e3b6"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "digest 0.10.7",
  "dirs",
  "fs-err",
@@ -5677,7 +5731,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "coalesced_map",
- "dashmap",
+ "dashmap 6.1.0",
  "dirs",
  "file_url",
  "fs-err",
@@ -5944,7 +5998,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -5987,7 +6041,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6298,6 +6352,7 @@ version = "2.1.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "async-rust-lsp",
  "automerge",
  "base64 0.22.1",
  "bytes",
@@ -8359,6 +8414,20 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -8391,7 +8460,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -8401,6 +8470,40 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap 5.5.3",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tower-service"
@@ -8418,6 +8521,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8490,6 +8605,26 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -113,3 +113,4 @@ nbformat = "1.2.1"
 serial_test = "3"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }
 notebook-sync = { path = "../notebook-sync" }
+async-rust-lsp = "0.1"

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1511,12 +1511,15 @@ impl Daemon {
             }
         };
 
-        // Get trust state (already verified during room creation)
-        let trust_state = room.trust_state.read().await;
-        let needs_trust_approval = !matches!(
-            trust_state.status,
-            runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
-        );
+        // Get trust state (already verified during room creation).
+        // Scope the read guard so it's dropped before the .await on send_json_frame.
+        let needs_trust_approval = {
+            let trust_state = room.trust_state.read().await;
+            !matches!(
+                trust_state.status,
+                runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
+            )
+        };
 
         // Send NotebookConnectionInfo response
         let (reader, mut writer) = tokio::io::split(stream);
@@ -1533,9 +1536,6 @@ impl Daemon {
 
         // working_dir derived from path's parent directory
         let working_dir_path = path_buf.parent().map(|p| p.to_path_buf());
-
-        // Drop the trust_state lock before continuing
-        drop(trust_state);
 
         // Continue with normal notebook sync (handles auto-launch internally).
         // If needs_load is Some, the sync loop will stream cells from disk
@@ -1743,12 +1743,14 @@ impl Daemon {
                     connection::send_json_frame(&mut stream, &response).await?;
                 }
                 BlobRequest::GetPort => {
-                    let port = self.blob_port.lock().await;
-                    let response = match *port {
-                        Some(p) => BlobResponse::Port { port: p },
-                        None => BlobResponse::Error {
-                            error: "blob server not running".to_string(),
-                        },
+                    let response = {
+                        let port = self.blob_port.lock().await;
+                        match *port {
+                            Some(p) => BlobResponse::Port { port: p },
+                            None => BlobResponse::Error {
+                                error: "blob server not running".to_string(),
+                            },
+                        }
                     };
                     connection::send_json_frame(&mut stream, &response).await?;
                 }

--- a/crates/runtimed/tests/tokio_mutex_lint.rs
+++ b/crates/runtimed/tests/tokio_mutex_lint.rs
@@ -7,7 +7,7 @@
 fn daemon_has_no_tokio_mutex_across_await() {
     let daemon_source =
         std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/daemon.rs"))
-            .expect("failed to read daemon.rs");
+            .unwrap_or_else(|e| panic!("failed to read daemon.rs: {e}"));
 
     let diagnostics =
         async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&daemon_source);

--- a/crates/runtimed/tests/tokio_mutex_lint.rs
+++ b/crates/runtimed/tests/tokio_mutex_lint.rs
@@ -1,0 +1,31 @@
+//! CI lint: ensure no tokio::sync::Mutex guards are held across .await points.
+//!
+//! Uses the async-rust-lsp rule engine (tree-sitter based) to scan daemon.rs
+//! for the pattern that caused the convoy deadlock fixed in PR #1614.
+
+#[test]
+fn daemon_has_no_tokio_mutex_across_await() {
+    let daemon_source =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/daemon.rs"))
+            .expect("failed to read daemon.rs");
+
+    let diagnostics =
+        async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&daemon_source);
+
+    if !diagnostics.is_empty() {
+        let mut msg =
+            String::from("Found tokio Mutex guard(s) held across .await in daemon.rs:\n\n");
+        for d in &diagnostics {
+            msg.push_str(&format!(
+                "  line {}: {}\n",
+                d.range.start.line + 1,
+                d.message
+            ));
+        }
+        msg.push_str(
+            "\nFix: clone the Arc in a scoped block, drop the lock, then await.\n\
+             See: https://github.com/nteract/desktop/pull/1614\n",
+        );
+        panic!("{msg}");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code LSP plugin that detects `tokio::sync::Mutex` guards held across `.await` points
- Uses the published [`async-rust-lsp`](https://crates.io/crates/async-rust-lsp) crate ([source](https://github.com/rgbkrk/async-rust-lsp))
- Registered in the `nteract-plugins` local marketplace alongside `biome-lsp`

## Context
Born from the deadlock fix in #1614 — we wanted static analysis to prevent regressions. Clippy's `await_holding_lock` only checks `std::sync::Mutex`, not `tokio::sync::Mutex`. This LSP fills that gap with real-time editor diagnostics.

## Install
Anyone using Claude Code on this repo gets it automatically. The LSP binary is installed via `cargo install async-rust-lsp`.

## Test plan
- [x] `cargo install async-rust-lsp` works
- [x] 21 tests passing in the upstream crate
- [x] Plugin structure matches existing `biome-lsp` pattern