### PR TITLE
fix(runt): parse JSON arrays in `config set` instead of blind comma-split

### DIFF
--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -674,6 +674,40 @@ pub fn extract_package_name(spec: &str) -> String {
         .to_lowercase()
 }
 
+/// Validate that a string is a plausible package specifier (PEP 508 or conda matchspec).
+///
+/// Uses [`extract_package_name`] to extract the base name, then checks that it is
+/// non-empty and contains only valid characters (alphanumeric, hyphens, underscores, dots).
+/// This does **not** fully validate PEP 508 — that is uv/conda's job at install time.
+/// The purpose is to catch obvious garbage like mangled JSON fragments (`["pandas"`,
+/// `"numpy"]`) early, before they silently corrupt settings.
+///
+/// # Examples
+///
+/// ```
+/// use notebook_doc::metadata::validate_package_specifier;
+/// assert!(validate_package_specifier("pandas>=2.0").is_ok());
+/// assert!(validate_package_specifier("requests[security]").is_ok());
+/// assert!(validate_package_specifier("[\"pandas\"").is_err());
+/// assert!(validate_package_specifier("").is_err());
+/// ```
+pub fn validate_package_specifier(spec: &str) -> Result<(), String> {
+    let name = extract_package_name(spec);
+    if name.is_empty() {
+        return Err("package specifier cannot be empty".into());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(format!(
+            "invalid package name '{name}' (extracted from '{spec}'). \
+             Package names may only contain letters, digits, hyphens, underscores, and dots"
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -911,6 +945,36 @@ mod tests {
     #[test]
     fn test_extract_package_name_whitespace() {
         assert_eq!(extract_package_name("  pandas  >=2.0"), "pandas");
+    }
+
+    // ── validate_package_specifier ─────────────────────────────
+
+    #[test]
+    fn test_validate_package_specifier_valid() {
+        assert!(validate_package_specifier("pandas").is_ok());
+        assert!(validate_package_specifier("pandas>=2.0").is_ok());
+        assert!(validate_package_specifier("numpy==1.24.0").is_ok());
+        assert!(validate_package_specifier("requests[security]").is_ok());
+        assert!(validate_package_specifier("django~=4.2").is_ok());
+        assert!(validate_package_specifier("pywin32 ; sys_platform == 'win32'").is_ok());
+        assert!(validate_package_specifier("mypackage@https://example.com/pkg.tar.gz").is_ok());
+        assert!(validate_package_specifier("my-package").is_ok());
+        assert!(validate_package_specifier("my_package").is_ok());
+        assert!(validate_package_specifier("zope.interface").is_ok());
+    }
+
+    #[test]
+    fn test_validate_package_specifier_empty() {
+        assert!(validate_package_specifier("").is_err());
+        assert!(validate_package_specifier("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_package_specifier_mangled_json() {
+        // These are the artifacts produced by the old comma-split bug
+        assert!(validate_package_specifier("[\"pandas\"").is_err());
+        assert!(validate_package_specifier("\"numpy\"").is_err());
+        assert!(validate_package_specifier("\"seaborn\"]").is_err());
     }
 
     // ── detect_runtime ───────────────────────────────────────────

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -665,10 +665,13 @@ impl Default for RuntMetadata {
 /// assert_eq!(extract_package_name("pandas>=2.0"), "pandas");
 /// assert_eq!(extract_package_name("requests[security]"), "requests");
 /// assert_eq!(extract_package_name("NumPy"), "numpy");
+/// assert_eq!(extract_package_name("conda-forge::numpy>=1.24"), "numpy");
 /// ```
 pub fn extract_package_name(spec: &str) -> String {
-    spec.trim()
-        .split(&['>', '<', '=', '!', '~', '[', ';', '@', ' '][..])
+    let spec = spec.trim();
+    // Strip conda channel qualifier (e.g. "conda-forge::numpy" -> "numpy")
+    let spec = spec.rsplit_once("::").map_or(spec, |(_, name)| name);
+    spec.split(&['>', '<', '=', '!', '~', '[', ';', '@', ' '][..])
         .next()
         .unwrap_or(spec)
         .to_lowercase()
@@ -947,6 +950,13 @@ mod tests {
         assert_eq!(extract_package_name("  pandas  >=2.0"), "pandas");
     }
 
+    #[test]
+    fn test_extract_package_name_conda_channel_qualifier() {
+        assert_eq!(extract_package_name("conda-forge::numpy"), "numpy");
+        assert_eq!(extract_package_name("conda-forge::numpy>=1.24"), "numpy");
+        assert_eq!(extract_package_name("defaults::scipy"), "scipy");
+    }
+
     // ── validate_package_specifier ─────────────────────────────
 
     #[test]
@@ -961,6 +971,10 @@ mod tests {
         assert!(validate_package_specifier("my-package").is_ok());
         assert!(validate_package_specifier("my_package").is_ok());
         assert!(validate_package_specifier("zope.interface").is_ok());
+        // Conda channel-qualified matchspecs
+        assert!(validate_package_specifier("conda-forge::numpy").is_ok());
+        assert!(validate_package_specifier("conda-forge::numpy>=1.24").is_ok());
+        assert!(validate_package_specifier("defaults::scipy").is_ok());
     }
 
     #[test]

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -303,15 +303,7 @@ const POPULAR_PACKAGES: &[&str] = &[
     "scapy",
 ];
 
-/// Extract package name from a dependency specifier.
-/// Handles version specifiers like `pandas>=2.0`, `numpy[extra]`, etc.
-fn extract_package_name(dep: &str) -> &str {
-    // Split on version specifiers and extras
-    dep.split(&['>', '<', '=', '!', '~', '[', ';', '@'][..])
-        .next()
-        .unwrap_or(dep)
-        .trim()
-}
+use notebook_doc::metadata::extract_package_name;
 
 /// Normalize a package name for comparison.
 /// PyPI considers `_`, `-`, and `.` as equivalent, and is case-insensitive.
@@ -325,7 +317,7 @@ fn normalize_name(name: &str) -> String {
 /// threshold of a popular package (but not an exact match).
 pub fn check_typosquat(package: &str) -> Option<TyposquatWarning> {
     let pkg_name = extract_package_name(package);
-    let normalized = normalize_name(pkg_name);
+    let normalized = normalize_name(&pkg_name);
 
     // Skip if the package is itself a popular package (exact match)
     for &popular in POPULAR_PACKAGES {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -424,7 +424,7 @@ enum ConfigCommands {
     Set {
         /// Setting key
         key: String,
-        /// New value (comma-separated for list keys like uv.default_packages)
+        /// New value. For list keys (e.g. uv.default_packages): JSON array '["pandas","numpy"]' or comma-separated 'pandas,numpy'
         value: String,
     },
 }
@@ -4041,10 +4041,23 @@ async fn config_command(command: Option<ConfigCommands>) -> Result<()> {
             // writing a bool into an enum field).
             let json_str = serde_json::to_string_pretty(&json_value)?;
             if serde_json::from_str::<runtimed::settings_doc::SyncedSettings>(&json_str).is_err() {
-                anyhow::bail!(
-                    "Invalid value '{value}' for setting '{key}'. \
-                     The value would produce an invalid settings file."
-                );
+                let hint = match key.as_str() {
+                    "theme" => "Must be one of: system, light, dark".to_string(),
+                    "default_runtime" => "Must be one of: python, deno".to_string(),
+                    "default_python_env" => "Must be one of: uv, conda, pixi".to_string(),
+                    "keep_alive_secs" => format!(
+                        "Must be a number between {} and {}",
+                        runtimed::settings_doc::MIN_KEEP_ALIVE_SECS,
+                        runtimed::settings_doc::MAX_KEEP_ALIVE_SECS,
+                    ),
+                    "onboarding_completed" => "Must be true or false".to_string(),
+                    k if k.ends_with("default_packages") => {
+                        "Must be a JSON array '[\"pkg1\",\"pkg2\"]' or comma-separated 'pkg1,pkg2'"
+                            .to_string()
+                    }
+                    _ => "The value would produce an invalid settings file".to_string(),
+                };
+                anyhow::bail!("Invalid value '{value}' for setting '{key}'. {hint}");
             }
 
             // Ensure parent directory exists
@@ -4128,13 +4141,52 @@ fn set_setting_value(root: &mut serde_json::Value, key: &str, raw_value: &str) -
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("Expected object at key path"))?;
 
-    // For list-valued keys (*.default_packages), split on commas
+    // For list-valued keys (*.default_packages), parse as JSON array or comma-separated
     let new_value = if *leaf == "default_packages" {
-        let items: Vec<serde_json::Value> = raw_value
-            .split(',')
-            .map(|s| serde_json::Value::String(s.trim().to_string()))
-            .collect();
-        serde_json::Value::Array(items)
+        let trimmed = raw_value.trim();
+        if trimmed.starts_with('[') {
+            // Looks like JSON — parse it
+            let parsed: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
+                anyhow::anyhow!(
+                    "Value looks like JSON but failed to parse: {e}\n\
+                     Hint: use valid JSON like '[\"pandas\",\"numpy\"]' \
+                     or comma-separated names like 'pandas,numpy'"
+                )
+            })?;
+            match &parsed {
+                serde_json::Value::Array(items) => {
+                    for item in items {
+                        match item {
+                            serde_json::Value::String(s) => {
+                                notebook_doc::metadata::validate_package_specifier(s)
+                                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                            }
+                            other => anyhow::bail!(
+                                "Expected array of strings, but found {other}. \
+                                 All elements must be quoted strings like '[\"pandas\",\"numpy\"]'."
+                            ),
+                        }
+                    }
+                    parsed
+                }
+                _ => anyhow::bail!(
+                    "Expected a JSON array, but got {parsed}. \
+                     Use '[\"pandas\",\"numpy\"]' or 'pandas,numpy'."
+                ),
+            }
+        } else {
+            // Comma-separated convenience syntax
+            let items: Vec<serde_json::Value> = trimmed
+                .split(',')
+                .map(|s| {
+                    let s = s.trim();
+                    notebook_doc::metadata::validate_package_specifier(s)
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    Ok(serde_json::Value::String(s.to_string()))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            serde_json::Value::Array(items)
+        }
     } else if raw_value == "true" || raw_value == "false" {
         serde_json::Value::Bool(raw_value == "true")
     } else if let Ok(n) = raw_value.parse::<u64>() {


### PR DESCRIPTION
## Summary

`runt config set conda.default_packages '["pandas","numpy"]'` was splitting on commas and wrapping each fragment as a string, producing mangled entries that silently broke conda pool warmup. Now the CLI detects JSON array syntax and parses it properly, while preserving comma-separated input for backwards compatibility.

- **JSON-aware parsing**: values starting with `[` are parsed as JSON arrays of strings; comma-separated syntax still works
- **Shared validation**: new `validate_package_specifier()` in `notebook-doc` catches mangled artifacts (e.g. `["pandas"`) early, reusing `extract_package_name()`
- **Unified code**: removed duplicate `extract_package_name` from `typosquat.rs`, now imports from `notebook-doc`
- **Better error messages**: round-trip validation failures show key-specific hints (e.g. "Must be one of: system, light, dark" for theme)

Closes #1612

## Verification

- [ ] `runt config set conda.default_packages '["pandas","numpy","matplotlib"]'` stores a clean JSON array
- [ ] `runt config set uv.default_packages 'pandas,numpy>=2.0'` still works (backwards compat)
- [ ] `runt config set conda.default_packages '["pandas", 123]'` errors with a helpful message
- [ ] `runt config set conda.default_packages '[not json'` errors with a hint about valid syntax
- [ ] `runt config set theme blue` errors with "Must be one of: system, light, dark"
- [ ] `runt config get conda.default_packages` after setting shows clean values (no escaped quotes or brackets)

_PR submitted by @rgbkrk's agent, Quill_