### PR TITLE
feat(runtimed): reuse pool envs for inline deps instead of rebuilding

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -454,6 +454,20 @@ impl Daemon {
         self.settings.read().await.get_all().pixi.default_packages
     }
 
+    /// Get the full list of UV pool packages (base + user default_packages).
+    pub async fn uv_pool_packages(&self) -> Vec<String> {
+        let settings = self.settings.read().await;
+        let synced = settings.get_all();
+        uv_prewarmed_packages(&synced.uv.default_packages)
+    }
+
+    /// Get the full list of Conda pool packages (base + user default_packages).
+    pub async fn conda_pool_packages(&self) -> Vec<String> {
+        let settings = self.settings.read().await;
+        let synced = settings.get_all();
+        conda_prewarmed_packages(&synced.conda.default_packages)
+    }
+
     /// Create a new daemon with the given configuration.
     ///
     /// Returns an error if another daemon is already running.

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -4,6 +4,7 @@
 //! providing a [`BroadcastProgressHandler`] that forwards progress events
 //! to connected notebook clients via the broadcast channel.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -110,4 +111,235 @@ pub async fn prepare_conda_inline_env(
         env_path: env.env_path,
         python_path: env.python_path,
     })
+}
+
+/// Result of comparing inline deps against pool packages.
+#[derive(Debug)]
+pub enum PoolDepRelation {
+    /// All inline deps are already installed in the pool env.
+    Subset,
+    /// Pool covers some deps; these extras need installing.
+    Additive { delta: Vec<String> },
+    /// Cannot determine compatibility (version pins, etc.) — build from scratch.
+    Independent,
+}
+
+/// Extract the bare package name from a dependency specifier.
+///
+/// Returns `None` if the dep has a version constraint (anything beyond a bare name),
+/// since we can't guarantee the pool's installed version satisfies it.
+fn bare_package_name(dep: &str) -> Option<&str> {
+    let trimmed = dep.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // If the dep contains any version specifier characters, it's not bare.
+    // This is conservative: "pandas>=2.0" → None, "pandas" → Some("pandas")
+    let specifier_chars = ['>', '<', '=', '!', '~', '[', ';', '@'];
+    if trimmed.contains(|c: char| specifier_chars.contains(&c) || c.is_whitespace()) {
+        return None;
+    }
+    Some(trimmed)
+}
+
+/// Normalize a package name for comparison: lowercase, replace `_` with `-`.
+fn normalize_package_name(name: &str) -> String {
+    name.to_lowercase().replace('_', "-")
+}
+
+/// Compare inline deps against pool prewarmed packages.
+///
+/// Conservative approach: only bare package names (no version specifiers)
+/// are eligible for pool reuse. If any dep has a version constraint,
+/// returns `Independent`.
+pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) -> PoolDepRelation {
+    if inline_deps.is_empty() {
+        return PoolDepRelation::Subset;
+    }
+
+    let pool_normalized: HashSet<String> = pool_packages
+        .iter()
+        .map(|p| normalize_package_name(p))
+        .collect();
+
+    let mut delta = Vec::new();
+
+    for dep in inline_deps {
+        let Some(bare) = bare_package_name(dep) else {
+            // Has a version specifier — can't guarantee pool compatibility
+            return PoolDepRelation::Independent;
+        };
+
+        let normalized = normalize_package_name(bare);
+        if !pool_normalized.contains(&normalized) {
+            delta.push(dep.clone());
+        }
+    }
+
+    if delta.is_empty() {
+        PoolDepRelation::Subset
+    } else {
+        PoolDepRelation::Additive { delta }
+    }
+}
+
+/// Check if a cached UV inline environment already exists for the given deps.
+///
+/// Returns `Some(PreparedEnv)` on cache hit, `None` on miss.
+pub fn check_uv_inline_cache(deps: &[String], prerelease: Option<&str>) -> Option<PreparedEnv> {
+    let uv_deps = kernel_env::UvDependencies {
+        dependencies: deps.to_vec(),
+        requires_python: Some(">=3.13".to_string()),
+        prerelease: prerelease.map(|s| s.to_string()),
+    };
+
+    let hash = kernel_env::uv::compute_env_hash(&uv_deps, None);
+    let cache_dir = get_inline_cache_dir();
+    let venv_path = cache_dir.join(&hash);
+
+    #[cfg(unix)]
+    let python_path = venv_path.join("bin").join("python");
+    #[cfg(windows)]
+    let python_path = venv_path.join("Scripts").join("python.exe");
+
+    if python_path.exists() {
+        Some(PreparedEnv {
+            env_path: venv_path,
+            python_path,
+        })
+    } else {
+        None
+    }
+}
+
+/// Check if a cached Conda inline environment already exists for the given deps.
+///
+/// Returns `Some(PreparedEnv)` on cache hit, `None` on miss.
+pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<PreparedEnv> {
+    let conda_deps = kernel_env::CondaDependencies {
+        dependencies: deps.to_vec(),
+        channels: if channels.is_empty() {
+            vec!["conda-forge".to_string()]
+        } else {
+            channels.to_vec()
+        },
+        python: None,
+        env_id: None,
+    };
+
+    let hash = kernel_env::conda::compute_env_hash(&conda_deps);
+    let cache_dir = get_inline_cache_dir();
+    let env_path = cache_dir.join(&hash);
+
+    #[cfg(unix)]
+    let python_path = env_path.join("bin").join("python");
+    #[cfg(windows)]
+    let python_path = env_path.join("Scripts").join("python.exe");
+
+    if python_path.exists() {
+        Some(PreparedEnv {
+            env_path,
+            python_path,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bare_package_name() {
+        assert_eq!(bare_package_name("pandas"), Some("pandas"));
+        assert_eq!(bare_package_name("numpy"), Some("numpy"));
+        assert_eq!(bare_package_name("  pandas  "), Some("pandas"));
+        assert_eq!(bare_package_name(""), None);
+
+        // Version specifiers → None
+        assert_eq!(bare_package_name("pandas>=2.0"), None);
+        assert_eq!(bare_package_name("pandas==2.0.0"), None);
+        assert_eq!(bare_package_name("pandas<3"), None);
+        assert_eq!(bare_package_name("pandas~=2.0"), None);
+        assert_eq!(bare_package_name("pandas!=1.0"), None);
+
+        // Extras / markers → None
+        assert_eq!(bare_package_name("pandas[sql]"), None);
+        assert_eq!(bare_package_name("pandas ; python_version >= '3.8'"), None);
+        assert_eq!(bare_package_name("pandas @ https://example.com"), None);
+    }
+
+    #[test]
+    fn test_normalize_package_name() {
+        assert_eq!(normalize_package_name("Pandas"), "pandas");
+        assert_eq!(normalize_package_name("scikit_learn"), "scikit-learn");
+        assert_eq!(normalize_package_name("PyArrow"), "pyarrow");
+    }
+
+    #[test]
+    fn test_compare_subset() {
+        let pool = vec![
+            "ipykernel".into(),
+            "pandas".into(),
+            "numpy".into(),
+            "matplotlib".into(),
+        ];
+        let deps = vec!["pandas".into(), "numpy".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_case_insensitive() {
+        let pool = vec!["ipykernel".into(), "PyArrow".into()];
+        let deps = vec!["pyarrow".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_additive() {
+        let pool = vec!["ipykernel".into(), "pandas".into()];
+        let deps = vec!["pandas".into(), "scikit-learn".into()];
+        match compare_deps_to_pool(&deps, &pool) {
+            PoolDepRelation::Additive { delta } => {
+                assert_eq!(delta, vec!["scikit-learn".to_string()]);
+            }
+            other => panic!("expected Additive, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_compare_independent_version_pin() {
+        let pool = vec!["ipykernel".into(), "pandas".into()];
+        let deps = vec!["pandas==2.0.0".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_empty_deps() {
+        let pool = vec!["ipykernel".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&[], &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_underscore_normalization() {
+        let pool = vec!["scikit-learn".into()];
+        let deps = vec!["scikit_learn".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3091,68 +3091,75 @@ async fn reset_starting_state(room: &NotebookRoom) {
 
 /// Try to satisfy UV inline deps from the prewarmed pool.
 ///
-/// Returns `Ok((PooledEnv, pool_packages))` if the pool can serve the deps
-/// (either as a direct subset or by installing a small delta).
-/// Returns `Err(())` if the deps are incompatible or the pool is unavailable.
+/// Takes the pool env first, then compares against its *actual* `prewarmed_packages`
+/// (not current settings) to avoid misclassifying stale pool entries.
+/// Returns `Ok((PooledEnv, actual_packages))` on success, `Err(())` on failure.
 async fn try_uv_pool_for_inline_deps(
     deps: &[String],
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
-    let pool_packages = daemon.uv_pool_packages().await;
-    let relation = crate::inline_env::compare_deps_to_pool(deps, &pool_packages);
+    // Quick pre-check: if any dep has version specifiers, skip pool entirely
+    // (avoids consuming a pool env we'd have to discard)
+    let settings_packages = daemon.uv_pool_packages().await;
+    if matches!(
+        crate::inline_env::compare_deps_to_pool(deps, &settings_packages),
+        crate::inline_env::PoolDepRelation::Independent
+    ) {
+        debug!("[notebook-sync] UV inline deps have version constraints, skipping pool reuse");
+        return Err(());
+    }
+
+    // Take the env, then compare against what it *actually* has installed
+    let env = match daemon.take_uv_env().await {
+        Some(env) => env,
+        None => {
+            info!("[notebook-sync] UV pool empty, falling back to full build");
+            return Err(());
+        }
+    };
+
+    let actual_packages = env.prewarmed_packages.clone();
+    let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
 
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {
-            info!("[notebook-sync] Inline UV deps are subset of pool, taking pool env");
-            match daemon.take_uv_env().await {
-                Some(env) => Ok((env, pool_packages)),
-                None => {
-                    info!("[notebook-sync] UV pool empty, falling back to full build");
-                    Err(())
-                }
-            }
+            info!("[notebook-sync] Inline UV deps are subset of pool env, reusing directly");
+            Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
             info!(
-                "[notebook-sync] Inline UV deps are additive to pool, delta: {:?}",
+                "[notebook-sync] Inline UV deps are additive to pool env, delta: {:?}",
                 delta
             );
-            match daemon.take_uv_env().await {
-                Some(env) => {
-                    let uv_env = kernel_env::UvEnvironment {
-                        venv_path: env.venv_path.clone(),
-                        python_path: env.python_path.clone(),
-                    };
-                    progress_handler.on_progress(
-                        "uv",
-                        kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+            let uv_env = kernel_env::UvEnvironment {
+                venv_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
+            };
+            progress_handler.on_progress(
+                "uv",
+                kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+            );
+            match kernel_env::uv::sync_dependencies(&uv_env, &delta).await {
+                Ok(()) => {
+                    info!(
+                        "[notebook-sync] Installed {} delta packages into pool env",
+                        delta.len()
                     );
-                    match kernel_env::uv::sync_dependencies(&uv_env, &delta).await {
-                        Ok(()) => {
-                            info!(
-                                "[notebook-sync] Installed {} delta packages into pool env",
-                                delta.len()
-                            );
-                            Ok((env, pool_packages))
-                        }
-                        Err(e) => {
-                            warn!(
-                                "[notebook-sync] Failed to install delta into UV pool env: {}, falling back",
-                                e
-                            );
-                            Err(())
-                        }
-                    }
+                    Ok((env, actual_packages))
                 }
-                None => {
-                    info!("[notebook-sync] UV pool empty, falling back to full build");
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to install delta into UV pool env: {}, falling back",
+                        e
+                    );
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
-            debug!("[notebook-sync] UV inline deps have version constraints, skipping pool reuse");
+            // Shouldn't reach here (pre-check above), but handle gracefully
+            debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
             Err(())
         }
     }
@@ -3161,7 +3168,8 @@ async fn try_uv_pool_for_inline_deps(
 /// Try to satisfy Conda inline deps from the prewarmed pool.
 ///
 /// Only attempts pool reuse when channels are default (conda-forge).
-/// Returns `Ok((PooledEnv, pool_packages))` on success, `Err(())` on failure.
+/// Takes the pool env first, then compares against its *actual* `prewarmed_packages`.
+/// Returns `Ok((PooledEnv, actual_packages))` on success, `Err(())` on failure.
 async fn try_conda_pool_for_inline_deps(
     deps: &[String],
     channels: &[String],
@@ -3179,68 +3187,71 @@ async fn try_conda_pool_for_inline_deps(
         return Err(());
     }
 
-    let pool_packages = daemon.conda_pool_packages().await;
-    let relation = crate::inline_env::compare_deps_to_pool(deps, &pool_packages);
+    // Quick pre-check: if any dep has version specifiers, skip pool entirely
+    let settings_packages = daemon.conda_pool_packages().await;
+    if matches!(
+        crate::inline_env::compare_deps_to_pool(deps, &settings_packages),
+        crate::inline_env::PoolDepRelation::Independent
+    ) {
+        debug!("[notebook-sync] Conda inline deps have version constraints, skipping pool reuse");
+        return Err(());
+    }
+
+    // Take the env, then compare against what it *actually* has installed
+    let env = match daemon.take_conda_env().await {
+        Some(env) => env,
+        None => {
+            info!("[notebook-sync] Conda pool empty, falling back to full build");
+            return Err(());
+        }
+    };
+
+    let actual_packages = env.prewarmed_packages.clone();
+    let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
 
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {
-            info!("[notebook-sync] Inline Conda deps are subset of pool, taking pool env");
-            match daemon.take_conda_env().await {
-                Some(env) => Ok((env, pool_packages)),
-                None => {
-                    info!("[notebook-sync] Conda pool empty, falling back to full build");
-                    Err(())
-                }
-            }
+            info!("[notebook-sync] Inline Conda deps are subset of pool env, reusing directly");
+            Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
             info!(
-                "[notebook-sync] Inline Conda deps are additive to pool, delta: {:?}",
+                "[notebook-sync] Inline Conda deps are additive to pool env, delta: {:?}",
                 delta
             );
-            match daemon.take_conda_env().await {
-                Some(env) => {
-                    let conda_env = kernel_env::CondaEnvironment {
-                        env_path: env.venv_path.clone(),
-                        python_path: env.python_path.clone(),
-                    };
-                    let conda_deps = kernel_env::CondaDependencies {
-                        dependencies: delta.clone(),
-                        channels: vec!["conda-forge".to_string()],
-                        python: None,
-                        env_id: None,
-                    };
-                    progress_handler.on_progress(
-                        "conda",
-                        kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+            let conda_env = kernel_env::CondaEnvironment {
+                env_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
+            };
+            let conda_deps = kernel_env::CondaDependencies {
+                dependencies: delta.clone(),
+                channels: vec!["conda-forge".to_string()],
+                python: None,
+                env_id: None,
+            };
+            progress_handler.on_progress(
+                "conda",
+                kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+            );
+            match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps).await {
+                Ok(()) => {
+                    info!(
+                        "[notebook-sync] Installed {} delta packages into Conda pool env",
+                        delta.len()
                     );
-                    match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps).await {
-                        Ok(()) => {
-                            info!(
-                                "[notebook-sync] Installed {} delta packages into Conda pool env",
-                                delta.len()
-                            );
-                            Ok((env, pool_packages))
-                        }
-                        Err(e) => {
-                            warn!(
-                                "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
-                                e
-                            );
-                            Err(())
-                        }
-                    }
+                    Ok((env, actual_packages))
                 }
-                None => {
-                    info!("[notebook-sync] Conda pool empty, falling back to full build");
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
+                        e
+                    );
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
-            debug!(
-                "[notebook-sync] Conda inline deps have version constraints, skipping pool reuse"
-            );
+            debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
             Err(())
         }
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -250,6 +250,9 @@ fn build_launched_config(
             config.uv_deps = inline_deps.map(|d| d.to_vec());
             config.venv_path = venv_path;
             config.python_path = python_path;
+            if let Some(pkgs) = prewarmed_packages {
+                config.prewarmed_packages = pkgs.to_vec();
+            }
         }
         "conda:inline" => {
             config.conda_deps = inline_deps.map(|d| d.to_vec());
@@ -257,6 +260,9 @@ fn build_launched_config(
             config.python_path = python_path;
             if let Some(snapshot) = metadata_snapshot {
                 config.conda_channels = Some(get_inline_conda_channels(snapshot));
+            }
+            if let Some(pkgs) = prewarmed_packages {
+                config.prewarmed_packages = pkgs.to_vec();
             }
         }
         "uv:prewarmed" => {
@@ -3083,6 +3089,163 @@ async fn reset_starting_state(room: &NotebookRoom) {
     *guard = None;
 }
 
+/// Try to satisfy UV inline deps from the prewarmed pool.
+///
+/// Returns `Ok((PooledEnv, pool_packages))` if the pool can serve the deps
+/// (either as a direct subset or by installing a small delta).
+/// Returns `Err(())` if the deps are incompatible or the pool is unavailable.
+async fn try_uv_pool_for_inline_deps(
+    deps: &[String],
+    daemon: &std::sync::Arc<crate::daemon::Daemon>,
+    progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
+) -> Result<(crate::PooledEnv, Vec<String>), ()> {
+    let pool_packages = daemon.uv_pool_packages().await;
+    let relation = crate::inline_env::compare_deps_to_pool(deps, &pool_packages);
+
+    match relation {
+        crate::inline_env::PoolDepRelation::Subset => {
+            info!("[notebook-sync] Inline UV deps are subset of pool, taking pool env");
+            match daemon.take_uv_env().await {
+                Some(env) => Ok((env, pool_packages)),
+                None => {
+                    info!("[notebook-sync] UV pool empty, falling back to full build");
+                    Err(())
+                }
+            }
+        }
+        crate::inline_env::PoolDepRelation::Additive { delta } => {
+            info!(
+                "[notebook-sync] Inline UV deps are additive to pool, delta: {:?}",
+                delta
+            );
+            match daemon.take_uv_env().await {
+                Some(env) => {
+                    let uv_env = kernel_env::UvEnvironment {
+                        venv_path: env.venv_path.clone(),
+                        python_path: env.python_path.clone(),
+                    };
+                    progress_handler.on_progress(
+                        "uv",
+                        kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+                    );
+                    match kernel_env::uv::sync_dependencies(&uv_env, &delta).await {
+                        Ok(()) => {
+                            info!(
+                                "[notebook-sync] Installed {} delta packages into pool env",
+                                delta.len()
+                            );
+                            Ok((env, pool_packages))
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] Failed to install delta into UV pool env: {}, falling back",
+                                e
+                            );
+                            Err(())
+                        }
+                    }
+                }
+                None => {
+                    info!("[notebook-sync] UV pool empty, falling back to full build");
+                    Err(())
+                }
+            }
+        }
+        crate::inline_env::PoolDepRelation::Independent => {
+            debug!("[notebook-sync] UV inline deps have version constraints, skipping pool reuse");
+            Err(())
+        }
+    }
+}
+
+/// Try to satisfy Conda inline deps from the prewarmed pool.
+///
+/// Only attempts pool reuse when channels are default (conda-forge).
+/// Returns `Ok((PooledEnv, pool_packages))` on success, `Err(())` on failure.
+async fn try_conda_pool_for_inline_deps(
+    deps: &[String],
+    channels: &[String],
+    daemon: &std::sync::Arc<crate::daemon::Daemon>,
+    progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
+) -> Result<(crate::PooledEnv, Vec<String>), ()> {
+    // Only use pool for default conda-forge channel
+    let is_default_channels =
+        channels.is_empty() || (channels.len() == 1 && channels[0] == "conda-forge");
+    if !is_default_channels {
+        debug!(
+            "[notebook-sync] Conda inline deps use non-default channels {:?}, skipping pool reuse",
+            channels
+        );
+        return Err(());
+    }
+
+    let pool_packages = daemon.conda_pool_packages().await;
+    let relation = crate::inline_env::compare_deps_to_pool(deps, &pool_packages);
+
+    match relation {
+        crate::inline_env::PoolDepRelation::Subset => {
+            info!("[notebook-sync] Inline Conda deps are subset of pool, taking pool env");
+            match daemon.take_conda_env().await {
+                Some(env) => Ok((env, pool_packages)),
+                None => {
+                    info!("[notebook-sync] Conda pool empty, falling back to full build");
+                    Err(())
+                }
+            }
+        }
+        crate::inline_env::PoolDepRelation::Additive { delta } => {
+            info!(
+                "[notebook-sync] Inline Conda deps are additive to pool, delta: {:?}",
+                delta
+            );
+            match daemon.take_conda_env().await {
+                Some(env) => {
+                    let conda_env = kernel_env::CondaEnvironment {
+                        env_path: env.venv_path.clone(),
+                        python_path: env.python_path.clone(),
+                    };
+                    let conda_deps = kernel_env::CondaDependencies {
+                        dependencies: delta.clone(),
+                        channels: vec!["conda-forge".to_string()],
+                        python: None,
+                        env_id: None,
+                    };
+                    progress_handler.on_progress(
+                        "conda",
+                        kernel_env::EnvProgressPhase::Installing { total: delta.len() },
+                    );
+                    match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps).await {
+                        Ok(()) => {
+                            info!(
+                                "[notebook-sync] Installed {} delta packages into Conda pool env",
+                                delta.len()
+                            );
+                            Ok((env, pool_packages))
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
+                                e
+                            );
+                            Err(())
+                        }
+                    }
+                }
+                None => {
+                    info!("[notebook-sync] Conda pool empty, falling back to full build");
+                    Err(())
+                }
+            }
+        }
+        crate::inline_env::PoolDepRelation::Independent => {
+            debug!(
+                "[notebook-sync] Conda inline deps have version constraints, skipping pool reuse"
+            );
+            Err(())
+        }
+    }
+}
+
 /// Auto-launch kernel for a trusted notebook when first peer connects.
 /// This is similar to handle_notebook_request(LaunchKernel) but without a request/response.
 ///
@@ -3462,40 +3625,110 @@ async fn auto_launch_kernel(
             let prerelease = metadata_snapshot
                 .as_ref()
                 .and_then(get_inline_uv_prerelease);
-            info!(
-                "[notebook-sync] Preparing cached UV env for inline deps: {:?} (prerelease: {:?})",
-                deps, prerelease
-            );
-            match crate::inline_env::prepare_uv_inline_env(
-                &deps,
-                prerelease.as_deref(),
-                progress_handler.clone(),
-            )
-            .await
+
+            // Fast path: check inline env cache first (instant on hit)
+            if let Some(cached) =
+                crate::inline_env::check_uv_inline_cache(&deps, prerelease.as_deref())
             {
-                Ok(prepared) => {
-                    info!(
-                        "[notebook-sync] Using cached inline env at {:?}",
-                        prepared.python_path
-                    );
-                    let env = Some(crate::PooledEnv {
-                        env_type: crate::EnvType::Uv,
-                        venv_path: prepared.env_path,
-                        python_path: prepared.python_path,
-                        prewarmed_packages: vec![],
-                    });
-                    (env, Some(deps))
+                info!(
+                    "[notebook-sync] UV inline cache hit at {:?}",
+                    cached.python_path
+                );
+                let env = Some(crate::PooledEnv {
+                    env_type: crate::EnvType::Uv,
+                    venv_path: cached.env_path,
+                    python_path: cached.python_path,
+                    prewarmed_packages: vec![],
+                });
+                (env, Some(deps))
+            } else if prerelease.is_none() {
+                // Try pool reuse for bare deps without prerelease
+                match try_uv_pool_for_inline_deps(&deps, &daemon, progress_handler.clone()).await {
+                    Ok((env, pool_pkgs)) => {
+                        let mut pooled = env;
+                        pooled.prewarmed_packages = pool_pkgs;
+                        (Some(pooled), Some(deps))
+                    }
+                    Err(_) => {
+                        // Pool path failed, fall back to full build
+                        info!(
+                            "[notebook-sync] Preparing cached UV env for inline deps: {:?}",
+                            deps
+                        );
+                        match crate::inline_env::prepare_uv_inline_env(
+                            &deps,
+                            prerelease.as_deref(),
+                            progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok(prepared) => {
+                                info!(
+                                    "[notebook-sync] Using cached inline env at {:?}",
+                                    prepared.python_path
+                                );
+                                let env = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Uv,
+                                    venv_path: prepared.env_path,
+                                    python_path: prepared.python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (env, Some(deps))
+                            }
+                            Err(e) => {
+                                error!("[notebook-sync] Failed to prepare inline env: {}", e);
+                                let _ = room.kernel_broadcast_tx.send(
+                                    NotebookBroadcast::KernelStatus {
+                                        status: format!(
+                                            "error: Failed to prepare environment: {}",
+                                            e
+                                        ),
+                                        cell_id: None,
+                                    },
+                                );
+                                reset_starting_state(room).await;
+                                return;
+                            }
+                        }
+                    }
                 }
-                Err(e) => {
-                    error!("[notebook-sync] Failed to prepare inline env: {}", e);
-                    let _ = room
-                        .kernel_broadcast_tx
-                        .send(NotebookBroadcast::KernelStatus {
-                            status: format!("error: Failed to prepare environment: {}", e),
-                            cell_id: None,
+            } else {
+                // Has prerelease — can't use pool, go straight to full build
+                info!(
+                    "[notebook-sync] Preparing cached UV env for inline deps: {:?} (prerelease: {:?})",
+                    deps, prerelease
+                );
+                match crate::inline_env::prepare_uv_inline_env(
+                    &deps,
+                    prerelease.as_deref(),
+                    progress_handler.clone(),
+                )
+                .await
+                {
+                    Ok(prepared) => {
+                        info!(
+                            "[notebook-sync] Using cached inline env at {:?}",
+                            prepared.python_path
+                        );
+                        let env = Some(crate::PooledEnv {
+                            env_type: crate::EnvType::Uv,
+                            venv_path: prepared.env_path,
+                            python_path: prepared.python_path,
+                            prewarmed_packages: vec![],
                         });
-                    reset_starting_state(room).await;
-                    return;
+                        (env, Some(deps))
+                    }
+                    Err(e) => {
+                        error!("[notebook-sync] Failed to prepare inline env: {}", e);
+                        let _ = room
+                            .kernel_broadcast_tx
+                            .send(NotebookBroadcast::KernelStatus {
+                                status: format!("error: Failed to prepare environment: {}", e),
+                                cell_id: None,
+                            });
+                        reset_starting_state(room).await;
+                        return;
+                    }
                 }
             }
         } else {
@@ -3507,40 +3740,77 @@ async fn auto_launch_kernel(
                 .as_ref()
                 .map(get_inline_conda_channels)
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
-            info!(
-                "[notebook-sync] Preparing cached Conda env for inline deps: {:?} (channels: {:?})",
-                deps, channels
-            );
-            match crate::inline_env::prepare_conda_inline_env(
-                &deps,
-                &channels,
-                progress_handler.clone(),
-            )
-            .await
-            {
-                Ok(prepared) => {
-                    info!(
-                        "[notebook-sync] Using cached conda inline env at {:?}",
-                        prepared.python_path
-                    );
-                    let env = Some(crate::PooledEnv {
-                        env_type: crate::EnvType::Conda,
-                        venv_path: prepared.env_path,
-                        python_path: prepared.python_path,
-                        prewarmed_packages: vec![],
-                    });
-                    (env, Some(deps))
-                }
-                Err(e) => {
-                    error!("[notebook-sync] Failed to prepare conda inline env: {}", e);
-                    let _ = room
-                        .kernel_broadcast_tx
-                        .send(NotebookBroadcast::KernelStatus {
-                            status: format!("error: Failed to prepare conda environment: {}", e),
-                            cell_id: None,
-                        });
-                    reset_starting_state(room).await;
-                    return;
+
+            // Fast path: check inline env cache first (instant on hit)
+            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
+                info!(
+                    "[notebook-sync] Conda inline cache hit at {:?}",
+                    cached.python_path
+                );
+                let env = Some(crate::PooledEnv {
+                    env_type: crate::EnvType::Conda,
+                    venv_path: cached.env_path,
+                    python_path: cached.python_path,
+                    prewarmed_packages: vec![],
+                });
+                (env, Some(deps))
+            } else {
+                // Try pool reuse (only for default conda-forge channel)
+                match try_conda_pool_for_inline_deps(
+                    &deps,
+                    &channels,
+                    &daemon,
+                    progress_handler.clone(),
+                )
+                .await
+                {
+                    Ok((env, pool_pkgs)) => {
+                        let mut pooled = env;
+                        pooled.prewarmed_packages = pool_pkgs;
+                        (Some(pooled), Some(deps))
+                    }
+                    Err(_) => {
+                        // Pool path failed, fall back to full build
+                        info!(
+                            "[notebook-sync] Preparing cached Conda env for inline deps: {:?} (channels: {:?})",
+                            deps, channels
+                        );
+                        match crate::inline_env::prepare_conda_inline_env(
+                            &deps,
+                            &channels,
+                            progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok(prepared) => {
+                                info!(
+                                    "[notebook-sync] Using cached conda inline env at {:?}",
+                                    prepared.python_path
+                                );
+                                let env = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Conda,
+                                    venv_path: prepared.env_path,
+                                    python_path: prepared.python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (env, Some(deps))
+                            }
+                            Err(e) => {
+                                error!("[notebook-sync] Failed to prepare conda inline env: {}", e);
+                                let _ = room.kernel_broadcast_tx.send(
+                                    NotebookBroadcast::KernelStatus {
+                                        status: format!(
+                                            "error: Failed to prepare conda environment: {}",
+                                            e
+                                        ),
+                                        cell_id: None,
+                                    },
+                                );
+                                reset_starting_state(room).await;
+                                return;
+                            }
+                        }
+                    }
                 }
             }
         } else {
@@ -4376,35 +4646,98 @@ async fn handle_notebook_request(
                     let prerelease = metadata_snapshot
                         .as_ref()
                         .and_then(get_inline_uv_prerelease);
-                    info!(
-                        "[notebook-sync] LaunchKernel: Preparing cached UV env for inline deps: {:?} (prerelease: {:?})",
-                        deps, prerelease
-                    );
-                    match crate::inline_env::prepare_uv_inline_env(
-                        &deps,
-                        prerelease.as_deref(),
-                        launch_progress_handler.clone(),
-                    )
-                    .await
+
+                    // Fast path: check inline env cache first (instant on hit)
+                    if let Some(cached) =
+                        crate::inline_env::check_uv_inline_cache(&deps, prerelease.as_deref())
                     {
-                        Ok(prepared) => {
-                            info!(
-                                "[notebook-sync] LaunchKernel: Using cached inline env at {:?}",
-                                prepared.python_path
-                            );
-                            let env = Some(crate::PooledEnv {
-                                env_type: crate::EnvType::Uv,
-                                venv_path: prepared.env_path,
-                                python_path: prepared.python_path,
-                                prewarmed_packages: vec![],
-                            });
-                            (env, Some(deps))
+                        info!(
+                            "[notebook-sync] LaunchKernel: UV inline cache hit at {:?}",
+                            cached.python_path
+                        );
+                        let env = Some(crate::PooledEnv {
+                            env_type: crate::EnvType::Uv,
+                            venv_path: cached.env_path,
+                            python_path: cached.python_path,
+                            prewarmed_packages: vec![],
+                        });
+                        (env, Some(deps))
+                    } else if prerelease.is_none() {
+                        // Try pool reuse for bare deps without prerelease
+                        match try_uv_pool_for_inline_deps(
+                            &deps,
+                            &daemon,
+                            launch_progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok((env, pool_pkgs)) => {
+                                let mut pooled = env;
+                                pooled.prewarmed_packages = pool_pkgs;
+                                (Some(pooled), Some(deps))
+                            }
+                            Err(_) => {
+                                // Pool path failed, fall back to full build
+                                info!(
+                                    "[notebook-sync] LaunchKernel: Preparing cached UV env for inline deps: {:?}",
+                                    deps
+                                );
+                                match crate::inline_env::prepare_uv_inline_env(
+                                    &deps,
+                                    prerelease.as_deref(),
+                                    launch_progress_handler.clone(),
+                                )
+                                .await
+                                {
+                                    Ok(prepared) => {
+                                        let env = Some(crate::PooledEnv {
+                                            env_type: crate::EnvType::Uv,
+                                            venv_path: prepared.env_path,
+                                            python_path: prepared.python_path,
+                                            prewarmed_packages: vec![],
+                                        });
+                                        (env, Some(deps))
+                                    }
+                                    Err(e) => {
+                                        reset_starting_state(room).await;
+                                        return NotebookResponse::Error {
+                                            error: format!(
+                                                "Failed to prepare inline environment: {}",
+                                                e
+                                            ),
+                                        };
+                                    }
+                                }
+                            }
                         }
-                        Err(e) => {
-                            reset_starting_state(room).await;
-                            return NotebookResponse::Error {
-                                error: format!("Failed to prepare inline environment: {}", e),
-                            };
+                    } else {
+                        // Has prerelease — can't use pool, go straight to full build
+                        info!(
+                            "[notebook-sync] LaunchKernel: Preparing cached UV env for inline deps: {:?} (prerelease: {:?})",
+                            deps, prerelease
+                        );
+                        match crate::inline_env::prepare_uv_inline_env(
+                            &deps,
+                            prerelease.as_deref(),
+                            launch_progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok(prepared) => {
+                                let env = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Uv,
+                                    venv_path: prepared.env_path,
+                                    python_path: prepared.python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (env, Some(deps))
+                            }
+                            Err(e) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: format!("Failed to prepare inline environment: {}", e),
+                                };
+                            }
                         }
                     }
                 } else {
@@ -4416,35 +4749,70 @@ async fn handle_notebook_request(
                         .as_ref()
                         .map(get_inline_conda_channels)
                         .unwrap_or_else(|| vec!["conda-forge".to_string()]);
-                    info!(
-                        "[notebook-sync] LaunchKernel: Preparing cached Conda env for inline deps: {:?} (channels: {:?})",
-                        deps, channels
-                    );
-                    match crate::inline_env::prepare_conda_inline_env(
-                        &deps,
-                        &channels,
-                        launch_progress_handler.clone(),
-                    )
-                    .await
+
+                    // Fast path: check inline env cache first (instant on hit)
+                    if let Some(cached) =
+                        crate::inline_env::check_conda_inline_cache(&deps, &channels)
                     {
-                        Ok(prepared) => {
-                            info!(
-                                "[notebook-sync] LaunchKernel: Using cached conda inline env at {:?}",
-                                prepared.python_path
-                            );
-                            let env = Some(crate::PooledEnv {
-                                env_type: crate::EnvType::Conda,
-                                venv_path: prepared.env_path,
-                                python_path: prepared.python_path,
-                                prewarmed_packages: vec![],
-                            });
-                            (env, Some(deps))
-                        }
-                        Err(e) => {
-                            reset_starting_state(room).await;
-                            return NotebookResponse::Error {
-                                error: format!("Failed to prepare conda inline environment: {}", e),
-                            };
+                        info!(
+                            "[notebook-sync] LaunchKernel: Conda inline cache hit at {:?}",
+                            cached.python_path
+                        );
+                        let env = Some(crate::PooledEnv {
+                            env_type: crate::EnvType::Conda,
+                            venv_path: cached.env_path,
+                            python_path: cached.python_path,
+                            prewarmed_packages: vec![],
+                        });
+                        (env, Some(deps))
+                    } else {
+                        // Try pool reuse (only for default conda-forge channel)
+                        match try_conda_pool_for_inline_deps(
+                            &deps,
+                            &channels,
+                            &daemon,
+                            launch_progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok((env, pool_pkgs)) => {
+                                let mut pooled = env;
+                                pooled.prewarmed_packages = pool_pkgs;
+                                (Some(pooled), Some(deps))
+                            }
+                            Err(_) => {
+                                // Pool path failed, fall back to full build
+                                info!(
+                                    "[notebook-sync] LaunchKernel: Preparing cached Conda env for inline deps: {:?} (channels: {:?})",
+                                    deps, channels
+                                );
+                                match crate::inline_env::prepare_conda_inline_env(
+                                    &deps,
+                                    &channels,
+                                    launch_progress_handler.clone(),
+                                )
+                                .await
+                                {
+                                    Ok(prepared) => {
+                                        let env = Some(crate::PooledEnv {
+                                            env_type: crate::EnvType::Conda,
+                                            venv_path: prepared.env_path,
+                                            python_path: prepared.python_path,
+                                            prewarmed_packages: vec![],
+                                        });
+                                        (env, Some(deps))
+                                    }
+                                    Err(e) => {
+                                        reset_starting_state(room).await;
+                                        return NotebookResponse::Error {
+                                            error: format!(
+                                                "Failed to prepare conda inline environment: {}",
+                                                e
+                                            ),
+                                        };
+                                    }
+                                }
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary

When a notebook declares inline dependencies (e.g. `["pandas", "numpy", "matplotlib"]`), the daemon previously built a fresh environment from scratch — even when all those packages were already in the prewarmed pool. For conda, this took ~20-30s per notebook.

Now, before building from scratch, the daemon checks whether inline deps can be satisfied by a pool env:

- **Subset**: all deps already in pool → take pool env directly (instant)
- **Additive**: pool covers some deps → take pool env + install only the delta
- **Independent**: version-pinned deps or pool unavailable → fall back to full build (existing behavior)

An inline env cache check runs first, so previously-built inline envs are still instant. The pool optimization only kicks in on cache misses.

Closes #1611

## Changes

- **`inline_env.rs`** — Added `PoolDepRelation` enum, `compare_deps_to_pool()` (conservative: bare package names only, version pins fall through), `check_uv_inline_cache()` / `check_conda_inline_cache()` for lightweight cache-hit checks, plus unit tests
- **`daemon.rs`** — Added `uv_pool_packages()` / `conda_pool_packages()` to expose full prewarmed package lists
- **`notebook_sync_server.rs`** — Added `try_uv_pool_for_inline_deps()` / `try_conda_pool_for_inline_deps()` helpers; modified all 4 inline env code paths (auto-launch + LaunchKernel × UV + Conda); updated `build_launched_config()` to propagate `prewarmed_packages` for inline sources

## Verification

- [ ] Create a conda notebook with `["pandas", "numpy", "matplotlib", "pyarrow"]` (all in default pool) — kernel should start in <2s, daemon logs show "subset of pool"
- [ ] Create a UV notebook with `["pandas", "scikit-learn"]` where `scikit-learn` is not in pool — daemon logs show "additive to pool" and installs only the delta
- [ ] Create a notebook with `["pandas==2.0.0"]` (version pin) — should fall through to existing from-scratch build path
- [ ] Notebook with no inline deps (prewarmed) still works as before
- [ ] Second restart with same deps hits inline cache (instant, no pool consumed)

_PR submitted by @rgbkrk's agent, Quill_