### PR TITLE
fix(runtimed): classify pool errors, show contextual banner messages

### DIFF
--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -1,11 +1,48 @@
 import { invoke } from "@tauri-apps/api/core";
-import { AlertTriangle, Settings, X } from "lucide-react";
+import { AlertTriangle, Clock, Settings, X } from "lucide-react";
 import type { PoolErrorWithTimestamp } from "../hooks/usePoolState";
 
 interface PoolErrorItemProps {
   envType: "UV" | "Conda";
   error: PoolErrorWithTimestamp;
   onDismiss: () => void;
+}
+
+function errorTitle(error: PoolErrorWithTimestamp): string {
+  switch (error.error_kind) {
+    case "timeout":
+      return "Environment setup timed out";
+    case "import_error":
+      return "Package import failed";
+    case "setup_failed":
+      return "Environment setup failed";
+    default:
+      return "Invalid or unavailable package";
+  }
+}
+
+function errorSubtitle(
+  error: PoolErrorWithTimestamp,
+  envType: "UV" | "Conda",
+): string {
+  switch (error.error_kind) {
+    case "timeout":
+      return "Retrying automatically";
+    case "import_error":
+      return `Check package compatibility in ${envType.toLowerCase()} settings`;
+    case "setup_failed":
+      return "Retrying automatically";
+    default:
+      return `Check package name in ${envType.toLowerCase()} settings`;
+  }
+}
+
+function showSettingsButton(error: PoolErrorWithTimestamp): boolean {
+  return (
+    error.error_kind === "invalid_package" ||
+    error.error_kind === "import_error" ||
+    error.error_kind === undefined
+  );
 }
 
 function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
@@ -15,16 +52,20 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
     });
   };
 
+  const isTimeout = error.error_kind === "timeout";
+
   return (
     <div
       className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white"
       title={error.message}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <AlertTriangle className="h-3 w-3 flex-shrink-0" />
-        <span className="font-medium flex-shrink-0">
-          Invalid or unavailable package
-        </span>
+        {isTimeout ? (
+          <Clock className="h-3 w-3 flex-shrink-0" />
+        ) : (
+          <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+        )}
+        <span className="font-medium flex-shrink-0">{errorTitle(error)}</span>
         {error.failed_package && (
           <>
             <span className="text-amber-200 flex-shrink-0">—</span>
@@ -34,19 +75,19 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
           </>
         )}
         <span className="text-amber-200 flex-shrink-0">—</span>
-        <span className="text-amber-100">
-          Check package name in {envType.toLowerCase()} settings.
-        </span>
+        <span className="text-amber-100">{errorSubtitle(error, envType)}</span>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
-        <button
-          type="button"
-          onClick={openSettings}
-          className="flex items-center gap-1 rounded bg-amber-700/60 px-2 py-0.5 hover:bg-amber-700 transition-colors"
-        >
-          <Settings className="h-3 w-3" />
-          <span>Settings</span>
-        </button>
+        {showSettingsButton(error) && (
+          <button
+            type="button"
+            onClick={openSettings}
+            className="flex items-center gap-1 rounded bg-amber-700/60 px-2 py-0.5 hover:bg-amber-700 transition-colors"
+          >
+            <Settings className="h-3 w-3" />
+            <span>Settings</span>
+          </button>
+        )}
         <button
           type="button"
           onClick={onDismiss}
@@ -71,7 +112,7 @@ interface PoolErrorBannerProps {
  * Banner component showing pool warming errors.
  *
  * Displays amber warning banners for UV and/or Conda pool errors,
- * with the failed package name and a link to open settings to fix the issue.
+ * with contextual messages based on error type.
  */
 export function PoolErrorBanner({
   uvError,

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -17,6 +17,7 @@ function errorsEqual(
   return (
     a.message === b.message &&
     a.failed_package === b.failed_package &&
+    a.error_kind === b.error_kind &&
     a.consecutive_failures === b.consecutive_failures &&
     a.retry_in_secs === b.retry_in_secs
   );
@@ -30,6 +31,7 @@ function extractError(
   return {
     message: pool.error,
     failed_package: pool.failed_package,
+    error_kind: pool.error_kind,
     consecutive_failures: pool.consecutive_failures,
     retry_in_secs: pool.retry_in_secs,
     receivedAt: Date.now(),

--- a/apps/notebook/src/lib/pool-state.ts
+++ b/apps/notebook/src/lib/pool-state.ts
@@ -20,6 +20,8 @@ export interface RuntimePoolState {
   error?: string;
   /** Package that failed to install (undefined if not identified). */
   failed_package?: string;
+  /** Error classification: "timeout", "invalid_package", "import_error", "setup_failed". */
+  error_kind?: string;
   /** Number of consecutive failures (0 if healthy). */
   consecutive_failures: number;
   /** Seconds until next retry (0 if retry is imminent or healthy). */
@@ -36,6 +38,7 @@ export interface PoolState {
 export interface PoolErrorWithTimestamp {
   message: string;
   failed_package?: string;
+  error_kind?: string;
   consecutive_failures: number;
   retry_in_secs: number;
   /** When this state was received (epoch ms). */

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -15,6 +15,7 @@
 //!     consecutive_failures: u64
 //!     retry_in_secs: u64
 //!     error: Str (optional — deleted when None)
+//!     error_kind: Str (optional — "timeout"|"invalid_package"|"import_error"|"setup_failed")
 //!   conda/
 //!     available: u64
 //!     warming: u64
@@ -22,6 +23,7 @@
 //!     consecutive_failures: u64
 //!     retry_in_secs: u64
 //!     error: Str (optional — deleted when None)
+//!     error_kind: Str (optional — "timeout"|"invalid_package"|"import_error"|"setup_failed")
 //! ```
 
 use automerge::{
@@ -44,6 +46,10 @@ pub struct RuntimePoolState {
     /// Package that failed to install (None if not identified or healthy).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failed_package: Option<String>,
+    /// Error classification: "timeout", "invalid_package", "import_error", "setup_failed".
+    /// None if healthy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
     /// Number of consecutive failures (0 if healthy).
     #[serde(default)]
     pub consecutive_failures: u32,
@@ -219,6 +225,16 @@ impl PoolDoc {
             }
         }
 
+        // Error kind: set string when Some, delete key when None
+        match &state.error_kind {
+            Some(kind) => {
+                self.doc.put(&obj, "error_kind", kind.as_str())?;
+            }
+            None => {
+                let _ = self.doc.delete(&obj, "error_kind");
+            }
+        }
+
         Ok(())
     }
 
@@ -267,6 +283,7 @@ impl PoolDoc {
             pool_size: get_u64("pool_size"),
             error: get_str("error"),
             failed_package: get_str("failed_package"),
+            error_kind: get_str("error_kind"),
             consecutive_failures: get_u64("consecutive_failures") as u32,
             retry_in_secs: get_u64("retry_in_secs"),
         }
@@ -338,6 +355,7 @@ mod tests {
                 pool_size: 4,
                 error: None,
                 failed_package: None,
+                error_kind: None,
                 consecutive_failures: 0,
                 retry_in_secs: 0,
             },
@@ -347,6 +365,7 @@ mod tests {
                 pool_size: 3,
                 error: Some("Failed to create env".into()),
                 failed_package: Some("badpkg".into()),
+                error_kind: Some("invalid_package".into()),
                 consecutive_failures: 2,
                 retry_in_secs: 30,
             },
@@ -384,6 +403,7 @@ mod tests {
                 pool_size: 4,
                 error: Some("test error".into()),
                 failed_package: Some("badpkg".into()),
+                error_kind: Some("timeout".into()),
                 consecutive_failures: 3,
                 retry_in_secs: 60,
             },

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -100,6 +100,8 @@ struct FailureState {
     last_error: Option<String>,
     /// Failed package name if identified.
     failed_package: Option<String>,
+    /// Error classification for the frontend banner.
+    error_kind: Option<String>,
 }
 
 /// Result of parsing a package installation error.
@@ -109,6 +111,8 @@ struct PackageInstallError {
     failed_package: Option<String>,
     /// Full error message from uv.
     error_message: String,
+    /// Error classification: "timeout", "invalid_package", "import_error", "setup_failed".
+    error_kind: String,
 }
 
 /// Parse UV stderr to identify the failed package.
@@ -147,6 +151,7 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
                         return Some(PackageInstallError {
                             failed_package: Some(package_name),
                             error_message: stderr.to_string(),
+                            error_kind: "invalid_package".to_string(),
                         });
                     }
                 }
@@ -159,6 +164,7 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
         return Some(PackageInstallError {
             failed_package: None,
             error_message: stderr.to_string(),
+            error_kind: "setup_failed".to_string(),
         });
     }
 
@@ -333,6 +339,7 @@ impl Pool {
         if let Some(err) = error {
             self.failure_state.last_error = Some(err.error_message);
             self.failure_state.failed_package = err.failed_package;
+            self.failure_state.error_kind = Some(err.error_kind);
         }
     }
 
@@ -1763,7 +1770,7 @@ impl Daemon {
     /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
     /// Automatically triggers replenishment when an environment is taken.
     pub async fn take_uv_env(self: &Arc<Self>) -> Option<PooledEnv> {
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(90);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
             let (env, stale_paths) = self.uv_pool.lock().await.take();
@@ -1836,7 +1843,7 @@ impl Daemon {
     /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
     /// Automatically triggers replenishment when an environment is taken.
     pub async fn take_conda_env(self: &Arc<Self>) -> Option<PooledEnv> {
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(90);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
             let (env, stale_paths) = self.conda_pool.lock().await.take();
@@ -2603,6 +2610,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to create cache dir: {}", e),
+                    error_kind: "setup_failed".to_string(),
                 }));
             self.update_pool_doc().await;
             return;
@@ -2622,6 +2630,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to parse conda-forge channel: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2662,6 +2671,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to parse match specs: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2685,6 +2695,7 @@ impl Daemon {
                             "Could not determine rattler cache directory: {}",
                             e
                         ),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2699,6 +2710,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Could not create rattler cache directory: {}", e),
+                    error_kind: "setup_failed".to_string(),
                 }));
             self.update_pool_doc().await;
             return;
@@ -2715,6 +2727,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create HTTP client: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2749,6 +2762,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to fetch repodata: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2773,6 +2787,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to detect virtual packages: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2796,6 +2811,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to solve dependencies: {}", e),
+                        error_kind: "invalid_package".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -2823,6 +2839,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to install packages: {}", e),
+                    error_kind: "setup_failed".to_string(),
                 }));
             self.update_pool_doc().await;
             return;
@@ -2841,6 +2858,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Python not found at {:?} after install", python_path),
+                    error_kind: "setup_failed".to_string(),
                 }));
             self.update_pool_doc().await;
             return;
@@ -2879,6 +2897,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: "Conda warmup failed (timed out or imports errored)".into(),
+                    error_kind: "import_error".to_string(),
                 }));
             self.update_pool_doc().await;
         }
@@ -2914,7 +2933,7 @@ impl Daemon {
         );
 
         let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(180),
             tokio::process::Command::new(python_path)
                 .args(["-c", &warmup_script])
                 .stdout(Stdio::piped())
@@ -3019,6 +3038,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         error_message: format!("{}", e),
                         failed_package: None,
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
             }
@@ -3046,6 +3066,7 @@ impl Daemon {
                 pool_size: self.config.uv_pool_size as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
+                error_kind: pool.failure_state.error_kind.clone(),
                 consecutive_failures: pool.failure_state.consecutive_failures,
                 retry_in_secs: pool.retry_in_secs(),
             }
@@ -3059,6 +3080,7 @@ impl Daemon {
                 pool_size: self.config.conda_pool_size as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
+                error_kind: pool.failure_state.error_kind.clone(),
                 consecutive_failures: pool.failure_state.consecutive_failures,
                 retry_in_secs: pool.retry_in_secs(),
             }
@@ -3073,6 +3095,7 @@ impl Daemon {
                 pool_size: self.config.pixi_pool_size as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
+                error_kind: pool.failure_state.error_kind.clone(),
                 consecutive_failures: pool.failure_state.consecutive_failures,
                 retry_in_secs: pool.retry_in_secs(),
             }
@@ -3106,6 +3129,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to get uv path: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -3131,6 +3155,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to create cache dir: {}", e),
+                    error_kind: "setup_failed".to_string(),
                 }));
             self.update_pool_doc().await;
             return;
@@ -3161,6 +3186,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create venv: {}", stderr),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -3173,6 +3199,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create venv: {}", e),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -3186,6 +3213,7 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: "Timeout creating venv after 60 seconds".to_string(),
+                        error_kind: "timeout".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -3204,7 +3232,7 @@ impl Daemon {
         };
         let install_packages = uv_prewarmed_packages(&user_default_packages);
 
-        // Install packages (120 second timeout)
+        // Install packages (180 second timeout)
         // Use hardlink mode to share files from uv's global cache,
         // dramatically reducing per-env disk usage. uv falls back to
         // copies automatically if hardlinks aren't supported.
@@ -3219,7 +3247,7 @@ impl Daemon {
         install_args.extend(install_packages.clone());
 
         let install_result = tokio::time::timeout(
-            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(180),
             tokio::process::Command::new(&uv_path)
                 .args(&install_args)
                 .stdout(Stdio::piped())
@@ -3284,19 +3312,21 @@ impl Daemon {
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
                         error_message: e.to_string(),
+                        error_kind: "setup_failed".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
             }
             Err(_) => {
-                error!("[runtimed] Timeout installing packages (120s)");
+                error!("[runtimed] Timeout installing packages (180s)");
                 tokio::fs::remove_dir_all(&venv_path).await.ok();
                 self.uv_pool
                     .lock()
                     .await
                     .warming_failed_with_error(Some(PackageInstallError {
                         failed_package: None,
-                        error_message: "Timeout after 120 seconds".to_string(),
+                        error_message: "Timeout after 180 seconds".to_string(),
+                        error_kind: "timeout".to_string(),
                     }));
                 self.update_pool_doc().await;
                 return;
@@ -3326,7 +3356,7 @@ impl Daemon {
         );
 
         let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(180),
             tokio::process::Command::new(&python_path)
                 .args(["-c", &warmup_script])
                 .output(),
@@ -3379,6 +3409,7 @@ impl Daemon {
                 .warming_failed_with_error(Some(PackageInstallError {
                     failed_package: None,
                     error_message: "UV warmup failed (timed out or imports errored)".into(),
+                    error_kind: "import_error".to_string(),
                 }));
             self.update_pool_doc().await;
         }
@@ -3675,6 +3706,7 @@ mod tests {
         pool.warming_failed_with_error(Some(PackageInstallError {
             failed_package: Some("bad-pkg".to_string()),
             error_message: "not found".to_string(),
+            error_kind: "invalid_package".to_string(),
         }));
         pool.warming_failed_with_error(None);
         assert_eq!(pool.failure_state.consecutive_failures, 2);
@@ -3695,6 +3727,7 @@ mod tests {
         pool.warming_failed_with_error(Some(PackageInstallError {
             failed_package: Some("scitkit-learn".to_string()),
             error_message: "Package not found".to_string(),
+            error_kind: "invalid_package".to_string(),
         }));
         assert_eq!(pool.failure_state.consecutive_failures, 1);
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -171,6 +171,16 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
     None
 }
 
+/// Outcome of a warmup script execution.
+enum WarmupOutcome {
+    /// Warmup succeeded — environment is ready.
+    Ok,
+    /// Warmup timed out.
+    Timeout,
+    /// Warmup script failed (import error or process failure).
+    ImportError(String),
+}
+
 /// Spawn background deletion of environment directories.
 fn spawn_env_deletions(paths: Vec<PathBuf>) {
     if paths.is_empty() {
@@ -2865,52 +2875,68 @@ impl Daemon {
         }
 
         // Run warmup script
-        let warmup_ok = self
+        let warmup_outcome = self
             .warmup_conda_env(&python_path, &env_path, &extra_conda_packages)
             .await;
 
-        if warmup_ok {
-            {
-                let mut pool = self.conda_pool.lock().await;
-                pool.add(PooledEnv {
-                    env_type: EnvType::Conda,
-                    venv_path: env_path.clone(),
-                    python_path,
-                    prewarmed_packages: conda_install_packages,
-                });
+        match warmup_outcome {
+            WarmupOutcome::Ok => {
+                {
+                    let mut pool = self.conda_pool.lock().await;
+                    pool.add(PooledEnv {
+                        env_type: EnvType::Conda,
+                        venv_path: env_path.clone(),
+                        python_path,
+                        prewarmed_packages: conda_install_packages,
+                    });
+                }
+
+                info!(
+                    "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
+                    env_path,
+                    self.conda_pool.lock().await.stats().0,
+                    self.config.conda_pool_size
+                );
+
+                self.update_pool_doc().await;
             }
-
-            info!(
-                "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
-                env_path,
-                self.conda_pool.lock().await.stats().0,
-                self.config.conda_pool_size
-            );
-
-            self.update_pool_doc().await;
-        } else {
-            // Clean up failed env and record failure
-            let _ = tokio::fs::remove_dir_all(&env_path).await;
-            self.conda_pool
-                .lock()
-                .await
-                .warming_failed_with_error(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: "Conda warmup failed (timed out or imports errored)".into(),
-                    error_kind: "import_error".to_string(),
-                }));
-            self.update_pool_doc().await;
+            WarmupOutcome::Timeout => {
+                let _ = tokio::fs::remove_dir_all(&env_path).await;
+                self.conda_pool
+                    .lock()
+                    .await
+                    .warming_failed_with_error(Some(PackageInstallError {
+                        failed_package: None,
+                        error_message: "Conda warmup timed out".into(),
+                        error_kind: "timeout".to_string(),
+                    }));
+                self.update_pool_doc().await;
+            }
+            WarmupOutcome::ImportError(msg) => {
+                let _ = tokio::fs::remove_dir_all(&env_path).await;
+                self.conda_pool
+                    .lock()
+                    .await
+                    .warming_failed_with_error(Some(PackageInstallError {
+                        failed_package: None,
+                        error_message: format!(
+                            "Conda warmup failed: {}",
+                            msg.chars().take(200).collect::<String>()
+                        ),
+                        error_kind: "import_error".to_string(),
+                    }));
+                self.update_pool_doc().await;
+            }
         }
     }
 
     /// Warm up a conda environment by running Python to trigger .pyc compilation.
-    /// Returns `true` if warmup succeeded (ipykernel imports work).
     async fn warmup_conda_env(
         &self,
         python_path: &PathBuf,
         env_path: &PathBuf,
         extra_packages: &[String],
-    ) -> bool {
+    ) -> WarmupOutcome {
         let site_packages = {
             let lib_dir = env_path.join("lib");
             std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
@@ -2947,7 +2973,7 @@ impl Daemon {
                 // Create marker file
                 tokio::fs::write(env_path.join(".warmed"), "").await.ok();
                 info!("[runtimed] Conda warmup complete for {:?}", env_path);
-                true
+                WarmupOutcome::Ok
             }
             Ok(Ok(output)) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2956,15 +2982,15 @@ impl Daemon {
                     env_path,
                     stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
                 );
-                false
+                WarmupOutcome::ImportError(stderr.to_string())
             }
             Ok(Err(e)) => {
                 error!("[runtimed] Failed to run conda warmup: {}", e);
-                false
+                WarmupOutcome::ImportError(e.to_string())
             }
             Err(_) => {
-                error!("[runtimed] Conda warmup timed out");
-                false
+                error!("[runtimed] Conda warmup timed out (180s)");
+                WarmupOutcome::Timeout
             }
         }
     }
@@ -3363,11 +3389,11 @@ impl Daemon {
         )
         .await;
 
-        let warmup_ok = match warmup_result {
+        let warmup_outcome = match warmup_result {
             Ok(Ok(output)) if output.status.success() => {
                 // Create marker file
                 tokio::fs::write(venv_path.join(".warmed"), "").await.ok();
-                true
+                WarmupOutcome::Ok
             }
             Ok(Ok(output)) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
@@ -3375,43 +3401,60 @@ impl Daemon {
                     "[runtimed] UV warmup failed, NOT adding to pool: {}",
                     stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
                 );
-                false
+                WarmupOutcome::ImportError(stderr.to_string())
             }
             Ok(Err(e)) => {
                 error!("[runtimed] Failed to run UV warmup: {}", e);
-                false
+                WarmupOutcome::ImportError(e.to_string())
             }
             Err(_) => {
-                error!("[runtimed] UV warmup timed out, NOT adding to pool");
-                false
+                error!("[runtimed] UV warmup timed out, NOT adding to pool (180s)");
+                WarmupOutcome::Timeout
             }
         };
 
-        if warmup_ok {
-            info!("[runtimed] UV environment ready at {:?}", venv_path);
+        match warmup_outcome {
+            WarmupOutcome::Ok => {
+                info!("[runtimed] UV environment ready at {:?}", venv_path);
 
-            {
-                let mut pool = self.uv_pool.lock().await;
-                pool.add(PooledEnv {
-                    env_type: EnvType::Uv,
-                    venv_path,
-                    python_path,
-                    prewarmed_packages: install_packages,
-                });
+                {
+                    let mut pool = self.uv_pool.lock().await;
+                    pool.add(PooledEnv {
+                        env_type: EnvType::Uv,
+                        venv_path,
+                        python_path,
+                        prewarmed_packages: install_packages,
+                    });
+                }
+                self.update_pool_doc().await;
             }
-            self.update_pool_doc().await;
-        } else {
-            // Clean up failed env and record failure
-            let _ = tokio::fs::remove_dir_all(&venv_path).await;
-            self.uv_pool
-                .lock()
-                .await
-                .warming_failed_with_error(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: "UV warmup failed (timed out or imports errored)".into(),
-                    error_kind: "import_error".to_string(),
-                }));
-            self.update_pool_doc().await;
+            WarmupOutcome::Timeout => {
+                let _ = tokio::fs::remove_dir_all(&venv_path).await;
+                self.uv_pool
+                    .lock()
+                    .await
+                    .warming_failed_with_error(Some(PackageInstallError {
+                        failed_package: None,
+                        error_message: "UV warmup timed out".into(),
+                        error_kind: "timeout".to_string(),
+                    }));
+                self.update_pool_doc().await;
+            }
+            WarmupOutcome::ImportError(msg) => {
+                let _ = tokio::fs::remove_dir_all(&venv_path).await;
+                self.uv_pool
+                    .lock()
+                    .await
+                    .warming_failed_with_error(Some(PackageInstallError {
+                        failed_package: None,
+                        error_message: format!(
+                            "UV warmup failed: {}",
+                            msg.chars().take(200).collect::<String>()
+                        ),
+                        error_kind: "import_error".to_string(),
+                    }));
+                self.update_pool_doc().await;
+            }
         }
     }
 }

--- a/packages/runtimed/src/pool-state.ts
+++ b/packages/runtimed/src/pool-state.ts
@@ -14,6 +14,8 @@ export interface RuntimePoolState {
   error?: string;
   /** Package that failed to install (undefined if not identified). */
   failed_package?: string;
+  /** Error classification: "timeout", "invalid_package", "import_error", "setup_failed". */
+  error_kind?: string;
   /** Number of consecutive failures (0 if healthy). */
   consecutive_failures: number;
   /** Seconds until next retry (0 if retry is imminent or healthy). */


### PR DESCRIPTION
## Summary

Fixes the misleading "Invalid or unavailable package" error banner that appeared for **all** pool warming failures — including timeouts, import errors, and infra issues. The daemon now classifies errors with an `error_kind` field in the PoolDoc schema, and the frontend renders contextual messages based on the error type.

Closes #1618

## What changed

**Daemon (`crates/runtimed/src/daemon.rs`):**
- Added `error_kind` to `PackageInstallError` and `FailureState` structs
- Classified all ~25 `warming_failed_with_error` call sites into four categories: `timeout`, `invalid_package`, `import_error`, `setup_failed`
- Bumped timeouts: UV pip install/warmup and Conda warmup from 120s → 180s, pool env wait from 90s → 120s

**PoolDoc schema (`crates/notebook-doc/src/pool_state.rs`):**
- Added `error_kind: Option<String>` to `RuntimePoolState` with Automerge read/write support

**Frontend:**
- Added `error_kind` to TypeScript types in both `packages/runtimed` and `apps/notebook`
- `PoolErrorBanner` now renders contextually:

| Error kind | Banner message | Settings button? |
|---|---|---|
| `timeout` | "Environment setup timed out — Retrying automatically" | No |
| `invalid_package` | "Invalid or unavailable package — `{pkg}` — Check package name" | Yes |
| `import_error` | "Package import failed — Check package compatibility" | Yes |
| `setup_failed` | "Environment setup failed — Retrying automatically" | No |

<!-- Screenshots of each banner variant go here -->

## Verification

- [ ] Configure an invalid package in UV settings → banner shows "Invalid or unavailable package" with the package name and a Settings button
- [ ] Configure many heavy packages that cause warmup to take a long time → if it times out, banner shows "Environment setup timed out" with a clock icon, no Settings button
- [ ] After a transient failure resolves, banner clears on next successful warm
- [ ] Dismiss button still works for all error variants
- [ ] Tooltip on hover still shows the raw error message

_PR submitted by @rgbkrk's agent, Quill_