### PR TITLE
fix(ci): add lfs: true to release Python wheel builds, bump v2.1.3

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -656,6 +656,8 @@ jobs:
     needs: compute-version
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -704,6 +706,8 @@ jobs:
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -6436,7 +6436,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "kernel-env",
  "log",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.1.2"
+version = "2.1.3"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.1.2"
+version = "2.1.3"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.1.2"
+version = "2.1.3"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.1.2"
+version = "2.1.3"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.1.2"
+version = "2.1.3"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.1.2"
+version = "2.1.3"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Fix nightly release failure caused by Git LFS pointers not being resolved during Python wheel builds.

- Add `lfs: true` to `build-nteract-package` and `build-python-wheels` checkout steps in `release-common.yml`
- The compile-time LFS guard caught this: `plotly.js appears to be a Git LFS pointer — run git lfs pull`
- Bump version to 2.1.3 across all crates and Python packages

## Context

PR #1619 added `include_bytes!` for renderer plugins committed via Git LFS. The release workflow's Python wheel jobs didn't have `lfs: true`, so they got LFS pointer stubs instead of real files, triggering the compile-time guard.

## Test plan

- [ ] CI passes (especially Python Lint & Unit Tests, linux wheel build)
- [ ] Nightly release succeeds after merge