### PR TITLE
fix(mcp-app): add connectDomains and tile CDN to MCP App CSP

### DIFF
--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -16,9 +16,15 @@ const OUTPUT_MIME_TYPE: &str = "text/html;profile=mcp-app";
 /// The build script copies the file to `crates/runt-mcp/assets/_output.html`.
 const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
 
-/// Build `_meta` for the output widget resource with CSP allowing blob image loading.
+/// Build `_meta` for the output widget resource with CSP domains.
 ///
-/// Wire format: `{ "ui": { "csp": { "resourceDomains": ["http://localhost:{port}"] } } }`
+/// MCP Apps spec CSP fields (from ext-apps specification):
+/// - `resourceDomains` → `img-src`, `script-src`, `style-src`, `font-src`, `media-src`
+/// - `connectDomains`  → `connect-src` (fetch/XHR/WebSocket)
+///
+/// The daemon's blob HTTP server URL is needed in both: `resourceDomains` for
+/// loading plugin JS/CSS via `<script>`/`<link>` tags, and `connectDomains` for
+/// `fetch()` calls to resolve blob-stored output data (plotly JSON, geojson, etc.).
 ///
 /// Claude Desktop requires `localhost` (not `127.0.0.1`) for domain allowlists.
 fn resource_ui_meta(blob_base_url: &Option<String>) -> Option<Meta> {
@@ -28,7 +34,12 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> Option<Meta> {
         "ui".to_string(),
         serde_json::json!({
             "csp": {
-                "resourceDomains": [url]
+                "resourceDomains": [
+                    url,
+                    // CartoDB basemap tiles used by the Leaflet renderer plugin
+                    "https://*.basemaps.cartocdn.com",
+                ],
+                "connectDomains": [url]
             }
         }),
     );


### PR DESCRIPTION
## Summary

- Add `connectDomains` to the MCP App resource `_meta` so the host includes the daemon URL in `connect-src` — fixes `fetch()` for all blob-backed outputs (plotly, geojson, large text/stream) in the MCP App iframe on claude.ai
- Add `https://*.basemaps.cartocdn.com` to `resourceDomains` so Leaflet tile images load in the MCP App context

The MCP Apps spec (ext-apps) separates CSP domains into distinct fields:

| Field | CSP Directives |
|-------|---------------|
| `resourceDomains` | `img-src`, `script-src`, `style-src`, `font-src`, `media-src` |
| `connectDomains` | `connect-src` (fetch/XHR/WebSocket) |

We were only declaring `resourceDomains`, so plugin JS/CSS loaded fine via `<script>` tags but `fetch()` calls to the daemon's blob server were blocked by `connect-src: 'self'`.

Wire format is now:
```json
{
  "ui": {
    "csp": {
      "resourceDomains": ["http://localhost:{port}", "https://*.basemaps.cartocdn.com"],
      "connectDomains": ["http://localhost:{port}"]
    }
  }
}
```

Closes #1631

## Test plan

- [ ] Verify plotly outputs render in MCP App on claude.ai (no `connect-src` CSP errors)
- [ ] Verify Leaflet/geojson maps show tile basemaps (no `img-src` CSP errors)
- [ ] Verify blob-backed text outputs (large stdout, tracebacks) resolve correctly
- [ ] Verify existing rendering in Claude Desktop and nteract app is unaffected