### PR TITLE
fix(ci): add mcpb-runt sidecar to all CI workflow build steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,15 +286,17 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
+            cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
+            cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
           fi
 
       - name: Clippy (notebook crate)
@@ -313,8 +315,10 @@ jobs:
           path: |
             target/release/runtimed
             target/release/runt
+            target/release/mcpb-runt
             crates/notebook/binaries/runtimed-*
             crates/notebook/binaries/runt-*
+            crates/notebook/binaries/mcpb-runt-*
           retention-days: 1
 
       - name: Build Tauri E2E app
@@ -325,6 +329,7 @@ jobs:
           mkdir -p target/release/binaries
           cp crates/notebook/binaries/runtimed-* target/release/binaries/
           cp crates/notebook/binaries/runt-* target/release/binaries/
+          cp crates/notebook/binaries/mcpb-runt-* target/release/binaries/
 
       - name: Upload E2E app
         uses: actions/upload-artifact@v4
@@ -452,15 +457,17 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
+            cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
+            cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
           fi
 
       - name: Clippy

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -190,21 +190,23 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
 
           mkdir -p crates/notebook/binaries target/release/binaries
 
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
+          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
           cp target/release/runtimed "target/release/binaries/runtimed-$TARGET"
           cp target/release/runt "target/release/binaries/runt-$TARGET"
+          cp target/release/mcpb-runt "target/release/binaries/mcpb-runt-$TARGET"
 
       - name: Build external binaries (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           $target = (rustc --print host-tuple).Trim()
 
           New-Item -ItemType Directory -Force crates/notebook/binaries | Out-Null
@@ -212,8 +214,10 @@ jobs:
 
           Copy-Item target/release/runtimed.exe "crates/notebook/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "crates/notebook/binaries/runt-$target.exe"
+          Copy-Item target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$target.exe"
           Copy-Item target/release/runtimed.exe "target/release/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "target/release/binaries/runt-$target.exe"
+          Copy-Item target/release/mcpb-runt.exe "target/release/binaries/mcpb-runt-$target.exe"
 
       - name: Build notebook app (no bundle)
         working-directory: crates/notebook

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -327,11 +327,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
+          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -482,11 +483,12 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
           cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
+          cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -617,11 +619,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
+          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## Summary

PR #1629 added `mcpb-runt` as a Tauri sidecar binary (`externalBin` in `tauri.conf.json`) but didn't update the CI workflows that manually build and copy sidecar binaries. This caused the Tauri E2E build to fail with:

```
resource path `binaries/mcpb-runt-x86_64-unknown-linux-gnu` doesn't exist
```

This PR adds `-p mcpb-runt` to every `cargo build` invocation that builds sidecar binaries, plus matching `cp`/`Copy-Item` commands, across all three CI workflow files:

- **`build.yml`** — `build-linux` (build + artifact upload + E2E staging) and `build` matrix (macOS/Windows)
- **`pr-binary-generation.yml`** — Unix and Windows build steps
- **`release-common.yml`** — macOS ARM64, Windows x64, and Linux x64 notebook bundle jobs

Standalone `runt-cli` builds (for the CLI distribution) are intentionally unchanged — they don't produce Tauri bundles.

## Verification

- [ ] `build-linux` job passes the "Build Tauri E2E app" step that was previously failing
- [ ] `build` matrix job (macOS/Windows) passes clippy and build with `mcpb-runt` sidecar present
- [ ] Grep all workflows for `runt-cli` — every Tauri-related occurrence now includes `mcpb-runt`

_PR submitted by @rgbkrk's agent, Quill_