### PR TITLE
refactor(runtimed): migrate from log/env_logger to tracing

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -62,7 +62,7 @@ Use consistent prefixes for filtering:
 
 ### Log File Rotation
 
-Daemon logs rotate on startup — each daemon session gets a clean log file. Previous logs are preserved as `runtimed.log.prev`. This makes `runt daemon logs -f` show only the current session.
+Daemon logs rotate on startup — each daemon session gets a clean log file. Previous logs are preserved as `runtimed.log.1`. This makes `runt daemon logs -f` show only the current session.
 
 ### Enabling Debug Logs
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -8,7 +8,21 @@ paths:
 
 ## Rust Logging
 
-Use the `log` crate with `env_logger`. Import log macros at the top of your file:
+### runtimed daemon
+
+Use the `tracing` crate. Import log macros at the top of your file:
+
+```rust
+use tracing::{debug, info, warn, error};
+```
+
+The daemon uses `tracing-subscriber` with layered subscribers (stderr + file).
+Dependencies that use the `log` crate are automatically bridged into tracing
+via `tracing-log` (set up by `.init()`).
+
+### Tauri app (notebook crate)
+
+The notebook app still uses `log` with `tauri-plugin-log`:
 
 ```rust
 use log::{debug, info, warn, error};

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter 0.1.4",
+ "env_filter",
  "log",
 ]
 
@@ -1646,29 +1646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter 1.0.1",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,30 +3049,6 @@ dependencies = [
  "gobject-sys 0.18.0",
  "libc",
  "system-deps 6.2.2",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4900,15 +4853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6388,7 +6332,6 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
- "env_logger",
  "futures",
  "hex",
  "http-body-util",
@@ -6399,7 +6342,6 @@ dependencies = [
  "kernel-env",
  "kernel-launch",
  "libc",
- "log",
  "loro_fractional_index",
  "nbformat",
  "nix 0.31.2",
@@ -6431,6 +6373,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "ts-rs",
  "uuid",
  "windows-sys 0.52.0",

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -4,7 +4,19 @@ This guide covers logging conventions for contributors working on the nteract de
 
 ## Rust Logging
 
-We use the `log` crate with `env_logger`. Import log macros at the top of your file:
+### runtimed daemon
+
+The daemon uses `tracing` with `tracing-subscriber` (layered subscribers for stderr + file output). Import tracing macros at the top of your file:
+
+```rust
+use tracing::{debug, info, warn, error};
+```
+
+Dependencies that use the `log` crate (runtimelib, automerge, rattler, etc.) are automatically bridged into the tracing subscriber via `tracing-log`.
+
+### Tauri app (notebook crate)
+
+The notebook app uses `log` with `tauri-plugin-log`:
 
 ```rust
 use log::{debug, info, warn, error};

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -29,8 +29,8 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }
 loro_fractional_index = { workspace = true }
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dirs = "6"
 
 # Jupyter kernel management

--- a/crates/runtimed/examples/test_inline_deps.rs
+++ b/crates/runtimed/examples/test_inline_deps.rs
@@ -16,7 +16,12 @@ use runtimed::protocol::{NotebookRequest, NotebookResponse};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     let temp_dir = TempDir::new()?;
     println!("Test directory: {:?}", temp_dir.path());

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -23,8 +23,8 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use log::{error, info};
 use tokio::net::TcpListener;
+use tracing::{error, info};
 
 use crate::blob_store::BlobStore;
 use crate::embedded_plugins;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -10,10 +10,10 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
-use log::{debug, error, info, warn};
 use notify_debouncer_mini::DebounceEventResult;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{Mutex, Notify};
+use tracing::{debug, error, info, warn};
 
 #[cfg(unix)]
 use tokio::net::UnixListener;
@@ -500,7 +500,7 @@ impl Daemon {
 
         // Write the settings JSON Schema for editor autocomplete
         if let Err(e) = crate::settings_doc::write_settings_schema() {
-            log::warn!("[settings] Failed to write schema file: {}", e);
+            tracing::warn!("[settings] Failed to write schema file: {}", e);
         }
 
         let (settings_changed, _) = tokio::sync::broadcast::channel(16);
@@ -1193,7 +1193,7 @@ impl Daemon {
             } else {
                 // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
                 // big-endian length prefix. Read remaining 3 length bytes.
-                log::debug!("[runtimed] Legacy client detected (no magic preamble)");
+                tracing::debug!("[runtimed] Legacy client detected (no magic preamble)");
                 let mut len_rest = [0u8; 3];
                 tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
                     .await

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -22,9 +22,9 @@ use jupyter_protocol::{
     CompleteRequest, ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest,
     JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
 };
-use log::{debug, error, info, warn};
 use serde::Serialize;
 use tokio::sync::{broadcast, mpsc, oneshot, watch, RwLock};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::blob_store::BlobStore;
@@ -77,7 +77,7 @@ async fn store_widget_buffers(
         {
             Ok(h) => h,
             Err(e) => {
-                log::warn!("[kernel-manager] Failed to store widget buffer: {}", e);
+                tracing::warn!("[kernel-manager] Failed to store widget buffer: {}", e);
                 continue;
             }
         };
@@ -208,7 +208,7 @@ async fn blob_store_large_state_values(
                 _ => match serde_json::to_vec(value) {
                     Ok(b) => (b, "application/json"),
                     Err(e) => {
-                        log::warn!(
+                        tracing::warn!(
                             "[kernel-manager] Failed to serialize comm state key '{}': {}",
                             key,
                             e
@@ -231,7 +231,7 @@ async fn blob_store_large_state_values(
                     );
                 }
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "[kernel-manager] Failed to blob-store comm state key '{}' ({} bytes): {}",
                         key,
                         size,

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -15,12 +15,12 @@
 //! so no file locking is needed — Tokio's cooperative scheduling ensures the
 //! synchronous read-modify-write won't interleave between tasks.
 
-use log::error;
-#[cfg(unix)]
-use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::error;
+#[cfg(unix)]
+use tracing::{info, warn};
 
 use crate::daemon_base_dir;
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -6,11 +6,11 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use log::info;
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
 use runtimed::singleton::get_running_daemon_info;
+use tracing::info;
 
 #[derive(Parser, Debug)]
 #[command(name = "runtimed")]
@@ -157,6 +157,18 @@ fn early_log(msg: &str) {
     }
 }
 
+/// Formats timestamps using local time, matching our existing log format.
+/// Uses chrono::Local directly to handle DST transitions correctly
+/// (unlike `OffsetTime` which captures the offset once at startup).
+#[derive(Clone)]
+struct LocalTime;
+
+impl tracing_subscriber::fmt::time::FormatTime for LocalTime {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        write!(w, "{}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S"))
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Install panic hook to ensure panics are logged to the daemon log file.
@@ -230,35 +242,33 @@ async fn main() -> anyhow::Result<()> {
                 }
                 runt_workspace::BuildChannel::Stable => "warn".to_string(),
             });
-    let mut builder = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or(&effective_log_level),
-    );
 
-    // If we can open the log file, write to it; otherwise just use stderr
-    if let Ok(file) = log_file {
-        use std::io::Write;
-        use std::sync::{Arc, Mutex};
+    // Build tracing subscriber with stderr + optional file output.
+    // EnvFilter respects RUST_LOG env var, falling back to channel defaults.
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&effective_log_level));
 
-        let file = Arc::new(Mutex::new(file));
-        builder.format(move |_buf, record| {
-            let formatted = format!(
-                "{} [{}] {}: {}\n",
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                record.level(),
-                record.target(),
-                record.args()
-            );
-            // Write to stderr (terminal)
-            eprint!("{}", formatted);
-            // Write to file
-            if let Ok(mut f) = file.lock() {
-                let _ = f.write_all(formatted.as_bytes());
-                let _ = f.flush();
-            }
-            Ok(())
-        });
-    }
-    builder.init();
+    let timer = LocalTime;
+
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_timer(timer.clone());
+
+    // File layer writes to the log file without ANSI escape codes.
+    // If the file can't be opened, we fall back to stderr-only logging.
+    let file_layer = log_file.ok().map(|file| {
+        tracing_subscriber::fmt::layer()
+            .with_writer(std::sync::Mutex::new(file))
+            .with_ansi(false)
+            .with_timer(timer)
+    });
+
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stderr_layer)
+        .with(file_layer)
+        .init();
 
     // Log dev mode status
     if runtimed::is_dev_mode() {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -31,9 +31,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use automerge::sync;
-use log::{debug, error, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
+use tracing::{debug, error, info, warn};
 
 use notify_debouncer_mini::DebounceEventResult;
 
@@ -2745,7 +2745,7 @@ where
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        log::debug!(
+                        tracing::debug!(
                             "[notebook-sync] Peer {} lagged {} runtime state updates",
                             peer_id, n
                         );
@@ -2816,7 +2816,7 @@ where
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        log::debug!(
+                        tracing::debug!(
                             "[notebook-sync] Peer {} lagged {} pool state updates",
                             peer_id, n
                         );
@@ -2870,7 +2870,7 @@ where
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         // Missed some presence updates — send a full snapshot to catch up
-                        log::debug!(
+                        tracing::debug!(
                             "[notebook-sync] Peer {} lagged {} presence updates, sending snapshot",
                             peer_id, n
                         );

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -33,7 +33,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use log::{debug, info, warn};
 use notebook_doc::presence::PresenceState;
 use notebook_doc::runtime_state::{CommDocEntry, RuntimeStateDoc};
 use notebook_protocol::connection::{
@@ -42,6 +41,7 @@ use notebook_protocol::connection::{
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use tokio::sync::{broadcast, RwLock};
+use tracing::{debug, info, warn};
 
 use crate::blob_store::BlobStore;
 use crate::kernel_manager::{QueueCommand, RoomKernel};

--- a/crates/runtimed/src/runtime_agent_handle.rs
+++ b/crates/runtimed/src/runtime_agent_handle.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::Result;
-use log::{info, warn};
+use tracing::{info, warn};
 
 /// Handle to a running runtime agent subprocess.
 ///

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -8,7 +8,7 @@ use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 
 use chrono::Utc;
-use log::{info, warn};
+use tracing::{info, warn};
 
 // Re-export all client-side singleton items so `runtimed::singleton::*` still works.
 use runtimed_client::singleton as client_singleton;

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -7,9 +7,9 @@
 use std::sync::Arc;
 
 use automerge::sync;
-use log::{info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
+use tracing::{info, warn};
 
 use crate::connection;
 use crate::settings_doc::SettingsDoc;


### PR DESCRIPTION
## Summary

- Replaces `log` + `env_logger` in runtimed with `tracing` + `tracing-subscriber`
- Uses layered subscriber architecture: `EnvFilter` + stderr layer + file layer
- All 502 log macro call sites unchanged — `tracing` exports the same macro names
- Dependencies using `log` (runtimelib, automerge, rattler) bridged automatically via `tracing-log`

This lays the groundwork for adding platform-native logging as additional subscriber layers:
- **macOS**: `os_log` → `log show`, Console.app, sysdiagnose capture
- **Windows**: ETW → Event Viewer
- **Linux**: journald → `journalctl`

## Design

The subscriber stack is composable — each output target is an independent layer:

```rust
tracing_subscriber::registry()
    .with(env_filter)      // RUST_LOG or channel defaults
    .with(stderr_layer)    // terminal output
    .with(file_layer)      // runtimed.log (optional)
    // Future: .with(oslog_layer) on macOS
    .init();
```

Custom `LocalTime` formatter calls `chrono::Local::now()` per-event to handle DST transitions correctly (unlike `OffsetTime` which captures offset once at startup).

## Test plan

- [x] `cargo check -p runtimed` — compiles clean
- [x] `cargo check -p runtimed --examples` — example compiles
- [x] `cargo check --workspace` — no downstream breakage
- [x] `cargo xtask lint --fix` — passes
- [ ] Manual: `cargo xtask dev-daemon` + tail logs, verify format and filtering
- [ ] Manual: verify `RUST_LOG=debug` override still works