### PR TITLE
fix(runtimed): fix cross-lock ordering and expand tokio mutex lint to all sources

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -722,10 +722,15 @@ impl Daemon {
                     )
                     .await;
                 }
-                let mut ra_guard = room.runtime_agent_handle.lock().await;
-                *ra_guard = None;
-                let mut tx = room.runtime_agent_request_tx.lock().await;
-                *tx = None;
+                // Scope each lock independently to avoid cross-lock ordering.
+                {
+                    let mut ra_guard = room.runtime_agent_handle.lock().await;
+                    *ra_guard = None;
+                }
+                {
+                    let mut tx = room.runtime_agent_request_tx.lock().await;
+                    *tx = None;
+                }
             }
         }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2190,10 +2190,15 @@ impl Daemon {
                             )
                             .await;
                         }
-                        let mut ra_guard = room.runtime_agent_handle.lock().await;
-                        *ra_guard = None;
-                        let mut tx = room.runtime_agent_request_tx.lock().await;
-                        *tx = None;
+                        // Scope each lock independently to avoid cross-lock ordering.
+                        {
+                            let mut ra_guard = room.runtime_agent_handle.lock().await;
+                            *ra_guard = None;
+                        }
+                        {
+                            let mut tx = room.runtime_agent_request_tx.lock().await;
+                            *tx = None;
+                        }
                     }
                     info!("[runtimed] Evicted room for notebook: {}", notebook_id);
                     Response::NotebookShutdown { found: true }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2075,10 +2075,15 @@ where
                                 );
                             }
                         }
-                        let mut guard = room_for_eviction.runtime_agent_handle.lock().await;
-                        *guard = None;
-                        let mut tx = room_for_eviction.runtime_agent_request_tx.lock().await;
-                        *tx = None;
+                        // Scope each lock independently to avoid cross-lock ordering.
+                        {
+                            let mut guard = room_for_eviction.runtime_agent_handle.lock().await;
+                            *guard = None;
+                        }
+                        {
+                            let mut tx = room_for_eviction.runtime_agent_request_tx.lock().await;
+                            *tx = None;
+                        }
                     }
                 }
 
@@ -2314,8 +2319,10 @@ where
     // The sync handshake takes multiple roundtrips; by the time it completes,
     // transient states like starting phases may have already passed.
     {
-        let sd = room.state_doc.read().await;
-        let state = sd.read_state();
+        let state = {
+            let sd = room.state_doc.read().await;
+            sd.read_state()
+        };
         connection::send_typed_json_frame(
             writer,
             NotebookFrameType::Broadcast,
@@ -5077,6 +5084,10 @@ async fn handle_notebook_request(
                                 // Write kernel status + info + prewarmed packages
                                 // to RuntimeStateDoc
                                 {
+                                    // Read agent ID before taking the write lock to
+                                    // avoid holding state_doc across an .await.
+                                    let agent_id =
+                                        room.current_runtime_agent_id.read().await.clone();
                                     let mut sd = room.state_doc.write().await;
                                     let mut changed = false;
                                     changed |= sd.set_kernel_status("idle");
@@ -5088,9 +5099,7 @@ async fn handle_notebook_request(
                                     changed |= sd.set_prewarmed_packages(
                                         &launched_config.prewarmed_packages,
                                     );
-                                    if let Some(ref aid) =
-                                        *room.current_runtime_agent_id.read().await
-                                    {
+                                    if let Some(ref aid) = agent_id {
                                         changed |= sd.set_runtime_agent_id(aid);
                                     }
                                     if changed {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2341,25 +2341,33 @@ where
     // We filter out the receiver's own peer_id to prevent them from rendering
     // their own cursor as a remote peer (clients don't know their server-assigned ID).
     {
-        let presence_state = room.presence.read().await;
-        if presence_state.peer_count() > 0 {
-            // Build snapshot excluding this peer (they shouldn't see themselves)
-            let other_peers: Vec<presence::PeerSnapshot> = presence_state
-                .peers()
-                .values()
-                .filter(|p| p.peer_id != peer_id)
-                .map(|p| presence::PeerSnapshot {
-                    peer_id: p.peer_id.clone(),
-                    peer_label: p.peer_label.clone(),
-                    actor_label: p.actor_label.clone(),
-                    channels: p.channels.values().cloned().collect(),
-                })
-                .collect();
-            if !other_peers.is_empty() {
-                let snapshot_bytes = presence::encode_snapshot("daemon", &other_peers);
-                connection::send_typed_frame(writer, NotebookFrameType::Presence, &snapshot_bytes)
-                    .await?;
+        let snapshot_bytes = {
+            let presence_state = room.presence.read().await;
+            if presence_state.peer_count() > 0 {
+                // Build snapshot excluding this peer (they shouldn't see themselves)
+                let other_peers: Vec<presence::PeerSnapshot> = presence_state
+                    .peers()
+                    .values()
+                    .filter(|p| p.peer_id != peer_id)
+                    .map(|p| presence::PeerSnapshot {
+                        peer_id: p.peer_id.clone(),
+                        peer_label: p.peer_label.clone(),
+                        actor_label: p.actor_label.clone(),
+                        channels: p.channels.values().cloned().collect(),
+                    })
+                    .collect();
+                if !other_peers.is_empty() {
+                    Some(presence::encode_snapshot("daemon", &other_peers))
+                } else {
+                    None
+                }
+            } else {
+                None
             }
+        }; // presence read guard dropped
+        if let Some(snapshot_bytes) = snapshot_bytes {
+            connection::send_typed_frame(writer, NotebookFrameType::Presence, &snapshot_bytes)
+                .await?;
         }
     }
 
@@ -3937,9 +3945,12 @@ async fn auto_launch_kernel(
         {
             Ok(ra) => {
                 // Store handle and set provenance
+                // Scope each lock independently to avoid cross-lock ordering.
                 {
                     let mut ra_guard = room.runtime_agent_handle.lock().await;
                     *ra_guard = Some(ra);
+                }
+                {
                     let mut id = room.current_runtime_agent_id.write().await;
                     *id = Some(runtime_agent_id.clone());
                 }

--- a/crates/runtimed/tests/tokio_mutex_lint.rs
+++ b/crates/runtimed/tests/tokio_mutex_lint.rs
@@ -1,29 +1,62 @@
 //! CI lint: ensure no tokio::sync::Mutex guards are held across .await points.
 //!
-//! Uses the async-rust-lsp rule engine (tree-sitter based) to scan daemon.rs
-//! for the pattern that caused the convoy deadlock fixed in PR #1614.
+//! Uses the async-rust-lsp rule engine (tree-sitter based) to scan all runtimed
+//! source files for the pattern that caused the convoy deadlock fixed in PR #1614.
 
 #[test]
-fn daemon_has_no_tokio_mutex_across_await() {
-    let daemon_source =
-        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/daemon.rs"))
-            .unwrap_or_else(|e| panic!("failed to read daemon.rs: {e}"));
+fn runtimed_has_no_tokio_mutex_across_await() {
+    let src_dir = std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
 
-    let diagnostics =
-        async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&daemon_source);
+    let rs_files: Vec<std::path::PathBuf> = std::fs::read_dir(&src_dir)
+        .unwrap_or_else(|e| panic!("failed to read src dir: {e}"))
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
 
-    if !diagnostics.is_empty() {
-        let mut msg =
-            String::from("Found tokio Mutex guard(s) held across .await in daemon.rs:\n\n");
-        for d in &diagnostics {
-            msg.push_str(&format!(
-                "  line {}: {}\n",
+    assert!(
+        !rs_files.is_empty(),
+        "no .rs files found in {}",
+        src_dir.display()
+    );
+
+    let mut all_violations = Vec::new();
+
+    for path in &rs_files {
+        let source = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        let diagnostics =
+            async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&source);
+
+        let file_name = path.file_name().map_or_else(
+            || panic!("no file name for {}", path.display()),
+            |n| n.to_string_lossy().to_string(),
+        );
+        for d in diagnostics {
+            all_violations.push(format!(
+                "  {}:{}: {}",
+                file_name,
                 d.range.start.line + 1,
                 d.message
             ));
         }
+    }
+
+    if !all_violations.is_empty() {
+        let mut msg =
+            String::from("Found tokio Mutex guard(s) held across .await in runtimed sources:\n\n");
+        for v in &all_violations {
+            msg.push_str(v);
+            msg.push('\n');
+        }
         msg.push_str(
-            "\nFix: clone the Arc in a scoped block, drop the lock, then await.\n\
+            "\nFix: scope each lock in its own block so the guard drops before the next .await.\n\
              See: https://github.com/nteract/desktop/pull/1614\n",
         );
         panic!("{msg}");


### PR DESCRIPTION
## Summary

- Fix 4 lock-across-`.await` violations caught by expanding the tokio mutex lint
- Expand `tokio_mutex_lint` test from scanning only `daemon.rs` to all 19 `.rs` files in `crates/runtimed/src/`

### Violations fixed

| File | Line | Issue |
|------|------|-------|
| `notebook_sync_server.rs` | 2078 | `runtime_agent_handle` guard held across `runtime_agent_request_tx.lock().await` (eviction teardown) |
| `daemon.rs` | 2193 | Same cross-lock pattern in `ShutdownNotebook` handler |
| `notebook_sync_server.rs` | 2326 | `state_doc` read guard held across `send_typed_json_frame().await` (client handshake) |
| `notebook_sync_server.rs` | 5099 | `state_doc` write guard held across `current_runtime_agent_id.read().await` (kernel launch) |

### How

- Cross-lock: scope each lock in its own block so the guard drops before the next `.await`
- `state_doc` read guard: extract the state, drop the guard, then send
- `state_doc` write guard: read the agent ID first, then take the write lock

## Test plan

- [x] `cargo xtask lint` passes
- [x] `cargo test -p runtimed --test tokio_mutex_lint` passes (now covers all source files)
- [ ] CI green