### PR TITLE
fix(notebook): prevent stale asset resolution in materialization pipeline

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -322,6 +322,7 @@ export function useAutomergeNotebook() {
           resetNotebookCells();
           resetRuntimeState();
           resetPoolState();
+          outputCacheRef.current.clear();
           setIsLoading(true);
           return from(
             bootstrap().catch((err: unknown) => {

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -573,6 +573,23 @@ describe("materializeChangeset", () => {
     expect(deps.materializeCells).toHaveBeenCalledWith(handle);
   });
 
+  it("falls back to full materialization for resolved_assets changes", async () => {
+    const handle = createMockHandle({});
+    const deps = createDeps(handle);
+
+    await materializeChangeset(
+      {
+        changed: [{ cell_id: "c1", fields: { resolved_assets: true } }],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(deps.materializeCells).toHaveBeenCalledWith(handle);
+  });
+
   it("resolves uncached manifest objects via async resolution", async () => {
     const execResult: JupyterOutput = {
       output_type: "execute_result",

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -77,15 +77,21 @@ export async function materializeChangeset(
     return;
   }
 
-  // Structural changes (cells added/removed/reordered) require full
-  // materialization — the cell ID list and ordering need updating.
+  // Structural changes (cells added/removed/reordered) or resolved_assets
+  // changes require full materialization. resolved_assets are only available
+  // from get_cells_json() (full serialization), not per-cell WASM accessors,
+  // so the incremental path would serve stale values from the previous cell.
+  const hasResolvedAssetChanges = changeset.changed.some(
+    (c) => c.fields.resolved_assets,
+  );
   if (
     changeset.added.length > 0 ||
     changeset.removed.length > 0 ||
-    changeset.order_changed
+    changeset.order_changed ||
+    hasResolvedAssetChanges
   ) {
     logger.debug(
-      `[frame-pipeline] full materialization: +${changeset.added.length} -${changeset.removed.length} reorder=${changeset.order_changed}`,
+      `[frame-pipeline] full materialization: +${changeset.added.length} -${changeset.removed.length} reorder=${changeset.order_changed} assets=${hasResolvedAssetChanges}`,
     );
     await deps.materializeCells(handle);
     notifyMetadataChanged();


### PR DESCRIPTION
## Summary

- **Clear output cache on daemon reconnect** — `outputCacheRef` in `useAutomergeNotebook` now gets cleared in the `daemon:ready` handler. Previously, cached `JupyterOutput` objects with blob URLs pointing at the old blob server port survived daemon restarts, producing broken images when the safety-net resolution path was hit.
- **Fall back to full materialization on `resolved_assets` changes** — The incremental materializer in `frame-pipeline.ts` now triggers full materialization when any changed cell has `fields.resolved_assets = true`. Previously, `materializeCellFromWasm` preserved stale `resolvedAssets` from the previous cell since per-cell WASM accessors don't provide them.

## Test plan

- [x] `frame-pipeline.test.ts` — 20 tests pass
- [x] `blob-port.test.ts` — 8 tests pass
- [x] `cargo xtask lint --fix` — clean
- [ ] Manual: restart daemon mid-session, verify images re-resolve at new blob port
- [ ] Manual: edit markdown cell asset references, verify new assets render without full page reload