### PR TITLE
fix(runtimed): fall back to room.working_dir in LaunchKernel handler

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4398,6 +4398,21 @@ async fn handle_notebook_request(
                 room.presence_tx.clone(),
             );
             let notebook_path = notebook_path.map(std::path::PathBuf::from);
+            // Fall back to room.working_dir for untitled notebooks (mirrors auto-launch path).
+            // Enables project file detection (environment.yaml, pyproject.toml, pixi.toml)
+            // when MCP callers send notebook_path: None for UUID-based notebooks.
+            let notebook_path = match notebook_path {
+                some @ Some(_) => some,
+                None => {
+                    let wd = room.working_dir.read().await;
+                    wd.clone().inspect(|p| {
+                        info!(
+                            "[notebook-sync] LaunchKernel: using room working_dir for project file detection: {}",
+                            p.display()
+                        );
+                    })
+                }
+            };
 
             // Resolve metadata snapshot from Automerge doc (preferred) or disk
             let metadata_snapshot = resolve_metadata_snapshot(room, notebook_path.as_deref()).await;

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1013,7 +1013,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // Connect pipe client (relay mode — no local doc, no initial sync)
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe00sync01".to_string(),
+        "00000000-0000-0000-0000-000000000001".to_string(),
         frame_tx,
     )
     .await
@@ -1022,7 +1022,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // Second client (full peer) adds a cell and updates source
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe00sync01".to_string(),
+        "00000000-0000-0000-0000-000000000001".to_string(),
         "test",
     )
     .await
@@ -1080,7 +1080,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
 
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe0bcast01".to_string(),
+        "00000000-0000-0000-0000-000000000002".to_string(),
         frame_tx,
     )
     .await
@@ -1092,7 +1092,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     // verifies the type-byte filter, not broadcast-specific forwarding.
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe0bcast01".to_string(),
+        "00000000-0000-0000-0000-000000000002".to_string(),
         "test",
     )
     .await
@@ -1158,7 +1158,7 @@ async fn test_pipe_mode_does_not_forward_response_frames() {
 
     let result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe00resp01".to_string(),
+        "00000000-0000-0000-0000-000000000004".to_string(),
         frame_tx,
     )
     .await
@@ -1230,7 +1230,7 @@ async fn test_pipe_mode_preserves_frame_order() {
 
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         frame_tx,
     )
     .await
@@ -1239,7 +1239,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     // Second client rapidly adds multiple cells
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         "test",
     )
     .await
@@ -1310,7 +1310,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     // received (in channel order) represents the correct state transitions.
     let client3 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         "test",
     )
     .await

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2447,6 +2447,37 @@ class TestCreateNotebook:
 
         assert await session.is_connected()
 
+    async def test_create_notebook_conda_with_environment_yml(self, client, tmp_path):
+        """create_notebook() with working_dir containing environment.yml detects conda.
+
+        When working_dir points to a directory with an environment.yml file,
+        the daemon should detect it via project file search and use conda:env_yml
+        as the env_source (not conda:prewarmed or uv:prewarmed).
+
+        Regression test for nteract/desktop#1643.
+        """
+        # Create environment.yml in tmp_path
+        (tmp_path / "environment.yml").write_text(
+            "name: test-conda\nchannels:\n  - conda-forge\ndependencies:\n  - python\n"
+        )
+
+        session = await client.create_notebook(runtime="python", working_dir=str(tmp_path))
+        assert await session.is_connected()
+
+        # Shutdown auto-launched kernel and restart with auto:conda to trigger
+        # project file detection. The daemon should find environment.yml via
+        # room.working_dir and resolve to conda:env_yml.
+        await async_shutdown_and_start_kernel(
+            session,
+            kernel_type="python",
+            env_source="auto:conda",
+            expected_env_source="conda:env_yml",
+            retries=8,
+            delay=2.0,
+        )
+
+        assert await session.env_source() == "conda:env_yml"
+
 
 class TestTrustApproval:
     """Test trust approval flow for notebooks with inline dependencies."""


### PR DESCRIPTION
## Summary

Fixes #1643 — conda `environment.yaml` not discovered when creating notebook with `package_manager="conda"`.

- When MCP callers send `LaunchKernel` with `notebook_path: None` (all UUID-based notebooks from `create_notebook`, `restart_kernel`, `add_dependency`), the daemon's Priority 3 project file detection was skipped entirely
- The auto-launch path already had a `room.working_dir` fallback for untitled notebooks — this makes the explicit `LaunchKernel` handler consistent
- Adds integration test for `create_notebook` with conda + `environment.yml`

## Verified

Reproduced and verified via nteract-dev MCP tools:
- `create_notebook(package_manager="conda", working_dir=<dir with environment.yml>)`
- `restart_kernel()` → daemon logs confirm `LaunchKernel: using room working_dir` → `Auto-detected project file: environment.yml -> conda:env_yml`

## Test plan

- [x] `cargo build -p runtimed` compiles
- [x] `cargo test -p runtimed` passes
- [x] `cargo xtask lint --fix` clean
- [x] MCP reproduction confirms fix
- [ ] `cargo xtask integration test_create_notebook_conda` (new test)
- [ ] `cargo xtask integration test_environment_yml` (existing, no regression)