### PR TITLE
feat(frontend): show pixi.toml dependency names in header

### DIFF
--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -137,22 +137,52 @@ export function PixiDependencyHeader({
               </span>
             </div>
 
-            {(pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (
-              <div className="mt-1.5 flex gap-2 text-muted-foreground">
-                {pixiInfo.has_dependencies && (
-                  <span className="rounded bg-muted px-1.5 py-0.5">
-                    {pixiInfo.dependency_count} conda dep
-                    {pixiInfo.dependency_count !== 1 ? "s" : ""}
+            {/* Show dep names from CRDT (bootstrapped from pixi.toml) */}
+            {pixiDeps && pixiDeps.dependencies.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {pixiDeps.dependencies.map((dep) => (
+                  <span
+                    key={dep}
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+                  >
+                    {dep}
                   </span>
-                )}
-                {pixiInfo.has_pypi_dependencies && (
-                  <span className="rounded bg-muted px-1.5 py-0.5">
-                    {pixiInfo.pypi_dependency_count} pypi dep
-                    {pixiInfo.pypi_dependency_count !== 1 ? "s" : ""}
-                  </span>
-                )}
+                ))}
               </div>
             )}
+            {(pixiDeps?.pypiDependencies?.length ?? 0) > 0 && (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  <span className="text-muted-foreground text-[10px] uppercase tracking-wide self-center">
+                    PyPI
+                  </span>
+                  {pixiDeps.pypiDependencies.map((dep) => (
+                    <span
+                      key={dep}
+                      className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+                    >
+                      {dep}
+                    </span>
+                  ))}
+                </div>
+              )}
+            {/* Fallback: show counts if CRDT deps not yet bootstrapped */}
+            {(!pixiDeps || pixiDeps.dependencies.length === 0) &&
+              (pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (
+                <div className="mt-1.5 flex gap-2 text-muted-foreground">
+                  {pixiInfo.has_dependencies && (
+                    <span className="rounded bg-muted px-1.5 py-0.5">
+                      {pixiInfo.dependency_count} conda dep
+                      {pixiInfo.dependency_count !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {pixiInfo.has_pypi_dependencies && (
+                    <span className="rounded bg-muted px-1.5 py-0.5">
+                      {pixiInfo.pypi_dependency_count} pypi dep
+                      {pixiInfo.pypi_dependency_count !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                </div>
+              )}
 
             {pixiInfo.channels.length > 0 && (
               <div className="mt-1.5 flex items-center gap-1.5 text-muted-foreground">

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -138,7 +138,7 @@ export function PixiDependencyHeader({
             </div>
 
             {/* Show dep names from CRDT (bootstrapped from pixi.toml) */}
-            {pixiDeps && pixiDeps.dependencies.length > 0 && (
+            {pixiDeps?.dependencies?.length ? (
               <div className="mt-1.5 flex flex-wrap gap-1.5">
                 {pixiDeps.dependencies.map((dep) => (
                   <span
@@ -149,22 +149,22 @@ export function PixiDependencyHeader({
                   </span>
                 ))}
               </div>
-            )}
-            {(pixiDeps?.pypiDependencies?.length ?? 0) > 0 && (
-                <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  <span className="text-muted-foreground text-[10px] uppercase tracking-wide self-center">
-                    PyPI
+            ) : null}
+            {pixiDeps?.pypiDependencies?.length ? (
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                <span className="text-muted-foreground text-[10px] uppercase tracking-wide self-center">
+                  PyPI
+                </span>
+                {pixiDeps.pypiDependencies.map((dep) => (
+                  <span
+                    key={dep}
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+                  >
+                    {dep}
                   </span>
-                  {pixiDeps.pypiDependencies.map((dep) => (
-                    <span
-                      key={dep}
-                      className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
-                    >
-                      {dep}
-                    </span>
-                  ))}
-                </div>
-              )}
+                ))}
+              </div>
+            ) : null}
             {/* Fallback: show counts if CRDT deps not yet bootstrapped */}
             {(!pixiDeps || pixiDeps.dependencies.length === 0) &&
               (pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (


### PR DESCRIPTION
## Summary

- Replace the generic "N conda deps" count badge with individual package name badges in the pixi:toml dependency header
- Dep names come from the CRDT metadata (bootstrapped from pixi.toml by the daemon in #1650)
- PyPI deps shown in a separate row with a "PyPI" label
- Falls back to count display if CRDT deps aren't bootstrapped yet

## Test plan

- [ ] Open a notebook in a pixi.toml directory — verify dep names (not just counts) appear in the header
- [ ] Open a notebook without pixi.toml — verify no regression in inline/prewarmed mode

Closes #1651