### PR TITLE
fix(runtimed): mark in-flight executions as failed on kernel restart/death

### DIFF
--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -420,6 +420,15 @@ async fn handle_runtime_agent_request(
                 kernel_type, env_source
             );
 
+            // Capture in-flight executions before shutdown so we can mark them
+            // as failed in RuntimeStateDoc (the old kernel can't finish them).
+            let interrupted_eid = state.executing_cell().map(|(_, eid)| eid.clone());
+            let stale_queue: Vec<_> = state
+                .queued_entries()
+                .iter()
+                .map(|e| e.execution_id.clone())
+                .collect();
+
             // Shut down existing kernel
             if let Some(ref mut k) = kernel {
                 k.shutdown().await.ok();
@@ -461,6 +470,21 @@ async fn handle_runtime_agent_request(
                 env_vars: vec![],
                 pooled_env,
             };
+
+            // Mark stale executions as failed in RuntimeStateDoc.
+            // The old kernel is gone after shutdown, so these executions
+            // can never complete — do this before launching the new kernel.
+            {
+                let mut sd = ctx.state_doc.write().await;
+                if let Some(ref eid) = interrupted_eid {
+                    sd.set_execution_done(eid, false);
+                }
+                for eid in &stale_queue {
+                    sd.set_execution_done(eid, false);
+                }
+                sd.set_queue(None, &[]);
+                let _ = ctx.state_changed_tx.send(());
+            }
 
             match JupyterKernel::launch(config, shared).await {
                 Ok((k, rx)) => {
@@ -708,8 +732,14 @@ async fn handle_queue_command(
 
         QueueCommand::KernelDied => {
             warn!("[runtime-agent] Kernel died");
-            state.kernel_died();
+            let (interrupted, cleared) = state.kernel_died();
             let mut sd = ctx.state_doc.write().await;
+            if let Some((_, ref eid)) = interrupted {
+                sd.set_execution_done(eid, false);
+            }
+            for entry in &cleared {
+                sd.set_execution_done(&entry.execution_id, false);
+            }
             sd.set_kernel_status("error");
             sd.set_queue(None, &[]);
             let _ = ctx.state_changed_tx.send(());


### PR DESCRIPTION
## Summary

When a kernel is restarted or dies mid-execution, the `RestartKernel` and `KernelDied` handlers cleared in-memory `KernelState` but never updated `RuntimeStateDoc`. This left execution entries stuck in `"running"` status permanently — the cell appeared to be eternally executing in the UI.

- Capture in-flight and queued execution IDs before clearing state, then call `set_execution_done(eid, false)` + `set_queue(None, &[])` on RuntimeStateDoc
- Follows the same pattern already used by `InterruptExecution` and `CellError` handlers in the same file

Closes #1652

## Verification

- [ ] Execute a long-running cell (e.g. `import time; time.sleep(30)`), restart the kernel mid-execution, confirm the cell transitions to error status (not stuck as running)
- [ ] Execute a long-running cell, kill the kernel process externally, confirm the cell transitions to error status
- [ ] Execute multiple cells in sequence, restart mid-execution, confirm both the running cell and queued cells show error status

_PR submitted by @rgbkrk's agent, Quill_