### PR TITLE
test(runtimed): add coverage for kernel restart/death execution cleanup

### DIFF
--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -403,3 +403,202 @@ impl KernelState {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
+    use crate::kernel_manager::QueueCommand;
+    use crate::protocol::CompletionItem;
+    use anyhow::Result;
+    use notebook_protocol::protocol::LaunchedEnvConfig;
+    use std::path::PathBuf;
+
+    /// Minimal mock that records execute calls and succeeds.
+    struct MockKernel {
+        executes: Vec<(String, String)>,
+    }
+
+    impl MockKernel {
+        fn new() -> Self {
+            Self {
+                executes: Vec::new(),
+            }
+        }
+    }
+
+    impl KernelConnection for MockKernel {
+        async fn launch(
+            _config: KernelLaunchConfig,
+            _shared: KernelSharedRefs,
+        ) -> Result<(Self, tokio::sync::mpsc::Receiver<QueueCommand>)> {
+            unimplemented!("tests create MockKernel directly")
+        }
+
+        async fn execute(
+            &mut self,
+            cell_id: &str,
+            execution_id: &str,
+            _source: &str,
+        ) -> Result<()> {
+            self.executes
+                .push((cell_id.to_string(), execution_id.to_string()));
+            Ok(())
+        }
+
+        async fn interrupt(&mut self) -> Result<()> {
+            Ok(())
+        }
+        async fn shutdown(&mut self) -> Result<()> {
+            Ok(())
+        }
+        async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
+            Ok(())
+        }
+        async fn send_comm_update(&mut self, _: &str, _: serde_json::Value) -> Result<()> {
+            Ok(())
+        }
+        async fn complete(
+            &mut self,
+            _: &str,
+            _: usize,
+        ) -> Result<(Vec<CompletionItem>, usize, usize)> {
+            Ok((vec![], 0, 0))
+        }
+        async fn get_history(
+            &mut self,
+            _: Option<&str>,
+            _: i32,
+            _: bool,
+        ) -> Result<Vec<crate::protocol::HistoryEntry>> {
+            Ok(vec![])
+        }
+        fn kernel_type(&self) -> &str {
+            "python"
+        }
+        fn env_source(&self) -> &str {
+            "test"
+        }
+        fn launched_config(&self) -> &LaunchedEnvConfig {
+            // Leak a static default — fine for tests.
+            Box::leak(Box::new(LaunchedEnvConfig::default()))
+        }
+        fn env_path(&self) -> Option<&PathBuf> {
+            None
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        fn update_launched_uv_deps(&mut self, _: Vec<String>) {}
+    }
+
+    /// Build a `KernelState` wired to the given `RuntimeStateDoc`.
+    fn test_state(
+        state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    ) -> (KernelState, broadcast::Receiver<NotebookBroadcast>) {
+        let (state_changed_tx, _) = broadcast::channel(64);
+        let (broadcast_tx, broadcast_rx) = broadcast::channel(64);
+        let state = KernelState::new(state_doc, state_changed_tx, broadcast_tx);
+        (state, broadcast_rx)
+    }
+
+    // ── kernel_died tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn kernel_died_returns_interrupted_execution_and_cleared_queue() {
+        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        let (mut state, _rx) = test_state(sd.clone());
+        let mut mock = MockKernel::new();
+        state.set_idle();
+
+        // Queue two cells — first starts executing, second stays queued
+        state
+            .queue_cell("c1".into(), "e1".into(), "x=1".into(), &mut mock)
+            .await
+            .unwrap();
+        state
+            .queue_cell("c2".into(), "e2".into(), "x=2".into(), &mut mock)
+            .await
+            .unwrap();
+
+        assert!(state.executing_cell().is_some());
+        assert_eq!(state.queued_entries().len(), 1);
+
+        let (interrupted, cleared) = state.kernel_died();
+
+        // Should return the executing cell
+        let (cid, eid) = interrupted.unwrap();
+        assert_eq!(cid, "c1");
+        assert_eq!(eid, "e1");
+
+        // Should return the cleared queued entry
+        assert_eq!(cleared.len(), 1);
+        assert_eq!(cleared[0].cell_id, "c2");
+        assert_eq!(cleared[0].execution_id, "e2");
+
+        // State should be cleared
+        assert!(state.executing_cell().is_none());
+        assert!(state.queued_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn kernel_died_idempotent_when_already_dead() {
+        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        let (mut state, _rx) = test_state(sd.clone());
+        let mut mock = MockKernel::new();
+        state.set_idle();
+
+        state
+            .queue_cell("c1".into(), "e1".into(), "x=1".into(), &mut mock)
+            .await
+            .unwrap();
+
+        // First call returns data
+        let (interrupted, _) = state.kernel_died();
+        assert!(interrupted.is_some());
+
+        // Second call is a no-op
+        let (interrupted2, cleared2) = state.kernel_died();
+        assert!(interrupted2.is_none());
+        assert!(cleared2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn kernel_died_with_empty_queue() {
+        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        let (mut state, _rx) = test_state(sd.clone());
+        state.set_idle();
+
+        let (interrupted, cleared) = state.kernel_died();
+        assert!(interrupted.is_none());
+        assert!(cleared.is_empty());
+    }
+
+    // ── reset tests ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn reset_clears_executing_and_queue() {
+        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        let (mut state, _rx) = test_state(sd.clone());
+        let mut mock = MockKernel::new();
+        state.set_idle();
+
+        state
+            .queue_cell("c1".into(), "e1".into(), "x=1".into(), &mut mock)
+            .await
+            .unwrap();
+        state
+            .queue_cell("c2".into(), "e2".into(), "x=2".into(), &mut mock)
+            .await
+            .unwrap();
+
+        assert!(state.executing_cell().is_some());
+        assert_eq!(state.queued_entries().len(), 1);
+
+        state.reset();
+
+        assert!(state.executing_cell().is_none());
+        assert!(state.queued_entries().is_empty());
+    }
+}

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -793,3 +793,173 @@ fn diff_comm_state(
     }
     updates
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
+    use crate::protocol::CompletionItem;
+    use anyhow::Result;
+    use notebook_protocol::protocol::LaunchedEnvConfig;
+    use std::path::PathBuf;
+
+    /// Minimal mock kernel for testing queue/state logic without ZeroMQ.
+    struct MockKernel;
+
+    impl KernelConnection for MockKernel {
+        async fn launch(
+            _config: KernelLaunchConfig,
+            _shared: KernelSharedRefs,
+        ) -> Result<(Self, mpsc::Receiver<QueueCommand>)> {
+            unimplemented!()
+        }
+        async fn execute(&mut self, _: &str, _: &str, _: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn interrupt(&mut self) -> Result<()> {
+            Ok(())
+        }
+        async fn shutdown(&mut self) -> Result<()> {
+            Ok(())
+        }
+        async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
+            Ok(())
+        }
+        async fn send_comm_update(&mut self, _: &str, _: serde_json::Value) -> Result<()> {
+            Ok(())
+        }
+        async fn complete(
+            &mut self,
+            _: &str,
+            _: usize,
+        ) -> Result<(Vec<CompletionItem>, usize, usize)> {
+            Ok((vec![], 0, 0))
+        }
+        async fn get_history(
+            &mut self,
+            _: Option<&str>,
+            _: i32,
+            _: bool,
+        ) -> Result<Vec<crate::protocol::HistoryEntry>> {
+            Ok(vec![])
+        }
+        fn kernel_type(&self) -> &str {
+            "python"
+        }
+        fn env_source(&self) -> &str {
+            "test"
+        }
+        fn launched_config(&self) -> &LaunchedEnvConfig {
+            Box::leak(Box::new(LaunchedEnvConfig::default()))
+        }
+        fn env_path(&self) -> Option<&PathBuf> {
+            None
+        }
+        fn is_connected(&self) -> bool {
+            true
+        }
+        fn update_launched_uv_deps(&mut self, _: Vec<String>) {}
+    }
+
+    /// Build test fixtures: RuntimeAgentContext + KernelState wired to the same doc.
+    fn test_fixtures() -> (
+        RuntimeAgentContext,
+        KernelState,
+        Arc<RwLock<RuntimeStateDoc>>,
+    ) {
+        let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        let (state_changed_tx, _) = broadcast::channel(64);
+        let (broadcast_tx, _) = broadcast::channel(64);
+        let (presence_tx, _) = broadcast::channel(16);
+        let blob_store = Arc::new(BlobStore::new(std::env::temp_dir().join("test-blobs")));
+        let presence = Arc::new(RwLock::new(PresenceState::new()));
+
+        let ctx = RuntimeAgentContext {
+            state_doc: state_doc.clone(),
+            state_changed_tx: state_changed_tx.clone(),
+            blob_store,
+            broadcast_tx: broadcast_tx.clone(),
+            presence,
+            presence_tx,
+        };
+        let state = KernelState::new(state_doc.clone(), state_changed_tx, broadcast_tx);
+        (ctx, state, state_doc)
+    }
+
+    #[tokio::test]
+    async fn kernel_died_marks_inflight_executions_as_failed_in_state_doc() {
+        let (ctx, mut state, state_doc) = test_fixtures();
+        let mut mock = MockKernel;
+        state.set_idle();
+
+        // Queue two cells: c1 starts executing, c2 stays queued
+        state
+            .queue_cell("c1".into(), "e1".into(), "x=1".into(), &mut mock)
+            .await
+            .unwrap();
+        state
+            .queue_cell("c2".into(), "e2".into(), "x=2".into(), &mut mock)
+            .await
+            .unwrap();
+
+        // Verify initial state in doc
+        {
+            let sd = state_doc.read().await;
+            let e1 = sd.get_execution("e1").unwrap();
+            assert_eq!(e1.status, "running");
+            let e2 = sd.get_execution("e2").unwrap();
+            assert_eq!(e2.status, "queued");
+        }
+
+        // Simulate kernel death
+        handle_queue_command(
+            QueueCommand::KernelDied,
+            &ctx,
+            &mut None::<JupyterKernel>,
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+        // Both executions should now be marked as error in RuntimeStateDoc
+        let sd = state_doc.read().await;
+        let e1 = sd.get_execution("e1").unwrap();
+        assert_eq!(e1.status, "error");
+        assert_eq!(e1.success, Some(false));
+
+        let e2 = sd.get_execution("e2").unwrap();
+        assert_eq!(e2.status, "error");
+        assert_eq!(e2.success, Some(false));
+
+        // Queue should be cleared
+        let queue = sd.read_state();
+        assert!(queue.queue.executing.is_none());
+        assert!(queue.queue.queued.is_empty());
+
+        // Kernel status should be error
+        assert_eq!(queue.kernel.status, "error");
+    }
+
+    #[tokio::test]
+    async fn kernel_died_with_no_inflight_executions_clears_state() {
+        let (ctx, mut state, state_doc) = test_fixtures();
+        state.set_idle();
+
+        // No cells queued — just fire KernelDied
+        handle_queue_command(
+            QueueCommand::KernelDied,
+            &ctx,
+            &mut None::<JupyterKernel>,
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+        let sd = state_doc.read().await;
+        let rs = sd.read_state();
+        assert_eq!(rs.kernel.status, "error");
+        assert!(rs.queue.executing.is_none());
+        assert!(rs.queue.queued.is_empty());
+    }
+}

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -595,7 +595,24 @@ async fn test_notebook_cell_delete_propagation() {
         .unwrap()
         .handle;
 
-    assert_eq!(client2.get_cells().len(), 3);
+    // Wait for sync convergence before asserting
+    let mut watcher = client2.subscribe();
+    let mut cells = client2.get_cells();
+    for _ in 0..10 {
+        if cells.len() == 3 {
+            break;
+        }
+        match tokio::time::timeout(Duration::from_millis(200), watcher.changed()).await {
+            Ok(Ok(())) => cells = client2.get_cells(),
+            _ => break,
+        }
+    }
+
+    assert_eq!(
+        cells.len(),
+        3,
+        "client2 should see 3 cells after sync convergence"
+    );
 
     // Client1 deletes the middle cell
     client1.delete_cell("to-delete").unwrap();


### PR DESCRIPTION
## Summary

Adds automated test coverage for the kernel restart and kernel death execution cleanup paths fixed in #1655. The Codex review noted that these code paths lacked targeted tests — the manual verification scenarios were the only coverage.

- Introduces `MockKernel` implementing `KernelConnection` for testing queue/state logic without ZeroMQ (as envisioned by the trait's doc comment)
- Adds `KernelState` unit tests: `kernel_died()` return values, idempotency, and empty queue edge case; `reset()` state clearing
- Adds `handle_queue_command(KernelDied)` integration tests verifying RuntimeStateDoc marks in-flight and queued executions as `error` with `success: false`

## Verification

- [ ] CI passes all new tests (`cargo test -p runtimed -- kernel_state::tests runtime_agent::tests`)
- [ ] No regressions in existing `runtimed` integration tests

_PR submitted by @rgbkrk's agent, Quill_