### PR TITLE
fix(frontend): show daemon error message in pool error banner

### DIFF
--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -8,19 +8,6 @@ interface PoolErrorItemProps {
   onDismiss: () => void;
 }
 
-function errorTitle(error: PoolErrorWithTimestamp): string {
-  switch (error.error_kind) {
-    case "timeout":
-      return "Environment setup timed out";
-    case "import_error":
-      return "Package import failed";
-    case "setup_failed":
-      return "Environment setup failed";
-    default:
-      return "Invalid or unavailable package";
-  }
-}
-
 function errorSubtitle(
   error: PoolErrorWithTimestamp,
   envType: "UV" | "Conda",
@@ -55,17 +42,14 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
   const isTimeout = error.error_kind === "timeout";
 
   return (
-    <div
-      className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white"
-      title={error.message}
-    >
+    <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white">
       <div className="flex items-center gap-2 min-w-0">
         {isTimeout ? (
           <Clock className="h-3 w-3 flex-shrink-0" />
         ) : (
           <AlertTriangle className="h-3 w-3 flex-shrink-0" />
         )}
-        <span className="font-medium flex-shrink-0">{errorTitle(error)}</span>
+        <span className="font-medium flex-shrink-0">{error.message}</span>
         {error.failed_package && (
           <>
             <span className="text-amber-200 flex-shrink-0">—</span>


### PR DESCRIPTION
## Summary

The pool error banner was hiding the daemon's actual error message (e.g. "Conda warmup timed out") in a `title` tooltip attribute, while showing a generic category label like "Invalid or unavailable package" as the visible text. Now the banner displays `error.message` directly so users see what actually went wrong.

- Removed the `errorTitle()` abstraction that mapped `error_kind` to generic labels
- Removed the `title` tooltip attribute (no longer needed — the message is visible)
- Kept `errorSubtitle()`, failed package badge, Settings button, and dismiss as-is

## Verification

- [ ] Trigger a pool error (e.g. add a bogus package to conda default_packages) and confirm the banner shows the daemon's specific error message, not a generic title
- [ ] Confirm the banner still shows the subtitle, failed package badge (when applicable), Settings button, and dismiss button

| Before | After |
|--------|-------|
| _screenshot_ | _screenshot_ |

_PR submitted by @rgbkrk's agent, Quill_