### PR TITLE
feat(runtimed): ephemeral notebooks for MCP agents

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -666,11 +666,12 @@ mod tests {
             cell_count: 5,
             needs_trust_approval: false,
             error: None,
+            ephemeral: false,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
             json,
-            r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false}"#
+            r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false,"ephemeral":false}"#
         );
 
         // With version info
@@ -682,6 +683,7 @@ mod tests {
             cell_count: 5,
             needs_trust_approval: false,
             error: None,
+            ephemeral: false,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
@@ -696,6 +698,7 @@ mod tests {
             cell_count: 1,
             needs_trust_approval: true,
             error: None,
+            ephemeral: false,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""needs_trust_approval":true"#));
@@ -709,6 +712,7 @@ mod tests {
             cell_count: 0,
             needs_trust_approval: false,
             error: Some("File not found".into()),
+            ephemeral: false,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""error":"File not found""#));

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -626,6 +626,7 @@ mod tests {
             runtime: "python".into(),
             working_dir: None,
             notebook_id: None,
+            ephemeral: None,
         })
         .unwrap();
         assert_eq!(json, r#"{"channel":"create_notebook","runtime":"python"}"#);
@@ -635,6 +636,7 @@ mod tests {
             runtime: "deno".into(),
             working_dir: Some("/home/user/project".into()),
             notebook_id: None,
+            ephemeral: None,
         })
         .unwrap();
         assert_eq!(
@@ -647,6 +649,7 @@ mod tests {
             runtime: "python".into(),
             working_dir: None,
             notebook_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+            ephemeral: None,
         })
         .unwrap();
         assert_eq!(

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -108,6 +108,10 @@ pub enum Handshake {
         /// a new notebook is created and this ID is used as the notebook_id/env_id.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         notebook_id: Option<String>,
+        /// When true, the notebook exists only in memory — no .automerge persisted to disk.
+        /// Defaults to false (backward compat). MCP agents use true for scratch compute.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ephemeral: Option<bool>,
     },
 }
 
@@ -232,6 +236,9 @@ pub struct NotebookConnectionInfo {
     /// Error message if the notebook could not be opened/created.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Whether this notebook is ephemeral (in-memory only, no persistence).
+    #[serde(default)]
+    pub ephemeral: bool,
 }
 
 /// Frame types for notebook sync connections.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -347,8 +347,17 @@ pub async fn connect_create(
     runtime: &str,
     working_dir: Option<PathBuf>,
     actor_label: &str,
+    ephemeral: bool,
 ) -> Result<CreateResult, SyncError> {
-    connect_create_inner(socket_path, runtime, working_dir, None, actor_label).await
+    connect_create_inner(
+        socket_path,
+        runtime,
+        working_dir,
+        None,
+        actor_label,
+        ephemeral,
+    )
+    .await
 }
 
 async fn connect_create_inner(
@@ -357,6 +366,7 @@ async fn connect_create_inner(
     working_dir: Option<PathBuf>,
     notebook_id: Option<String>,
     actor_label: &str,
+    ephemeral: bool,
 ) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -373,7 +383,7 @@ async fn connect_create_inner(
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
-        ephemeral: None,
+        ephemeral: if ephemeral { Some(true) } else { None },
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -586,6 +596,7 @@ pub async fn connect_create_relay(
     working_dir: Option<PathBuf>,
     notebook_id: Option<String>,
     frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    ephemeral: bool,
 ) -> Result<RelayCreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -602,7 +613,7 @@ pub async fn connect_create_relay(
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
-        ephemeral: None,
+        ephemeral: if ephemeral { Some(true) } else { None },
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -373,6 +373,7 @@ async fn connect_create_inner(
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
+        ephemeral: None,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -601,6 +602,7 @@ pub async fn connect_create_relay(
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
+        ephemeral: None,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -646,6 +646,7 @@ async fn initialize_notebook_sync_create(
         working_dir,
         notebook_id_hint,
         frame_tx,
+        false,
     )
     .await
     .map_err(|e| format!("sync connect (create): {}", e))?;

--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -44,7 +44,7 @@
   },
   {
     "name": "create_notebook",
-    "description": "Create a new notebook, making it your active session. Supports uv, conda, or pixi via package_manager param (defaults to user's default_python_env setting). The kernel starts automatically with deps installed. Call save_notebook(path) to persist to disk.",
+    "description": "Create a new notebook, making it your active session. Notebooks are ephemeral by default (in-memory only) — use save_notebook(path) to persist to disk. Set ephemeral=false for session-restorable persistence. Supports uv, conda, or pixi via package_manager param.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -80,6 +80,14 @@
           "description": "Working directory for the kernel.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "ephemeral": {
+          "default": true,
+          "description": "When true (default), notebook exists only in memory. Use save_notebook(path) to persist.",
+          "type": [
+            "boolean",
             "null"
           ]
         }

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -102,7 +102,7 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(always_load_meta()),
         Tool::new(
             "create_notebook",
-            "Create a new notebook, making it your active session. Supports uv, conda, or pixi via package_manager param (defaults to user's default_python_env setting). The kernel starts automatically with deps installed. Call save_notebook(path) to persist to disk.",
+            "Create a new notebook, making it your active session. Notebooks are ephemeral by default (in-memory only) — use save_notebook(path) to persist to disk. Set ephemeral=false for session-restorable persistence. Supports uv, conda, or pixi via package_manager param.",
             schema_for::<session::CreateNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
@@ -332,8 +332,6 @@ pub async fn dispatch(
         "create_notebook" => session::create_notebook(server, request).await,
         "save_notebook" => session::save_notebook(server, request).await,
         "launch_app" => session::show_notebook(server, request).await,
-        // Backward compat: show_notebook routes to launch_app
-        "show_notebook" => session::show_notebook(server, request).await,
         // Cell read
         "get_cell" => cell_read::get_cell(server, request).await,
         "get_all_cells" => cell_read::get_all_cells(server, request).await,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -194,6 +194,10 @@ pub struct CreateNotebookParams {
     /// Defaults to the user's default_python_env setting.
     #[serde(default)]
     pub package_manager: Option<String>,
+    /// When true (default for MCP), notebook exists only in memory.
+    /// Use save_notebook(path=...) to persist to disk.
+    #[serde(default)]
+    pub ephemeral: Option<bool>,
 }
 
 #[allow(dead_code)]
@@ -373,6 +377,12 @@ pub async fn create_notebook(
     let runtime = arg_str(request, "runtime").unwrap_or("python");
     let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
     let working_dir_for_detection = working_dir.clone();
+    let ephemeral = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("ephemeral"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     let prev = previous_notebook_id(server).await;
 
@@ -381,7 +391,7 @@ pub async fn create_notebook(
         runtime,
         working_dir,
         &server.get_peer_label().await,
-        false,
+        ephemeral,
     )
     .await
     {
@@ -517,6 +527,7 @@ pub async fn create_notebook(
                 "runtime": { "language": runtime },
                 "dependencies": deps,
                 "package_manager": pkg_manager,
+                "ephemeral": ephemeral,
             });
 
             if let Some(ref prev_id) = prev {
@@ -643,6 +654,12 @@ pub async fn show_notebook(
         ));
     }
 
+    let is_ephemeral = rooms
+        .iter()
+        .find(|r| r.notebook_id == target)
+        .map(|r| r.ephemeral)
+        .unwrap_or(false);
+
     // Launch the app using the binary's build channel.
     // NOTE: If RUNTIMED_SOCKET_PATH points at a different channel's daemon,
     // this may open the wrong app. That's a known dev-only edge case.
@@ -655,7 +672,11 @@ pub async fn show_notebook(
             .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
     }
 
-    let result = serde_json::json!({ "notebook_id": target, "opened": true });
+    let mut result = serde_json::json!({ "notebook_id": target, "opened": true });
+    if is_ephemeral {
+        result["warning"] =
+            serde_json::json!("This notebook is ephemeral. Save it from the app to keep it.");
+    }
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -381,6 +381,7 @@ pub async fn create_notebook(
         runtime,
         working_dir,
         &server.get_peer_label().await,
+        false,
     )
     .await
     {

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -153,6 +153,8 @@ pub struct RoomInfo {
     /// Kernel status if running (e.g., "idle", "busy", "starting")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_status: Option<String>,
+    #[serde(default)]
+    pub ephemeral: bool,
 }
 
 /// Blob channel request.

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -21,6 +21,7 @@ struct RoomInfoData {
     kernel_type: Option<String>,
     kernel_status: Option<String>,
     env_source: Option<String>,
+    ephemeral: bool,
 }
 
 /// Async client for the runtimed daemon.
@@ -116,6 +117,7 @@ impl AsyncClient {
                     kernel_type: room.kernel_type,
                     kernel_status: room.kernel_status,
                     env_source: room.env_source,
+                    ephemeral: room.ephemeral,
                 })
                 .collect();
             Ok(result)

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -725,6 +725,8 @@ pub struct NotebookConnectionInfo {
     pub cell_count: usize,
     /// True if the notebook has untrusted dependencies requiring user approval.
     pub needs_trust_approval: bool,
+    /// Whether this notebook is ephemeral (in-memory only, no persistence).
+    pub ephemeral: bool,
 }
 
 #[pymethods]
@@ -748,6 +750,7 @@ impl NotebookConnectionInfo {
             notebook_id: info.notebook_id,
             cell_count: info.cell_count,
             needs_trust_approval: info.needs_trust_approval,
+            ephemeral: info.ephemeral,
         }
     }
 }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -361,6 +361,7 @@ pub(crate) async fn connect_create(
         runtime,
         working_dir.clone(),
         label,
+        false,
     )
     .await
     .map_err(to_py_err)?;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -417,6 +417,12 @@ impl Pool {
     }
 }
 
+/// Entry in the redirect map for re-keyed ephemeral rooms.
+pub(crate) struct RedirectEntry {
+    pub(crate) new_notebook_id: String,
+    pub(crate) created_at: tokio::time::Instant,
+}
+
 /// The pool daemon state.
 pub struct Daemon {
     config: DaemonConfig,
@@ -446,6 +452,9 @@ pub struct Daemon {
     blob_port: Mutex<Option<u16>>,
     /// Per-notebook Automerge sync rooms.
     notebook_rooms: NotebookRooms,
+    /// Redirect map: old ephemeral UUID -> new canonical path after rekey.
+    /// Used so peers reconnecting with the old UUID find the re-keyed room.
+    pub(crate) redirect_map: std::sync::Mutex<HashMap<String, RedirectEntry>>,
 }
 
 /// Error returned when another daemon is already running.
@@ -527,6 +536,7 @@ impl Daemon {
             blob_store,
             blob_port: Mutex::new(None),
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
+            redirect_map: std::sync::Mutex::new(HashMap::new()),
         }))
     }
 
@@ -1465,6 +1475,20 @@ impl Daemon {
                 .to_string()
         };
 
+        // Check if this notebook_id was re-keyed (ephemeral -> saved).
+        let notebook_id = {
+            let redirects = self.redirect_map.lock().unwrap();
+            if let Some(entry) = redirects.get(&notebook_id) {
+                info!(
+                    "[runtimed] Redirecting open {} -> {} (re-keyed room)",
+                    notebook_id, entry.new_notebook_id
+                );
+                entry.new_notebook_id.clone()
+            } else {
+                notebook_id
+            }
+        };
+
         // Get or create room for this notebook.
         // First check if an existing room (including UUID-keyed ephemeral rooms)
         // already owns this path — prevents duplicate rooms and re-key collisions.
@@ -1637,6 +1661,23 @@ impl Daemon {
 
         // Use provided notebook_id (session restore) or generate a new UUID
         let notebook_id = notebook_id_hint.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        // Check if this notebook_id was re-keyed (ephemeral -> saved).
+        // If so, redirect to the new canonical path so the peer joins the
+        // existing room instead of creating a new empty one.
+        let notebook_id = {
+            let redirects = self.redirect_map.lock().unwrap();
+            if let Some(entry) = redirects.get(&notebook_id) {
+                info!(
+                    "[runtimed] Redirecting {} -> {} (re-keyed room)",
+                    notebook_id, entry.new_notebook_id
+                );
+                entry.new_notebook_id.clone()
+            } else {
+                notebook_id
+            }
+        };
+
         let ephemeral = ephemeral.unwrap_or(false);
 
         // Create room for this notebook
@@ -2191,6 +2232,7 @@ impl Daemon {
                         kernel_type,
                         env_source,
                         kernel_status,
+                        ephemeral: room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed),
                     });
                 }
                 Response::RoomsList { rooms: room_infos }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1258,6 +1258,7 @@ impl Daemon {
                         &notebook_id,
                         &docs_dir,
                         self.blob_store.clone(),
+                        false, // NotebookSync handshake is always persistent
                     )
                 };
                 let (reader, writer) = tokio::io::split(stream);
@@ -1290,8 +1291,9 @@ impl Daemon {
                 runtime,
                 working_dir,
                 notebook_id,
+                ephemeral,
             } => {
-                self.handle_create_notebook(stream, runtime, working_dir, notebook_id)
+                self.handle_create_notebook(stream, runtime, working_dir, notebook_id, ephemeral)
                     .await
             }
             Handshake::RuntimeAgent {
@@ -1360,6 +1362,7 @@ impl Daemon {
                 cell_count: 0,
                 needs_trust_approval: false,
                 error: Some(error),
+                ephemeral: false,
             };
             send_json_frame(writer, &response).await?;
             Ok(())
@@ -1477,6 +1480,7 @@ impl Daemon {
                     &notebook_id,
                     &docs_dir,
                     self.blob_store.clone(),
+                    false, // OpenNotebook handshake is always persistent
                 )
             }
         };
@@ -1573,6 +1577,7 @@ impl Daemon {
             cell_count,
             needs_trust_approval,
             error: None,
+            ephemeral: false,
         };
         send_json_frame(&mut writer, &response).await?;
 
@@ -1610,6 +1615,7 @@ impl Daemon {
         runtime: String,
         working_dir: Option<String>,
         notebook_id_hint: Option<String>,
+        ephemeral: Option<bool>,
     ) -> anyhow::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin,
@@ -1630,6 +1636,7 @@ impl Daemon {
 
         // Use provided notebook_id (session restore) or generate a new UUID
         let notebook_id = notebook_id_hint.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let ephemeral = ephemeral.unwrap_or(false);
 
         // Create room for this notebook
         let docs_dir = self.config.notebook_docs_dir.clone();
@@ -1640,6 +1647,7 @@ impl Daemon {
                 &notebook_id,
                 &docs_dir,
                 self.blob_store.clone(),
+                ephemeral,
             )
         };
 
@@ -1691,6 +1699,7 @@ impl Daemon {
                 cell_count: 0,
                 needs_trust_approval: false,
                 error: Some(format!("Failed to create notebook: {}", e)),
+                ephemeral: false,
             };
             send_json_frame(&mut writer, &response).await?;
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
@@ -1708,6 +1717,7 @@ impl Daemon {
             cell_count,
             needs_trust_approval: false,
             error: None,
+            ephemeral,
         };
         send_json_frame(&mut writer, &response).await?;
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2371,6 +2371,46 @@ impl Daemon {
                 }
             }
 
+            // Clean up orphaned notebook-docs (emergency persist files, legacy untitled docs)
+            let notebook_docs_dir = self.config.notebook_docs_dir.clone();
+            if notebook_docs_dir.exists() {
+                let active_rooms = self.notebook_rooms.lock().await;
+                let active_hashes: std::collections::HashSet<String> = active_rooms
+                    .keys()
+                    .map(|id| notebook_doc::notebook_doc_filename(id))
+                    .collect();
+                drop(active_rooms);
+
+                let docs_max_age = std::time::Duration::from_secs(24 * 3600); // 24 hours
+                let mut docs_cleaned = 0;
+                if let Ok(mut entries) = tokio::fs::read_dir(&notebook_docs_dir).await {
+                    while let Ok(Some(entry)) = entries.next_entry().await {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if !name.ends_with(".automerge") {
+                            continue;
+                        }
+                        if active_hashes.contains(&name) {
+                            continue;
+                        }
+                        if let Ok(metadata) = entry.metadata().await {
+                            if let Ok(modified) = metadata.modified() {
+                                if modified.elapsed().unwrap_or_default() > docs_max_age {
+                                    if tokio::fs::remove_file(entry.path()).await.is_ok() {
+                                        docs_cleaned += 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if docs_cleaned > 0 {
+                    info!(
+                        "[runtimed] GC: cleaned up {} orphaned notebook-doc files",
+                        docs_cleaned
+                    );
+                }
+            }
+
             // Run every 6 hours
             tokio::time::sleep(std::time::Duration::from_secs(6 * 3600)).await;
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1667,22 +1667,22 @@ impl Daemon {
         // Check if this notebook_id was re-keyed (ephemeral -> saved).
         // If so, redirect to the new canonical path so the peer joins the
         // existing room instead of creating a new empty one.
-        let notebook_id = match self.redirect_map.lock() {
+        // Check redirect map and resolve ephemeral flag together.
+        // If the UUID was re-keyed (saved), the room is now file-backed — force persistent.
+        let (notebook_id, ephemeral) = match self.redirect_map.lock() {
             Ok(redirects) => {
                 if let Some(entry) = redirects.get(&notebook_id) {
                     info!(
                         "[runtimed] Redirecting {} -> {} (re-keyed room)",
                         notebook_id, entry.new_notebook_id
                     );
-                    entry.new_notebook_id.clone()
+                    (entry.new_notebook_id.clone(), false)
                 } else {
-                    notebook_id
+                    (notebook_id, ephemeral.unwrap_or(false))
                 }
             }
-            Err(_) => notebook_id,
+            Err(_) => (notebook_id, ephemeral.unwrap_or(false)),
         };
-
-        let ephemeral = ephemeral.unwrap_or(false);
 
         // Create room for this notebook
         let docs_dir = self.config.notebook_docs_dir.clone();

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1476,17 +1476,19 @@ impl Daemon {
         };
 
         // Check if this notebook_id was re-keyed (ephemeral -> saved).
-        let notebook_id = {
-            let redirects = self.redirect_map.lock().unwrap();
-            if let Some(entry) = redirects.get(&notebook_id) {
-                info!(
-                    "[runtimed] Redirecting open {} -> {} (re-keyed room)",
-                    notebook_id, entry.new_notebook_id
-                );
-                entry.new_notebook_id.clone()
-            } else {
-                notebook_id
+        let notebook_id = match self.redirect_map.lock() {
+            Ok(redirects) => {
+                if let Some(entry) = redirects.get(&notebook_id) {
+                    info!(
+                        "[runtimed] Redirecting open {} -> {} (re-keyed room)",
+                        notebook_id, entry.new_notebook_id
+                    );
+                    entry.new_notebook_id.clone()
+                } else {
+                    notebook_id
+                }
             }
+            Err(_) => notebook_id,
         };
 
         // Get or create room for this notebook.
@@ -1665,17 +1667,19 @@ impl Daemon {
         // Check if this notebook_id was re-keyed (ephemeral -> saved).
         // If so, redirect to the new canonical path so the peer joins the
         // existing room instead of creating a new empty one.
-        let notebook_id = {
-            let redirects = self.redirect_map.lock().unwrap();
-            if let Some(entry) = redirects.get(&notebook_id) {
-                info!(
-                    "[runtimed] Redirecting {} -> {} (re-keyed room)",
-                    notebook_id, entry.new_notebook_id
-                );
-                entry.new_notebook_id.clone()
-            } else {
-                notebook_id
+        let notebook_id = match self.redirect_map.lock() {
+            Ok(redirects) => {
+                if let Some(entry) = redirects.get(&notebook_id) {
+                    info!(
+                        "[runtimed] Redirecting {} -> {} (re-keyed room)",
+                        notebook_id, entry.new_notebook_id
+                    );
+                    entry.new_notebook_id.clone()
+                } else {
+                    notebook_id
+                }
             }
+            Err(_) => notebook_id,
         };
 
         let ephemeral = ephemeral.unwrap_or(false);
@@ -2392,14 +2396,14 @@ impl Daemon {
                         if active_hashes.contains(&name) {
                             continue;
                         }
-                        if let Ok(metadata) = entry.metadata().await {
-                            if let Ok(modified) = metadata.modified() {
-                                if modified.elapsed().unwrap_or_default() > docs_max_age {
-                                    if tokio::fs::remove_file(entry.path()).await.is_ok() {
-                                        docs_cleaned += 1;
-                                    }
-                                }
-                            }
+                        let is_stale = entry
+                            .metadata()
+                            .await
+                            .ok()
+                            .and_then(|m| m.modified().ok())
+                            .is_some_and(|t| t.elapsed().unwrap_or_default() > docs_max_age);
+                        if is_stale && tokio::fs::remove_file(entry.path()).await.is_ok() {
+                            docs_cleaned += 1;
                         }
                     }
                 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1405,6 +1405,7 @@ impl Daemon {
                         settings.default_runtime.to_string(),
                         Some(dir_path),
                         None,
+                        None,
                     )
                     .await;
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1199,6 +1199,11 @@ impl NotebookRoom {
 
         // Spawn debounced persistence task (watch channel keeps latest value only)
         // Ephemeral rooms skip persistence entirely.
+        // Store ephemeral flag in doc metadata so the GUI can show a banner
+        if ephemeral {
+            let _ = doc.set_metadata("ephemeral", "true");
+        }
+
         let persist_tx = if ephemeral {
             None
         } else {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -9073,6 +9073,32 @@ mod tests {
         std::env::remove_var("RUNT_TRUST_KEY_PATH");
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_ephemeral_room_skips_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = Arc::new(BlobStore::new(dir.path().join("blobs")));
+        let notebook_id = uuid::Uuid::new_v4().to_string();
+        let room = NotebookRoom::new_fresh(&notebook_id, dir.path(), blob_store, true);
+
+        assert!(room.persist_tx.is_none());
+        assert!(room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed));
+
+        // No .automerge file should exist
+        let filename = notebook_doc_filename(&notebook_id);
+        assert!(!dir.path().join(&filename).exists());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_session_room_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = Arc::new(BlobStore::new(dir.path().join("blobs")));
+        let notebook_id = uuid::Uuid::new_v4().to_string();
+        let room = NotebookRoom::new_fresh(&notebook_id, dir.path(), blob_store, false);
+
+        assert!(room.persist_tx.is_some());
+        assert!(!room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
     /// Helper to build a snapshot with UV inline deps.
     fn snapshot_with_uv(deps: Vec<String>) -> NotebookMetadataSnapshot {
         NotebookMetadataSnapshot {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2512,6 +2512,18 @@ where
                                         path,
                                         room,
                                     ).await {
+                                        // Insert redirect so peers reconnecting with the old UUID
+                                        // get routed to the re-keyed room.
+                                        {
+                                            let mut redirects = daemon.redirect_map.lock().unwrap();
+                                            redirects.insert(notebook_id.clone(), crate::daemon::RedirectEntry {
+                                                new_notebook_id: new_id.clone(),
+                                                created_at: tokio::time::Instant::now(),
+                                            });
+                                            // Prune old entries (older than 1 hour)
+                                            let cutoff = tokio::time::Instant::now() - std::time::Duration::from_secs(3600);
+                                            redirects.retain(|_, v| v.created_at > cutoff);
+                                        }
                                         notebook_id = new_id.clone();
                                         NotebookResponse::NotebookSaved {
                                             path: path.clone(),
@@ -4348,8 +4360,15 @@ async fn rekey_ephemeral_room(
             new_notebook_id: canonical.clone(),
         });
 
+    // Clear the ephemeral flag — this room is now backed by a file on disk.
+    room.is_ephemeral.store(false, Ordering::Relaxed);
+    {
+        let mut doc = room.doc.write().await;
+        let _ = doc.set_metadata("ephemeral", "");
+    }
+
     info!(
-        "[notebook-sync] Re-keyed room {} -> {}",
+        "[notebook-sync] Re-keyed room {} -> {} (ephemeral cleared)",
         old_notebook_id, canonical
     );
 
@@ -5813,9 +5832,21 @@ async fn handle_notebook_request(
                     path: saved_path,
                     new_notebook_id: None,
                 },
-                Err(e) => NotebookResponse::Error {
-                    error: format!("Failed to save notebook: {e}"),
-                },
+                Err(e) => {
+                    // Emergency persist for ephemeral rooms: if saving to .ipynb
+                    // failed, at least write the Automerge doc so data isn't lost.
+                    if room.is_ephemeral.load(Ordering::Relaxed) && room.persist_tx.is_none() {
+                        let bytes = room.doc.write().await.save();
+                        persist_notebook_bytes(&bytes, &room.persist_path);
+                        warn!(
+                            "[notebook-sync] Save failed for ephemeral room — emergency persist to {:?}",
+                            room.persist_path
+                        );
+                    }
+                    NotebookResponse::Error {
+                        error: format!("Failed to save notebook: {e}"),
+                    }
+                }
             }
         }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -8897,8 +8897,8 @@ mod tests {
         let blob_store = test_blob_store(&tmp);
         let mut rooms = HashMap::new();
 
-        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store.clone());
-        let room2 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store);
+        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store.clone(), false);
+        let room2 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store, false);
 
         // Should be the same Arc (same room)
         assert!(Arc::ptr_eq(&room1, &room2));
@@ -8910,8 +8910,8 @@ mod tests {
         let blob_store = test_blob_store(&tmp);
         let mut rooms = HashMap::new();
 
-        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store.clone());
-        let room2 = get_or_create_room(&mut rooms, "nb2", tmp.path(), blob_store);
+        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path(), blob_store.clone(), false);
+        let room2 = get_or_create_room(&mut rooms, "nb2", tmp.path(), blob_store, false);
 
         // Should be different rooms
         assert!(!Arc::ptr_eq(&room1, &room2));
@@ -8941,7 +8941,7 @@ mod tests {
     async fn test_new_fresh_creates_empty_doc() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
-        let room = NotebookRoom::new_fresh("fresh-test", tmp.path(), blob_store);
+        let room = NotebookRoom::new_fresh("fresh-test", tmp.path(), blob_store, false);
 
         let doc = room.doc.try_read().unwrap();
         assert_eq!(doc.notebook_id(), Some("fresh-test".to_string()));
@@ -8969,7 +8969,7 @@ mod tests {
         assert!(persist_path.exists(), "Persisted file should exist");
 
         // Create fresh room - should delete persisted doc and start empty
-        let room = NotebookRoom::new_fresh("stale-test", tmp.path(), blob_store);
+        let room = NotebookRoom::new_fresh("stale-test", tmp.path(), blob_store, false);
 
         // Persisted file should be deleted
         assert!(
@@ -9006,7 +9006,7 @@ mod tests {
         assert!(persist_path.exists(), "Persisted file should exist");
 
         // Create fresh room for untitled notebook — should load persisted doc
-        let room = NotebookRoom::new_fresh(notebook_id, tmp.path(), blob_store);
+        let room = NotebookRoom::new_fresh(notebook_id, tmp.path(), blob_store, false);
 
         // Persisted file should still exist (not deleted)
         assert!(
@@ -9061,7 +9061,7 @@ mod tests {
 
         // Simulate daemon restart: create a fresh room with the same UUID.
         // new_fresh should load the persisted doc and read trust from it.
-        let room = NotebookRoom::new_fresh(notebook_id, tmp.path(), blob_store);
+        let room = NotebookRoom::new_fresh(notebook_id, tmp.path(), blob_store, false);
 
         let ts = room.trust_state.try_read().unwrap();
         assert_eq!(
@@ -9256,10 +9256,11 @@ mod tests {
             kernel_broadcast_tx,
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
-            persist_tx,
+            persist_tx: Some(persist_tx),
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
+            is_ephemeral: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(TrustState {
                 status: runt_trust::TrustStatus::Untrusted,
@@ -10737,7 +10738,9 @@ mod tests {
 
         // 1. Create an ephemeral room with a UUID notebook_id
         let uuid_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-        let room = Arc::new(NotebookRoom::new_fresh(uuid_id, &docs_dir, blob_store));
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid_id, &docs_dir, blob_store, false,
+        ));
         assert!(is_untitled_notebook(uuid_id));
 
         // Add an initial cell so the first save has content

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1141,13 +1141,6 @@ fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bool {
 }
 
 impl NotebookRoom {
-    /// Persist the current doc state to disk (no-op for ephemeral rooms).
-    pub fn persist_doc(&self, doc: &mut NotebookDoc) {
-        if let Some(ref tx) = self.persist_tx {
-            let _ = tx.send(Some(doc.save()));
-        }
-    }
-
     /// Create a fresh room, ignoring any persisted state.
     ///
     /// The .ipynb file is the source of truth. When a room is created, we start
@@ -9132,6 +9125,17 @@ mod tests {
 
         assert!(room.persist_tx.is_some());
         assert!(!room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_ephemeral_room_has_metadata_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = Arc::new(BlobStore::new(dir.path().join("blobs")));
+        let notebook_id = uuid::Uuid::new_v4().to_string();
+        let room = NotebookRoom::new_fresh(&notebook_id, dir.path(), blob_store, true);
+
+        let doc = room.doc.read().await;
+        assert_eq!(doc.get_metadata("ephemeral"), Some("true".to_string()));
     }
 
     /// Helper to build a snapshot with UV inline deps.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2514,8 +2514,7 @@ where
                                     ).await {
                                         // Insert redirect so peers reconnecting with the old UUID
                                         // get routed to the re-keyed room.
-                                        {
-                                            let mut redirects = daemon.redirect_map.lock().unwrap();
+                                        if let Ok(mut redirects) = daemon.redirect_map.lock() {
                                             redirects.insert(notebook_id.clone(), crate::daemon::RedirectEntry {
                                                 new_notebook_id: new_id.clone(),
                                                 created_at: tokio::time::Instant::now(),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -626,7 +626,9 @@ async fn process_markdown_assets(room: &NotebookRoom) {
     };
 
     let _ = room.changed_tx.send(());
-    let _ = room.persist_tx.send(Some(persist_bytes));
+    if let Some(ref tx) = room.persist_tx {
+        let _ = tx.send(Some(persist_bytes));
+    }
 }
 
 /// Check if the current metadata differs from kernel's launched config and broadcast sync state.
@@ -978,13 +980,15 @@ pub struct NotebookRoom {
     pub presence: Arc<RwLock<PresenceState>>,
     /// Channel to send doc bytes to the debounced persistence task.
     /// Uses watch for "latest value" semantics - always keeps most recent state.
-    pub persist_tx: watch::Sender<Option<Vec<u8>>>,
+    pub persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
     /// Persistence path for this room's document.
     pub persist_path: PathBuf,
     /// Number of active peer connections in this room.
     pub active_peers: AtomicUsize,
     /// Whether at least one peer has ever connected to this room.
     pub had_peers: AtomicBool,
+    /// Whether this notebook is ephemeral (in-memory only, no persistence).
+    pub is_ephemeral: AtomicBool,
     /// Blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
     /// Trust state for this notebook (for auto-launch decisions).
@@ -1137,6 +1141,13 @@ fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bool {
 }
 
 impl NotebookRoom {
+    /// Persist the current doc state to disk (no-op for ephemeral rooms).
+    pub fn persist_doc(&self, doc: &mut NotebookDoc) {
+        if let Some(ref tx) = self.persist_tx {
+            let _ = tx.send(Some(doc.save()));
+        }
+    }
+
     /// Create a fresh room, ignoring any persisted state.
     ///
     /// The .ipynb file is the source of truth. When a room is created, we start
@@ -1149,7 +1160,12 @@ impl NotebookRoom {
     /// Note: Trust state is initialized from disk because the Automerge doc
     /// starts empty (first client hasn't synced yet). Once the doc is populated,
     /// `check_and_update_trust_state` keeps room.trust_state current.
-    pub fn new_fresh(notebook_id: &str, docs_dir: &Path, blob_store: Arc<BlobStore>) -> Self {
+    pub fn new_fresh(
+        notebook_id: &str,
+        docs_dir: &Path,
+        blob_store: Arc<BlobStore>,
+        ephemeral: bool,
+    ) -> Self {
         let filename = notebook_doc_filename(notebook_id);
         let persist_path = docs_dir.join(&filename);
 
@@ -1159,14 +1175,14 @@ impl NotebookRoom {
         // For saved notebooks (file paths), .ipynb is the source of truth, so
         // delete stale persisted docs and start fresh (daemon loads from disk).
         let runtimed_actor = "runtimed";
-        let mut doc = if is_untitled_notebook(notebook_id) && persist_path.exists() {
+        let mut doc = if !ephemeral && is_untitled_notebook(notebook_id) && persist_path.exists() {
             info!(
                 "[notebook-sync] Loading persisted doc for untitled notebook: {:?}",
                 persist_path
             );
             NotebookDoc::load_or_create_with_actor(&persist_path, notebook_id, runtimed_actor)
         } else {
-            if persist_path.exists() {
+            if !ephemeral && persist_path.exists() {
                 if snapshot_before_delete(&persist_path, docs_dir) {
                     let _ = std::fs::remove_file(&persist_path);
                 } else {
@@ -1182,8 +1198,14 @@ impl NotebookRoom {
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
 
         // Spawn debounced persistence task (watch channel keeps latest value only)
-        let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
-        spawn_persist_debouncer(persist_rx, persist_path.clone());
+        // Ephemeral rooms skip persistence entirely.
+        let persist_tx = if ephemeral {
+            None
+        } else {
+            let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
+            spawn_persist_debouncer(persist_rx, persist_path.clone());
+            Some(persist_tx)
+        };
 
         let notebook_path = PathBuf::from(notebook_id);
         let trust_state = if is_untitled_notebook(notebook_id) {
@@ -1254,6 +1276,7 @@ impl NotebookRoom {
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
+            is_ephemeral: AtomicBool::new(ephemeral),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             notebook_path: RwLock::new(notebook_path),
@@ -1338,10 +1361,11 @@ impl NotebookRoom {
             kernel_broadcast_tx,
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
-            persist_tx,
+            persist_tx: Some(persist_tx),
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
+            is_ephemeral: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             notebook_path: RwLock::new(notebook_path),
@@ -1458,12 +1482,18 @@ pub fn get_or_create_room(
     notebook_id: &str,
     docs_dir: &Path,
     blob_store: Arc<BlobStore>,
+    ephemeral: bool,
 ) -> Arc<NotebookRoom> {
     rooms
         .entry(notebook_id.to_string())
         .or_insert_with(|| {
             info!("[notebook-sync] Creating room for {}", notebook_id);
-            let room = Arc::new(NotebookRoom::new_fresh(notebook_id, docs_dir, blob_store));
+            let room = Arc::new(NotebookRoom::new_fresh(
+                notebook_id,
+                docs_dir,
+                blob_store,
+                ephemeral,
+            ));
 
             // Spawn file watcher for .ipynb files (not for untitled notebooks with UUID IDs)
             if !is_untitled_notebook(notebook_id) {
@@ -2447,7 +2477,9 @@ where
                                 }
 
                                 // Send to debounced persistence task
-                                let _ = room.persist_tx.send(Some(persist_bytes));
+                                if let Some(ref tx) = room.persist_tx {
+                                    let _ = tx.send(Some(persist_bytes));
+                                }
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
                                 if metadata_changed {
@@ -5468,7 +5500,9 @@ async fn handle_notebook_request(
             }
 
             // Send to debounced persistence task
-            let _ = room.persist_tx.send(Some(persist_bytes));
+            if let Some(ref tx) = room.persist_tx {
+                let _ = tx.send(Some(persist_bytes));
+            }
 
             // Broadcast for cross-window UI sync (fast path)
             let _ = room
@@ -5810,8 +5844,10 @@ async fn handle_notebook_request(
                     // Notify peers of the change
                     let _ = room.changed_tx.send(());
                     // Persist
-                    let bytes = doc.save();
-                    let _ = room.persist_tx.send(Some(bytes));
+                    if let Some(ref tx) = room.persist_tx {
+                        let bytes = doc.save();
+                        let _ = tx.send(Some(bytes));
+                    }
                     NotebookResponse::MetadataSet {}
                 }
                 Err(e) => NotebookResponse::Error {
@@ -5840,8 +5876,10 @@ async fn handle_notebook_request(
                                 // Notify peers of the change
                                 let _ = room.changed_tx.send(());
                                 // Persist
-                                let bytes = doc.save();
-                                let _ = room.persist_tx.send(Some(bytes));
+                                if let Some(ref tx) = room.persist_tx {
+                                    let bytes = doc.save();
+                                    let _ = tx.send(Some(bytes));
+                                }
                                 Ok(())
                             }
                             Err(e) => Err(format!("Failed to set metadata snapshot: {e}")),

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -391,7 +391,7 @@ async fn test_notebook_sync_via_unified_socket() {
     assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
 
     // Create first notebook via connect_create — should get empty notebook
-    let result1 = connect::connect_create(socket_path.clone(), "python", None, "test")
+    let result1 = connect::connect_create(socket_path.clone(), "python", None, "test", false)
         .await
         .expect("client1 should connect");
     let notebook_id_1 = result1.info.notebook_id.clone();
@@ -417,7 +417,7 @@ async fn test_notebook_sync_via_unified_socket() {
     assert_eq!(cells[0].cell_type, "code");
 
     // Create a different notebook — should be independent
-    let client3 = connect::connect_create(socket_path.clone(), "python", None, "test")
+    let client3 = connect::connect_create(socket_path.clone(), "python", None, "test", false)
         .await
         .expect("client3 should connect")
         .handle;
@@ -445,7 +445,7 @@ async fn test_notebook_sync_cross_window_propagation() {
     assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
 
     // First client creates a notebook; second client joins it
-    let result = connect::connect_create(socket_path.clone(), "python", None, "test")
+    let result = connect::connect_create(socket_path.clone(), "python", None, "test", false)
         .await
         .unwrap();
     let notebook_id = result.info.notebook_id.clone();
@@ -511,7 +511,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
     // Phase 1: Two clients connect, add cells, then both disconnect
     let notebook_id;
     {
-        let result = connect::connect_create(socket_path.clone(), "python", None, "test")
+        let result = connect::connect_create(socket_path.clone(), "python", None, "test", false)
             .await
             .unwrap();
         notebook_id = result.info.notebook_id.clone();
@@ -572,7 +572,7 @@ async fn test_notebook_cell_delete_propagation() {
     assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
 
     // Client1 creates a notebook with three cells
-    let result = connect::connect_create(socket_path.clone(), "python", None, "test")
+    let result = connect::connect_create(socket_path.clone(), "python", None, "test", false)
         .await
         .unwrap();
     let notebook_id = result.info.notebook_id.clone();
@@ -667,9 +667,9 @@ async fn test_multiple_notebooks_concurrent_isolation() {
 
     // Create three notebooks concurrently via connect_create
     let (nb_a, nb_b, nb_c) = tokio::join!(
-        connect::connect_create(socket_path.clone(), "python", None, "test"),
-        connect::connect_create(socket_path.clone(), "python", None, "test"),
-        connect::connect_create(socket_path.clone(), "python", None, "test"),
+        connect::connect_create(socket_path.clone(), "python", None, "test", false),
+        connect::connect_create(socket_path.clone(), "python", None, "test", false),
+        connect::connect_create(socket_path.clone(), "python", None, "test", false),
     );
     let nb_a = nb_a.unwrap();
     let nb_b = nb_b.unwrap();


### PR DESCRIPTION
## Summary

Closes #1668

MCP agents create many short-lived notebooks that leave orphaned `.automerge` files on disk, causing daemon startup delays. This adds an `ephemeral` mode to `create_notebook` — ephemeral notebooks exist only in memory with no persistence overhead, promotable to file-backed via `save_notebook(path=...)`.

- **Protocol**: `ephemeral: Option<bool>` on `CreateNotebook` handshake, `ephemeral: bool` on `NotebookConnectionInfo` response
- **NotebookRoom**: `persist_tx` becomes `Option` — ephemeral rooms skip the persist debouncer and `doc.save()` serialization entirely
- **MCP default**: `create_notebook` defaults to `ephemeral=true` for agents; GUI always creates persistent notebooks
- **Save transition**: `save_notebook(path=...)` promotes ephemeral → persistent, clears metadata flag, spawns autosave + file watcher. Emergency persist on save failure for data recovery
- **Redirect map**: After rekey, peers reconnecting with the old UUID get redirected to the new path-keyed room (1h TTL)
- **RoomInfo**: `ephemeral` flag in listing so `launch_app` can warn about ephemeral rooms
- **GC**: Orphaned `.automerge` files older than 24h cleaned up in the existing GC loop
- **Tool cleanup**: Removed dead `show_notebook` backward-compat alias

## Test plan

- [x] 223 lib tests pass (`cargo test -p runtimed --lib`)
- [x] Protocol tests pass (`cargo test -p notebook-protocol`)
- [x] New tests: `test_ephemeral_room_skips_persistence`, `test_session_room_persists`, `test_ephemeral_room_has_metadata_flag`
- [x] Lint clean (`cargo xtask lint`)
- [ ] Manual: `create_notebook()` via MCP → verify no `.automerge` in `notebook-docs/`
- [ ] Manual: `save_notebook(path=...)` → verify `.ipynb` written, room re-keyed
- [ ] Manual: GUI `open_notebook` → still persistent, `.automerge` written
- [ ] Manual: GUI joins ephemeral room → ephemeral banner visible

## Follow-ups

**From code review:**
- [ ] Cap redirect map to ~1000 entries (spec mentions it, only TTL pruning implemented)
- [ ] Add comment in `rekey_ephemeral_room` explaining promoted rooms intentionally lack `.automerge` persistence
- [ ] Use `delete_metadata` instead of `set_metadata("ephemeral", "")` or document empty-string-is-falsy convention
- [ ] Blob store GC — mark-and-sweep for orphaned blobs after ephemeral room eviction

**From spec gaps:**
- [ ] GUI ephemeral banner — read `ephemeral` from doc metadata, show "Save to keep" banner with Save As action
- [ ] Python bindings — `create_session` should accept and forward `ephemeral` param

**From spec future work:**
- [ ] Fork-from-existing: `create_notebook(source="/path/to/existing.ipynb", ephemeral=true)`
- [ ] Atomic write in `save_notebook_to_disk` (temp file + rename for crash safety)