### PR TITLE
feat(runt-mcp): add 'kernel' alias for 'runtime' in create_notebook

### DIFF
--- a/crates/notebook/gen/schemas/linux-schema.json
+++ b/crates/notebook/gen/schemas/linux-schema.json
@@ -2355,22 +2355,22 @@
           "markdownDescription": "Denies the unminimize command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
           "type": "string",
           "const": "dialog:default",
-          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
         },
         {
-          "description": "Enables the ask command without any pre-configured scope.",
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-ask",
-          "markdownDescription": "Enables the ask command without any pre-configured scope."
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
-          "description": "Enables the confirm command without any pre-configured scope.",
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-confirm",
-          "markdownDescription": "Enables the confirm command without any pre-configured scope."
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
           "description": "Enables the message command without any pre-configured scope.",
@@ -2391,16 +2391,16 @@
           "markdownDescription": "Enables the save command without any pre-configured scope."
         },
         {
-          "description": "Denies the ask command without any pre-configured scope.",
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-ask",
-          "markdownDescription": "Denies the ask command without any pre-configured scope."
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
-          "description": "Denies the confirm command without any pre-configured scope.",
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-confirm",
-          "markdownDescription": "Denies the confirm command without any pre-configured scope."
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
           "description": "Denies the message command without any pre-configured scope.",

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -184,6 +184,9 @@ pub struct CreateNotebookParams {
     /// Runtime type: "python" or "deno".
     #[serde(default)]
     pub runtime: Option<String>,
+    /// Alias for runtime (deprecated but supported for convenience).
+    #[serde(default)]
+    pub kernel: Option<String>,
     /// Working directory for the kernel.
     #[serde(default)]
     pub working_dir: Option<String>,
@@ -370,7 +373,12 @@ pub async fn create_notebook(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let runtime = arg_str(request, "runtime").unwrap_or("python");
+    // Support both 'runtime' and 'kernel' params (kernel is an alias for convenience)
+    let kernel_alias = arg_str(request, "kernel");
+    let runtime_arg = arg_str(request, "runtime");
+    let used_kernel_alias = kernel_alias.is_some() && runtime_arg.is_none();
+    let runtime = runtime_arg.or(kernel_alias).unwrap_or("python");
+
     let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
     let working_dir_for_detection = working_dir.clone();
 
@@ -522,6 +530,10 @@ pub async fn create_notebook(
                 if *prev_id != notebook_id {
                     info["switched_from"] = serde_json::json!(prev_id);
                 }
+            }
+
+            if used_kernel_alias {
+                info["info"] = serde_json::json!("Used 'kernel' parameter (alias for 'runtime')");
             }
 
             Ok(CallToolResult::success(vec![Content::text(


### PR DESCRIPTION
## Summary
Adds `kernel` as an intuitive alias for the `runtime` parameter in `create_notebook`. When the alias is used, an `info` field is added to the response to gently indicate that `runtime` is the canonical parameter name.

## Motivation
During testing, I naturally used `kernel="python"` instead of `runtime="python"` when creating a notebook. This is an easy mistake to make since:
- Jupyter terminology uses "kernel" heavily (kernel status, kernel restart, etc.)
- The tool manages kernel lifecycle
- `runtime` is less intuitive for new users

Rather than silently ignoring the incorrect parameter (which led to dependencies not being installed), we now accept both and provide helpful feedback.

## Changes
- Added `kernel` field to `CreateNotebookParams` struct
- Updated `create_notebook` to accept both `runtime` and `kernel` parameters
- Added logic to prefer `runtime` when both are provided (backward compatibility)
- Adds `info` field to response when `kernel` alias is used: `"Used 'kernel' parameter (alias for 'runtime')"`

## Example Usage
```python
# Using the alias
create_notebook(kernel="python", dependencies=["pandas", "matplotlib"])

# Response includes helpful info
{
  "notebook_id": "...",
  "runtime": { "language": "python" },
  "dependencies": ["pandas", "matplotlib"],
  "package_manager": "uv",
  "info": "Used 'kernel' parameter (alias for 'runtime')"
}
```

## Testing
- ✅ Tested with `kernel="python"` - dependencies installed correctly
- ✅ Verified `info` field appears in response
- ✅ All linting passes (`cargo xtask lint`)
- ✅ Backward compatibility maintained (existing code using `runtime` unaffected)

## Future Consideration
This pattern could be applied to other tools where parameter naming isn't immediately intuitive, improving the overall developer experience.