### PR TITLE
test(runtimed-py): probe widget runtime state

### DIFF
--- a/python/runtimed/src/runtimed/_internals.pyi
+++ b/python/runtimed/src/runtimed/_internals.pyi
@@ -354,6 +354,34 @@ class ExecutionState:
         """Whether the execution succeeded (None if still running)."""
         ...
 
+class CommDocEntry:
+    """A single comm entry from RuntimeStateDoc."""
+
+    @property
+    def target_name(self) -> str:
+        """Widget protocol target, e.g. "jupyter.widget"."""
+        ...
+    @property
+    def model_module(self) -> str:
+        """Widget model module, e.g. "@jupyter-widgets/controls"."""
+        ...
+    @property
+    def model_name(self) -> str:
+        """Widget model name, e.g. "IntSliderModel"."""
+        ...
+    @property
+    def state(self) -> dict[str, Any]:
+        """Current comm state as a JSON-compatible dictionary."""
+        ...
+    @property
+    def outputs(self) -> list[dict[str, Any]]:
+        """Output manifests for OutputModel widgets."""
+        ...
+    @property
+    def seq(self) -> int:
+        """Insertion order for dependency-correct replay."""
+        ...
+
 class RuntimeState:
     """Full runtime state snapshot from the daemon's RuntimeStateDoc."""
 
@@ -376,6 +404,10 @@ class RuntimeState:
     @property
     def executions(self) -> dict[str, ExecutionState]:
         """Execution lifecycle entries keyed by execution_id."""
+        ...
+    @property
+    def comms(self) -> dict[str, CommDocEntry]:
+        """Runtime comm entries keyed by comm_id."""
         ...
 
 class HistoryEntry:

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -56,18 +56,16 @@ class Notebook:
         """Current runtime state read from the local replica.
 
         Returns a ``RuntimeState`` with ``.kernel``, ``.queue``, ``.env``,
-        ``.executions``, and ``.comms`` — useful for polling kernel status
-        or inspecting widget state.
+        ``.executions``, and ``.comms`` — useful for polling kernel status.
         """
         return self._session.get_runtime_state_sync()
 
     @property
-    def widgets(self) -> dict:
-        """Active ipywidgets keyed by comm_id.
+    def _widgets(self) -> dict:
+        """Private snapshot of active ipywidget comms keyed by comm_id.
 
-        Each value is a ``CommDocEntry`` with ``.model_name``, ``.state``
-        (dict), ``.model_module``, etc. Filters ``runtime.comms`` to entries
-        with ``target_name == "jupyter.widget"``.
+        This reads from RuntimeStateDoc via the local CRDT replica. It is for
+        tests and diagnostics, not a stable Python widget API.
         """
         return {
             cid: entry

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1971,6 +1971,47 @@ class TestKernelLifecycle:
         assert not await session.kernel_started()
 
 
+class TestWidgetRuntimeState:
+    """Widget comms are visible through the CRDT-backed runtime state."""
+
+    async def test_private_widget_snapshot_reads_runtime_state_comms(self, session):
+        """ipywidgets comm_open state lands in RuntimeStateDoc for Python inspection."""
+        await async_start_kernel_with_retry(session)
+
+        cell_id = await session.create_cell(
+            "from IPython.display import display\n"
+            "import ipywidgets as widgets\n"
+            "slider = widgets.IntSlider(value=7, description='probe')\n"
+            "display(slider)\n"
+        )
+
+        result = await session.execute_cell(cell_id)
+        assert result.success, result.stderr
+
+        notebook = runtimed.Notebook(session)
+
+        def has_slider_comm():
+            return any(
+                entry.model_name == "IntSliderModel"
+                and entry.model_module == "@jupyter-widgets/controls"
+                and entry.state.get("value") == 7
+                and entry.state.get("description") == "probe"
+                for entry in notebook._widgets.values()
+            )
+
+        await async_wait_for_sync(
+            has_slider_comm,
+            timeout=20.0,
+            interval=0.25,
+            description="widget comm state in RuntimeStateDoc",
+        )
+
+        slider = next(
+            entry for entry in notebook._widgets.values() if entry.model_name == "IntSliderModel"
+        )
+        assert slider.target_name == "jupyter.widget"
+
+
 class TestOutputTypes:
     """Test different output types from execution."""
 

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -175,6 +175,38 @@ class TestSyncGuards:
         assert hasattr(runtimed.EnvState, "__await__")
 
 
+class _CommEntry:
+    def __init__(self, target_name):
+        self.target_name = target_name
+
+
+class _WidgetRuntimeState:
+    comms = {
+        "widget": _CommEntry("jupyter.widget"),
+        "other": _CommEntry("custom.target"),
+    }
+
+
+class _RuntimeStateSession:
+    notebook_id = "runtime-state-notebook"
+
+    def get_runtime_state_sync(self):
+        return _WidgetRuntimeState()
+
+
+class TestPrivateWidgetSnapshot:
+    """Private widget snapshot reads the CRDT runtime-state comm map."""
+
+    def test_widgets_are_private_and_filtered_from_runtime_comms(self):
+        from runtimed._notebook import Notebook
+
+        notebook = Notebook(_RuntimeStateSession())  # ty: ignore[invalid-argument-type]
+
+        assert set(notebook._widgets) == {"widget"}
+        assert notebook._widgets["widget"].target_name == "jupyter.widget"
+        assert not hasattr(notebook, "widgets")
+
+
 class TestKernelStatusConstants:
     """Typed kernel-status constants mirror the Rust daemon strings."""
 


### PR DESCRIPTION
## Summary

- Removes the old public `Notebook.widgets` convenience property and replaces it with a deliberately private `Notebook._widgets` snapshot helper.
- Adds `CommDocEntry` / `RuntimeState.comms` type stubs so Python-side probes reflect the current RuntimeStateDoc shape.
- Adds unit and daemon integration coverage for ipywidgets comm state flowing through the CRDT-backed runtime state.

## Notes

This intentionally avoids presenting widgets as a stable native Python API. The helper is only a private diagnostic/test surface around RuntimeStateDoc comm entries.

## Validation

- `python/runtimed/.venv/bin/python -m pytest ...` could not run in this worktree because `python/runtimed/.venv` is absent.
- `.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -q` passed: `38 passed`.
- `cargo xtask lint --fix` passed.
- Exact daemon integration node was attempted in CI-mode locally, but the shared daemon health fixture failed before reaching this test body with `Unexpected response: NoKernel` after kernel start reported OK. CI should give the authoritative signal here.
