### PR TITLE
fix(runtimed): stabilize pyproject watcher metadata

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1126,6 +1126,63 @@ pub(crate) fn project_file_deps_match_trust_info(
     }
 }
 
+/// Apply the same derived pyproject.toml dependency view used by auto-launch
+/// to a metadata snapshot parsed from disk.
+///
+/// The file watcher compares external `.ipynb` metadata against the in-memory
+/// CRDT snapshot. For project-backed notebooks, auto-launch intentionally
+/// injects `[project].dependencies` into `metadata.runt.uv` so the UI and MCP
+/// can expose the active environment. Those deps are derived from
+/// `pyproject.toml`, so the `.ipynb` on disk may not contain them yet. Normalize
+/// the parsed snapshot before comparing; otherwise the watcher treats the
+/// derived deps as an external deletion and churns metadata on every watch
+/// event.
+pub(crate) fn apply_pyproject_bootstrap_to_snapshot(
+    notebook_path: &Path,
+    snapshot: &mut NotebookMetadataSnapshot,
+) -> bool {
+    let Some(detected) = crate::project_file::detect_project_file(notebook_path) else {
+        return false;
+    };
+    if detected.kind != crate::project_file::ProjectFileKind::PyprojectToml {
+        return false;
+    }
+    let Ok(content) = std::fs::read_to_string(&detected.path) else {
+        return false;
+    };
+    let deps = extract_pyproject_deps(&content);
+    if deps.is_empty() {
+        return false;
+    }
+
+    let current_deps = snapshot.runt.uv.as_ref().map(|u| &u.dependencies);
+    let deps_match = current_deps.is_some_and(|d| d == &deps);
+    let trust_ok = matches!(
+        verify_trust_from_snapshot(snapshot).status,
+        runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies,
+    );
+    if deps_match && trust_ok {
+        return false;
+    }
+
+    let uv = snapshot
+        .runt
+        .uv
+        .get_or_insert_with(|| notebook_doc::metadata::UvInlineMetadata {
+            dependencies: Vec::new(),
+            requires_python: None,
+            prerelease: None,
+        });
+    uv.dependencies = deps;
+    if let Err(e) = auto_sign_in_place(snapshot) {
+        warn!(
+            "[notebook-sync] Failed to auto-sign pyproject.toml watcher metadata: {}",
+            e
+        );
+    }
+    true
+}
+
 /// Verify trust status of a notebook by reading its file from disk.
 /// Returns TrustState with the verification result.
 ///

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -915,7 +915,13 @@ pub(crate) fn spawn_notebook_file_watcher(
                                     continue;
                                 }
                             };
-                            let external_metadata = parse_metadata_from_ipynb(&json);
+                            let mut external_metadata = parse_metadata_from_ipynb(&json);
+                            if let Some(ref mut meta) = external_metadata {
+                                super::metadata::apply_pyproject_bootstrap_to_snapshot(
+                                    &notebook_path,
+                                    meta,
+                                );
+                            }
 
                             // Check if kernel is running (to preserve outputs)
                             let has_kernel = room.has_kernel().await;

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -4248,6 +4248,57 @@ async fn test_pyproject_bootstrap_state_lands_trusted() {
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
 
+#[tokio::test]
+#[serial]
+async fn test_file_watcher_normalizes_pyproject_bootstrap_metadata() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let project_dir = tempfile::tempdir().unwrap();
+    let notebook_path = project_dir.path().join("project.ipynb");
+    std::fs::write(
+        project_dir.path().join("pyproject.toml"),
+        r#"[project]
+name = "project"
+version = "0.1.0"
+dependencies = ["httpx", "numpy"]
+"#,
+    )
+    .unwrap();
+
+    // External .ipynb metadata as parsed from disk: no inline dependency
+    // section yet. Auto-launch derives that section from pyproject.toml in
+    // memory, and the watcher must compare against the same derived shape.
+    let mut external = snapshot_empty();
+    assert!(external.runt.uv.is_none());
+
+    let changed =
+        super::metadata::apply_pyproject_bootstrap_to_snapshot(&notebook_path, &mut external);
+    assert!(changed);
+    assert_eq!(
+        external.runt.uv.as_ref().map(|uv| uv.dependencies.clone()),
+        Some(vec!["httpx".to_string(), "numpy".to_string()])
+    );
+    assert_eq!(
+        verify_trust_from_snapshot(&external).status,
+        runt_trust::TrustStatus::Trusted
+    );
+
+    let mut current = snapshot_empty();
+    current.runt.uv = external.runt.uv.clone();
+    current.runt.trust_signature = external.runt.trust_signature.clone();
+    current.runt.trust_timestamp = external.runt.trust_timestamp.clone();
+
+    assert_eq!(
+        Some(&external),
+        Some(&current),
+        "normalized external metadata should match the CRDT bootstrap shape"
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
 // ── Per-agent oneshot channel tests ──────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the UV Pyproject E2E failure seen in the Build workflow by normalizing file-watcher metadata for pyproject-backed notebooks before comparing it to the CRDT snapshot.

## Root Cause

Auto-launch derives `metadata.runt.uv.dependencies` from the adjacent `pyproject.toml` so the UI and MCP consumers can see the active project environment. The notebook file on disk may not contain that derived metadata yet. The `.ipynb` file watcher compared the raw parsed file metadata against the in-memory CRDT snapshot, interpreted the derived deps as an external deletion, and churned metadata on each watch event.

## Changes

- Added a shared pyproject bootstrap normalizer for metadata snapshots parsed from disk.
- Applied that normalizer in the notebook file watcher before deciding whether external metadata changed.
- Added a regression test for the raw `.ipynb` metadata vs bootstrapped CRDT metadata comparison.

## Verification

- `cargo xtask wasm`
- `cargo test -p runtimed test_file_watcher_normalizes_pyproject_bootstrap_metadata -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
