### PR TITLE
fix(runtimed): keep project deps out of notebook metadata

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -223,6 +223,7 @@ function AppContent() {
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
   const [envBuildDialogOpen, setEnvBuildDialogOpen] = useState(false);
   const [dismissedEnvBuildDetails, setDismissedEnvBuildDetails] = useState<string | null>(null);
+  const [envBuildCreating, setEnvBuildCreating] = useState(false);
   const [pendingTrustAction, setPendingTrustAction] = useState<PendingTrustAction | null>(null);
   const pendingTrustActionRef = useRef<PendingTrustAction | null>(null);
   const [trustActionNotice, setTrustActionNotice] = useState<string | null>(null);
@@ -376,6 +377,7 @@ function AppContent() {
     interruptKernel,
     shutdownKernel,
     syncEnvironment,
+    approveProjectEnvironment,
     runAllCells: daemonRunAllCells,
     runAllCellsGuarded,
     sendCommMessage,
@@ -1060,13 +1062,29 @@ function AppContent() {
     [errorDetails],
   );
 
-  const handleEnvBuildRetry = useCallback(async () => {
+  const handleEnvBuildCreate = useCallback(async () => {
     setDismissedEnvBuildDetails(null);
-    const started = await tryStartKernel();
-    if (!started) {
-      setEnvBuildDialogOpen(true);
+    setEnvBuildCreating(true);
+    try {
+      const projectFilePath =
+        runtimeState.project_context.state === "Detected" &&
+        runtimeState.project_context.project_file.kind === "EnvironmentYml"
+          ? runtimeState.project_context.project_file.absolute_path
+          : undefined;
+      const approval = await approveProjectEnvironment(projectFilePath);
+      if (approval.result === "error") {
+        logger.error("[App] approveProjectEnvironment failed", approval.error);
+        setEnvBuildDialogOpen(true);
+        return;
+      }
+      const started = await tryStartKernel();
+      if (!started) {
+        setEnvBuildDialogOpen(true);
+      }
+    } finally {
+      setEnvBuildCreating(false);
     }
-  }, [tryStartKernel]);
+  }, [approveProjectEnvironment, runtimeState.project_context, tryStartKernel]);
 
   // Start kernel explicitly with pyproject.toml (user action from DependencyHeader)
   const handleStartKernelWithPyproject = useCallback(async () => {
@@ -1762,7 +1780,8 @@ function AppContent() {
           open={envBuildDialogOpen}
           onOpenChange={handleEnvBuildDialogOpenChange}
           errorDetails={errorDetails}
-          onRetry={handleEnvBuildRetry}
+          onCreate={handleEnvBuildCreate}
+          creating={envBuildCreating}
         />
         <CrdtBridgeProvider
           getHandle={getHandle}

--- a/apps/notebook/src/components/EnvBuildDecisionDialog.tsx
+++ b/apps/notebook/src/components/EnvBuildDecisionDialog.tsx
@@ -7,12 +7,13 @@ interface EnvBuildDecisionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   errorDetails: string | null;
-  onRetry: () => void;
+  onCreate: () => void;
+  creating?: boolean;
 }
 
 export function extractCondaEnvCreateCommand(details: string | null): string | null {
   if (!details) return null;
-  const match = details.match(/conda env create -f .+$/m);
+  const match = details.match(/conda env create .+$/m);
   return match?.[0].trim() ?? null;
 }
 
@@ -20,7 +21,8 @@ export function EnvBuildDecisionDialog({
   open,
   onOpenChange,
   errorDetails,
-  onRetry,
+  onCreate,
+  creating = false,
 }: EnvBuildDecisionDialogProps) {
   const [copied, setCopied] = useState(false);
   const command = useMemo(() => extractCondaEnvCreateCommand(errorDetails), [errorDetails]);
@@ -31,10 +33,10 @@ export function EnvBuildDecisionDialog({
     setCopied(true);
   }, [command]);
 
-  const retry = useCallback(() => {
+  const create = useCallback(() => {
     setCopied(false);
-    onRetry();
-  }, [onRetry]);
+    onCreate();
+  }, [onCreate]);
 
   return (
     <RuntimeDecisionDialog
@@ -62,16 +64,17 @@ export function EnvBuildDecisionDialog({
             <Copy className="mr-2 size-4" />
             {copied ? "Copied" : "Copy command"}
           </Button>
-          <Button onClick={retry} data-testid="env-build-retry-button">
+          <Button onClick={create} disabled={creating} data-testid="env-build-create-button">
             <RotateCw className="mr-2 size-4" />
-            Retry
+            {creating ? "Creating..." : "Create environment"}
           </Button>
         </>
       }
     >
       <div className="space-y-3">
         <p className="text-sm text-muted-foreground">
-          Build the declared environment in a terminal, then retry kernel launch.
+          Create the declared environment to continue kernel launch. Future opens can launch
+          automatically while the declared packages are approved.
         </p>
         {errorDetails && (
           <pre className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-xs leading-relaxed">

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -114,10 +114,9 @@ export function PixiDependencyHeader({
               </span>
             </div>
 
-            {/* Show dep names from CRDT (bootstrapped from pixi.toml) */}
-            {pixiDeps?.dependencies?.length ? (
+            {pixiInfo.dependencies.length > 0 ? (
               <div className="mt-1.5 flex flex-wrap gap-1.5">
-                {pixiDeps.dependencies.map((dep) => (
+                {pixiInfo.dependencies.map((dep) => (
                   <span
                     key={dep}
                     className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
@@ -127,12 +126,12 @@ export function PixiDependencyHeader({
                 ))}
               </div>
             ) : null}
-            {pixiDeps?.pypiDependencies?.length ? (
+            {pixiInfo.pypi_dependencies.length > 0 ? (
               <div className="mt-1.5 flex flex-wrap gap-1.5">
                 <span className="text-muted-foreground text-[10px] uppercase tracking-wide self-center">
                   PyPI
                 </span>
-                {pixiDeps.pypiDependencies.map((dep) => (
+                {pixiInfo.pypi_dependencies.map((dep) => (
                   <span
                     key={dep}
                     className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
@@ -142,24 +141,6 @@ export function PixiDependencyHeader({
                 ))}
               </div>
             ) : null}
-            {/* Fallback: show counts if CRDT deps not yet bootstrapped */}
-            {(!pixiDeps || pixiDeps.dependencies.length === 0) &&
-              (pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (
-                <div className="mt-1.5 flex gap-2 text-muted-foreground">
-                  {pixiInfo.has_dependencies && (
-                    <span className="rounded bg-muted px-1.5 py-0.5">
-                      {pixiInfo.dependency_count} conda dep
-                      {pixiInfo.dependency_count !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                  {pixiInfo.has_pypi_dependencies && (
-                    <span className="rounded bg-muted px-1.5 py-0.5">
-                      {pixiInfo.pypi_dependency_count} pypi dep
-                      {pixiInfo.pypi_dependency_count !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                </div>
-              )}
 
             {pixiInfo.channels.length > 0 && (
               <div className="mt-1.5 flex items-center gap-1.5 text-muted-foreground">

--- a/apps/notebook/src/components/__tests__/env-build-decision-dialog.test.tsx
+++ b/apps/notebook/src/components/__tests__/env-build-decision-dialog.test.tsx
@@ -13,6 +13,14 @@ describe("extractCondaEnvCreateCommand", () => {
     );
   });
 
+  it("extracts explicit prefix create commands", () => {
+    expect(
+      extractCondaEnvCreateCommand(
+        "environment.yml declares conda env '/tmp/envs/hash', which is not built on this machine. Run: conda env create -p /tmp/envs/hash -f /tmp/project/environment.yml",
+      ),
+    ).toBe("conda env create -p /tmp/envs/hash -f /tmp/project/environment.yml");
+  });
+
   it("returns null when no command is present", () => {
     expect(extractCondaEnvCreateCommand("environment missing")).toBeNull();
   });
@@ -31,7 +39,7 @@ describe("EnvBuildDecisionDialog", () => {
         open
         onOpenChange={() => {}}
         errorDetails={DETAILS}
-        onRetry={() => {}}
+        onCreate={() => {}}
       />,
     );
 
@@ -53,7 +61,7 @@ describe("EnvBuildDecisionDialog", () => {
         open
         onOpenChange={() => {}}
         errorDetails={DETAILS}
-        onRetry={() => {}}
+        onCreate={() => {}}
       />,
     );
 
@@ -62,25 +70,25 @@ describe("EnvBuildDecisionDialog", () => {
     expect(screen.getByText("Copied")).toBeInTheDocument();
   });
 
-  it("invokes cancel and retry actions", async () => {
+  it("invokes cancel and create actions", async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
-    const onRetry = vi.fn();
+    const onCreate = vi.fn();
 
     render(
       <EnvBuildDecisionDialog
         open
         onOpenChange={onOpenChange}
         errorDetails={DETAILS}
-        onRetry={onRetry}
+        onCreate={onCreate}
       />,
     );
 
     await user.click(screen.getByTestId("env-build-cancel-button"));
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
-    await user.click(screen.getByTestId("env-build-retry-button"));
-    expect(onRetry).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByTestId("env-build-create-button"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
   });
 
   it("disables copy when details do not include a command", () => {
@@ -89,7 +97,7 @@ describe("EnvBuildDecisionDialog", () => {
         open
         onOpenChange={() => {}}
         errorDetails="environment.yml is missing a named env"
-        onRetry={() => {}}
+        onCreate={() => {}}
       />,
     );
 

--- a/apps/notebook/src/hooks/__tests__/project-context-derivers.test.ts
+++ b/apps/notebook/src/hooks/__tests__/project-context-derivers.test.ts
@@ -196,8 +196,10 @@ describe("derivePixiInfo", () => {
       path: "/proj/pixi.toml",
       relative_path: "pixi.toml",
       workspace_name: null,
+      dependencies: ["python", "numpy"],
       has_dependencies: true,
       dependency_count: 2,
+      pypi_dependencies: ["requests", "rich"],
       has_pypi_dependencies: true,
       pypi_dependency_count: 2,
       python: "3.11.*",
@@ -208,7 +210,9 @@ describe("derivePixiInfo", () => {
   it("reports empty counts but does not return null for an empty pixi project", () => {
     const info = derivePixiInfo(pixiCtx());
     expect(info).not.toBeNull();
+    expect(info?.dependencies).toEqual([]);
     expect(info?.has_dependencies).toBe(false);
+    expect(info?.pypi_dependencies).toEqual([]);
     expect(info?.has_pypi_dependencies).toBe(false);
     expect(info?.channels).toEqual([]);
   });

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -104,7 +104,7 @@ export function useCondaDependencies() {
   const runtimeState = useRuntimeState();
 
   // Reactive read from the WASM Automerge doc via useSyncExternalStore.
-  // Re-renders automatically when the doc changes (bootstrap, sync, writes).
+  // Re-renders automatically when notebook metadata changes.
   const condaDeps = useCondaDeps();
   const dependencies = condaDeps
     ? {

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -297,6 +297,12 @@ export function useDaemonKernel({
     [client],
   );
 
+  const approveProjectEnvironment = useCallback(
+    (projectFilePath?: string) =>
+      client.approveProjectEnvironment(projectFilePath) as Promise<NotebookResponse>,
+    [client],
+  );
+
   const runAllCells = useCallback(
     () => client.runAllCells() as Promise<NotebookResponse>,
     [client],
@@ -336,6 +342,7 @@ export function useDaemonKernel({
     interruptKernel,
     shutdownKernel,
     syncEnvironment,
+    approveProjectEnvironment,
     runAllCells,
     runAllCellsGuarded,
     sendCommMessage,

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -107,7 +107,7 @@ export function useDependencies() {
   const runtimeState = useRuntimeState();
 
   // Reactive read from the WASM Automerge doc via useSyncExternalStore.
-  // Re-renders automatically when the doc changes (bootstrap, sync, writes).
+  // Re-renders automatically when notebook metadata changes.
   const uvDeps = useUvDependencies();
   const dependencies = uvDeps
     ? {

--- a/apps/notebook/src/hooks/usePixiDetection.ts
+++ b/apps/notebook/src/hooks/usePixiDetection.ts
@@ -13,8 +13,10 @@ export interface PixiInfo {
   path: string;
   relative_path: string;
   workspace_name: string | null;
+  dependencies: string[];
   has_dependencies: boolean;
   dependency_count: number;
+  pypi_dependencies: string[];
   has_pypi_dependencies: boolean;
   pypi_dependency_count: number;
   python: string | null;
@@ -45,8 +47,10 @@ export function derivePixiInfo(ctx: ProjectContext): PixiInfo | null {
     path: ctx.project_file.absolute_path,
     relative_path: ctx.project_file.relative_to_notebook,
     workspace_name: null,
+    dependencies: ctx.parsed.dependencies,
     has_dependencies: ctx.parsed.dependencies.length > 0,
     dependency_count: ctx.parsed.dependencies.length,
+    pypi_dependencies,
     has_pypi_dependencies: pypi_dependencies.length > 0,
     pypi_dependency_count: pypi_dependencies.length,
     python: ctx.parsed.requires_python,

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -440,6 +440,15 @@ pub enum NotebookRequest {
         dependency_fingerprint: Option<String>,
     },
 
+    /// Approve creating/syncing a project-file environment for the current
+    /// project file snapshot. This is intentionally separate from
+    /// `ApproveTrust`: it records local project setup approval and does not
+    /// sign notebook dependency metadata.
+    ApproveProjectEnvironment {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project_file_path: Option<String>,
+    },
+
     /// Get the full Automerge document bytes from the daemon's canonical doc.
     /// Used by the frontend to bootstrap its WASM Automerge peer.
     GetDocBytes {},
@@ -893,6 +902,9 @@ mod tests {
             NotebookRequest::ApproveTrust {
                 dependency_fingerprint: Some("{\"uv\":{\"dependencies\":[\"numpy\"]}}".into()),
             },
+            NotebookRequest::ApproveProjectEnvironment {
+                project_file_path: Some("/tmp/project/environment.yml".into()),
+            },
         ];
 
         for request in cases {
@@ -990,6 +1002,13 @@ mod tests {
                 serde_json::json!({
                     "action": "approve_trust",
                     "dependency_fingerprint": "{}",
+                }),
+            ),
+            (
+                "approve_project_environment",
+                serde_json::json!({
+                    "action": "approve_project_environment",
+                    "project_file_path": "/tmp/project/environment.yml",
                 }),
             ),
             (

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -937,11 +937,10 @@ async fn auto_approve_allowlisted_snapshot(room: &NotebookRoom) -> Result<bool, 
 /// and write the signature + timestamp back into the snapshot in place.
 ///
 /// Does not persist the snapshot — the caller writes it back to the doc.
-/// Used by both `resign_trusted_snapshot` (re-sign a previously-Trusted
-/// notebook whose deps changed) and the project-file bootstrap path in
-/// `auto_launch_kernel` (auto-sign deps the daemon itself sourced from
-/// pyproject.toml / pixi.toml / environment.yml so the trust dialog
-/// doesn't fire on deps that came from a file the user already owns).
+/// Used by `resign_trusted_snapshot` (re-sign a previously-Trusted notebook
+/// whose deps changed) and by explicit trust approval paths. Project-file deps
+/// are runtime context and should not be signed unless they have been copied
+/// into notebook metadata.
 pub(crate) fn auto_sign_in_place(snapshot: &mut NotebookMetadataSnapshot) -> Result<(), String> {
     let runt_value = serde_json::to_value(&snapshot.runt)
         .map_err(|e| format!("serialize runt metadata: {}", e))?;
@@ -1015,8 +1014,8 @@ pub(crate) async fn resolve_metadata_snapshot(
     None
 }
 
-/// If the detected project file is an `environment.yml` whose declared
-/// conda env isn't built on this machine, return the declared env name.
+/// If the detected project file is an `environment.yml` whose target
+/// conda env isn't built on this machine, return the build decision details.
 ///
 /// The auto-launch path uses this to detect the miss upfront and set a
 /// specific error lifecycle (with `KernelErrorReason::CondaEnvYmlMissing`
@@ -1024,39 +1023,105 @@ pub(crate) async fn resolve_metadata_snapshot(
 /// die with a generic "could not resolve conda environment prefix" and
 /// leaving the kernel stuck in `initializing` forever. Covers #2157.
 ///
-/// Returns `None` when the project file isn't `environment.yml`, when
-/// the env is built and usable, or when env.yml has no `name:`/`prefix:`
-/// (the kernel path's existing error handles the shape-broken case).
-pub(crate) fn missing_conda_env_yml_name(
+/// Returns `None` when the project file isn't `environment.yml` or when
+/// the env is already built and usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CondaEnvYmlBuildDecision {
+    pub label: String,
+    pub create_command: String,
+}
+
+pub(crate) fn missing_conda_env_yml_decision(
     detected: &crate::project_file::DetectedProjectFile,
-) -> Option<String> {
+) -> Option<CondaEnvYmlBuildDecision> {
     if detected.kind != crate::project_file::ProjectFileKind::EnvironmentYml {
         return None;
     }
-    // `resolve_conda_env_prefix` returns the `prefix:` value verbatim
-    // without checking existence (it only validates via `find_named_conda_env`
-    // for the `name:` path). For an env declared with `prefix: /missing`
-    // we'd incorrectly conclude the env is built and skip the typed
-    // error. Verify the python binary exists before accepting the prefix.
-    if let Some(prefix) = crate::project_file::resolve_conda_env_prefix(&detected.path) {
-        if crate::project_file::conda_python_path(&prefix).exists() {
-            return None;
+
+    let config = crate::project_file::parse_environment_yml(&detected.path).ok()?;
+    let conda_prefix = if let Some(ref prefix) = config.prefix {
+        prefix.clone()
+    } else if let Some(ref name) = config.name {
+        crate::project_file::find_named_conda_env(name)
+            .unwrap_or_else(|| crate::project_file::default_conda_envs_dir().join(name))
+    } else {
+        let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
+        let conda_deps_tmp = kernel_env::CondaDependencies {
+            dependencies: config.dependencies.clone(),
+            channels: config.channels.clone(),
+            python: config.python.clone(),
+            env_id: None,
+        };
+        cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
+    };
+
+    if crate::project_file::conda_python_path(&conda_prefix).exists() {
+        return None;
+    }
+
+    let label = config
+        .name
+        .clone()
+        .unwrap_or_else(|| conda_prefix.display().to_string());
+    let create_command = if config.name.is_some() && config.prefix.is_none() {
+        format!("conda env create -f {}", detected.path.display())
+    } else {
+        format!(
+            "conda env create -p {} -f {}",
+            conda_prefix.display(),
+            detected.path.display()
+        )
+    };
+
+    Some(CondaEnvYmlBuildDecision {
+        label,
+        create_command,
+    })
+}
+
+pub(crate) fn format_conda_env_yml_build_details(decision: &CondaEnvYmlBuildDecision) -> String {
+    format!(
+        "environment.yml declares conda env '{}', which is not built on this machine. Run: {}",
+        decision.label, decision.create_command
+    )
+}
+
+pub(crate) fn project_environment_build_approved(
+    room: &NotebookRoom,
+    detected: &crate::project_file::DetectedProjectFile,
+) -> bool {
+    let Ok(config) = crate::project_file::parse_environment_yml(&detected.path) else {
+        return false;
+    };
+    let trust_info = environment_yml_trust_info(&config);
+    match room.trusted_packages.all_dependencies_approved(&trust_info) {
+        Ok(approved) => approved,
+        Err(error) => {
+            warn!(
+                "[trusted-packages] Failed to check project environment approval for {:?}: {}",
+                detected.path, error
+            );
+            false
         }
     }
-    // Declared but not built. Prefer the `name:` for display, fall back
-    // to the `prefix:` path. If env.yml has neither, leave it to the
-    // existing conda:env_yml launch path instead of inventing a fake
-    // named-env decision for an unnamed spec.
-    let config = crate::project_file::parse_environment_yml(&detected.path).ok();
-    if let Some(ref c) = config {
-        if let Some(ref name) = c.name {
-            return Some(name.clone());
-        }
-        if let Some(ref prefix) = c.prefix {
-            return Some(prefix.display().to_string());
-        }
+}
+
+pub(crate) fn environment_yml_trust_info(
+    config: &crate::project_file::EnvironmentYmlConfig,
+) -> runt_trust::TrustInfo {
+    runt_trust::TrustInfo {
+        status: runt_trust::TrustStatus::Untrusted,
+        uv_dependencies: vec![],
+        approved_uv_dependencies: vec![],
+        conda_dependencies: config.dependencies.clone(),
+        approved_conda_dependencies: vec![],
+        conda_channels: config.channels.clone(),
+        pixi_dependencies: vec![],
+        approved_pixi_dependencies: vec![],
+        pixi_pypi_dependencies: vec![],
+        approved_pixi_pypi_dependencies: vec![],
+        pixi_channels: vec![],
     }
-    None
 }
 
 /// Check whether a notebook's inline dependency list exactly matches a
@@ -2551,151 +2616,6 @@ pub(crate) async fn auto_launch_kernel(
     let project_source: Option<notebook_protocol::connection::EnvSource> =
         detected_project_file.as_ref().map(|d| d.to_env_source());
 
-    // Step 3b: Bootstrap project deps into CRDT metadata.
-    // When a project file exists, populate the inline dep section with the
-    // project's deps so that the UI and MCP tools can see what's available.
-    if let Some(ref detected) = detected_project_file {
-        match detected.kind {
-            crate::project_file::ProjectFileKind::PixiToml => {
-                if let Ok(info) = kernel_launch::tools::pixi_info(&detected.path).await {
-                    let deps = info.default_deps_snapshot();
-                    if !deps.is_empty() {
-                        let mut doc = room.doc.write().await;
-                        let mut changed = false;
-                        doc.fork_and_merge(|fork| {
-                            let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                            let current_deps = snap.runt.pixi.as_ref().map(|p| &p.dependencies);
-                            let deps_match = current_deps.is_some_and(|d| d == &deps);
-                            // Re-sign even when deps already match if the snapshot
-                            // isn't verifiably trusted — covers notebooks bootstrapped
-                            // by the pre-fix build (matching deps, no signature).
-                            let trust_ok = matches!(
-                                verify_trust_from_snapshot(&snap).status,
-                                runt_trust::TrustStatus::Trusted
-                                    | runt_trust::TrustStatus::NoDependencies
-                            );
-                            if !deps_match || !trust_ok {
-                                let pixi = snap.pixi_section_or_default();
-                                pixi.dependencies = deps;
-                                if let Err(e) = auto_sign_in_place(&mut snap) {
-                                    warn!(
-                                        "[notebook-sync] Failed to auto-sign pixi.toml bootstrap: {}",
-                                        e
-                                    );
-                                }
-                                let _ = fork.set_metadata_snapshot(&snap);
-                                changed = true;
-                            }
-                        });
-                        if changed {
-                            info!("[notebook-sync] Bootstrapped pixi.toml deps into CRDT");
-                        } else {
-                            debug!(
-                                "[notebook-sync] Pixi deps already current in CRDT, skipping write"
-                            );
-                        }
-                    }
-                }
-            }
-            crate::project_file::ProjectFileKind::PyprojectToml => {
-                // Read [project.dependencies] from pyproject.toml
-                if let Ok(content) = std::fs::read_to_string(&detected.path) {
-                    let deps = extract_pyproject_deps(&content);
-                    if !deps.is_empty() {
-                        let mut doc = room.doc.write().await;
-                        let mut changed = false;
-                        doc.fork_and_merge(|fork| {
-                            let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                            let current_deps = snap.runt.uv.as_ref().map(|u| &u.dependencies);
-                            let deps_match = current_deps.is_some_and(|d| d == &deps);
-                            let trust_ok = matches!(
-                                verify_trust_from_snapshot(&snap).status,
-                                runt_trust::TrustStatus::Trusted
-                                    | runt_trust::TrustStatus::NoDependencies
-                            );
-                            if !deps_match || !trust_ok {
-                                let uv = snap.runt.uv.get_or_insert_with(|| {
-                                    notebook_doc::metadata::UvInlineMetadata {
-                                        dependencies: Vec::new(),
-                                        requires_python: None,
-                                        prerelease: None,
-                                    }
-                                });
-                                uv.dependencies = deps;
-                                if let Err(e) = auto_sign_in_place(&mut snap) {
-                                    warn!(
-                                        "[notebook-sync] Failed to auto-sign pyproject.toml bootstrap: {}",
-                                        e
-                                    );
-                                }
-                                let _ = fork.set_metadata_snapshot(&snap);
-                                changed = true;
-                            }
-                        });
-                        if changed {
-                            info!("[notebook-sync] Bootstrapped pyproject.toml deps into CRDT");
-                        } else {
-                            debug!("[notebook-sync] Pyproject deps already current in CRDT, skipping write");
-                        }
-                    }
-                }
-            }
-            crate::project_file::ProjectFileKind::EnvironmentYml => {
-                if let Ok(env_config) = crate::project_file::parse_environment_yml(&detected.path) {
-                    let deps = env_config.dependencies;
-                    let channels = env_config.channels;
-                    if !deps.is_empty() {
-                        let mut doc = room.doc.write().await;
-                        let mut changed = false;
-                        doc.fork_and_merge(|fork| {
-                            let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                            let current_deps = snap.runt.conda.as_ref().map(|c| &c.dependencies);
-                            let current_channels = snap.runt.conda.as_ref().map(|c| &c.channels);
-                            let deps_match = current_deps.is_some_and(|d| d == &deps);
-                            let channels_match = current_channels.is_some_and(|c| c == &channels);
-                            let trust_ok = matches!(
-                                verify_trust_from_snapshot(&snap).status,
-                                runt_trust::TrustStatus::Trusted
-                                    | runt_trust::TrustStatus::NoDependencies
-                            );
-                            if !deps_match || !channels_match || !trust_ok {
-                                let conda = snap.runt.conda.get_or_insert_with(|| {
-                                    notebook_doc::metadata::CondaInlineMetadata {
-                                        dependencies: Vec::new(),
-                                        channels: Vec::new(),
-                                        python: None,
-                                    }
-                                });
-                                conda.dependencies = deps;
-                                // Channels are part of the signed trust
-                                // payload. Mirror env.yml's channels
-                                // exactly so reconciliation on reopen
-                                // can verify the notebook's channel
-                                // list didn't drift from source.
-                                conda.channels = channels;
-                                if let Err(e) = auto_sign_in_place(&mut snap) {
-                                    warn!(
-                                        "[notebook-sync] Failed to auto-sign environment.yml bootstrap: {}",
-                                        e
-                                    );
-                                }
-                                let _ = fork.set_metadata_snapshot(&snap);
-                                changed = true;
-                            }
-                        });
-                        if changed {
-                            info!("[notebook-sync] Bootstrapped environment.yml deps into CRDT");
-                        } else {
-                            debug!(
-                                "[notebook-sync] Conda deps already current in CRDT, skipping write"
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     // #2157/#2170: If the detected project file is an environment.yml whose
     // declared conda env isn't built on this machine, surface an explicit
     // awaiting-user-decision lifecycle instead of spawning a runtime agent that would die with
@@ -2705,23 +2625,26 @@ pub(crate) async fn auto_launch_kernel(
     // Writing AwaitingEnvBuild + details gives the frontend enough to
     // render a cohesive decision dialog and MCP tools enough to report the miss.
     if let Some(ref detected) = detected_project_file {
-        if let Some(env_name) = missing_conda_env_yml_name(detected) {
-            let yml_path = detected.path.display().to_string();
-            let details = format!(
-                "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
-                env_name, yml_path
-            );
-            warn!("[notebook-sync] {}", details);
-            if let Err(e) = room.state.with_doc(|sd| {
-                sd.set_lifecycle_with_error_details(
-                    &RuntimeLifecycle::AwaitingEnvBuild,
-                    Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
-                    Some(&details),
-                )
-            }) {
-                warn!("[runtime-state] {}", e);
+        if let Some(decision) = missing_conda_env_yml_decision(detected) {
+            if project_environment_build_approved(room, detected) {
+                info!(
+                    "[notebook-sync] Approved environment.yml build for {:?}; continuing launch",
+                    detected.path
+                );
+            } else {
+                let details = format_conda_env_yml_build_details(&decision);
+                warn!("[notebook-sync] {}", details);
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::AwaitingEnvBuild,
+                        Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
+                        Some(&details),
+                    )
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
             }
-            return;
         }
     }
 
@@ -3189,23 +3112,26 @@ pub(crate) async fn auto_launch_kernel(
             path: yml_path.clone(),
             kind: crate::project_file::ProjectFileKind::EnvironmentYml,
         };
-        if let Some(env_name) = missing_conda_env_yml_name(&detected_yml) {
-            let details = format!(
-                "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
-                env_name,
-                yml_path.display()
-            );
-            warn!("[notebook-sync] {}", details);
-            if let Err(e) = room.state.with_doc(|sd| {
-                sd.set_lifecycle_with_error_details(
-                    &RuntimeLifecycle::AwaitingEnvBuild,
-                    Some(KernelErrorReason::CondaEnvYmlMissing),
-                    Some(&details),
-                )
-            }) {
-                warn!("[runtime-state] {}", e);
+        if let Some(decision) = missing_conda_env_yml_decision(&detected_yml) {
+            if project_environment_build_approved(room, &detected_yml) {
+                info!(
+                    "[notebook-sync] Approved environment.yml build for {:?}; continuing launch",
+                    detected_yml.path
+                );
+            } else {
+                let details = format_conda_env_yml_build_details(&decision);
+                warn!("[notebook-sync] {}", details);
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::AwaitingEnvBuild,
+                        Some(KernelErrorReason::CondaEnvYmlMissing),
+                        Some(&details),
+                    )
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
             }
-            return;
         }
 
         let env_config = match crate::project_file::parse_environment_yml(&yml_path) {
@@ -3762,6 +3688,7 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
         NotebookRequest::CloneAsEphemeral { .. } => "CloneAsEphemeral",
         NotebookRequest::SyncEnvironment { .. } => "SyncEnvironment",
         NotebookRequest::ApproveTrust { .. } => "ApproveTrust",
+        NotebookRequest::ApproveProjectEnvironment { .. } => "ApproveProjectEnvironment",
         NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
     }
 }
@@ -3846,16 +3773,20 @@ pub(crate) async fn handle_notebook_request(
             dependency_fingerprint,
         } => crate::requests::approve_trust::handle(room, dependency_fingerprint).await,
 
+        NotebookRequest::ApproveProjectEnvironment { project_file_path } => {
+            crate::requests::approve_project_environment::handle(room, project_file_path).await
+        }
+
         NotebookRequest::GetDocBytes {} => crate::requests::get_doc_bytes::handle(room).await,
     }
 }
 
 /// Promote inline deps from CRDT metadata to a project file.
 ///
-/// When a kernel is project-backed (pixi:toml or uv:pyproject), inline deps in
-/// the CRDT are "intent" — the user wants this package. This function promotes
-/// them to the project file via `pixi add` / `uv add`, then clears the inline
-/// section from the CRDT.
+/// When a kernel is project-backed (pixi:toml, uv:pyproject, or
+/// conda:env_yml), inline deps in the CRDT are notebook intent. This function
+/// promotes new inline deps to the project file without mirroring the full
+/// project-file dependency set back into notebook metadata.
 ///
 /// Find the byte offset in an environment.yml string where new dependencies
 /// should be inserted (end of the `dependencies:` list, before the next
@@ -4067,20 +3998,6 @@ pub(crate) async fn promote_inline_deps_to_project(
             }
         }
 
-        // Always re-bootstrap CRDT from pixi.toml (even on partial failure)
-        // so the CRDT reflects what actually happened.
-        if !promoted.is_empty() || !errors.is_empty() {
-            if let Ok(info) = kernel_launch::tools::pixi_info(pixi_toml_path).await {
-                let deps = info.default_deps_snapshot();
-                let mut doc = room.doc.write().await;
-                doc.fork_and_merge(|fork| {
-                    let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                    let pixi = snap.pixi_section_or_default();
-                    pixi.dependencies = deps;
-                    let _ = fork.set_metadata_snapshot(&snap);
-                });
-            }
-        }
         if !errors.is_empty() {
             return Err(errors.join("; "));
         }
@@ -4175,25 +4092,6 @@ pub(crate) async fn promote_inline_deps_to_project(
             }
         }
 
-        // Re-bootstrap CRDT from environment.yml after changes
-        if !promoted.is_empty() || !errors.is_empty() {
-            if let Ok(env_config) = crate::project_file::parse_environment_yml(yml_path) {
-                let deps = env_config.dependencies;
-                let mut doc = room.doc.write().await;
-                doc.fork_and_merge(|fork| {
-                    let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                    let conda = snap.runt.conda.get_or_insert_with(|| {
-                        notebook_doc::metadata::CondaInlineMetadata {
-                            dependencies: Vec::new(),
-                            channels: Vec::new(),
-                            python: None,
-                        }
-                    });
-                    conda.dependencies = deps;
-                    let _ = fork.set_metadata_snapshot(&snap);
-                });
-            }
-        }
         if !errors.is_empty() {
             return Err(errors.join("; "));
         }
@@ -4265,25 +4163,6 @@ pub(crate) async fn promote_inline_deps_to_project(
             }
         }
 
-        // Always re-bootstrap CRDT from pyproject.toml (even on partial failure)
-        if !promoted.is_empty() || !errors.is_empty() {
-            if let Ok(content) = std::fs::read_to_string(pyproject_path) {
-                let deps = extract_pyproject_deps(&content);
-                let mut doc = room.doc.write().await;
-                doc.fork_and_merge(|fork| {
-                    let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                    let uv = snap.runt.uv.get_or_insert_with(|| {
-                        notebook_doc::metadata::UvInlineMetadata {
-                            dependencies: Vec::new(),
-                            requires_python: None,
-                            prerelease: None,
-                        }
-                    });
-                    uv.dependencies = deps;
-                    let _ = fork.set_metadata_snapshot(&snap);
-                });
-            }
-        }
         if !errors.is_empty() {
             return Err(errors.join("; "));
         }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -867,7 +867,15 @@ where
                 let mut save_succeeded = false;
                 if let Some(ref launched) = launched_snapshot {
                     let has_saved_path = room_for_eviction.identity.path.read().await.is_some();
-                    if has_saved_path {
+                    let env_source = room_for_eviction
+                        .state
+                        .read(|sd| sd.read_state().kernel.env_source.clone())
+                        .unwrap_or_default();
+                    let project_backed = matches!(
+                        env_source.as_str(),
+                        "pixi:toml" | "uv:pyproject" | "conda:env_yml"
+                    );
+                    if has_saved_path && !project_backed {
                         for runtime in [CapturedEnvRuntime::Uv, CapturedEnvRuntime::Conda] {
                             if flush_launched_deps_to_metadata(
                                 &room_for_eviction,
@@ -895,6 +903,11 @@ where
                                 ),
                             }
                         }
+                    } else if project_backed {
+                        debug!(
+                            "[notebook-sync] Skipping launched dep metadata flush for project-backed env {}",
+                            env_source
+                        );
                     }
                 }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3369,6 +3369,108 @@ fn test_build_launched_config_conda_prewarmed_stores_paths() {
     );
 }
 
+#[test]
+fn test_build_launched_config_pyproject_records_context_without_notebook_deps() {
+    let tmp = tempfile::tempdir().unwrap();
+    let notebook_path = tmp.path().join("notebook.ipynb");
+    std::fs::write(&notebook_path, "{}").unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas", "numpy"]);
+
+    let config = build_launched_config(
+        "python",
+        "uv:pyproject",
+        None,
+        Some(&NotebookMetadataSnapshot::default()),
+        Some(PathBuf::from("/tmp/project/.venv")),
+        Some(PathBuf::from("/tmp/project/.venv/bin/python")),
+        None,
+        Some(&notebook_path),
+        notebook_protocol::protocol::FeatureFlags::default(),
+        None,
+    );
+
+    assert_eq!(
+        config.pyproject_path.as_deref(),
+        Some(tmp.path().join("pyproject.toml").as_path())
+    );
+    assert!(
+        config.uv_deps.is_none(),
+        "project-file deps are launch context, not notebook metadata deps"
+    );
+}
+
+#[test]
+fn test_build_launched_config_pixi_records_context_without_notebook_deps() {
+    let tmp = tempfile::tempdir().unwrap();
+    let notebook_path = tmp.path().join("notebook.ipynb");
+    std::fs::write(&notebook_path, "{}").unwrap();
+    std::fs::write(
+        tmp.path().join("pixi.toml"),
+        "[project]\nname = \"test\"\nchannels = [\"conda-forge\"]\nplatforms = [\"osx-arm64\"]\n[dependencies]\npandas = \">=2\"\n",
+    )
+    .unwrap();
+
+    let config = build_launched_config(
+        "python",
+        "pixi:toml",
+        None,
+        Some(&NotebookMetadataSnapshot::default()),
+        Some(PathBuf::from("/tmp/pixi-env")),
+        Some(PathBuf::from("/tmp/pixi-env/bin/python")),
+        None,
+        Some(&notebook_path),
+        notebook_protocol::protocol::FeatureFlags::default(),
+        None,
+    );
+
+    assert_eq!(
+        config.pixi_toml_path.as_deref(),
+        Some(tmp.path().join("pixi.toml").as_path())
+    );
+    assert_eq!(
+        config.pixi_toml_deps,
+        Some(vec!["pandas = \">=2\"".to_string()])
+    );
+    assert!(
+        config.pixi_deps.is_none(),
+        "pixi.toml deps must not become notebook metadata deps"
+    );
+}
+
+#[test]
+fn test_build_launched_config_env_yml_records_context_without_notebook_deps() {
+    let tmp = tempfile::tempdir().unwrap();
+    let notebook_path = tmp.path().join("notebook.ipynb");
+    std::fs::write(&notebook_path, "{}").unwrap();
+    write_env_yml(tmp.path(), &["conda-forge"], &["pandas", "numpy"]);
+
+    let config = build_launched_config(
+        "python",
+        "conda:env_yml",
+        None,
+        Some(&NotebookMetadataSnapshot::default()),
+        Some(PathBuf::from("/tmp/conda-env")),
+        Some(PathBuf::from("/tmp/conda-env/bin/python")),
+        None,
+        Some(&notebook_path),
+        notebook_protocol::protocol::FeatureFlags::default(),
+        None,
+    );
+
+    assert_eq!(
+        config.environment_yml_path.as_deref(),
+        Some(tmp.path().join("environment.yml").as_path())
+    );
+    assert_eq!(
+        config.environment_yml_deps,
+        Some(vec!["numpy".to_string(), "pandas".to_string()])
+    );
+    assert!(
+        config.conda_deps.is_none(),
+        "environment.yml deps must not become notebook metadata deps"
+    );
+}
+
 // ── check_and_broadcast_sync_state tests ──────────────────────────────
 
 #[tokio::test]
@@ -4084,14 +4186,11 @@ async fn test_check_and_update_trust_state_no_autoresign_when_not_previously_tru
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
 
-// ── auto_sign_in_place: regression coverage for project-file bootstrap ──
+// ── auto_sign_in_place: notebook dependency trust coverage ──
 //
-// The daemon's auto-launch path writes project-file deps (pyproject.toml,
-// pixi.toml, environment.yml) into `metadata.runt.{uv,conda,pixi}`. Before
-// this helper existed, those self-writes landed without a signature and
-// flipped the notebook to Untrusted — causing the trust dialog to fire
-// (and flicker on brand-new notebooks opened inside a project dir) for
-// deps the user already had on disk in a file they own.
+// Notebook dependency trust signs only deps copied into notebook metadata.
+// Project-file deps are runtime context and are intentionally not signed unless
+// the user explicitly copies them into metadata.
 
 #[tokio::test]
 #[serial]
@@ -4156,94 +4255,6 @@ async fn test_auto_sign_in_place_pixi_writes_signature() {
         verify_trust_from_snapshot(&snap).status,
         runt_trust::TrustStatus::Trusted,
     );
-
-    std::env::remove_var("RUNT_TRUST_KEY_PATH");
-}
-
-/// Regression for Codex P2: a notebook saved by the pre-fix build has
-/// pyproject deps already written into the CRDT but no trust signature.
-/// On reopen with the fix, the bootstrap must detect the untrusted state
-/// and sign even when deps match.
-#[tokio::test]
-#[serial]
-async fn test_bootstrap_re_signs_matching_but_unsigned_snapshot() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let key_path = temp_dir.path().join("trust-key");
-    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
-
-    // Pre-fix state: matching pyproject deps, no signature.
-    let mut snap = snapshot_with_uv(vec!["pandas".to_string(), "numpy".to_string()]);
-    assert!(snap.runt.trust_signature.is_none());
-    assert_eq!(
-        verify_trust_from_snapshot(&snap).status,
-        runt_trust::TrustStatus::Untrusted,
-        "precondition: matching unsigned deps verify as Untrusted"
-    );
-
-    // Apply the bootstrap's new gate: when deps match but the snapshot
-    // doesn't verify as Trusted/NoDependencies, sign it.
-    let pyproject_deps = vec!["pandas".to_string(), "numpy".to_string()];
-    let current_deps = snap.runt.uv.as_ref().map(|u| u.dependencies.clone());
-    let deps_match = current_deps.as_ref().is_some_and(|d| d == &pyproject_deps);
-    let trust_ok = matches!(
-        verify_trust_from_snapshot(&snap).status,
-        runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies,
-    );
-    assert!(deps_match);
-    assert!(!trust_ok);
-    if !deps_match || !trust_ok {
-        auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
-    }
-
-    assert_eq!(
-        verify_trust_from_snapshot(&snap).status,
-        runt_trust::TrustStatus::Trusted,
-        "bootstrap must sign matching-but-unsigned snapshots, not skip them"
-    );
-
-    std::env::remove_var("RUNT_TRUST_KEY_PATH");
-}
-
-/// Regression for the pyproject.toml trust-dialog flicker: simulate the
-/// auto-launch bootstrap end state (deps written + auto-signed) and drive
-/// it through `check_and_update_trust_state`. Trust must land on Trusted
-/// without a needs-approval transition.
-#[tokio::test]
-#[serial]
-async fn test_pyproject_bootstrap_state_lands_trusted() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let key_path = temp_dir.path().join("trust-key");
-    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
-
-    let tmp = tempfile::TempDir::new().unwrap();
-    let (room, _path) = test_room_with_path(&tmp, "pyproject_bootstrap.ipynb");
-
-    // Brand-new room state the user would see: trust banner is shown for
-    // a pyproject-backed notebook the daemon is about to populate.
-    {
-        room.state
-            .with_doc(|sd| sd.set_trust("untrusted", true))
-            .unwrap();
-    }
-
-    // What the bootstrap block writes into the doc after the fix: deps
-    // from pyproject.toml plus an auto-signature covering them.
-    let mut snap = snapshot_with_uv(vec!["pandas".to_string(), "numpy".to_string()]);
-    auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
-    {
-        let mut doc = room.doc.write().await;
-        doc.set_metadata_snapshot(&snap).unwrap();
-    }
-
-    check_and_update_trust_state(&room).await;
-
-    let ts = room.trust_state.read().await;
-    assert_eq!(ts.status, runt_trust::TrustStatus::Trusted);
-    drop(ts);
-
-    let state = room.state.read(|sd| sd.read_state()).unwrap();
-    assert_eq!(state.trust.status, "trusted");
-    assert!(!state.trust.needs_approval);
 
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
@@ -5880,8 +5891,10 @@ dependencies:
         ..Default::default()
     };
 
-    // CRDT says the user wants pyyaml as a conda dep
-    let snapshot = snapshot_with_conda(vec!["numpy".to_string(), "pyyaml".to_string()]);
+    // CRDT says the user wants pyyaml as a notebook-scoped conda dep. The
+    // environment.yml baseline remains project context and must not be copied
+    // back into the notebook metadata after promotion.
+    let snapshot = snapshot_with_conda(vec!["pyyaml".to_string()]);
     {
         let mut doc = room.doc.write().await;
         let _ = doc.set_metadata_snapshot(&snapshot);
@@ -5903,6 +5916,13 @@ dependencies:
     assert!(
         updated.contains("  - pip:\n    - pyyaml\n"),
         "pip block should be untouched:\n{updated}"
+    );
+
+    let after = room.doc.read().await.get_metadata_snapshot().unwrap();
+    assert_eq!(
+        after.runt.conda.unwrap().dependencies,
+        vec!["pyyaml".to_string()],
+        "project-file promotion must not mirror environment.yml deps into notebook metadata"
     );
 }
 
@@ -6147,7 +6167,7 @@ async fn test_new_fresh_leaves_untrusted_when_deps_differ() {
 // ── #2157: environment.yml declares unbuilt conda env ─────────────────
 
 #[test]
-fn test_missing_conda_env_yml_name_detects_unbuilt_named_env() {
+fn test_missing_conda_env_yml_decision_detects_unbuilt_named_env() {
     let tmp = tempfile::tempdir().unwrap();
     let yml_path = tmp.path().join("environment.yml");
     std::fs::write(
@@ -6159,25 +6179,28 @@ fn test_missing_conda_env_yml_name_detects_unbuilt_named_env() {
         path: yml_path,
         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
     };
+    let decision =
+        missing_conda_env_yml_decision(&detected).expect("unbuilt named env should gate launch");
     assert_eq!(
-        missing_conda_env_yml_name(&detected).as_deref(),
-        Some("nteract-integration-probe-definitely-not-built-xyz"),
+        decision.label,
+        "nteract-integration-probe-definitely-not-built-xyz"
     );
+    assert!(decision.create_command.starts_with("conda env create -f "));
 }
 
 #[test]
-fn test_missing_conda_env_yml_name_skips_non_envyml() {
+fn test_missing_conda_env_yml_decision_skips_non_envyml() {
     let tmp = tempfile::tempdir().unwrap();
     write_pyproject_with_deps(tmp.path(), &["pandas"]);
     let detected = crate::project_file::DetectedProjectFile {
         path: tmp.path().join("pyproject.toml"),
         kind: crate::project_file::ProjectFileKind::PyprojectToml,
     };
-    assert_eq!(missing_conda_env_yml_name(&detected), None);
+    assert_eq!(missing_conda_env_yml_decision(&detected), None);
 }
 
 #[test]
-fn test_missing_conda_env_yml_name_skips_unnamed_envyml() {
+fn test_missing_conda_env_yml_decision_detects_unbuilt_unnamed_envyml() {
     let tmp = tempfile::tempdir().unwrap();
     let yml_path = tmp.path().join("environment.yml");
     std::fs::write(
@@ -6189,10 +6212,53 @@ fn test_missing_conda_env_yml_name_skips_unnamed_envyml() {
         path: yml_path,
         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
     };
-    assert_eq!(
-        missing_conda_env_yml_name(&detected),
-        None,
-        "unnamed environment.yml should not enter the named-env build decision flow",
+    let decision =
+        missing_conda_env_yml_decision(&detected).expect("unnamed env should gate creation");
+    assert!(
+        decision.label.contains("conda-envs"),
+        "unnamed env label should point at the computed cache prefix; got {:?}",
+        decision.label
+    );
+    assert!(
+        decision.create_command.contains("conda env create -p ")
+            && decision.create_command.contains(" -f "),
+        "unnamed env should get an explicit prefix create command; got {:?}",
+        decision.create_command
+    );
+}
+
+#[tokio::test]
+async fn test_project_environment_build_uses_preapproved_packages() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store =
+        crate::trusted_packages::TrustedPackageStore::open(tmp.path().join("trusted.sqlite"))
+            .unwrap();
+    let (room, _notebook_path) =
+        test_room_with_path_and_store(&tmp, "project-env.ipynb", store.clone());
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        "channels:\n  - conda-forge\ndependencies:\n  - python\n  - pandas\n  - six\n",
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path.clone(),
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+
+    assert!(
+        !project_environment_build_approved(&room, &detected),
+        "unapproved project packages should gate environment creation",
+    );
+
+    let config = crate::project_file::parse_environment_yml(&yml_path).unwrap();
+    store
+        .add_from_info(&environment_yml_trust_info(&config), "test")
+        .unwrap();
+
+    assert!(
+        project_environment_build_approved(&room, &detected),
+        "preapproved project packages should allow seamless environment creation",
     );
 }
 
@@ -6218,10 +6284,17 @@ fn test_missing_conda_env_yml_name_prefix_missing_reports_path() {
         path: yml_path,
         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
     };
-    let reported = missing_conda_env_yml_name(&detected).expect("prefix: missing should report");
+    let decision =
+        missing_conda_env_yml_decision(&detected).expect("prefix: missing should report");
     assert!(
-        reported.contains("definitely-does-not-exist"),
-        "reported name should include the prefix path; got {reported:?}",
+        decision.label.contains("definitely-does-not-exist"),
+        "reported name should include the prefix path; got {:?}",
+        decision.label,
+    );
+    assert!(
+        decision.create_command.contains("conda env create -p "),
+        "prefix: missing should include an explicit create prefix; got {:?}",
+        decision.create_command,
     );
 }
 
@@ -6245,7 +6318,9 @@ fn test_missing_conda_env_yml_name_prefers_name_over_missing_prefix() {
         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
     };
     assert_eq!(
-        missing_conda_env_yml_name(&detected).as_deref(),
+        missing_conda_env_yml_decision(&detected)
+            .as_ref()
+            .map(|d| d.label.as_str()),
         Some("myenv"),
     );
 }
@@ -6274,7 +6349,7 @@ fn test_missing_conda_env_yml_name_prefix_with_python_is_not_missing() {
         path: yml_path,
         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
     };
-    assert_eq!(missing_conda_env_yml_name(&detected), None);
+    assert_eq!(missing_conda_env_yml_decision(&detected), None);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/runtimed/src/requests/approve_project_environment.rs
+++ b/crates/runtimed/src/requests/approve_project_environment.rs
@@ -1,0 +1,91 @@
+//! `NotebookRequest::ApproveProjectEnvironment` handler.
+//!
+//! Project environment approval is local setup consent. It records the
+//! project file's packages in the existing local package allowlist, without
+//! writing notebook dependency metadata or trust signatures.
+
+use std::path::PathBuf;
+
+use crate::notebook_sync_server::{environment_yml_trust_info, NotebookRoom};
+use crate::protocol::NotebookResponse;
+use tracing::warn;
+
+pub(crate) async fn handle(
+    room: &NotebookRoom,
+    project_file_path: Option<String>,
+) -> NotebookResponse {
+    let detected = match resolve_project_file(room, project_file_path).await {
+        Ok(detected) => detected,
+        Err(error) => return NotebookResponse::Error { error },
+    };
+
+    let trust_info = match detected.kind {
+        crate::project_file::ProjectFileKind::EnvironmentYml => {
+            let config = match crate::project_file::parse_environment_yml(&detected.path) {
+                Ok(config) => config,
+                Err(error) => return NotebookResponse::Error { error },
+            };
+            environment_yml_trust_info(&config)
+        }
+        _ => {
+            return NotebookResponse::Error {
+                error: "Project environment approval is only supported for environment.yml"
+                    .to_string(),
+            };
+        }
+    };
+
+    if let Err(error) = room
+        .trusted_packages
+        .add_from_info(&trust_info, "project_env_dialog")
+    {
+        warn!(
+            "[trusted-packages] Failed to approve project environment {:?}: {}",
+            detected.path, error
+        );
+        return NotebookResponse::Error {
+            error: format!("Failed to approve project environment: {}", error),
+        };
+    }
+
+    NotebookResponse::Ok {}
+}
+
+async fn resolve_project_file(
+    room: &NotebookRoom,
+    project_file_path: Option<String>,
+) -> Result<crate::project_file::DetectedProjectFile, String> {
+    if let Some(path) = project_file_path {
+        let path = PathBuf::from(path);
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let kind = match filename {
+            "environment.yml" | "environment.yaml" => {
+                crate::project_file::ProjectFileKind::EnvironmentYml
+            }
+            _ => {
+                return Err(format!(
+                    "Unsupported project environment file '{}'",
+                    path.to_string_lossy()
+                ));
+            }
+        };
+        return Ok(crate::project_file::DetectedProjectFile { path, kind });
+    }
+
+    let notebook_path = room.identity.path.read().await.clone();
+    let working_dir = room.identity.working_dir.read().await.clone();
+    let detection_path = notebook_path.as_ref().or(working_dir.as_ref());
+    let Some(path) = detection_path else {
+        return Err(
+            "No notebook path or working directory for project environment approval".into(),
+        );
+    };
+    crate::project_file::find_nearest_project_file(
+        path,
+        &[crate::project_file::ProjectFileKind::EnvironmentYml],
+    )
+    .ok_or_else(|| "No environment.yml found for project environment approval".to_string())
+}

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -17,12 +17,13 @@ use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
     acquire_prewarmed_env_with_capture, build_launched_config, captured_env_for_runtime,
     captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
-    extract_pixi_toml_deps, get_inline_conda_channels, get_inline_conda_deps, get_inline_uv_deps,
-    get_inline_uv_prerelease, missing_conda_env_yml_name, promote_inline_deps_to_project,
-    publish_kernel_state_presence, reset_starting_state, reset_starting_state_with_outcome,
-    resolve_metadata_snapshot, send_runtime_agent_request, try_conda_pool_for_inline_deps,
-    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
-    ResetOutcome,
+    extract_pixi_toml_deps, format_conda_env_yml_build_details, get_inline_conda_channels,
+    get_inline_conda_deps, get_inline_uv_deps, get_inline_uv_prerelease,
+    missing_conda_env_yml_decision, project_environment_build_approved,
+    promote_inline_deps_to_project, publish_kernel_state_presence, reset_starting_state,
+    reset_starting_state_with_outcome, resolve_metadata_snapshot, send_runtime_agent_request,
+    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, unified_env_on_disk,
+    CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -877,23 +878,26 @@ pub(crate) async fn handle(
                         path: yml.clone(),
                         kind: crate::project_file::ProjectFileKind::EnvironmentYml,
                     };
-                    if let Some(env_name) = missing_conda_env_yml_name(&detected_yml) {
-                        let details = format!(
-                            "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
-                            env_name,
-                            yml.display()
-                        );
-                        warn!("[notebook-sync] {}", details);
-                        if let Err(e) = room.state.with_doc(|sd| {
-                            sd.set_lifecycle_with_error_details(
-                                &RuntimeLifecycle::AwaitingEnvBuild,
-                                Some(KernelErrorReason::CondaEnvYmlMissing),
-                                Some(&details),
-                            )
-                        }) {
-                            warn!("[runtime-state] {}", e);
+                    if let Some(decision) = missing_conda_env_yml_decision(&detected_yml) {
+                        if project_environment_build_approved(room, &detected_yml) {
+                            info!(
+                                "[notebook-sync] Approved environment.yml build for {:?}; continuing launch",
+                                detected_yml.path
+                            );
+                        } else {
+                            let details = format_conda_env_yml_build_details(&decision);
+                            warn!("[notebook-sync] {}", details);
+                            if let Err(e) = room.state.with_doc(|sd| {
+                                sd.set_lifecycle_with_error_details(
+                                    &RuntimeLifecycle::AwaitingEnvBuild,
+                                    Some(KernelErrorReason::CondaEnvYmlMissing),
+                                    Some(&details),
+                                )
+                            }) {
+                                warn!("[runtime-state] {}", e);
+                            }
+                            return NotebookResponse::Error { error: details };
                         }
-                        return NotebookResponse::Error { error: details };
                     }
 
                     // Resolve the conda prefix: prefix: → direct path,

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -12,6 +12,7 @@
 //! This is a behavior-preserving split of the old 2k-line match statement —
 //! lock scoping, log lines, error strings, and response variants are untouched.
 
+pub(crate) mod approve_project_environment;
 pub(crate) mod approve_trust;
 pub(crate) mod clear_outputs;
 pub(crate) mod clone_notebook;

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -194,6 +194,39 @@ export async function waitForCellOutput(cell, timeout = 120000) {
 }
 
 /**
+ * Wait for a cell output to satisfy a predicate.
+ * Returns the matching output text.
+ */
+export async function waitForCellOutputMatching(
+  cell,
+  predicate,
+  timeout = 120000,
+) {
+  let matched = "";
+  await browser.waitUntil(
+    async () => {
+      let text = "";
+      try {
+        text = await waitForCellOutput(cell, 1000);
+      } catch {
+        return false;
+      }
+      if (predicate(text)) {
+        matched = text;
+        return true;
+      }
+      return false;
+    },
+    {
+      timeout,
+      timeoutMsg: `Matching output did not appear within ${timeout / 1000}s`,
+      interval: 500,
+    },
+  );
+  return matched;
+}
+
+/**
  * Wait for stream output containing specific text.
  * Returns the full output text.
  */

--- a/e2e/specs/uv-pyproject.spec.js
+++ b/e2e/specs/uv-pyproject.spec.js
@@ -14,9 +14,10 @@
 import { browser } from "@wdio/globals";
 import {
   setCellSource,
-  waitForCellOutput,
+  waitForCellOutputMatching,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForOutputContaining,
 } from "../helpers.js";
 
 describe("UV pyproject.toml Detection", () => {
@@ -67,7 +68,7 @@ describe("UV pyproject.toml Detection", () => {
     console.log("[uv-pyproject] Clicked execute button.");
 
     // Wait for output
-    const output = await waitForCellOutput(codeCell, 30000);
+    const output = await waitForOutputContaining(codeCell, "python", 30000);
     console.log(`[uv-pyproject] Cell output: ${output}`);
 
     // Should show a Python path
@@ -93,7 +94,11 @@ describe("UV pyproject.toml Detection", () => {
     console.log("[uv-pyproject] Clicked execute button.");
 
     // Wait for version output
-    const output = await waitForCellOutput(cell, 60000);
+    const output = await waitForCellOutputMatching(
+      cell,
+      (text) => /^\d+\.\d+/.test(text),
+      60000,
+    );
     console.log(`[uv-pyproject] httpx version output: ${output}`);
 
     // Should show httpx version (e.g., "0.27.0")

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -199,6 +199,19 @@ export class NotebookClient {
     }
   }
 
+  /** Approve creating/syncing the current project-file environment. */
+  async approveProjectEnvironment(projectFilePath?: string): Promise<NotebookResponse> {
+    try {
+      return await this.sendRequest({
+        type: "approve_project_environment",
+        ...(projectFilePath !== undefined ? { project_file_path: projectFilePath } : {}),
+      });
+    } catch (e) {
+      this.log.error("[notebook-client] Approve project environment failed:", e);
+      throw e;
+    }
+  }
+
   /** Run all code cells (daemon reads from synced doc). */
   async runAllCells(): Promise<NotebookResponse> {
     this.log.debug("[notebook-client] Running all cells");

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -30,6 +30,7 @@ export type NotebookRequest =
   | { type: "shutdown_kernel" }
   | { type: "sync_environment"; guard?: DependencyGuard }
   | { type: "approve_trust"; dependency_fingerprint?: string }
+  | { type: "approve_project_environment"; project_file_path?: string }
   | { type: "run_all_cells" }
   | { type: "run_all_cells_guarded"; observed_heads: string[] }
   | { type: "send_comm"; message: CommRequestMessage }

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -39,4 +39,15 @@ describe("NotebookClient", () => {
       },
     });
   });
+
+  it("emits project environment approval requests", async () => {
+    const { client, sendRequest } = stubClient();
+
+    await client.approveProjectEnvironment("/tmp/project/environment.yml");
+
+    expect(sendRequest).toHaveBeenCalledWith({
+      type: "approve_project_environment",
+      project_file_path: "/tmp/project/environment.yml",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- stop mirroring pyproject.toml, pixi.toml, and environment.yml dependencies into notebook metadata during auto-launch
- keep project-file environments launching from runtime project context while preserving copied notebook dependency metadata and trust reconciliation
- skip project-backed eviction flushes so launched project deps do not churn notebook metadata
- render Pixi project packages from runtimeState.project_context, matching the Conda path
- tighten the pyproject E2E output wait so the watcher spec ignores stale output from prior cells

## Trust model
- notebook trust continues to sign metadata.runt.{uv,conda,pixi} only
- project-file dependencies remain local project context unless explicitly copied into notebook metadata
- existing copied metadata reconciliation remains in place, including exact Conda dependency and channel order matching

## Tests
- cargo test -p runtimed records_context_without_notebook_deps -- --nocapture
- cargo test -p runtimed project_file_deps_match_trust_info_envyml -- --nocapture
- cargo test -p runtimed env_yml_conda_dep_not_blocked_by_pip_duplicate -- --nocapture
- pnpm test:run -- project-context-derivers
- cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb e2e/specs/uv-pyproject.spec.js
- cargo xtask lint --fix