### PR TITLE
chore(xtask): remove sccache, strip RUSTC_WRAPPER for wasm-pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 
 Local dev uses cargo's incremental cache. Tight edit-check loops on one crate reuse rustc's per-function incremental artifacts and run in seconds. No extra setup required.
 
-sccache is not wired on by default locally. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It's still useful for CI (fresh target dir every run) and for the rare cross-worktree case. If you want it locally, opt in with `NTERACT_SCCACHE=1` and install with `brew install sccache`.
+sccache is not used. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It also breaks WASM builds (sccache's clang doesn't support `wasm32-unknown-unknown`). If a developer has `RUSTC_WRAPPER=sccache` in their environment, xtask strips it for wasm-pack invocations.
 
 ### lld linker (macOS arm64)
 
@@ -399,7 +399,7 @@ The supervisor does not watch source files. Rebuild on demand:
 - **Only the MCP server itself changed** (`crates/runt-mcp/src/`) → `up rebuild=true` covers this too.
 - **Daemon source changed** → `up rebuild=true`, optionally with `daemon=true` to bounce the daemon as well.
 
-If you want the old always-on file watcher, set `NTERACT_DEV_WATCH=1` in the supervisor's environment. It's off by default because every source touch kicked `cargo build` + `maturin develop`, which churned sccache keys across the workspace and put the Rust cache-hit rate near zero during normal edits.
+If you want the old always-on file watcher, set `NTERACT_DEV_WATCH=1` in the supervisor's environment. It's off by default because every source touch kicked `cargo build` + `maturin develop`, which churned cache keys and put the Rust cache-hit rate near zero during normal edits.
 
 `SKIP_MATURIN=1` (already set in `.mcp.json`) tells `up rebuild=true` to skip the maturin step. Pair it with `NTERACT_DEV_AUTOMATURIN=1` only if you want the startup-probe reintroduced; by default the supervisor starts without touching Python bindings.
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -20,19 +20,17 @@
 | Lint (check mode) | `cargo xtask lint` |
 | Lint (auto-fix) | `cargo xtask lint --fix` |
 
-## Build Cache (sccache)
+## Build Cache
 
-Install [sccache](https://github.com/mozilla/sccache) to share compiled
-artifacts across worktrees. Without it, each worktree rebuilds ~788 crates from
-scratch.
+Local dev relies on cargo's built-in incremental compilation — tight edit-check
+loops reuse rustc's per-function artifacts and finish in seconds.
 
-```bash
-brew install sccache   # macOS
-```
-
-The xtask commands auto-detect sccache and set `RUSTC_WRAPPER` when it's
-available — no configuration needed. You'll see "Using sccache for compilation
-cache" in the build output when it's active.
+**sccache is not recommended.** It can't cache incremental builds, so enabling
+it forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It also breaks
+WASM builds: sccache wraps `clang` for C compilation, but its clang doesn't
+support `wasm32-unknown-unknown`, causing `zstd-sys` (and similar C deps) to
+fail. If you have `RUSTC_WRAPPER=sccache` in your shell profile, remove it or
+xtask will strip it automatically for `wasm-pack` invocations.
 
 ## Windows Target Checks From macOS
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,7 +6,6 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{exit, Child, Command, ExitStatus, Stdio};
-use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -477,7 +476,6 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 
     let vite_port = resolve_vite_port(force_dev_mode);
     let mut command = Command::new("cargo");
-    apply_sccache_env(&mut command);
 
     if attach {
         println!("Attaching to existing Vite server...");
@@ -2378,7 +2376,6 @@ fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
     command.args(args);
     if cmd == "cargo" {
         apply_build_channel_env(&mut command);
-        apply_sccache_env(&mut command);
     }
 
     command.status().map(|s| s.success()).unwrap_or_else(|e| {
@@ -2474,7 +2471,9 @@ fn run_cmd(cmd: &str, args: &[&str]) {
     command.args(args);
     if cmd == "cargo" {
         apply_build_channel_env(&mut command);
-        apply_sccache_env(&mut command);
+    }
+    if cmd == "wasm-pack" {
+        strip_rustc_wrapper_for_wasm(&mut command);
     }
 
     let status = command.status().unwrap_or_else(|e| {
@@ -2640,63 +2639,13 @@ fn run_frontend_build(debug_bundle: bool) {
     }
 }
 
-/// Set `RUSTC_WRAPPER=sccache` for CI runs. Off for local dev by default.
-///
-/// sccache can't cache incremental builds, so turning it on forces
-/// `CARGO_INCREMENTAL=0` and loses cargo's per-function incremental
-/// speedup. That's fine in CI (fresh target dir every run) and bad
-/// locally (the incremental cache is already warm).
-///
-/// Enabled when `CI=1`/`CI=true` is set. Overridable in either
-/// direction:
-///
-/// - `NTERACT_SCCACHE=1` forces sccache on even for local runs.
-/// - `NTERACT_SCCACHE=0` forces it off even in CI.
-/// - An existing `RUSTC_WRAPPER` is always respected.
-fn apply_sccache_env(command: &mut Command) {
+fn strip_rustc_wrapper_for_wasm(command: &mut Command) {
     if env::var_os("RUSTC_WRAPPER").is_some() {
-        return;
-    }
-
-    let want_sccache = match env::var("NTERACT_SCCACHE").as_deref() {
-        Ok("1") | Ok("true") => true,
-        Ok("0") | Ok("false") => false,
-        _ => matches!(env::var("CI").as_deref(), Ok("1") | Ok("true")),
-    };
-    if !want_sccache {
-        return;
-    }
-
-    static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    let available = *AVAILABLE.get_or_init(|| {
-        let found = Command::new("sccache")
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if found {
-            println!("Using sccache for compilation cache");
-        }
-        found
-    });
-    if available {
-        command.env("RUSTC_WRAPPER", "sccache");
-        // sccache can't cache incremental builds. Disable it so every
-        // crate is cacheable. Respect an explicit user override.
-        if env::var_os("CARGO_INCREMENTAL").is_none() {
-            command.env("CARGO_INCREMENTAL", "0");
-        }
-        // Cap the on-disk cache generously. Multiple worktrees, lld
-        // rustflag rotations, and maturin vs. workspace builds each
-        // occupy their own cache keys; 10 GiB evicts hot entries.
-        // An explicit user override wins. `sccache/config` on disk
-        // wins over this env var when sccache-server is already
-        // running; this is the floor for first-start setups.
-        if env::var_os("SCCACHE_CACHE_SIZE").is_none() {
-            command.env("SCCACHE_CACHE_SIZE", "200G");
-        }
+        eprintln!(
+            "Note: stripping RUSTC_WRAPPER for wasm-pack \
+             (sccache/mold/etc. break wasm32 C builds)"
+        );
+        command.env_remove("RUSTC_WRAPPER");
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove `apply_sccache_env()` and its three call sites. sccache was opt-in via `NTERACT_SCCACHE=1` and auto-enabled in CI, but we determined cargo's incremental cache is better for how we work locally — incremental edit-check loops beat sccache's cross-worktree reuse in day-to-day development.
- Add `strip_rustc_wrapper_for_wasm()` so developers who still have `RUSTC_WRAPPER=sccache` in their shell profile don't hit a wall of cc-rs errors when `cargo xtask build` runs `wasm-pack` on a fresh checkout.
- Update `AGENTS.md` and `contributing/development.md` to reflect the new story.

## Why

When a developer has `RUSTC_WRAPPER=sccache` ambient in their environment, it leaks into wasm-pack's internal cargo invocation. sccache wraps `clang` for C compilation (zstd-sys pulls in native C), and its clang doesn't support the `wasm32-unknown-unknown` triple, so the build explodes with:

```
error: unable to create target: 'No available targets are compatible with triple "wasm32-unknown-unknown"'
error occurred in cc-rs: command did not execute successfully
```

Before: onboarding docs mentioned sccache as optional, but a dev with it already installed globally would hit this wall with no signal about why. After: xtask strips it for wasm-pack with a one-line note so the reason is visible.

## Test plan

- [x] `cargo check -p xtask` passes
- [ ] `cargo xtask build` completes on a fresh clone (with and without ambient `RUSTC_WRAPPER=sccache`)
- [ ] `cargo xtask wasm` completes with `RUSTC_WRAPPER=sccache` set in the shell (should print the strip note and succeed)
- [ ] CI green

🪶 Generated with Quill Agent