### PR TITLE
ci: move macOS jobs to macos-14-xlarge runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
       matrix:
         platform:
           - name: macOS
-            runner: macos-latest
+            runner: macos-14-xlarge
             setup: echo "No extra deps needed on macOS"
             run_on_pr: false
             non_blocking: false

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -68,7 +68,7 @@ jobs:
   build:
     name: Build ${{ inputs.target_os == 'linux' && 'Linux x64' || inputs.target_os == 'macos' && 'macOS' || 'Windows x64' }} binary
     needs: [resolve-pr]
-    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-latest' || 'windows-latest' }}
+    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-14-xlarge' || 'windows-latest' }}
 
     steps:
       - name: Checkout pinned PR commit

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -171,7 +171,7 @@ jobs:
 
   build-macos:
     name: Build macOS Executables
-    runs-on: macos-latest
+    runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
@@ -235,7 +235,7 @@ jobs:
 
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
-    runs-on: macos-latest
+    runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
@@ -403,7 +403,7 @@ jobs:
 
   build-notebook-macos-x64:
     name: Build macOS x64 Notebook
-    runs-on: macos-latest
+    runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
@@ -908,9 +908,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-latest
+          - runner: macos-14-xlarge
             target: aarch64-apple-darwin
-          - runner: macos-latest
+          - runner: macos-14-xlarge
             target: x86_64-apple-darwin
           - runner: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
Move every `macos-latest` reference in CI to `macos-14-xlarge`. Same OS image (macos-latest currently resolves to macos-14), bigger silicon (12-core M1 Pro, 24 GB).

## Affected workflows

- `release-common.yml` - `build-macos`, `build-notebook-macos-arm64`, `build-notebook-macos-x64`, and the macOS rows of `build-python-wheels` (arm64 + x64)
- `build.yml` - macOS row in the platform matrix
- `pr-binary-generation.yml` - macOS target

## Why macos-14 and not macos-15

`macos-latest` already resolves to macos-14. This is a silicon and core-count change only, with no shift in deployment-target floor for the distributed binary. `macos-15-xlarge` stays available as a separate ratchet once baseline numbers exist.

## Cost trade

xlarge macOS runs at roughly 4x the per-minute rate of standard `macos-latest`. M1 Pro 12-core typically gives a 3-5x wallclock improvement on Rust + Cargo workloads, so net spend usually breaks even or wins, with release latency back. First release run on this branch will give actual numbers.
