### PR TITLE
ci: route Windows Python wheels to nteract-windows-xlarge

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -914,7 +914,7 @@ jobs:
             target: x86_64-apple-darwin
           - runner: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
-          - runner: windows-latest
+          - runner: nteract-windows-xlarge
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Route the `x86_64-pc-windows-msvc` row of the `build-python-wheels` matrix in `release-common.yml` to a 32-core provisioned Windows Server 2025 runner. One-line change, one job moved, leaves every other Windows job alone for now.

## Why only one job

The latest nightly run had this job sitting on stock `windows-latest` (4 vCPU) at 8m+ and still going when other jobs had finished. Moving it alone gives a clean before/after wallclock comparison without confounders. If the speedup is real, the same swap can extend to `build-notebook-windows-x64` (currently on `blacksmith-4vcpu-windows-2025`) and the `pr-binary-generation` Windows path.

## Why a provisioned runner instead of `windows-latest-large`

The runner `nteract-windows-xlarge` is provisioned at the org level via `POST /orgs/nteract/actions/hosted-runners`: 32 vCPU, 128 GB RAM, 1.2 TB storage, image 2307 (Windows Latest 2025), runner group `Beefier`. Going through the provisioned API instead of a stock larger-runner label sets up the rails for a custom image later. When we want Tauri CLI / cargo-binstall / Node / pnpm pre-baked, we change the runner's image ID and don't touch any workflow YAML.

## Cost note

The org has a 100% off OSS coupon on GitHub-hosted runner minutes, so 32-core is essentially free for this experiment. Cargo compilation is amdahl-limited so the speedup probably tops out well before 32x of cores, but going big once gives a clear ceiling. We can dial down to 16-core later if the data says 32 is wasted.

## Test plan

Next nightly release run on this branch will land the comparison. Looking for:

- Wallclock for `Build Python Wheels (x86_64-pc-windows-msvc)` significantly under the 8m baseline.
- Job runs on `runner_group_name: Beefier` and `runner_name: nteract-windows-xlarge`.
- No new install / setup failures from the larger-runner image.
