### PR TITLE
ci: route release Rust jobs through sccache

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -106,6 +106,9 @@ jobs:
     name: Build Linux Executables
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -125,6 +128,9 @@ jobs:
         with:
           shared-key: "linux-release"
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -133,9 +139,6 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
-
-      - name: Build UI
-        run: pnpm build
 
       - name: Set version in Cargo.toml
         run: |
@@ -173,6 +176,9 @@ jobs:
     name: Build macOS Executables
     runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -189,6 +195,9 @@ jobs:
         with:
           shared-key: "macos-release"
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -197,9 +206,6 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
-
-      - name: Build UI
-        run: pnpm build
 
       - name: Set version in Cargo.toml
         run: |
@@ -237,6 +243,9 @@ jobs:
     name: Build macOS ARM64 Notebook
     runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -249,6 +258,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-notebook-arm64"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -405,6 +417,9 @@ jobs:
     name: Build macOS x64 Notebook
     runs-on: macos-14-xlarge
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -420,6 +435,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-notebook-x64"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -576,6 +594,9 @@ jobs:
     name: Build Windows x64 Notebook
     runs-on: blacksmith-4vcpu-windows-2025
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -588,6 +609,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "windows-notebook-x64"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -711,6 +735,9 @@ jobs:
     name: Build Linux x64 Notebook
     runs-on: blacksmith-4vcpu-ubuntu-2204
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -729,6 +756,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "linux-notebook-x64"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -905,6 +935,9 @@ jobs:
     name: Build Python Wheels (${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
     needs: [compute-version, build-wasm]
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     strategy:
       matrix:
         platform:
@@ -928,6 +961,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "python-${{ matrix.platform.target }}"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,9 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 
 Local dev uses cargo's incremental cache. Tight edit-check loops on one crate reuse rustc's per-function incremental artifacts and run in seconds. No extra setup required.
 
-sccache is not used. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It also breaks WASM builds (sccache's clang doesn't support `wasm32-unknown-unknown`). If a developer has `RUSTC_WRAPPER=sccache` in their environment, xtask strips it for wasm-pack invocations.
+Local dev does not use sccache. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It also breaks WASM builds (sccache's clang doesn't support `wasm32-unknown-unknown`). If a developer has `RUSTC_WRAPPER=sccache` in their environment, xtask strips it for wasm-pack invocations.
+
+CI release jobs do route Rust compiles through sccache, backed by the GitHub Actions cache. The local-dev concerns don't apply: the release profile already disables incremental, and the release jobs that still build wasm (`build-wasm`) don't run with sccache wired in. Every other Rust job in `release-common.yml` (build-linux, build-macos, build-notebook-*, the pre-maturin step in build-python-wheels, and maturin itself via `sccache: true`) shares one sccache cache, which is what lets `runtimed` compile once and be reused across jobs that need it as both a binary sidecar and a Rust library dep.
 
 ### lld linker (macOS arm64)
 


### PR DESCRIPTION
Wire `mozilla-actions/sccache-action@v0.0.10` with the GitHub Actions cache backend into every release-common Rust job, so the recompile-runtimed-seven-times problem stops costing wallclock.

## What changed

- Job-level `RUSTC_WRAPPER: sccache` + `SCCACHE_GHA_ENABLED: true` on `build-linux`, `build-macos`, `build-notebook-{linux-x64,macos-arm64,macos-x64,windows-x64}`, and `build-python-wheels`. `Install sccache` step added between `Swatinem/rust-cache` and the first cargo invocation in each.
- `build-wasm` is intentionally left out. sccache's clang can't target `wasm32-unknown-unknown`, and the existing `xtask` strip-RUSTC_WRAPPER guard for local dev only kicks in when wasm-pack runs through xtask, not when the action runs wasm-pack directly.
- `maturin-action`'s existing `sccache: true` flag is left alone. With `RUSTC_WRAPPER` pre-set at job level, the maturin invocation already routes through sccache; the flag is now defensive but harmless.
- Dead `pnpm build` step ("Build UI") removed from `build-linux` and `build-macos`. Those jobs output CLI binaries; the UI build moved upstream a while back and these never got cleaned up.

## Why this and not the cli-binaries refactor

Discussed in the prior conversation: the architecture refactor (one cli-binaries job per platform, downstream jobs download artifacts) is a real win on the notebook path, but doesn't actually save the wheels job's time because `runtimed-py` still has to compile `runtimed` as a Rust library dep through maturin. sccache solves *both* paths in one go without needing artifact passing or Tauri config changes. The architecture refactor is still valid follow-up if we want to skip even the linking time, but this PR captures the bulk of the savings first.

## AGENTS.md update

`AGENTS.md` previously read "sccache is not used", which was true for local dev but contradicted by `release-common.yml:992` already having `sccache: true` on the maturin-action. The paragraph now explicitly splits local dev (still no sccache, for the same incremental + wasm reasons) from CI release jobs (sccache via GHA cache), and explains why the constraints differ.

## Test plan

The next nightly run is the comparison. Looking for:

- First run: cache populates. Wallclock probably similar to baseline since this is a cold sccache, but rust-cache is still warm so it shouldn't be worse.
- Subsequent runs: `Build Python Wheels (x86_64-pc-windows-msvc)` drops well below 8m as the second compile of `runtimed` (for `runtimed-py` via maturin) hits sccache from the first (the explicit `cargo build -p runtimed`).
- Notebook builds also restore from sccache when their Tauri sidecar build hits the same crates already compiled in `build-linux` / equivalent.
- Job logs should show `sccache: Compile requests` and `Cache hits` in the post-build summary that mozilla-actions/sccache-action prints.

If sccache wedges anything (e.g., a step that doesn't tolerate `RUSTC_WRAPPER` being set), revert is one PR; the `Install sccache` step is non-destructive and the env block is the only thing that activates wrapping.
