### PR TITLE
test(runtimed-py): improve deno integration diagnostics

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -315,18 +315,24 @@ async fn ensure_create_runtime_ready(
     let mut forced_launch = false;
 
     loop {
-        let (lifecycle, runtime) = {
+        let (lifecycle, error_reason, error_details, runtime) = {
             let st = state.lock().await;
             let handle = st
                 .handle
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
-            let lifecycle = handle
+            let (lifecycle, error_reason, error_details) = handle
                 .get_runtime_state()
                 .ok()
-                .map(|rs| rs.kernel.lifecycle)
-                .unwrap_or(RuntimeLifecycle::NotStarted);
-            (lifecycle, st.runtime.clone())
+                .map(|rs| {
+                    (
+                        rs.kernel.lifecycle,
+                        rs.kernel.error_reason,
+                        rs.kernel.error_details,
+                    )
+                })
+                .unwrap_or((RuntimeLifecycle::NotStarted, None, None));
+            (lifecycle, error_reason, error_details, st.runtime.clone())
         };
 
         match lifecycle {
@@ -347,9 +353,18 @@ async fn ensure_create_runtime_ready(
                 }
             }
             RuntimeLifecycle::Error => {
-                return Err(to_py_err(
-                    "Kernel auto-launch failed during notebook creation",
-                ));
+                let mut message = "Kernel auto-launch failed during notebook creation".to_string();
+                if let Some(details) = error_details.as_deref().filter(|value| !value.is_empty()) {
+                    message.push_str(": ");
+                    message.push_str(details);
+                } else if let Some(reason) =
+                    error_reason.as_deref().filter(|value| !value.is_empty())
+                {
+                    message.push_str(" (");
+                    message.push_str(reason);
+                    message.push(')');
+                }
+                return Err(to_py_err(message));
             }
             RuntimeLifecycle::NotStarted
             | RuntimeLifecycle::AwaitingTrust

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -380,7 +380,7 @@ async def daemon_health_check(daemon_process):
 
 
 @pytest.fixture(scope="module")
-def daemon_process():
+def daemon_process(request):
     """Fixture that ensures a daemon is running.
 
     In CI mode (RUNTIMED_INTEGRATION_TEST=1), spawns a daemon process.
@@ -556,7 +556,8 @@ def daemon_process():
 
                 dest_dir = Path(artifact_dir)
                 dest_dir.mkdir(parents=True, exist_ok=True)
-                dest = dest_dir / "daemon.log"
+                module_name = request.module.__name__.replace(".", "_")
+                dest = dest_dir / f"daemon-{module_name}.log"
                 shutil.copy2(log_file, dest)
                 print(f"[test] Copied daemon log to {dest}", file=sys.stderr)
 
@@ -1396,8 +1397,12 @@ class TestDenoKernel:
         except Exception:
             pass
 
-    async def test_deno_kernel_launch(self, deno_session):
-        """Deno kernel launches and executes TypeScript."""
+    async def test_create_deno_notebook_launches_kernel(self, deno_session):
+        """Creating a Deno notebook returns with a usable Deno kernel."""
+        assert await deno_session.is_connected()
+        assert await deno_session.kernel_started()
+        assert await deno_session.kernel_type() == "deno"
+
         result = await deno_session.execute_cell(
             await deno_session.create_cell("console.log('hello from deno')")
         )
@@ -1424,6 +1429,10 @@ class TestDenoKernel:
         assert ks["name"] == "deno"
         assert ks["display_name"] == "Deno"
         assert ks.get("language") == "typescript"
+
+        # Has zero cells (frontend creates the first cell locally)
+        cells = await deno_session.get_cells()
+        assert len(cells) == 0
 
         # Verify the kernel is actually Deno by executing TypeScript
         result = await deno_session.execute_cell(
@@ -2584,17 +2593,6 @@ class TestCreateNotebook:
         assert info.notebook_id == session.notebook_id
         # New notebooks don't need trust approval
         assert info.needs_trust_approval is False
-
-    async def test_create_deno_notebook(self, client):
-        """Creating Deno notebook returns after the auto-launched kernel is usable."""
-        session = await client.create_notebook(runtime="deno")
-        assert await session.is_connected()
-        assert await session.kernel_started()
-        assert await session.kernel_type() == "deno"
-
-        # Has zero cells (frontend creates the first cell locally)
-        cells = await session.get_cells()
-        assert len(cells) == 0
 
     async def test_create_notebook_with_working_dir(self, client, tmp_path):
         """working_dir is used for project file detection."""


### PR DESCRIPTION
## Summary
- preserve per-module runtimed-py integration daemon logs so later modules do not overwrite failing logs
- include runtime-state error details in Deno create_notebook auto-launch failures
- keep explicit Deno create/launch coverage while avoiding the duplicate late-suite Deno launch

## Validation
- cargo fmt -p runtimed-py
- ruff check python/runtimed/tests/test_daemon_integration.py
- cargo check -p runtimed-py --no-default-features
- git diff --check