### PR TITLE
test(protocol): check TypeScript protocol surface

### DIFF
--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -173,6 +173,22 @@ After the handshake, frames are typed by their first byte:
 requests must include an `id`, and clients must route responses by id because
 broadcasts, state sync, and out-of-order responses may interleave freely.
 
+The TypeScript protocol surface in `packages/runtimed` is checked against
+these Rust wire discriminants:
+
+- `packages/runtimed/src/transport.ts` owns the exported `FrameType` constants.
+- `packages/runtimed/src/request-types.ts` owns the frontend-visible
+  `NotebookRequest` and `NotebookResponse` unions.
+- `packages/runtimed/src/protocol-contract.ts` exports the request, response,
+  and session-control discriminant lists with TypeScript exhaustiveness checks.
+- `crates/notebook-protocol/src/protocol.rs` includes a contract test that
+  compares those TypeScript lists and frame bytes to the Rust protocol.
+
+When adding or renaming a request, response, frame type, or session-control
+phase, update the Rust protocol and `packages/runtimed` contract in the same
+patch, then run `cargo test -p notebook-protocol` and the focused
+`packages/runtimed` tests.
+
 ## Automerge Sync
 
 The notebook document is a CRDT shared between two peers:
@@ -375,6 +391,8 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 | `crates/notebook-protocol/src/connection/handshake.rs` | Protocol version, handshake, capabilities, connection info |
 | `crates/notebook-protocol/src/connection/env.rs` | Launch spec, package manager, and environment source wire types |
 | `crates/notebook-protocol/src/protocol.rs` | Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast` |
+| `packages/runtimed/src/request-types.ts` | TypeScript request/response protocol unions consumed by JS clients |
+| `packages/runtimed/src/protocol-contract.ts` | Checked TypeScript discriminant lists for frame/session/request/response drift tests |
 | `crates/runtimed-client/src/protocol.rs` | Daemon-internal types (`Request`, `Response`, `BlobRequest`), re-exports from `notebook-protocol` |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup (`connect_open_relay`, `connect_create_relay`) |

--- a/contributing/typescript-bindings.md
+++ b/contributing/typescript-bindings.md
@@ -8,6 +8,18 @@ The `ts-rs` crate generates TypeScript type definitions from Rust types annotate
 
 **`ts-rs` is an optional dependency**, gated behind `features = ["ts-bindings"]` in `runtimed-client`. It pulls in ~159 transitive crates (dprint, SWC, deno_ast) that are only needed when regenerating bindings, not during normal development.
 
+Protocol wire types are handled separately. `packages/runtimed/src/request-types.ts`
+contains the TypeScript `NotebookRequest` / `NotebookResponse` unions used by
+JS clients, and `packages/runtimed/src/protocol-contract.ts` exports checked
+discriminant lists for request, response, and session-control shapes. The
+`notebook-protocol` test suite reads those TypeScript files and compares them
+to the Rust wire discriminants and frame bytes, so protocol drift is caught by:
+
+```bash
+cargo test -p notebook-protocol
+pnpm exec vp test run packages/runtimed/tests/protocol-contract.test.ts
+```
+
 ## Source Files
 
 | Rust File | Generated Types |

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -734,6 +734,7 @@ impl RuntimeAgentRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn env_kind_uv_round_trip() {
@@ -1039,6 +1040,37 @@ mod tests {
                     "cursor_pos": 13,
                 }),
             ),
+            (
+                "save_notebook",
+                serde_json::json!({
+                    "action": "save_notebook",
+                    "format_cells": true,
+                    "path": "/tmp/example.ipynb",
+                }),
+            ),
+            (
+                "clone_as_ephemeral",
+                serde_json::json!({
+                    "action": "clone_as_ephemeral",
+                    "source_notebook_id": "source-room",
+                }),
+            ),
+            (
+                "get_doc_bytes",
+                serde_json::json!({ "action": "get_doc_bytes" }),
+            ),
+            (
+                "send_comm",
+                serde_json::json!({
+                    "action": "send_comm",
+                    "message": {
+                        "header": {},
+                        "content": {},
+                        "buffers": [],
+                        "channel": "shell",
+                    },
+                }),
+            ),
         ];
 
         for (name, json) in cases {
@@ -1059,6 +1091,181 @@ mod tests {
                 )
             });
         }
+    }
+
+    fn extract_string_array(source: &str, const_name: &str) -> BTreeSet<String> {
+        let needle = format!("export const {const_name} = [");
+        let start = source
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing TS const {const_name}"))
+            + needle.len();
+        let rest = &source[start..];
+        let end = rest
+            .find("] as const")
+            .unwrap_or_else(|| panic!("missing end of TS const {const_name}"));
+
+        rest[..end]
+            .split(',')
+            .filter_map(|part| {
+                let value = part.trim().trim_matches('\n').trim();
+                value
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+
+    fn extract_frame_type_object(source: &str) -> BTreeMap<String, u8> {
+        let needle = "export const FrameType = {";
+        let start = source.find(needle).expect("missing TS FrameType object") + needle.len();
+        let rest = &source[start..];
+        let end = rest
+            .find("} as const")
+            .expect("missing end of TS FrameType");
+
+        rest[..end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with("/**") || line.starts_with('*') {
+                    return None;
+                }
+                let (name, value) = line.trim_end_matches(',').split_once(':')?;
+                let value = value.trim();
+                let parsed = if let Some(hex) = value.strip_prefix("0x") {
+                    u8::from_str_radix(hex, 16).expect("valid hex frame byte")
+                } else {
+                    value.parse::<u8>().expect("valid decimal frame byte")
+                };
+                Some((name.trim().to_owned(), parsed))
+            })
+            .collect()
+    }
+
+    fn expected_notebook_request_actions() -> BTreeSet<String> {
+        [
+            "launch_kernel",
+            "execute_cell",
+            "execute_cell_guarded",
+            "clear_outputs",
+            "interrupt_execution",
+            "shutdown_kernel",
+            "run_all_cells",
+            "run_all_cells_guarded",
+            "send_comm",
+            "get_history",
+            "complete",
+            "save_notebook",
+            "clone_as_ephemeral",
+            "sync_environment",
+            "approve_trust",
+            "approve_project_environment",
+            "get_doc_bytes",
+        ]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect()
+    }
+
+    fn expected_notebook_response_results() -> BTreeSet<String> {
+        [
+            "kernel_launched",
+            "kernel_already_running",
+            "cell_queued",
+            "outputs_cleared",
+            "interrupt_sent",
+            "kernel_shutting_down",
+            "no_kernel",
+            "guard_rejected",
+            "all_cells_queued",
+            "notebook_saved",
+            "save_error",
+            "notebook_cloned",
+            "ok",
+            "error",
+            "history_result",
+            "completion_result",
+            "sync_environment_complete",
+            "sync_environment_failed",
+            "doc_bytes",
+        ]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect()
+    }
+
+    #[test]
+    fn typescript_protocol_contract_matches_rust_wire_discriminants() {
+        let ts_contract = include_str!("../../../packages/runtimed/src/protocol-contract.ts");
+        let ts_transport = include_str!("../../../packages/runtimed/src/transport.ts");
+
+        assert_eq!(
+            extract_string_array(ts_contract, "NOTEBOOK_REQUEST_TYPES"),
+            expected_notebook_request_actions()
+        );
+        assert_eq!(
+            extract_string_array(ts_contract, "NOTEBOOK_RESPONSE_RESULTS"),
+            expected_notebook_response_results()
+        );
+        assert_eq!(
+            extract_string_array(ts_contract, "SESSION_CONTROL_TYPES"),
+            BTreeSet::from(["sync_status".to_string()])
+        );
+        assert_eq!(
+            extract_string_array(ts_contract, "NOTEBOOK_DOC_PHASES"),
+            BTreeSet::from([
+                "pending".to_string(),
+                "syncing".to_string(),
+                "interactive".to_string()
+            ])
+        );
+        assert_eq!(
+            extract_string_array(ts_contract, "RUNTIME_STATE_PHASES"),
+            BTreeSet::from([
+                "pending".to_string(),
+                "syncing".to_string(),
+                "ready".to_string()
+            ])
+        );
+        assert_eq!(
+            extract_string_array(ts_contract, "INITIAL_LOAD_PHASES"),
+            BTreeSet::from([
+                "not_needed".to_string(),
+                "streaming".to_string(),
+                "ready".to_string(),
+                "failed".to_string()
+            ])
+        );
+
+        assert_eq!(
+            extract_frame_type_object(ts_transport),
+            BTreeMap::from([
+                (
+                    "AUTOMERGE_SYNC".to_string(),
+                    notebook_doc::frame_types::AUTOMERGE_SYNC
+                ),
+                ("REQUEST".to_string(), notebook_doc::frame_types::REQUEST),
+                ("RESPONSE".to_string(), notebook_doc::frame_types::RESPONSE),
+                (
+                    "BROADCAST".to_string(),
+                    notebook_doc::frame_types::BROADCAST
+                ),
+                ("PRESENCE".to_string(), notebook_doc::frame_types::PRESENCE),
+                (
+                    "RUNTIME_STATE_SYNC".to_string(),
+                    notebook_doc::frame_types::RUNTIME_STATE_SYNC
+                ),
+                (
+                    "POOL_STATE_SYNC".to_string(),
+                    notebook_doc::frame_types::POOL_STATE_SYNC
+                ),
+                (
+                    "SESSION_CONTROL".to_string(),
+                    notebook_doc::frame_types::SESSION_CONTROL
+                ),
+            ])
+        );
     }
 
     #[test]

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -18,6 +18,17 @@ export {
   type FrameTypeValue,
 } from "./transport";
 
+// Protocol contract
+export {
+  INITIAL_LOAD_PHASES,
+  NOTEBOOK_DOC_PHASES,
+  NOTEBOOK_REQUEST_TYPES,
+  NOTEBOOK_RESPONSE_RESULTS,
+  RUNTIME_STATE_PHASES,
+  SESSION_CONTROL_TYPES,
+  type SessionControlMessage,
+} from "./protocol-contract";
+
 // Handle
 export type {
   SyncableHandle,
@@ -119,8 +130,10 @@ export type {
   CommRequestMessage,
   CompletionItem,
   DependencyGuard,
+  DenoLaunchedConfig,
   GuardedNotebookProvenance,
   HistoryEntry,
+  LaunchedEnvConfig,
   NotebookRequest,
   NotebookResponse,
   SaveErrorKind,

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -1,0 +1,114 @@
+import type {
+  InitialLoadPhase,
+  NotebookDocPhase,
+  RuntimeStatePhase,
+  SessionStatus,
+} from "./handle";
+import type { NotebookRequest, NotebookResponse } from "./request-types";
+
+type MissingUnionMember<Union extends string, Values extends readonly string[]> = Exclude<
+  Union,
+  Values[number]
+>;
+
+export const NOTEBOOK_REQUEST_TYPES = [
+  "launch_kernel",
+  "execute_cell",
+  "execute_cell_guarded",
+  "clear_outputs",
+  "interrupt_execution",
+  "shutdown_kernel",
+  "run_all_cells",
+  "run_all_cells_guarded",
+  "send_comm",
+  "get_history",
+  "complete",
+  "save_notebook",
+  "clone_as_ephemeral",
+  "sync_environment",
+  "approve_trust",
+  "approve_project_environment",
+  "get_doc_bytes",
+] as const satisfies readonly NotebookRequest["type"][];
+
+export const NOTEBOOK_REQUEST_TYPES_EXHAUSTIVE: MissingUnionMember<
+  NotebookRequest["type"],
+  typeof NOTEBOOK_REQUEST_TYPES
+> extends never
+  ? true
+  : never = true;
+
+export const NOTEBOOK_RESPONSE_RESULTS = [
+  "kernel_launched",
+  "kernel_already_running",
+  "cell_queued",
+  "outputs_cleared",
+  "interrupt_sent",
+  "kernel_shutting_down",
+  "no_kernel",
+  "guard_rejected",
+  "all_cells_queued",
+  "notebook_saved",
+  "save_error",
+  "notebook_cloned",
+  "ok",
+  "error",
+  "history_result",
+  "completion_result",
+  "sync_environment_complete",
+  "sync_environment_failed",
+  "doc_bytes",
+] as const satisfies readonly NotebookResponse["result"][];
+
+export const NOTEBOOK_RESPONSE_RESULTS_EXHAUSTIVE: MissingUnionMember<
+  NotebookResponse["result"],
+  typeof NOTEBOOK_RESPONSE_RESULTS
+> extends never
+  ? true
+  : never = true;
+
+export type SessionControlMessage = { type: "sync_status" } & SessionStatus;
+
+export const SESSION_CONTROL_TYPES = [
+  "sync_status",
+] as const satisfies readonly SessionControlMessage["type"][];
+
+export const NOTEBOOK_DOC_PHASES = [
+  "pending",
+  "syncing",
+  "interactive",
+] as const satisfies readonly NotebookDocPhase[];
+
+export const NOTEBOOK_DOC_PHASES_EXHAUSTIVE: MissingUnionMember<
+  NotebookDocPhase,
+  typeof NOTEBOOK_DOC_PHASES
+> extends never
+  ? true
+  : never = true;
+
+export const RUNTIME_STATE_PHASES = [
+  "pending",
+  "syncing",
+  "ready",
+] as const satisfies readonly RuntimeStatePhase[];
+
+export const RUNTIME_STATE_PHASES_EXHAUSTIVE: MissingUnionMember<
+  RuntimeStatePhase,
+  typeof RUNTIME_STATE_PHASES
+> extends never
+  ? true
+  : never = true;
+
+export const INITIAL_LOAD_PHASES = [
+  "not_needed",
+  "streaming",
+  "ready",
+  "failed",
+] as const satisfies readonly InitialLoadPhase["phase"][];
+
+export const INITIAL_LOAD_PHASES_EXHAUSTIVE: MissingUnionMember<
+  InitialLoadPhase["phase"],
+  typeof INITIAL_LOAD_PHASES
+> extends never
+  ? true
+  : never = true;

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -1,9 +1,10 @@
 /**
- * Frontend client subset of NotebookRequest/NotebookResponse from
- * crates/notebook-protocol/src/protocol.rs. This intentionally includes only
- * variants currently used by the frontend client.
+ * Frontend-visible NotebookRequest/NotebookResponse wire types from
+ * crates/notebook-protocol/src/protocol.rs.
  * These are transport-agnostic — callers encode them as needed.
  */
+
+import type { QueueEntry } from "./runtime-state";
 
 // ── Requests ────────────────────────────────────────────────────────
 
@@ -14,6 +15,34 @@ export interface GuardedNotebookProvenance {
 export interface DependencyGuard {
   observed_heads: string[];
   dependency_fingerprint: string;
+}
+
+export interface FeatureFlags {
+  bootstrap_dx?: boolean;
+}
+
+export interface DenoLaunchedConfig {
+  permissions: string[];
+  import_map?: string | null;
+  config?: string | null;
+  flexible_npm_imports: boolean;
+}
+
+export interface LaunchedEnvConfig extends FeatureFlags {
+  uv_deps?: string[] | null;
+  conda_deps?: string[] | null;
+  conda_channels?: string[] | null;
+  pixi_deps?: string[] | null;
+  pixi_toml_deps?: string[] | null;
+  pixi_toml_path?: string | null;
+  pyproject_path?: string | null;
+  environment_yml_path?: string | null;
+  environment_yml_deps?: string[] | null;
+  deno_config?: DenoLaunchedConfig | null;
+  venv_path?: string | null;
+  python_path?: string | null;
+  launch_id?: string | null;
+  prewarmed_packages?: string[];
 }
 
 export type NotebookRequest =
@@ -50,7 +79,9 @@ export type NotebookRequest =
       format_cells: boolean;
       /** Target path. Omit to save in place. */
       path?: string;
-    };
+    }
+  | { type: "clone_as_ephemeral"; source_notebook_id: string }
+  | { type: "get_doc_bytes" };
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {
@@ -63,6 +94,8 @@ export interface HistoryEntry {
 export interface CompletionItem {
   label: string;
   kind?: string | null;
+  detail?: string | null;
+  source?: string | null;
 }
 
 /** Message shape for send_comm requests. */
@@ -78,11 +111,17 @@ export interface CommRequestMessage {
 // ── Responses ───────────────────────────────────────────────────────
 
 export type NotebookResponse =
-  | { result: "kernel_launched"; kernel_type: string; env_source: string }
+  | {
+      result: "kernel_launched";
+      kernel_type: string;
+      env_source: string;
+      launched_config: LaunchedEnvConfig;
+    }
   | {
       result: "kernel_already_running";
       kernel_type: string;
       env_source: string;
+      launched_config: LaunchedEnvConfig;
     }
   | { result: "cell_queued"; cell_id: string; execution_id: string }
   | { result: "outputs_cleared"; cell_id: string }
@@ -92,7 +131,7 @@ export type NotebookResponse =
   | { result: "guard_rejected"; reason: string }
   | {
       result: "all_cells_queued";
-      queued: { cell_id: string; execution_id: string }[];
+      queued: QueueEntry[];
     }
   | { result: "ok" }
   | { result: "error"; error: string }
@@ -110,7 +149,13 @@ export type NotebookResponse =
       cursor_end: number;
     }
   | { result: "notebook_saved"; path: string }
-  | { result: "save_error"; error: SaveErrorKind };
+  | { result: "save_error"; error: SaveErrorKind }
+  | {
+      result: "notebook_cloned";
+      notebook_id: string;
+      working_dir?: string | null;
+    }
+  | { result: "doc_bytes"; bytes: number[] };
 
 /**
  * Structured save failures returned in `NotebookResponse::SaveError`.

--- a/packages/runtimed/tests/protocol-contract.test.ts
+++ b/packages/runtimed/tests/protocol-contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  INITIAL_LOAD_PHASES,
+  NOTEBOOK_DOC_PHASES,
+  NOTEBOOK_REQUEST_TYPES,
+  NOTEBOOK_RESPONSE_RESULTS,
+  RUNTIME_STATE_PHASES,
+  SESSION_CONTROL_TYPES,
+} from "../src";
+
+describe("protocol contract discriminants", () => {
+  it("lists notebook request discriminants in wire order", () => {
+    expect(NOTEBOOK_REQUEST_TYPES).toEqual([
+      "launch_kernel",
+      "execute_cell",
+      "execute_cell_guarded",
+      "clear_outputs",
+      "interrupt_execution",
+      "shutdown_kernel",
+      "run_all_cells",
+      "run_all_cells_guarded",
+      "send_comm",
+      "get_history",
+      "complete",
+      "save_notebook",
+      "clone_as_ephemeral",
+      "sync_environment",
+      "approve_trust",
+      "approve_project_environment",
+      "get_doc_bytes",
+    ]);
+  });
+
+  it("lists notebook response result discriminants in wire order", () => {
+    expect(NOTEBOOK_RESPONSE_RESULTS).toEqual([
+      "kernel_launched",
+      "kernel_already_running",
+      "cell_queued",
+      "outputs_cleared",
+      "interrupt_sent",
+      "kernel_shutting_down",
+      "no_kernel",
+      "guard_rejected",
+      "all_cells_queued",
+      "notebook_saved",
+      "save_error",
+      "notebook_cloned",
+      "ok",
+      "error",
+      "history_result",
+      "completion_result",
+      "sync_environment_complete",
+      "sync_environment_failed",
+      "doc_bytes",
+    ]);
+  });
+
+  it("lists session-control readiness discriminants", () => {
+    expect(SESSION_CONTROL_TYPES).toEqual(["sync_status"]);
+    expect(NOTEBOOK_DOC_PHASES).toEqual(["pending", "syncing", "interactive"]);
+    expect(RUNTIME_STATE_PHASES).toEqual(["pending", "syncing", "ready"]);
+    expect(INITIAL_LOAD_PHASES).toEqual(["not_needed", "streaming", "ready", "failed"]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a package-level TypeScript protocol contract for request, response, session-control, and readiness discriminants
- expand `packages/runtimed` request/response types to cover the current Rust wire surface
- add a `notebook-protocol` contract test that checks TypeScript discriminants and `FrameType` bytes against Rust
- document the checked protocol-surface workflow

Refs #2340.

## Verification

- `cargo test -p notebook-protocol`
- `cargo fmt --check`
- `pnpm exec vp check`
- `pnpm exec vp test run packages/runtimed/tests/protocol-contract.test.ts packages/runtimed/tests/transport.test.ts`
- `pnpm exec tsc --noEmit --project packages/runtimed/tsconfig.json`
- `pnpm exec tsc --noEmit --project apps/notebook/tsconfig.json`
- `git diff --check`