### PR TITLE
refactor(protocol): type environment launch sources

### DIFF
--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -256,11 +256,16 @@ Requests are one-shot JSON messages sent from the client to the daemon. Each req
 | `GetKernelInfo` | Query current kernel status |
 | `GetQueueState` | Query the execution queue |
 
+`LaunchKernel.env_source` is a request-time `LaunchSpec` string on the wire:
+`"auto"`, `"auto:uv"`, `"auto:conda"`, `"auto:pixi"`, or a concrete
+environment source such as `"uv:inline"`. The daemon resolves that spec before
+launch and downstream protocol responses carry a concrete `EnvSource`.
+
 ### Key response types
 
 | Response | Meaning |
 |----------|---------|
-| `KernelLaunched { env_source, ... }` | Kernel started, includes environment origin label |
+| `KernelLaunched { env_source, ... }` | Kernel started, includes resolved concrete environment origin label |
 | `CellQueued` | Cell added to execution queue |
 | `NotebookSaved` | File written to disk |
 | `CompletionResult { items, cursor_start, cursor_end }` | Code completion results (`items: Vec<CompletionItem>`) |

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -890,6 +890,28 @@ mod tests {
         assert_eq!(LaunchSpec::Concrete(EnvSource::Deno).auto_scope(), None);
     }
 
+    #[test]
+    fn launch_spec_serde_is_string() {
+        assert_eq!(
+            serde_json::to_value(LaunchSpec::AutoScoped(PackageManager::Pixi)).unwrap(),
+            serde_json::json!("auto:pixi")
+        );
+        assert_eq!(
+            serde_json::to_value(LaunchSpec::Concrete(EnvSource::Inline(PackageManager::Uv)))
+                .unwrap(),
+            serde_json::json!("uv:inline")
+        );
+
+        let auto: LaunchSpec = serde_json::from_value(serde_json::json!("auto")).unwrap();
+        assert_eq!(auto, LaunchSpec::Auto);
+        let concrete: LaunchSpec =
+            serde_json::from_value(serde_json::json!("conda:inline")).unwrap();
+        assert_eq!(
+            concrete,
+            LaunchSpec::Concrete(EnvSource::Inline(PackageManager::Conda))
+        );
+    }
+
     /// `recv_typed_frame` is built on `read_exact`, which is NOT cancel-
     /// safe: dropping the future mid-read silently discards bytes
     /// already pulled off the underlying reader.

--- a/crates/notebook-protocol/src/connection/env.rs
+++ b/crates/notebook-protocol/src/connection/env.rs
@@ -301,3 +301,29 @@ impl LaunchSpec {
         }
     }
 }
+
+impl fmt::Display for LaunchSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::AutoScoped(PackageManager::Uv) => f.write_str("auto:uv"),
+            Self::AutoScoped(PackageManager::Conda) => f.write_str("auto:conda"),
+            Self::AutoScoped(PackageManager::Pixi) => f.write_str("auto:pixi"),
+            Self::AutoScoped(PackageManager::Unknown(s)) => write!(f, "auto:{s}"),
+            Self::Concrete(source) => f.write_str(source.as_str()),
+        }
+    }
+}
+
+impl Serialize for LaunchSpec {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for LaunchSpec {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Ok(Self::parse(&raw))
+    }
+}

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -5,6 +5,7 @@
 
 use std::path::PathBuf;
 
+use crate::connection::{EnvSource, LaunchSpec};
 use serde::{Deserialize, Serialize};
 
 // ── Data structs referenced by protocol enums ───────────────────────────────
@@ -326,8 +327,8 @@ pub enum NotebookRequest {
     LaunchKernel {
         /// Kernel type: "python" or "deno"
         kernel_type: String,
-        /// Environment source: "uv:inline", "conda:prewarmed", etc.
-        env_source: String,
+        /// Request-time launch source: "auto", "auto:uv", "uv:inline", etc.
+        env_source: LaunchSpec,
         /// Path to the notebook file (for working directory)
         notebook_path: Option<String>,
     },
@@ -461,7 +462,7 @@ pub enum NotebookResponse {
     /// Kernel launched successfully.
     KernelLaunched {
         kernel_type: String,
-        env_source: String,
+        env_source: EnvSource,
         /// Environment config used at launch (for sync detection).
         launched_config: LaunchedEnvConfig,
     },
@@ -469,7 +470,7 @@ pub enum NotebookResponse {
     /// Kernel was already running (returned existing info).
     KernelAlreadyRunning {
         kernel_type: String,
-        env_source: String,
+        env_source: EnvSource,
         /// Environment config used at launch (for sync detection).
         launched_config: LaunchedEnvConfig,
     },
@@ -613,7 +614,7 @@ pub enum RuntimeAgentRequest {
     /// Environment is already prepared by the coordinator.
     LaunchKernel {
         kernel_type: String,
-        env_source: String,
+        env_source: EnvSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         notebook_path: Option<String>,
         launched_config: LaunchedEnvConfig,
@@ -634,7 +635,7 @@ pub enum RuntimeAgentRequest {
     /// one is already connected.
     RestartKernel {
         kernel_type: String,
-        env_source: String,
+        env_source: EnvSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         notebook_path: Option<String>,
         launched_config: LaunchedEnvConfig,
@@ -665,10 +666,10 @@ pub enum RuntimeAgentRequest {
 #[serde(tag = "result", rename_all = "snake_case")]
 pub enum RuntimeAgentResponse {
     /// Kernel launched successfully.
-    KernelLaunched { env_source: String },
+    KernelLaunched { env_source: EnvSource },
 
     /// Kernel restarted successfully (same runtime agent, new kernel).
-    KernelRestarted { env_source: String },
+    KernelRestarted { env_source: EnvSource },
 
     /// Code completion result.
     CompletionResult {
@@ -1334,7 +1335,7 @@ mod tests {
         assert!(!RuntimeAgentRequest::ShutdownKernel.is_command());
         assert!(!RuntimeAgentRequest::LaunchKernel {
             kernel_type: "python".into(),
-            env_source: "uv:prewarmed".into(),
+            env_source: EnvSource::Prewarmed(crate::connection::PackageManager::Uv),
             notebook_path: None,
             launched_config: Default::default(),
             env_vars: Default::default(),
@@ -1342,7 +1343,7 @@ mod tests {
         .is_command());
         assert!(!RuntimeAgentRequest::RestartKernel {
             kernel_type: "python".into(),
-            env_source: "conda:inline".into(),
+            env_source: EnvSource::Inline(crate::connection::PackageManager::Conda),
             notebook_path: None,
             launched_config: Default::default(),
             env_vars: Default::default(),

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -913,6 +913,7 @@ mod integration_tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
+    use notebook_protocol::connection::LaunchSpec;
     use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
     /// Get the daemon socket path for the current worktree.
@@ -1000,7 +1001,7 @@ mod integration_tests {
         let response = handle
             .send_request(NotebookRequest::LaunchKernel {
                 kernel_type: "python".into(),
-                env_source: "auto".into(),
+                env_source: LaunchSpec::Auto,
                 notebook_path: None,
             })
             .await

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -448,7 +448,9 @@ async fn apply_dependency_changes(
             match handle
                 .send_request(NotebookRequest::LaunchKernel {
                     kernel_type: "python".to_string(),
-                    env_source: restart_env_source,
+                    env_source: notebook_protocol::connection::LaunchSpec::parse(
+                        &restart_env_source,
+                    ),
                     notebook_path,
                 })
                 .await

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -126,7 +126,7 @@ pub async fn restart_kernel(
     let launch_result = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: kernel_type.clone(),
-            env_source: env_source.clone(),
+            env_source: notebook_protocol::connection::LaunchSpec::parse(&env_source),
             notebook_path: notebook_path.clone(),
         })
         .await;
@@ -150,7 +150,9 @@ pub async fn restart_kernel(
                     fresh_handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: kernel_type.clone(),
-                            env_source: env_source.clone(),
+                            env_source: notebook_protocol::connection::LaunchSpec::parse(
+                                &env_source,
+                            ),
                             notebook_path,
                         })
                         .await

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use crate::{EnvType, PoolState, PooledEnv};
 
 // Re-export all notebook protocol types from the shared crate.
+pub use notebook_protocol::connection::{EnvSource, LaunchSpec};
 pub use notebook_protocol::protocol::{
     CompletionItem, DenoLaunchedConfig, DependencyGuard, EnvSyncDiff, GuardedNotebookProvenance,
     HistoryEntry, LaunchedEnvConfig, NotebookBroadcast, NotebookRequest, NotebookResponse,
@@ -486,7 +487,7 @@ mod tests {
     fn test_notebook_request_launch_kernel() {
         let req = NotebookRequest::LaunchKernel {
             kernel_type: "python".into(),
-            env_source: "uv:prewarmed".into(),
+            env_source: LaunchSpec::Concrete(EnvSource::parse("uv:prewarmed")),
             notebook_path: Some("/tmp/test.ipynb".into()),
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -519,7 +520,7 @@ mod tests {
     fn test_notebook_response_kernel_launched() {
         let resp = NotebookResponse::KernelLaunched {
             kernel_type: "python".into(),
-            env_source: "conda:inline".into(),
+            env_source: EnvSource::parse("conda:inline"),
             launched_config: LaunchedEnvConfig {
                 conda_deps: Some(vec!["numpy".into(), "pandas".into()]),
                 ..Default::default()

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -633,7 +633,7 @@ async fn ensure_kernel_started(state: &Arc<Mutex<SessionState>>) -> Result<()> {
     let response = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: runtime.clone(),
-            env_source: "auto".to_string(),
+            env_source: notebook_protocol::connection::LaunchSpec::Auto,
             notebook_path,
         })
         .await

--- a/crates/runtimed/examples/test_inline_deps.rs
+++ b/crates/runtimed/examples/test_inline_deps.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use tempfile::TempDir;
 use tokio::time::sleep;
 
+use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::protocol::{NotebookRequest, NotebookResponse};
@@ -99,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
 
     let request = NotebookRequest::LaunchKernel {
         kernel_type: "python".to_string(),
-        env_source: "auto".to_string(),
+        env_source: LaunchSpec::Auto,
         notebook_path: Some(notebook_path.to_string_lossy().to_string()),
     };
 
@@ -114,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
             println!("✅ Kernel launched!");
             println!("   kernel_type: {}", kernel_type);
             println!("   env_source: {}", env_source);
-            if env_source == "uv:inline" {
+            if env_source == EnvSource::Inline(PackageManager::Uv) {
                 println!("\n🎉 SUCCESS: Inline deps detected correctly!");
             } else {
                 println!(

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3510,7 +3510,7 @@ pub(crate) async fn auto_launch_kernel(
                 let launch_request =
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),
-                        env_source: env_source.as_str().to_string(),
+                        env_source: env_source.clone(),
                         notebook_path: notebook_path_opt
                             .as_deref()
                             .map(|p| p.to_str().unwrap_or("").to_string()),
@@ -3530,14 +3530,19 @@ pub(crate) async fn auto_launch_kernel(
                             *lc = Some(launched_config.clone());
                         }
 
-                        publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
-                            .await;
+                        let es_label = es.as_str().to_string();
+                        publish_kernel_state_presence(
+                            room,
+                            presence::KernelStatus::Idle,
+                            &es_label,
+                        )
+                        .await;
 
                         // Write Running(Idle) + kernel info to RuntimeStateDoc
                         // so frontends see "idle" via CRDT sync.
                         if let Err(e) = room.state.with_doc(|sd| {
                             sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-                            sd.set_kernel_info(kernel_type, kernel_type, &es)?;
+                            sd.set_kernel_info(kernel_type, kernel_type, &es_label)?;
                             sd.set_runtime_agent_id(&runtime_agent_id)?;
                             // Fresh kernel is in sync with its launched config
                             sd.set_env_sync(true, &[], &[], false, false)?;
@@ -3548,7 +3553,7 @@ pub(crate) async fn auto_launch_kernel(
 
                         info!(
                             "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
-                            kernel_type, es
+                            kernel_type, es_label
                         );
                     }
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -283,9 +283,7 @@ pub(crate) async fn handle(
                             .as_ref()
                             .filter(|p| !p.dependencies.is_empty())
                             .map(|_| EnvSource::Inline(PackageManager::Pixi)),
-                        _ => check_inline_deps(snap)
-                            .filter(|s| !matches!(s, EnvSource::Deno))
-                            .map(|s| s),
+                        _ => check_inline_deps(snap).filter(|s| !matches!(s, EnvSource::Deno)),
                     }
                 })
         {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -11,6 +11,7 @@ use tokio::sync::oneshot;
 use tracing::{error, info, warn};
 
 use notebook_doc::presence;
+use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
 use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle};
 
 use crate::daemon::Daemon;
@@ -32,7 +33,7 @@ pub(crate) async fn handle(
     room: &Arc<NotebookRoom>,
     daemon: &Arc<Daemon>,
     kernel_type: String,
-    env_source: String,
+    env_source: LaunchSpec,
     notebook_path: Option<String>,
 ) -> NotebookResponse {
     if let Err(rejection) = guarded::ensure_trusted(room).await {
@@ -174,8 +175,7 @@ pub(crate) async fn handle(
 
     // Classify the request-time input. Permissive: non-canonical values land in
     // `LaunchSpec::Concrete(EnvSource::Unknown(_))` and pass through unchanged.
-    use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
-    let launch_spec = LaunchSpec::parse(&env_source);
+    let launch_spec = env_source;
 
     // Deno kernels don't use Python environments - always use "deno" regardless
     // of what env_source was requested. Log a warning if caller passed a Python env.
@@ -195,7 +195,7 @@ pub(crate) async fn handle(
                 );
             }
         }
-        EnvSource::Deno.as_str().to_string()
+        EnvSource::Deno
     } else if matches!(launch_spec, LaunchSpec::Auto | LaunchSpec::AutoScoped(_)) {
         // Auto-detect Python environment, optionally scoped to a package manager family.
         // "auto:uv" constrains to UV sources, "auto:conda" to conda sources,
@@ -232,7 +232,7 @@ pub(crate) async fn handle(
                 detected.path,
                 detected.to_env_source().as_str()
             );
-            detected.to_env_source().as_str().to_string()
+            detected.to_env_source()
         }
         // Priority 2: Captured prewarmed env wins over inline deps.
         // Captured deps look structurally identical to user-authored
@@ -246,60 +246,52 @@ pub(crate) async fn handle(
         // notebook (or vice versa) falls through. `auto:pixi` always
         // falls through — no pixi capture path yet.
         else if let Some(captured_src) = captured_env_source_override(metadata_snapshot.as_ref())
-            .filter(|src| {
-                use notebook_protocol::connection::{EnvSource, PackageManager};
-                match auto_scope {
-                    Some("uv") => matches!(src, EnvSource::Prewarmed(PackageManager::Uv)),
-                    Some("conda") => matches!(src, EnvSource::Prewarmed(PackageManager::Conda)),
-                    Some("pixi") => false,
-                    _ => true,
-                }
+            .filter(|src| match auto_scope {
+                Some("uv") => matches!(src, EnvSource::Prewarmed(PackageManager::Uv)),
+                Some("conda") => matches!(src, EnvSource::Prewarmed(PackageManager::Conda)),
+                Some("pixi") => false,
+                _ => true,
             })
         {
             info!(
                 "[notebook-sync] LaunchKernel: captured env on disk -> {}",
                 captured_src.as_str()
             );
-            captured_src.as_str().to_string()
+            captured_src
         }
         // Priority 3: Check inline deps in notebook metadata
         else if let Some(inline_source) =
             metadata_snapshot
                 .as_ref()
-                .and_then(|snap| -> Option<String> {
-                    use notebook_protocol::connection::{EnvSource, PackageManager};
+                .and_then(|snap| -> Option<EnvSource> {
                     match auto_scope {
                         Some("uv") => snap
                             .runt
                             .uv
                             .as_ref()
                             .filter(|uv| !uv.dependencies.is_empty())
-                            .map(|_| EnvSource::Inline(PackageManager::Uv).as_str().to_string()),
+                            .map(|_| EnvSource::Inline(PackageManager::Uv)),
                         Some("conda") => snap
                             .runt
                             .conda
                             .as_ref()
                             .filter(|c| !c.dependencies.is_empty())
-                            .map(|_| {
-                                EnvSource::Inline(PackageManager::Conda)
-                                    .as_str()
-                                    .to_string()
-                            }),
+                            .map(|_| EnvSource::Inline(PackageManager::Conda)),
                         Some("pixi") => snap
                             .runt
                             .pixi
                             .as_ref()
                             .filter(|p| !p.dependencies.is_empty())
-                            .map(|_| EnvSource::Inline(PackageManager::Pixi).as_str().to_string()),
+                            .map(|_| EnvSource::Inline(PackageManager::Pixi)),
                         _ => check_inline_deps(snap)
                             .filter(|s| !matches!(s, EnvSource::Deno))
-                            .map(|s| s.as_str().to_string()),
+                            .map(|s| s),
                     }
                 })
         {
             info!(
                 "[notebook-sync] Found inline deps in notebook metadata -> {}",
-                inline_source
+                inline_source.as_str()
             );
             inline_source
         } else {
@@ -323,50 +315,59 @@ pub(crate) async fn handle(
 
             if has_pep723_deps {
                 let pep723_source = match auto_scope {
-                    Some("uv") => "uv:pep723",
-                    Some("pixi") => "pixi:pep723",
+                    Some("uv") => EnvSource::Pep723(PackageManager::Uv),
+                    Some("pixi") => EnvSource::Pep723(PackageManager::Pixi),
                     Some("conda") => unreachable!("conda scope skips PEP 723"),
                     _ => {
                         let default_env = daemon.default_python_env().await;
                         match default_env {
-                            crate::settings_doc::PythonEnvType::Pixi => "pixi:pep723",
-                            _ => "uv:pep723",
+                            crate::settings_doc::PythonEnvType::Pixi => {
+                                EnvSource::Pep723(PackageManager::Pixi)
+                            }
+                            _ => EnvSource::Pep723(PackageManager::Uv),
                         }
                     }
                 };
                 info!(
                     "[notebook-sync] Found PEP 723 deps in cell source ({})",
-                    pep723_source
+                    pep723_source.as_str()
                 );
-                pep723_source.to_string()
+                pep723_source
             }
             // Priority 4: Fall back to prewarmed (scoped to family)
             else {
                 let fallback = match auto_scope {
-                    Some("conda") => "conda:prewarmed",
-                    Some("pixi") => "pixi:prewarmed",
+                    Some("conda") => EnvSource::Prewarmed(PackageManager::Conda),
+                    Some("pixi") => EnvSource::Prewarmed(PackageManager::Pixi),
                     _ => {
                         let default_env = daemon.default_python_env().await;
                         match default_env {
-                            crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                            crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
-                            _ => "uv:prewarmed",
+                            crate::settings_doc::PythonEnvType::Conda => {
+                                EnvSource::Prewarmed(PackageManager::Conda)
+                            }
+                            crate::settings_doc::PythonEnvType::Pixi => {
+                                EnvSource::Prewarmed(PackageManager::Pixi)
+                            }
+                            _ => EnvSource::Prewarmed(PackageManager::Uv),
                         }
                     }
                 };
                 info!(
                     "[notebook-sync] No project file detected, using {}",
-                    fallback
+                    fallback.as_str()
                 );
-                fallback.to_string()
+                fallback
             }
         }
     } else {
         // Use explicit env_source (e.g., "uv:inline", "conda:inline")
-        env_source.clone()
+        match launch_spec {
+            LaunchSpec::Concrete(source) => source,
+            LaunchSpec::Auto | LaunchSpec::AutoScoped(_) => unreachable!("auto handled above"),
+        }
     };
 
-    let parsed_resolved = EnvSource::parse(&resolved_env_source);
+    let parsed_resolved = resolved_env_source.clone();
 
     // For pixi:toml, verify ipykernel is declared before launching.
     // Unlike uv (`uv run --with ipykernel`) and conda:env_yml (daemon
@@ -485,8 +486,12 @@ pub(crate) async fn handle(
                             .map(|d| d.path)
                     });
                 }
-                match promote_inline_deps_to_project(room, &resolved_env_source, &promo_config)
-                    .await
+                match promote_inline_deps_to_project(
+                    room,
+                    resolved_env_source.as_str(),
+                    &promo_config,
+                )
+                .await
                 {
                     Ok(promoted) if !promoted.is_empty() => {
                         info!(
@@ -535,7 +540,7 @@ pub(crate) async fn handle(
                 // the claimed one, leaking envs and bypassing drift
                 // detection's "captured baseline" logic.
                 match acquire_prewarmed_env_with_capture(
-                    &resolved_env_source,
+                    resolved_env_source.as_str(),
                     daemon,
                     room,
                     metadata_snapshot.as_ref(),
@@ -545,7 +550,8 @@ pub(crate) async fn handle(
                     Some(Some(env)) => {
                         info!(
                             "[notebook-sync] LaunchKernel: acquired {} env: {:?}",
-                            resolved_env_source, env.python_path
+                            resolved_env_source.as_str(),
+                            env.python_path
                         );
                         Some(env)
                     }
@@ -1208,7 +1214,7 @@ pub(crate) async fn handle(
     };
     let launched_config = build_launched_config(
         &resolved_kernel_type,
-        &resolved_env_source,
+        resolved_env_source.as_str(),
         inline_deps.as_deref(),
         metadata_snapshot.as_ref(),
         venv_path,
@@ -1252,10 +1258,16 @@ pub(crate) async fn handle(
                         *lc = Some(launched_config.clone());
                     }
 
-                    publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es).await;
+                    let es_label = es.as_str().to_string();
+                    publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es_label)
+                        .await;
                     if let Err(e) = room.state.with_doc(|sd| {
                         sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-                        sd.set_kernel_info(&resolved_kernel_type, &resolved_kernel_type, &es)?;
+                        sd.set_kernel_info(
+                            &resolved_kernel_type,
+                            &resolved_kernel_type,
+                            &es_label,
+                        )?;
                         sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
                         // runtime_agent_id doesn't change on restart — same runtime agent
                         Ok(())
@@ -1390,8 +1402,13 @@ pub(crate) async fn handle(
                             *lc = Some(launched_config.clone());
                         }
 
-                        publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
-                            .await;
+                        let es_label = es.as_str().to_string();
+                        publish_kernel_state_presence(
+                            room,
+                            presence::KernelStatus::Idle,
+                            &es_label,
+                        )
+                        .await;
 
                         // Write kernel status + info + prewarmed packages
                         // to RuntimeStateDoc
@@ -1404,7 +1421,7 @@ pub(crate) async fn handle(
                                 sd.set_kernel_info(
                                     &resolved_kernel_type,
                                     &resolved_kernel_type,
-                                    &es,
+                                    &es_label,
                                 )?;
                                 sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
                                 if let Some(ref aid) = agent_id {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use notebook_doc::presence::PresenceState;
 use notebook_protocol::connection::{
     send_json_frame, send_preamble, send_typed_frame, FramedReader, Handshake, NotebookFrameType,
+    PackageManager,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use runtime_doc::RuntimeStateHandle;
@@ -539,7 +540,7 @@ async fn handle_runtime_agent_request(
                     .python_path
                     .as_ref()
                     .map(|python| runtimed_client::PooledEnv {
-                        env_type: if env_source.starts_with("conda") {
+                        env_type: if env_source.package_manager() == Some(PackageManager::Conda) {
                             runtimed_client::EnvType::Conda
                         } else {
                             runtimed_client::EnvType::Uv
@@ -559,7 +560,7 @@ async fn handle_runtime_agent_request(
             };
             let config = KernelLaunchConfig {
                 kernel_type,
-                env_source: env_source.clone(),
+                env_source: env_source.as_str().to_string(),
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
                 env_vars: vec![],
@@ -573,7 +574,9 @@ async fn handle_runtime_agent_request(
                     state.reset();
                     state.set_idle();
                     (
-                        RuntimeAgentResponse::KernelLaunched { env_source: es },
+                        RuntimeAgentResponse::KernelLaunched {
+                            env_source: notebook_protocol::connection::EnvSource::parse(&es),
+                        },
                         Some(rx),
                     )
                 }
@@ -621,7 +624,7 @@ async fn handle_runtime_agent_request(
                     .python_path
                     .as_ref()
                     .map(|python| runtimed_client::PooledEnv {
-                        env_type: if env_source.starts_with("conda") {
+                        env_type: if env_source.package_manager() == Some(PackageManager::Conda) {
                             runtimed_client::EnvType::Conda
                         } else {
                             runtimed_client::EnvType::Uv
@@ -641,7 +644,7 @@ async fn handle_runtime_agent_request(
             };
             let config = KernelLaunchConfig {
                 kernel_type,
-                env_source: env_source.clone(),
+                env_source: env_source.as_str().to_string(),
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
                 env_vars: vec![],
@@ -685,7 +688,9 @@ async fn handle_runtime_agent_request(
                     state.reset();
                     state.set_idle();
                     (
-                        RuntimeAgentResponse::KernelRestarted { env_source: es },
+                        RuntimeAgentResponse::KernelRestarted {
+                            env_source: notebook_protocol::connection::EnvSource::parse(&es),
+                        },
                         Some(rx),
                     )
                 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use notebook_protocol::connection::LaunchSpec;
 use notebook_sync::connect;
 use runtime_doc::RuntimeLifecycle;
 use runtimed::client::PoolClient;
@@ -801,7 +802,7 @@ async fn test_untrusted_launch_and_sync_environment_are_daemon_rejected() {
     let launch = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: "python".to_string(),
-            env_source: "auto".to_string(),
+            env_source: LaunchSpec::Auto,
             notebook_path: None,
         })
         .await

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use notebook_protocol::connection::EnvSource;
 use notebook_protocol::protocol::{
     RuntimeAgentRequest, RuntimeAgentRequestEnvelope, RuntimeAgentResponse,
 };
@@ -360,7 +361,7 @@ async fn shutdown_then_launch_serialized() {
         &tx,
         RuntimeAgentRequest::LaunchKernel {
             kernel_type: "python".into(),
-            env_source: "conda:inline".into(),
+            env_source: EnvSource::parse("conda:inline"),
             notebook_path: None,
             launched_config: Default::default(),
             env_vars: Default::default(),

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -131,11 +131,14 @@ export type {
   CompletionItem,
   DependencyGuard,
   DenoLaunchedConfig,
+  EnvSource,
   GuardedNotebookProvenance,
   HistoryEntry,
   LaunchedEnvConfig,
+  LaunchSpec,
   NotebookRequest,
   NotebookResponse,
+  PackageManager,
   SaveErrorKind,
 } from "./request-types";
 

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -17,6 +17,20 @@ export interface DependencyGuard {
   dependency_fingerprint: string;
 }
 
+export type PackageManager = "uv" | "conda" | "pixi" | (string & {});
+
+export type EnvSource =
+  | `${PackageManager}:prewarmed`
+  | `${PackageManager}:inline`
+  | "uv:pyproject"
+  | "pixi:toml"
+  | "conda:env_yml"
+  | `${PackageManager}:pep723`
+  | "deno"
+  | (string & {});
+
+export type LaunchSpec = "auto" | "" | "prewarmed" | `auto:${PackageManager}` | EnvSource;
+
 export interface FeatureFlags {
   bootstrap_dx?: boolean;
 }
@@ -49,7 +63,7 @@ export type NotebookRequest =
   | {
       type: "launch_kernel";
       kernel_type: string;
-      env_source: string;
+      env_source: LaunchSpec;
       notebook_path?: string;
     }
   | { type: "execute_cell"; cell_id: string }
@@ -114,13 +128,13 @@ export type NotebookResponse =
   | {
       result: "kernel_launched";
       kernel_type: string;
-      env_source: string;
+      env_source: EnvSource;
       launched_config: LaunchedEnvConfig;
     }
   | {
       result: "kernel_already_running";
       kernel_type: string;
-      env_source: string;
+      env_source: EnvSource;
       launched_config: LaunchedEnvConfig;
     }
   | { result: "cell_queued"; cell_id: string; execution_id: string }


### PR DESCRIPTION
## Summary

- make request-time `LaunchKernel.env_source` a typed Rust `LaunchSpec` while preserving string wire serde
- make resolved launch responses and runtime-agent launch messages carry typed `EnvSource` values
- add TypeScript `LaunchSpec`, `EnvSource`, and `PackageManager` protocol aliases in `packages/runtimed`
- update MCP, Node, auto-launch, and runtime-agent call sites to parse or stringify at boundaries
- document the request-time `LaunchSpec` vs resolved `EnvSource` distinction

Refs #2340.

## Verification

- `cargo test -p notebook-protocol`
- `cargo check -p notebook-protocol -p runtimed -p runt -p runtimed-client -p notebook-sync -p runtimed-node -p runt-mcp`
- `cargo test -p runtimed --lib --no-run`
- `cargo fmt --check`
- `pnpm exec vp check`
- `pnpm exec vp test run packages/runtimed/tests/protocol-contract.test.ts packages/runtimed/tests/transport.test.ts`
- `pnpm exec tsc --noEmit --project packages/runtimed/tsconfig.json`
- `pnpm exec tsc --noEmit --project apps/notebook/tsconfig.json`
- `git diff --check`