### PR TITLE
docs: condense agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,333 +1,171 @@
-# Agent Instructions
+# Agent Guide
 
 <!-- This file is canonical. CLAUDE.md is a symlink to AGENTS.md. -->
 
-This document provides guidance for AI agents working in this repository. Claude agents also receive contextual rules (`.claude/rules/`) and skills (`.claude/skills/`) auto-loaded when relevant. All agents should run `cargo xtask help` to discover build commands.
+This file is a map, not the full handbook. Keep repo-specific facts here only
+when they prevent wrong turns. Detailed setup, architecture, and subsystem
+workflow docs live under `contributing/`, `docs/`, and `.codex/skills/`.
+Claude-specific rules and skills also live under `.claude/`.
 
-Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
-- `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification
-- `nteract-python-bindings` for `maturin develop`, venv selection, and MCP server work
-- `nteract-notebook-sync` for Automerge ownership, output manifests, and sync-path changes
-- `nteract-testing` for choosing and running the right verification path
-
-## Development Setup Requirements
-
-### direnv (Optional Convenience)
-
-direnv is useful because it automatically puts the repo's `bin/` wrappers on
-`PATH` and enables the local linker/cache environment when you enter the repo
-directory. It is **not required** for `cargo xtask dev-daemon`, `cargo xtask
-notebook`, or `cargo xtask run-mcp`: xtask detects the current git worktree and
-passes `RUNTIMED_DEV=1` plus `RUNTIMED_WORKSPACE_PATH` to the subprocesses it
-starts.
-
-You still want direnv if you run unqualified commands like `runt daemon status`
-and expect the repo's `bin/runt` wrapper to shadow the system install. Without
-direnv, use `./target/debug/runt ...` or pass the dev env vars explicitly for raw
-commands.
-
-**Install and configure:**
-```bash
-# Install direnv
-sudo apt install direnv  # Ubuntu/Debian
-brew install direnv      # macOS
-
-# Add hook to shell (bash)
-echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-source ~/.bashrc
-
-# Allow the repo's .envrc
-cd /path/to/nteract/desktop
-direnv allow
-```
-
-The `.envrc` file sets:
-- `PATH_add bin` — adds `bin/runt` wrapper to PATH (shadows system `runt`)
-- `export RUNTIMED_DEV=1` — enables per-worktree daemon isolation
-- `export RUNTIMED_WORKSPACE_PATH="$(pwd)"` — pins daemon to this worktree
-- `export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"` (if `ld64.lld` is installed) — uses LLVM's lld linker on macOS arm64
-
-**Verify it works:**
-```bash
-cd /path/to/nteract/desktop
-echo $RUNTIMED_DEV              # Should print "1" when direnv is active
-echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path when direnv is active
-which runt                      # Should be repo/bin/runt (not /usr/local/bin/runt)
-```
-
-### Build cache story
-
-Local dev uses cargo's incremental cache. Tight edit-check loops on one crate reuse rustc's per-function incremental artifacts and run in seconds. No extra setup required.
-
-Local dev does not use sccache. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It also breaks WASM builds (sccache's clang doesn't support `wasm32-unknown-unknown`). If a developer has `RUSTC_WRAPPER=sccache` in their environment, xtask strips it for wasm-pack invocations.
-
-CI release jobs do route Rust compiles through sccache, backed by the GitHub Actions cache. The local-dev concerns don't apply: the release profile already disables incremental, and the release jobs that still build wasm (`build-wasm`) don't run with sccache wired in. Every other Rust job in `release-common.yml` (build-linux, build-macos, build-notebook-*, the pre-maturin step in build-python-wheels, and maturin itself via `sccache: true`) shares one sccache cache, which is what lets `runtimed` compile once and be reused across jobs that need it as both a binary sidecar and a Rust library dep.
-
-### lld linker (macOS arm64)
-
-`.envrc` links macOS arm64 builds through LLVM's `lld` when it's installed. Without `lld` the build falls back to Apple's system `ld`. Install to cut incremental link time by roughly a third:
+Start each session with:
 
 ```bash
-brew install lld
+cargo xtask help
 ```
 
-The rustflag goes through direnv, not `.cargo/config.toml`, so CI runners and contributors without `lld` aren't forced to install it.
+## First Places To Look
 
-### MCP Server Configuration
+Use the repo-local Codex skills when they match the task:
 
-**Three MCP servers** should be configured:
-
-1. **nteract-dev** (development, per-worktree daemon)
-   - Command: `cargo run -p mcp-supervisor` (used by `.mcp.json`). Build cost is small now that the supervisor no longer links `runtimed-client` — first run after `cargo clean` takes a few seconds, warm runs are instant.
-   - Working directory: `/path/to/nteract/desktop`
-   - Env vars: `.mcp.json`/`.codex/config.toml` set the mode; the supervisor derives the worktree path from the repo root
-   - Socket: `~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock`
-   - Tools: 26 nteract tools (proxied from `runt mcp`) + 5 dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
-
-2. **nteract-nightly** (system nightly daemon, for testing releases)
-   - Command: `env -i HOME=$HOME /usr/local/bin/runt-nightly mcp`
-   - Working directory: Can be anywhere (no repo dependency)
-   - Env vars: **MUST use `env -i`** to strip RUNTIMED_DEV and RUNTIMED_WORKSPACE_PATH
-   - Socket: `~/.cache/runt-nightly/runtimed.sock` (system socket, NOT worktrees/)
-   - Tools: 26 nteract tools (no dev tools)
-
-3. **nteract** (system stable daemon, for testing stable releases)
-   - Command: `env -i HOME=$HOME /usr/local/bin/runt mcp`
-   - Working directory: Can be anywhere
-   - Env vars: **MUST use `env -i`** to strip dev env vars
-   - Socket: `~/.cache/runt/runtimed.sock`
-   - Tools: 26 nteract tools (no dev tools)
-
-**Critical:** The `env -i` wrapper on nteract-nightly and nteract is required to prevent direnv's env vars from leaking into these MCP servers. Without it, they will incorrectly connect to the dev daemon instead of the system daemon.
-
-**This system's nightly installation:**
-- Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}`
-- Symlinks: `/usr/local/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}` → the install dir
-- Daemon socket: `~/.cache/runt-nightly/runtimed.sock`
-- Install command: `./scripts/install-nightly` (refuses on macOS and when an app bundle is installed)
-- Version: Built from source, updated after each PR merge
-
-**Verification steps:** See `.claude/rules/mcp-servers.md` § Verifying Daemon Isolation.
-
-## Quick Recipes (Common Dev Tasks)
-
-### If you have `up` / `down` / `status` tools — use them
-
-If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (provided by `nteract-dev`), **prefer those over manual terminal commands**. `nteract-dev` manages the dev daemon lifecycle for you — no env vars, no extra terminals.
-
-**Claude Code has nteract-dev locally** — `.mcp.json` launches `cargo run -p mcp-supervisor` on session start. If your current environment does not expose these tools, use the manual `cargo xtask` commands below.
-
-| Instead of… | Use… |
-|-------------|------|
-| `cargo xtask dev-daemon` (in a terminal) | `up` (idempotent: ensures daemon + child are healthy) |
-| `maturin develop` (rebuild bindings) | `up rebuild=true` |
-| `runt daemon status` (with env vars) | `status` |
-| `runt daemon logs` | `logs` |
-| `cargo xtask vite` | `up vite=true` |
-| `cargo xtask notebook` (stop dev processes) | `down` (stops Vite; `daemon=true` also stops daemon) |
-
-`nteract-dev` automatically handles per-worktree isolation, env var plumbing, zombie Vite cleanup, health probes, and lockfile-drift re-installs. You only need the manual commands below when `nteract-dev` isn't available (e.g. cloud sessions, CI).
-
-### Manual commands (when nteract-dev is not available)
-
-For `cargo xtask dev-daemon`, `cargo xtask notebook`, and `cargo xtask run-mcp`,
-no extra env vars are needed: xtask derives the current git worktree and passes
-the dev env to subprocesses. For raw `./target/debug/runt ...` commands, opt
-into dev mode explicitly. `RUNTIMED_DEV=1` is what enables per-worktree daemon
-isolation. `RUNTIMED_WORKSPACE_PATH` is the safest way to pin the current
-worktree.
-
-```bash
-# ── Recommended env vars for raw runt commands ───────────────
-export RUNTIMED_DEV=1
-export RUNTIMED_WORKSPACE_PATH="$(pwd)"
-```
-
-### Interacting with the dev daemon
-
-```bash
-# Check status (MUST use env vars or you'll see the system daemon)
-RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status
-
-# Tail logs
-RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon logs -f
-
-# List running notebooks
-RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt ps
-```
-
-### Rebuilding Python bindings (runtimed-py)
-
-There are **two venvs** that matter:
-
-| Venv | Purpose | Used by |
-|------|---------|---------|
-| `.venv` (repo root) | Workspace venv — has `nteract`, `runtimed`, and `gremlin` as editable installs | MCP server (`uv run nteract`), gremlin agent |
-| `python/runtimed/.venv` | Test-only venv — has `runtimed` + `maturin` + test deps | `pytest` integration tests |
-
-```bash
-# For the MCP server (most common — this is what `up rebuild=true` does):
-cd crates/runtimed-py && VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
-
-# For integration tests only:
-cd crates/runtimed-py && VIRTUAL_ENV=../../python/runtimed/.venv uv run --directory ../../python/runtimed maturin develop
-```
-
-**Common mistake:** Running `maturin develop` without `VIRTUAL_ENV` installs the `.so` into whichever venv `uv run` resolves, which is `python/runtimed/.venv`. The MCP server runs from `.venv` (repo root) and will never see it. Always set `VIRTUAL_ENV` explicitly.
-
-### Running Python integration tests
-
-```bash
-# Run against the dev daemon (must be running)
-RUNTIMED_SOCKET_PATH="$(RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status --json | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])')" \
-  python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py -v
-
-# Unit tests only (no daemon needed)
-python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -v
-```
-
-### Running the notebook app (dev mode)
-
-**Do not launch the notebook app from an agent terminal.** The app is a GUI process that blocks until the user quits it (⌘Q), and the agent will misinterpret the exit. Let the human launch it from their own terminal or Zed task.
-
-With `nteract-dev`, the daemon and vite are already managed — the human just runs:
-```bash
-cargo xtask notebook
-```
-
-Without `nteract-dev` (human runs both):
-```bash
-# Terminal 1: Start dev daemon
-cargo xtask dev-daemon
-
-# Terminal 2: Start the app
-cargo xtask notebook
-```
-
-### WASM rebuild (after changing notebook-doc, runtimed-wasm, or sift-wasm)
-
-```bash
-cargo xtask wasm             # rebuild both runtimed-wasm and sift-wasm;
-                             # also chains into `renderer-plugins` so the
-                             # plugin JS bundles re-embed fresh sift-wasm glue.
-cargo xtask wasm runtimed    # only runtimed-wasm (no plugin chain)
-cargo xtask wasm sift        # only sift-wasm (chains plugins)
-```
-
-The output directories under `apps/notebook/src/renderer-plugins/`,
-`apps/notebook/src/wasm/runtimed-wasm/`, `crates/runt-mcp/assets/plugins/`,
-and `crates/sift-wasm/pkg/` are gitignored. CI rebuilds them on every run.
-Locally, run `cargo xtask wasm` once after a fresh clone, and again whenever
-you edit anything under `crates/runtimed-wasm/`, `crates/sift-wasm/`, or
-`scripts/build-renderer-plugins.ts`.
-
-### Subsystem guides
-
-Before diving into a subsystem, read the relevant guide:
-
-| Task | Guide |
+| Task | Skill |
 |------|-------|
-| High-level architecture | `contributing/architecture.md` |
-| Development setup | `contributing/development.md` |
-| Python bindings / MCP | `contributing/runtimed.md` § Python Bindings |
-| Running tests | `contributing/testing.md` |
-| E2E tests (WebdriverIO) | `contributing/e2e.md` |
-| Frontend architecture | `contributing/frontend-architecture.md` |
-| UI components (Shadcn) | `contributing/ui.md` |
-| nteract Elements library | `contributing/nteract-elements.md` |
-| Wire protocol / sync | `contributing/protocol.md` |
-| Widget system | `contributing/widget-development.md` |
-| Daemon development | `contributing/runtimed.md` |
-| Environment management | `contributing/environments.md` |
-| Output iframe sandbox | `contributing/iframe-isolation.md` |
-| Renderer plugins (markdown, plotly, vega, leaflet) | `contributing/iframe-isolation.md` § Renderer Plugins |
-| CRDT mutation rules | `contributing/crdt-mutation-guide.md` |
-| TypeScript bindings (ts-rs) | `contributing/typescript-bindings.md` |
-| Logging guidelines | `contributing/logging.md` |
-| Build dependencies | `contributing/build-dependencies.md` |
-| Releasing | `contributing/releasing.md` |
-| Branch / worktree cleanup | `contributing/branch-hygiene.md` |
+| Daemon lifecycle, socket setup, daemon-backed verification | `.codex/skills/nteract-daemon-dev/` |
+| Python bindings, MCP server work, maturin/venv selection | `.codex/skills/nteract-python-bindings/` |
+| Automerge ownership, output manifests, notebook sync protocol | `.codex/skills/nteract-notebook-sync/` |
+| Choosing and running Rust, Python, JS, WASM, E2E, or daemon tests | `.codex/skills/nteract-testing/` |
 
-## Code Formatting (Required Before Committing)
+Use `packages/sift/CLAUDE.md` before touching `packages/sift/`.
 
-Run this command before every commit. CI will reject PRs that fail formatting checks.
+## Repo Map
 
-```bash
-cargo xtask lint --fix
-```
+| Path | What lives there |
+|------|------------------|
+| `apps/notebook/` | Tauri notebook app, React frontend, isolated output iframe |
+| `apps/renderer-test/` | Renderer test harness |
+| `apps/mcp-app/` | MCP app packaging |
+| `crates/notebook/` | Tauri shell and app-side Rust commands |
+| `crates/runtimed/` | Central daemon: rooms, runtime agents, env pools, sync server |
+| `crates/runt/` | CLI for daemon, kernels, notebooks, and MCP |
+| `crates/runt-mcp/` | Rust-native MCP notebook tools |
+| `crates/mcp-supervisor/` | `nteract-dev` supervisor/proxy with dev tools |
+| `crates/nteract-mcp/`, `crates/runt-mcp-proxy/` | Resilient shipped MCP proxies |
+| `crates/notebook-doc/` | Automerge notebook schema, cells, outputs, MIME classification |
+| `crates/runtime-doc/` | Runtime state Automerge schema |
+| `crates/notebook-protocol/` | Wire request, response, and broadcast types |
+| `crates/notebook-sync/` | Sync client and Python-facing document access |
+| `crates/runtimed-client/` | Shared client helpers for daemon paths, blobs, and outputs |
+| `crates/runtimed-py/` | PyO3 Rust bindings for `python/runtimed` |
+| `crates/runtimed-wasm/` | WASM bindings for notebook document operations |
+| `crates/kernel-env/` | UV/Conda/Pixi env creation, hashing, pooling, cleanup |
+| `crates/kernel-launch/` | Kernel launch/tool bootstrap logic |
+| `crates/runt-workspace/` | Per-worktree daemon/cache namespace logic |
+| `crates/runt-trust/` | Notebook trust |
+| `crates/repr-llm/` | LLM-friendly output summaries |
+| `crates/nteract-predicate/`, `crates/sift-wasm/` | Sift compute and WASM bindings |
+| `crates/automunge/` | Automerge helper tooling |
+| `crates/xtask/` | Build, lint, test, app, daemon, MCP orchestration |
+| `packages/notebook-host/` | JS host API for notebook embedding/Tauri transport |
+| `packages/runtimed/`, `packages/runtimed-node/` | JS runtimed clients/bindings |
+| `packages/sift/` | Table/data viewer package |
+| `python/runtimed/` | Python package backed by `crates/runtimed-py` |
+| `python/nteract/` | Python MCP wrapper that finds and launches `runt mcp` |
+| `python/gremlin/` | Notebook stress-test agent |
+| `python/dx/` | Python display helpers |
+| `python/prewarm/` | Package prewarm helper |
+| `python/nteract-kernel-launcher/` | Python launcher package |
+| `docs/` | User-facing feature docs |
+| `contributing/` | Maintainer/developer subsystem docs |
+| `scripts/` | Install, build, CI, metrics, and smoke-test helpers |
 
-This formats Rust, lints/formats TypeScript/JavaScript with vp (Vite+ unified toolchain), and lints/formats Python with ruff.
+## Command Map
 
-For CI-style check-only mode: `cargo xtask lint`
+All repo build/test/dev entry points should go through `cargo xtask` unless a
+subsystem doc says otherwise.
 
-Do not skip this. There are no pre-commit hooks — you must run it manually.
+| Need | Command |
+|------|---------|
+| Discover current commands | `cargo xtask help` |
+| Full debug build | `cargo xtask build` |
+| Rust-only rebuild | `cargo xtask build --rust-only` |
+| Run bundled debug binary | `cargo xtask run [notebook.ipynb]` |
+| Hot-reload notebook dev server | `cargo xtask notebook [notebook.ipynb]` |
+| Attach Tauri to existing Vite | `cargo xtask notebook --attach [notebook]` |
+| Vite only | `cargo xtask vite` |
+| Per-worktree daemon | `cargo xtask dev-daemon` |
+| Repo-local MCP supervisor | `cargo xtask run-mcp` |
+| Print MCP config | `cargo xtask run-mcp --print-config` |
+| MCP inspector UI | `cargo xtask mcp-inspector` |
+| Format and fix lint | `cargo xtask lint --fix` |
+| CI-style lint check | `cargo xtask lint` |
+| Clippy | `cargo xtask clippy` |
+| Python integration tests | `cargo xtask integration [filter]` |
+| E2E tests | `cargo xtask e2e [build\|test\|test-fixture\|test-all]` |
+| Rebuild WASM and renderer plugins | `cargo xtask wasm` |
+| Rebuild one WASM target | `cargo xtask wasm runtimed` or `cargo xtask wasm sift` |
+| Rebuild renderer plugins only | `cargo xtask renderer-plugins` |
+| Verify renderer plugin/wasm drift | `cargo xtask verify-plugins` |
+| Build app bundle | `cargo xtask build-app` |
+| Build DMG | `cargo xtask build-dmg` |
+| Generate icons | `cargo xtask icons [source.png]` |
+| Package MCP extension | `cargo xtask mcpb` |
+| Regenerate MCP tool cache | `cargo xtask sync-tool-cache` |
+| Check dependency budgets | `cargo xtask check-dep-budget` |
+| Bump all versioned artifacts | `cargo xtask bump [patch\|minor\|major]` |
 
-## Commit and PR Title Standard (Required)
+Do not launch the notebook GUI from an agent terminal unless the user explicitly
+asks; it blocks until the human quits the app.
 
-Use the Conventional Commits format for **both**:
-- Every git commit message
-- Every pull request title
+Run `cargo xtask lint --fix` before committing. Commit and PR titles must use
+Conventional Commits:
 
-Required format:
 ```text
 <type>(<optional-scope>)!: <short imperative summary>
 ```
 
-Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `revert`
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`,
+`perf`, `revert`.
 
-Examples:
-- `feat(kernel): add environment source labels`
-- `fix(runtimed): handle missing daemon socket`
+## Daemon And MCP
 
-## Workspace Description
+Development uses per-worktree daemon isolation. Prefer `nteract-dev` tools when
+the client exposes them:
 
-When working in a worktree, set a human-readable description:
+| If available | Use for |
+|--------------|---------|
+| `up` | Idempotently start/repair daemon, MCP child, and optionally Vite |
+| `down` | Stop managed Vite; pass `daemon=true` only when you mean it |
+| `status` | Inspect supervisor, child, daemon, and process state |
+| `logs` | Read daemon logs |
+| `vite_logs` | Read Vite logs |
+
+If those tools are not available, stop chasing MCP attachment and use manual
+`cargo xtask` commands. For raw `./target/debug/runt ...` commands, pin the
+worktree daemon explicitly:
 
 ```bash
-mkdir -p .context
-echo "Your description here" > .context/workspace-description
+RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" ./target/debug/runt daemon status
 ```
 
-The `.context/` directory is gitignored.
+Avoid system-wide process killers such as `pkill` and `killall`; they can affect
+other worktrees and agents. Use `down`, `./target/debug/runt daemon stop`, or
+the relevant `cargo xtask` flow.
+
+Installed stable/nightly MCP servers must be launched with `env -i HOME=$HOME`
+so worktree dev environment variables do not leak into system daemons.
+
+Source builds default to the nightly channel. Use `RUNT_BUILD_CHANNEL=stable`
+only when explicitly validating stable branding, stable socket/cache paths, or
+stable app-launch behavior.
 
 ## Python Workspace
 
-The UV workspace root is the **repository root** — `pyproject.toml` and `.venv` live at the top level (not under `python/`). Three packages are workspace members:
+The UV workspace root is the repository root. The repo has two important venvs:
 
-| Package | Path | Purpose |
-|---------|------|---------|
-| `runtimed` | `python/runtimed` | Python bindings for the Rust daemon (PyO3/maturin) |
-| `nteract` | `python/nteract` | MCP server convenience wrapper (finds and launches `runt mcp`) |
-| `gremlin` | `python/gremlin` | Autonomous notebook agent for stress testing |
+| Venv | Purpose |
+|------|---------|
+| `.venv` | Workspace venv used by `uv run nteract`, MCP, and gremlin |
+| `python/runtimed/.venv` | Test venv for `python/runtimed` integration tests |
 
-```bash
-runt mcp         # Run MCP server (shipped with the desktop app)
-uv run nteract   # Alternative: finds and launches runt mcp
-```
+When rebuilding bindings, always set `VIRTUAL_ENV` so `maturin develop` installs
+into the intended venv. See `.codex/skills/nteract-python-bindings/` and
+`contributing/runtimed.md`.
 
-### Stable vs Nightly
+## Notebook And Dependency Tools
 
-- Source builds default to the `nightly` channel. Only `RUNT_BUILD_CHANNEL=stable` opts a source-built `cargo xtask` or `cargo` flow into stable names, app launch behavior, and cache/socket namespaces.
-- Use the default nightly flow for normal repo development. Opt into stable only when you are specifically validating stable branding, stable socket/cache paths, or stable app-launch behavior.
-- `cargo xtask dev-daemon`, `cargo xtask notebook`, `cargo xtask run`, and `cargo xtask run-mcp` all follow `RUNT_BUILD_CHANNEL`.
-
-### Telemetry
-
-Anonymous daily heartbeat pings are sent to `telemetry.runtimed.com`. See `docs/telemetry.md` for the full schema, retention policy, and opt-out paths. Dev and CI builds never send telemetry: `RUNTIMED_DEV=1`, `CI=1`, and `NTERACT_TELEMETRY_DISABLE=1` all suppress pings. The shared telemetry module lives in `crates/runtimed-client/src/telemetry.rs`.
-
-### Python API Notes
-
-- **`Output.data` is typed by MIME kind**: `str` for text MIME types, `bytes` for binary (raw bytes, no base64), `dict` for JSON MIME types. Image outputs include a synthesized `text/llm+plain` key with blob URLs.
-- **Execution API**: `cell.run()` is sugar for `(await cell.execute()).result()`. For granular control use `Execution` handle: `execution = await cell.execute()` → `execution.status`, `execution.execution_id`, `await execution.result()`, `execution.cancel()`. Or `await cell.queue()` to enqueue without waiting.
-- **RuntimeState**: `notebook.runtime` provides sync reads of kernel status, queue, executions, env sync, and trust from the RuntimeStateDoc.
-- Use `default_socket_path()` for the current process or test harness because it respects `RUNTIMED_SOCKET_PATH`.
-- Use `socket_path_for_channel("stable"|"nightly")` only when you must target a specific channel explicitly or discover the other channel; it intentionally ignores `RUNTIMED_SOCKET_PATH`.
-
-## Creating Notebooks with Dependencies
-
-**Always use MCP tools** (`create_notebook`, `add_dependency`) to create notebooks and manage dependencies. Do not write `.ipynb` files by hand with dependency metadata — the metadata schema is internal and agents should not need to know it.
-
-If you must write a `.ipynb` file directly (e.g., test fixtures), dependencies go at `metadata.runt.uv.dependencies`:
+Use MCP notebook tools (`create_notebook`, `add_dependency`,
+`sync_environment`, `execute_cell`, `get_cell`, `run_all_cells`, etc.) when they
+are available. Do not hand-write dependency metadata into notebooks unless you
+are making test fixtures. Fixture dependency metadata lives at:
 
 ```json
 {
@@ -341,346 +179,111 @@ If you must write a `.ipynb` file directly (e.g., test fixtures), dependencies g
 }
 ```
 
-## MCP Server (Local Development)
-
-### nteract-dev
-
-```bash
-# Build and run nteract-dev (starts daemon if needed)
-cargo xtask run-mcp
-
-# Or print config JSON for your MCP client
-cargo xtask run-mcp --print-config
-```
-
-Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
-
-`.mcp.json` launches `cargo run -p mcp-supervisor`. The supervisor's compile graph is small — it no longer links `runtimed-client`, because the proxy now learns the daemon version from the child's MCP handshake instead of opening its own daemon socket. Cold builds take a few seconds, warm rebuilds are near-instant.
-
-### MCP Server
-
-`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt` on startup. Source edits don't trigger rebuilds by default; use `up rebuild=true` to pick up changes to the daemon or Python bindings.
-
-`runt mcp` can also be run standalone (no proxy): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
-
-For the installed app, `runt mcp` ships as a sidecar binary alongside `runtimed`, so MCP clients can use it directly without Python or uv.
-
-### nteract-dev Tools
-
-Two verbs plus three read-only tools layered on top of the proxied `runt mcp` toolset:
-
-| Tool | Purpose |
-|------|---------|
-| `up` | Idempotent "bring the dev environment to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild daemon + Python bindings first, `mode="debug"\|"release"` to switch build mode. Safe to call repeatedly. |
-| `down` | Stop the managed Vite dev server. Leaves the daemon alone by default (launchd / installed app may own it). Pass `daemon=true` to also stop the managed daemon. |
-| `status` | Read-only report of `nteract-dev`, child, daemon, and managed-process state. |
-| `logs` | Tail the daemon log file. |
-| `vite_logs` | Tail the Vite dev server log file. |
-
-### nteract MCP Tools (26 tools for notebook interaction)
-
-When `nteract-dev` is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
-
-| Category | Tools |
-|----------|-------|
-| Session | `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook` |
-| Kernel | `interrupt_kernel`, `restart_kernel` |
-| Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
-| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs` |
-| Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
-| Editing | `replace_match`, `replace_regex` |
-| Execution | `execute_cell`, `run_all_cells` |
-
-**Audit workflow example:** After modifying daemon or kernel code, use `connect_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
-
-### Rebuilding
-
-The supervisor does not watch source files. Rebuild on demand:
-
-- **Rust or Python bindings changed** → `up rebuild=true`. Rebuilds `runt` and runs `maturin develop`, then restarts the child.
-- **Only the MCP server itself changed** (`crates/runt-mcp/src/`) → `up rebuild=true` covers this too.
-- **Daemon source changed** → `up rebuild=true`, optionally with `daemon=true` to bounce the daemon as well.
-
-If you want the old always-on file watcher, set `NTERACT_DEV_WATCH=1` in the supervisor's environment. It's off by default because every source touch kicked `cargo build` + `maturin develop`, which churned cache keys and put the Rust cache-hit rate near zero during normal edits.
-
-`SKIP_MATURIN=1` (already set in `.mcp.json`) tells `up rebuild=true` to skip the maturin step. Pair it with `NTERACT_DEV_AUTOMATURIN=1` only if you want the startup-probe reintroduced; by default the supervisor starts without touching Python bindings.
-
-### Tool availability
-
-- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. It exposes `up` / `down` / `status` / `logs` / `vite_logs` plus the proxied nteract notebook tools. **Prefer these for daemon lifecycle** — they handle env vars and isolation automatically.
-- **Environments without `nteract-dev`** → use `cargo xtask` commands directly for build, daemon, and testing.
-- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no dev tools. Use manual terminal commands for daemon management.
-- **No MCP server** → use `cargo xtask run-mcp` to set one up
-- **Dev daemon not running** → call `up` — `nteract-dev` starts it if missing
-
-## Workspace Crates (21)
-
-| Crate | Purpose |
-|-------|---------|
-| `runtimed` | Central daemon — env pools, notebook sync, runtime agent subprocess coordination |
-| `runtimed-client` | Shared client library — output resolution, daemon paths, pool client |
-| `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
-| `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
-| `notebook` | Tauri desktop app — main GUI, bundles daemon+CLI as sidecars |
-| `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723, MIME classification |
-| `notebook-protocol` | Wire types — requests, responses, broadcasts |
-| `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
-| `runt` | CLI (`runt` binary) — daemon management, kernel control, notebook launching, MCP server |
-| `runt-mcp` | Rust-native MCP server — 26 tools for notebook interaction via `runt mcp` |
-| `runt-mcp-proxy` | Resilient proxy for `runt mcp` — child supervision, restart-with-retry, session tracking |
-| `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |
-| `runt-workspace` | Per-worktree daemon isolation, socket path management |
-| `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
-| `kernel-env` | Python environment management (UV + Conda) with progress reporting |
-| `repr-llm` | LLM-friendly text summaries of visualization specs incl. GeoJSON (`text/llm+plain` synthesis) |
-| `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs Sift (the `@nteract/sift` viewer; `nteract/dx` is the Python sender) |
-| `sift-wasm` | WASM bindings for `nteract-predicate` — used by `@nteract/sift` |
-| `mcp-supervisor` | `nteract-dev` MCP server — proxies `runt mcp` and adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) |
-| `nteract-mcp` | Resilient MCP proxy for `runt mcp` — shipped as a sidecar in the nteract desktop app and inside the `.mcpb` Claude Desktop extension |
-| `xtask` | Build system orchestration |
-
-## Build System (`cargo xtask`)
-
-All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask help` at the start of each session** — it's the source of truth.
-
-### Quick Reference
-
-| Category | Command | Description |
-|----------|---------|-------------|
-| Dev | `cargo xtask dev` | deps + sidecars + dev daemon + `cargo tauri dev` (Vite HMR). Skips the production bundle / `cargo tauri build` that the dev path discards anyway. |
-| | `cargo xtask dev --skip-build` | Skip sidecar rebuild and launch directly (the daemon spawn still rebuilds sidecars on demand if missing). |
-| | `cargo xtask dev --skip-install` | Reuse existing pnpm install before launch |
-| | `cargo xtask notebook` | Hot-reload dev server (Vite on port 5174) |
-| | `cargo xtask notebook --attach` | Attach Tauri to existing Vite server |
-| | `cargo xtask vite` | Start Vite standalone |
-| | `cargo xtask build` | Full debug build (frontend + Rust) |
-| | `cargo xtask build --rust-only` | Rebuild Rust only, reuse frontend |
-| | `cargo xtask run` | Run bundled debug binary |
-| Release | `cargo xtask build-app` | Build the desktop app bundle with icons |
-| | `cargo xtask build-dmg` | Build a DMG bundle (CI/release packaging) |
-| Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
-| | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
-| | `./scripts/install-nightly` | Install runtimed + runt + nteract-mcp as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
-| MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
-| | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
-| | `cargo xtask mcp-inspector` | Launch MCP Inspector UI for testing runt mcp |
-| Lint | `cargo xtask lint` | Check formatting (Rust fmt, JS/TS, Python) |
-| | `cargo xtask lint --fix` | Auto-fix formatting |
-| | `cargo xtask clippy` | Run cargo clippy (excludes runtimed-py; CI covers it) |
-| Test | `cargo xtask integration [filter]` | Python integration tests with isolated daemon |
-| | `cargo xtask e2e [build|test|test-fixture|test-all]` | E2E testing (WebdriverIO) |
-| Other | `cargo xtask wasm` | Rebuild runtimed-wasm |
-| | `cargo xtask icons [source.png]` | Generate icon variants |
-| | `cargo xtask mcpb` | Package nteract as a Claude Desktop extension (`.mcpb`) |
-
-## Runtime Daemon (`runtimed`)
-
-The daemon is a separate process from the notebook app. When you change code in `crates/runtimed/`, the running daemon still uses the old binary until you reinstall it.
-
-### Stopping the Daemon
-
-- `./target/debug/runt daemon stop` — stops only your worktree's daemon
-- `./scripts/install-nightly` — gracefully installs or reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
-
-Avoid system-wide process killers (`pkill`, `killall`) — they affect every worktree and every other agent on the machine.
-
-### Per-Worktree Daemon Isolation
-
-Each git worktree runs its own isolated daemon in dev mode. With `nteract-dev` available, the daemon is managed for you — use `up` to start it (idempotent), and `status` to check it.
-
-Without `nteract-dev` (manual two-terminal workflow):
-
-```bash
-# Terminal 1: Start dev daemon
-cargo xtask dev-daemon
-
-# Terminal 2: Run the notebook app
-cargo xtask notebook
-```
-
-Use `./target/debug/runt` to interact with the worktree daemon (or `status`/`logs` if available):
-
-```bash
-./target/debug/runt daemon status
-./target/debug/runt daemon logs -f
-./target/debug/runt ps
-./target/debug/runt notebooks
-./target/debug/runt daemon flush
-./target/debug/runt daemon status --json | jq -r .socket_path
-```
-
-### Conductor Workspace Integration
-
-| Conductor Variable | Translated To | Purpose |
-|-------------------|---------------|---------|
-| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Per-worktree daemon isolation |
-| `CONDUCTOR_PORT` | (used directly) | Vite dev server port |
-
-## High-Risk Architecture Invariants
-
-These invariants prevent bad edits. Read before modifying the relevant subsystems.
-
-### No Tokio Mutex Guards Across `.await` Points
-
-**Never hold a `tokio::sync::Mutex` or `tokio::sync::RwLock` guard across an `.await` point.** This causes convoy deadlocks — all tasks waiting for the lock block indefinitely if the holder is suspended on an async operation. CI enforces this via `cargo test -p runtimed --test tokio_mutex_lint` (hard failure, no exceptions).
-
-**Use block scoping, not `drop()`:**
-```rust
-// GOOD: guard dropped at block boundary, lint can verify
-let data = {
-    let guard = shared.lock().await;
-    guard.get_data().clone()
-}; // guard dropped here
-do_async_work(&data).await;
-
-// BAD: lint can't track drop() calls
-let guard = shared.lock().await;
-let data = guard.get_data().clone();
-drop(guard);  // lint still sees guard as live
-do_async_work(&data).await;
-```
-
-**Prefer owned state over shared locks.** If a task is the sole consumer of some state, own it as a local variable instead of wrapping it in `Arc<Mutex<...>>`. The runtime agent's `select!` loop owns `KernelState` and `JupyterKernel` directly — no mutex needed because only one task touches them. This follows the [actor pattern](https://ryhl.io/blog/actors-with-tokio/): a `select!` loop owns state, communicates via channels.
-
-**Use `std::sync::Mutex` for synchronous-only access.** If you never hold the guard across an `.await`, `std::sync::Mutex` is faster than `tokio::sync::Mutex` and the compiler prevents holding it across `.await` when the future must be `Send`. `tokio::sync::Mutex` is only needed when you genuinely must hold the guard across an async operation (which this lint now prohibits).
-
-### Fork+Merge for Async CRDT Mutations
-
-**Any code path that reads from the CRDT doc, does async work, then writes back MUST use `fork()` + `merge()`.** Direct mutation after an async gap can silently overwrite concurrent edits from other peers, the frontend, or background tasks.
-
-```rust
-// 1. Fork BEFORE the async work (captures the doc baseline)
-let fork = {
-    let mut doc = room.doc.write().await;
-    doc.fork()
-};
-
-// 2. Do async work (subprocess, network, I/O)
-let result = do_async_work().await;
-
-// 3. Apply result on the fork (diffs against the pre-async baseline)
-let mut fork = fork;
-fork.update_source(&cell_id, &result).ok();
-
-// 4. Merge back — concurrent edits compose via Automerge's text CRDT
-let mut doc = room.doc.write().await;
-doc.merge(&mut fork).ok();
-```
-
-For synchronous mutation blocks (no `.await` between fork and merge), use the helper:
-
-```rust
-// Fork at current heads, apply mutations, merge back
-doc.fork_and_merge(|fork| {
-    fork.update_source("cell-1", "x = 1\n");
-});
-```
-
-**Do NOT use `fork_at(historical_heads)`** — it triggers an automerge bug
-(`MissingOps` panic in the change collector) on documents with interleaved
-text splices and merges. See automerge/automerge#1327. Use `fork()` instead.
-
-**Key methods on `NotebookDoc`:** `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
-
-### No Independent `put_object` on Shared Keys
-
-**Never call `put_object()` on a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` calls from different actors create two distinct Automerge Map objects at the same key — a conflict. Automerge picks one winner; the loser's children become invisible.
-
-This is why `NotebookDoc::bootstrap()` only writes `schema_version` (a scalar). It does **not** create `cells` or `metadata` maps — those are created once by the daemon in `new_inner()` and arrive at other peers via sync. If bootstrap also created them, the daemon's populated maps (with cells, deps, etc.) could be shadowed by the bootstrap's empty maps depending on conflict resolution order.
-
-**Rule:** Document structure (Maps, Lists at well-known keys) must be created by exactly one peer — the daemon. All other peers receive it via Automerge sync. Scalars at the same key are safe (identical values converge).
-
-### The `is_binary_mime` Contract
-
-One canonical Rust implementation in `notebook-doc::mime` is the single source of truth for MIME classification. It exports `is_binary_mime()`, `mime_kind()`, and the `MimeKind` enum. All Rust crates (`runtimed`, `runtimed-client`, `runtimed-wasm`) use this module — the old per-crate copies have been deleted.
-
-On the TypeScript side, `isBinaryMime()` has been deleted from `manifest-resolution.ts`. **WASM now owns MIME classification end-to-end** — it resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly, so the frontend never needs to classify MIMEs itself.
-
-| Location | Function |
-|----------|----------|
-| `crates/notebook-doc/src/mime.rs` | `is_binary_mime()`, `mime_kind()`, `MimeKind` |
-
-The classification rules: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/*`, `video/*` → binary. `application/*` → binary by default (EXCEPT json, javascript, xml, and `+json`/`+xml` suffixes). `text/*` → always text.
-
-### Notebook Protocol and Upgrade Compatibility
-
-Notebook request/response compatibility is not a general "old UI can keep
-using a new daemon" guarantee. The supported in-place upgrade path is narrower:
-the old app opens the upgrade window, gathers notebook status, optionally shuts
-down busy kernels, downloads the update, closes notebook windows and clears sync
-handles, then installs the bundled daemon and waits for daemon readiness/version
-before relaunching the new app. After the daemon swap, the old upgrade window
-must not depend on normal notebook request/response traffic.
-
-When changing `notebook-protocol`:
-- Prefer `RuntimeStateDoc`, `PoolDoc`, daemon info, or typed sync state for
-  state queries. Do not keep request/response variants alive just because old
-  notebook windows once used them; those windows are closed before daemon
-  upgrade.
-- Keep upgrade-window commands working across the temporary old-UI/new-bundle
-  boundary. Those commands live in `crates/notebook/src/lib.rs` and should use
-  Tauri commands, daemon readiness checks, and daemon info rather than notebook
-  RPCs after the daemon is replaced.
-- If a true wire break is needed for active notebook sessions, make it explicit
-  in the protocol shape and be willing to bump the messaging/protocol version
-  rather than carrying stale compatibility shims indefinitely.
-- `packages/runtimed/src/request-types.ts` is a frontend client subset, not a
-  complete mirror of every Rust protocol variant. Add frontend-used variants
-  there intentionally; do not use it as a reason to preserve Rust-only dead
-  variants.
-
-### Crate Boundaries
-
-| Crate | Owns | Modify when |
-|-------|------|-------------|
-| `notebook-doc` | Automerge schema, cell CRUD, output writes, MIME classification, `CellChangeset` | Changing document schema or cell operations |
-| `notebook-protocol` | Wire types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`) | Adding request/response/broadcast types |
-| `notebook-sync` | `DocHandle`, sync infrastructure, per-cell accessors for Python | Changing Python client sync behavior |
-
-### CRDT State Ownership
-
-| State | Writer | Notes |
-|-------|--------|-------|
-| Cell source | Frontend WASM | Local-first, character-level merge |
-| Cell position, type, metadata | Frontend WASM | User-initiated via UI |
-| Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
-| Cell outputs (inline manifests) | Runtime agent subprocess | Kernel IOPub → blob store → inline manifest Maps in RuntimeStateDoc |
-| Execution count | Runtime agent subprocess | Set on `execute_input` from kernel |
-| Execution queue (source, seq, status) | Coordinator writes `queued`, runtime agent transitions to `running`/`done` | CRDT-driven execution — no RPC for cell execution |
-| RuntimeStateDoc (kernel, queue, executions, env, trust) | Runtime agent + Coordinator | Separate Automerge doc, frame type `0x05` |
-
-**Never write to the CRDT in response to a daemon broadcast.** The daemon already wrote. Writing again creates redundant sync traffic and incorrectly marks the notebook as dirty.
-
-### Iframe Security
-
-**NEVER add `allow-same-origin` to the iframe sandbox.** This is the single most important security invariant — tested in CI. It would give untrusted notebook outputs full access to Tauri APIs.
-
-### Renderer Plugins (Isolated Iframe)
-
-Heavy output renderers (markdown, plotly, vega, leaflet) are loaded as **on-demand CJS plugins** — not bundled into the core IIFE. Plugins are identified by **MIME types directly** — MIME types flow from CRDT outputs to the loading boundary without translation. Each plugin has its own Vite virtual module (`virtual:renderer-plugin/{name}`) for code splitting. The iframe's CJS loader provides React via a custom `require` shim — no window globals. `text/latex` is rendered via KaTeX inside the markdown renderer plugin. See `contributing/iframe-isolation.md` § Renderer Plugins for the full architecture and step-by-step guide to adding new plugins.
-
-**Key files:** `src/isolated-renderer/index.tsx` (registry + loader), `src/isolated-renderer/*-renderer.tsx` (plugins), `apps/notebook/vite-plugin-isolated-renderer.ts` (build), `src/components/isolated/iframe-libraries.ts` (single MIME→plugin mapping layer: `PLUGIN_MIME_TYPES`, `needsPlugin`, `loadPluginForMime`).
-
-### Unified Env Resolution
-
-**One hash rule for every cached env: `compute_unified_env_hash(deps, env_id)`.** Always includes `env_id`. No cross-notebook env sharing at the disk level — hot-sync on notebook A would silently mutate a shared env under notebook B. Rule lives in `kernel_env::{uv,conda}::compute_unified_env_hash`.
-
-**Base-package sets are the capture contract.** `kernel_env::uv::UV_BASE_PACKAGES` and `kernel_env::conda::CONDA_BASE_PACKAGES` are consumed by both the pool warmer and the first-launch capture step via `kernel_env::strip_base`. Adding a package to either set affects what gets stripped from newly-captured metadata — existing notebooks keep whatever set was captured the day they were first claimed.
-
-**Preserve-on-eviction requires a saved `.ipynb` path.** `should_preserve_env_on_eviction` in `notebook_sync_server.rs` returns true only when the room has a saved path AND the room's `runtime_agent_env_path` matches the captured unified-hash dir. Untitled notebooks, pool envs (`runtimed-{uv,conda,pixi}-*`), and saved notebooks whose env is still a pool dir all delete on eviction. Do not extend preservation to untitled notebooks without making autosave claim a file first.
-
-**Hot-sync coherence runs at eviction, not kernel shutdown.** `flush_launched_deps_to_metadata` + `save_notebook_to_disk` + `rename_env_dir_to_unified_hash` are sequenced after the runtime agent is shut down and before env cleanup. The kernel is guaranteed dead at this point — renaming mid-session would invalidate the kernel's `VIRTUAL_ENV` and any absolute-path subprocess handles.
-
-See issue #1954 and PRs #1958, #1960, #1962, #1963, #1964 for the full design + correction history.
-
-### Cell List Stable DOM Order (Iframe Reload Prevention)
-
-**The cell list in `NotebookView.tsx` MUST render in a stable DOM order (sorted by cell ID) and use CSS `order` for visual positioning.** Do NOT iterate `cellIds` directly in the JSX — iterate `stableDomOrder` instead.
-
-Moving an `<iframe>` element in the DOM causes the browser to destroy and reload it. React's keyed-list reconciliation uses `insertBefore` to reorder DOM nodes when children change position. This causes iframe reloads — visible as white flashes, lost widget state, and re-rendered outputs.
-
-The fix: render cells in a deterministic DOM order (`[...cellIds].sort()`) so React never moves existing nodes. Visual ordering is achieved via CSS `order` on each cell's wrapper, with the parent using `display: flex; flex-direction: column`.
-
-Key files:
-- `apps/notebook/src/components/NotebookView.tsx` — `stableDomOrder`, `cellIdToIndex`, flex container
-- `src/components/isolated/isolated-frame.tsx` — iframe reload detection (the fallback path if DOM does move)
+## Subsystem Docs
+
+| Need | Doc |
+|------|-----|
+| Architecture overview | `contributing/architecture.md` |
+| Development setup | `contributing/development.md` |
+| Running tests | `contributing/testing.md` |
+| E2E/WebdriverIO | `contributing/e2e.md` |
+| Frontend architecture | `contributing/frontend-architecture.md` |
+| UI components | `contributing/ui.md` |
+| nteract Elements | `contributing/nteract-elements.md` |
+| Wire protocol and sync | `contributing/protocol.md` |
+| CRDT mutation rules | `contributing/crdt-mutation-guide.md` |
+| Widgets | `contributing/widget-development.md` |
+| Daemon and Python bindings | `contributing/runtimed.md` |
+| Environments | `contributing/environments.md` |
+| Output iframe and renderer plugins | `contributing/iframe-isolation.md` |
+| TypeScript bindings | `contributing/typescript-bindings.md` |
+| Logging | `contributing/logging.md` |
+| Build dependencies | `contributing/build-dependencies.md` |
+| Releasing | `contributing/releasing.md` |
+| Branch/worktree cleanup | `contributing/branch-hygiene.md` |
+| User-facing docs | `docs/` |
+
+## High-Risk Invariants
+
+Keep these rules in mind before changing daemon, sync, output, iframe, or env
+code. The linked subsystem docs contain the full rationale.
+
+### Async Locks
+
+Never hold a `tokio::sync::Mutex` or `tokio::sync::RwLock` guard across an
+`.await`. Use block scoping so the guard is dropped before async work. Prefer
+owned actor-loop state or synchronous `std::sync::Mutex` when possible. CI
+enforces this with `cargo test -p runtimed --test tokio_mutex_lint`.
+
+### CRDT Writes
+
+Any code path that reads from a CRDT doc, does async work, then writes back must
+use `fork()` before the async work and `merge()` afterward. For synchronous
+mutation blocks, use `fork_and_merge`. Do not use `fork_at(historical_heads)`;
+it can trigger Automerge `MissingOps` panics on interleaved text edits.
+
+Never call `put_object()` on a shared key that another peer can create. Maps and
+lists at well-known keys are created by one owner, normally the daemon. Other
+peers receive structure through sync.
+
+Never write to the CRDT in response to a daemon broadcast. The daemon already
+wrote the change; writing again creates redundant sync traffic and dirty state.
+
+### Ownership Boundaries
+
+| State | Writer |
+|-------|--------|
+| Cell source, position, type, metadata | Frontend WASM |
+| Notebook metadata such as deps/runtime picker | Frontend WASM |
+| Cell outputs and execution count | Runtime agent subprocess |
+| Execution queue transitions | Coordinator and runtime agent |
+| RuntimeStateDoc | Runtime agent and coordinator |
+
+`notebook-doc` owns the document schema and MIME classification.
+`notebook-protocol` owns wire types. `notebook-sync` owns sync handles and
+Python-facing document access.
+
+### MIME Classification
+
+`notebook-doc::mime` is the single Rust source of truth for MIME classification:
+`is_binary_mime()`, `mime_kind()`, and `MimeKind`. WASM resolves `ContentRef`s
+to `Inline`, `Url`, or `Blob`; TypeScript should not reimplement binary MIME
+classification.
+
+### Protocol Compatibility
+
+Notebook protocol compatibility is not a blanket guarantee that an old UI can
+continue normal notebook traffic against a new daemon. The supported upgrade
+path closes notebook windows, clears sync handles, swaps the daemon, waits for
+readiness/version, and relaunches the new app. Keep upgrade-window Tauri
+commands working across that boundary, and prefer typed sync state over stale
+request/response variants.
+
+### Iframe Security And Renderers
+
+Never add `allow-same-origin` to the output iframe sandbox. This would let
+untrusted notebook output access Tauri APIs.
+
+Heavy renderers such as markdown, Plotly, Vega, and Leaflet load as on-demand
+CJS plugins identified by MIME type. Keep the MIME-to-plugin mapping centralized
+in the isolated renderer code; see `contributing/iframe-isolation.md`.
+
+The cell list in `NotebookView.tsx` must render in stable DOM order and use CSS
+`order` for visual order. Moving iframe DOM nodes reloads outputs and loses
+widget state.
+
+### Environment Caches
+
+Use the unified env hash rule from `kernel_env::{uv,conda}`:
+`compute_unified_env_hash(deps, env_id)`. The hash always includes `env_id`, so
+notebooks do not silently share mutable env directories.
+
+Base package sets are part of capture behavior:
+`kernel_env::uv::UV_BASE_PACKAGES` and
+`kernel_env::conda::CONDA_BASE_PACKAGES`. Changing them affects newly captured
+metadata; existing notebooks keep what they already captured.
+
+Env preservation on eviction requires a saved `.ipynb` path and a runtime env
+path that already matches the captured unified-hash directory. Untitled
+notebooks and pool envs should not be preserved unless the autosave/claim flow
+first gives them a real file path.


### PR DESCRIPTION
## Summary

- Reworked `AGENTS.md` from a long setup handbook into a compact repo map.
- Kept the canonical `CLAUDE.md -> AGENTS.md` note, repo skill pointers, directory map, xtask command map, subsystem doc links, and high-risk invariants.
- Moved detailed setup expectations back to the existing `contributing/`, `docs/`, and `.codex/skills/` surfaces by reference instead of duplicating them in the root guide.

## Validation

- `cargo xtask help`
- `cargo xtask lint --fix`
- `git diff --check`