### PR TITLE
refactor(runtimed): split peer pool sync module

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -55,6 +55,7 @@ mod metadata;
 mod nbformat_convert;
 mod path_index;
 mod peer;
+mod peer_pool_sync;
 mod peer_presence;
 mod peer_writer;
 mod persist;

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1,3 +1,6 @@
+use super::peer_pool_sync::{
+    forward_pool_state_broadcast, handle_pool_state_frame, send_initial_pool_sync,
+};
 use super::peer_presence::{
     cleanup_presence_on_disconnect, forward_presence_broadcast, handle_presence_frame,
     prune_stale_presence, send_initial_presence_snapshot,
@@ -1296,29 +1299,7 @@ where
         }
     }
 
-    // Initial PoolDoc sync — global pool state
-    let initial_pool_encoded = {
-        let mut pool_doc = daemon.pool_doc.write().await;
-        match catch_automerge_panic("initial-pool-sync", || {
-            pool_doc
-                .generate_sync_message(&mut pool_peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
-            Err(e) => {
-                warn!("{}", e);
-                pool_doc.rebuild_from_save();
-                pool_peer_state = sync::State::new();
-                pool_doc
-                    .generate_sync_message(&mut pool_peer_state)
-                    .map(|msg| msg.encode())
-            }
-        }
-    };
-    if let Some(encoded) = initial_pool_encoded {
-        connection::send_typed_frame(&mut writer, NotebookFrameType::PoolStateSync, &encoded)
-            .await?;
-    }
+    send_initial_pool_sync(&mut writer, &daemon, &mut pool_peer_state).await?;
 
     // Phase 1.5 (removed): CommSync broadcast is no longer needed.
     // Late joiners receive widget state via RuntimeStateDoc CRDT sync,
@@ -1627,53 +1608,15 @@ where
                             }
 
                             NotebookFrameType::PoolStateSync => {
-                                // Client's pool sync reply — apply with change stripping
-                                let message = sync::Message::decode(&frame.payload)
-                                    .map_err(|e| anyhow::anyhow!("decode pool sync: {}", e))?;
-                                let reply_encoded = {
-                                    let mut pool_doc = daemon.pool_doc.write().await;
-
-                                    let recv_result = catch_automerge_panic("pool-receive-sync", || {
-                                        pool_doc.receive_sync_message(
-                                            &mut pool_peer_state,
-                                            message,
-                                        )
-                                    });
-                                    match recv_result {
-                                        Ok(Ok(())) => {}
-                                        Ok(Err(e)) => {
-                                            warn!("[notebook-sync] pool receive_sync_message error: {}", e);
-                                            continue;
-                                        }
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            pool_doc.rebuild_from_save();
-                                            pool_peer_state = sync::State::new();
-                                            continue;
-                                        }
-                                    }
-
-                                    match catch_automerge_panic("pool-sync-reply", || {
-                                        pool_doc
-                                            .generate_sync_message(&mut pool_peer_state)
-                                            .map(|msg| msg.encode())
-                                    }) {
-                                        Ok(encoded) => encoded,
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            pool_doc.rebuild_from_save();
-                                            pool_peer_state = sync::State::new();
-                                            pool_doc
-                                                .generate_sync_message(&mut pool_peer_state)
-                                                .map(|msg| msg.encode())
-                                        }
-                                    }
-                                };
-                                if let Some(encoded) = reply_encoded {
-                                    peer_writer.send_frame(
-                                        NotebookFrameType::PoolStateSync,
-                                        encoded,
-                                    )?;
+                                if !handle_pool_state_frame(
+                                    &daemon,
+                                    &mut pool_peer_state,
+                                    &peer_writer,
+                                    &frame.payload,
+                                )
+                                .await?
+                                {
+                                    continue;
                                 }
                             }
 
@@ -1801,67 +1744,16 @@ where
 
             // PoolDoc changed — push update to this client
             result = pool_changed_rx.recv() => {
-                match result {
-                    Ok(()) => {
-                        let encoded = {
-                            let mut pool_doc = daemon.pool_doc.write().await;
-                            match catch_automerge_panic("pool-broadcast", || {
-                                pool_doc
-                                    .generate_sync_message(&mut pool_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => encoded,
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    pool_doc.rebuild_from_save();
-                                    pool_peer_state = sync::State::new();
-                                    pool_doc
-                                        .generate_sync_message(&mut pool_peer_state)
-                                        .map(|msg| msg.encode())
-                                }
-                            }
-                        };
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::PoolStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::debug!(
-                            "[notebook-sync] Peer {} lagged {} pool state updates",
-                            peer_id, n
-                        );
-                        let encoded = {
-                            let mut pool_doc = daemon.pool_doc.write().await;
-                            match catch_automerge_panic("pool-broadcast-lagged", || {
-                                pool_doc
-                                    .generate_sync_message(&mut pool_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => encoded,
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    pool_doc.rebuild_from_save();
-                                    pool_peer_state = sync::State::new();
-                                    pool_doc
-                                        .generate_sync_message(&mut pool_peer_state)
-                                        .map(|msg| msg.encode())
-                                }
-                            }
-                        };
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::PoolStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        // Pool doc channel closed — daemon is shutting down
-                        return Ok(());
-                    }
+                if !forward_pool_state_broadcast(
+                    &daemon,
+                    peer_id,
+                    &mut pool_peer_state,
+                    &peer_writer,
+                    result,
+                )
+                .await?
+                {
+                    return Ok(());
                 }
             }
 

--- a/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use automerge::sync;
+use tokio::io::AsyncWrite;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::connection::{self, NotebookFrameType};
+
+use super::catch_automerge_panic;
+use super::peer_writer::PeerWriter;
+
+pub(super) async fn send_initial_pool_sync<W>(
+    writer: &mut W,
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let initial_pool_encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+        match catch_automerge_panic("initial-pool-sync", || {
+            pool_doc
+                .generate_sync_message(pool_peer_state)
+                .map(|msg| msg.encode())
+        }) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                warn!("{}", e);
+                pool_doc.rebuild_from_save();
+                *pool_peer_state = sync::State::new();
+                pool_doc
+                    .generate_sync_message(pool_peer_state)
+                    .map(|msg| msg.encode())
+            }
+        }
+    };
+    if let Some(encoded) = initial_pool_encoded {
+        connection::send_typed_frame(writer, NotebookFrameType::PoolStateSync, &encoded).await?;
+    }
+    Ok(())
+}
+
+pub(super) async fn handle_pool_state_frame(
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    payload: &[u8],
+) -> anyhow::Result<bool> {
+    let message =
+        sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode pool sync: {}", e))?;
+    let reply_encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+
+        let recv_result = catch_automerge_panic("pool-receive-sync", || {
+            pool_doc.receive_sync_message(pool_peer_state, message)
+        });
+        match recv_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!("[notebook-sync] pool receive_sync_message error: {}", e);
+                return Ok(false);
+            }
+            Err(e) => {
+                warn!("{}", e);
+                pool_doc.rebuild_from_save();
+                *pool_peer_state = sync::State::new();
+                return Ok(false);
+            }
+        }
+
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, "pool-sync-reply")
+    };
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
+    }
+    Ok(true)
+}
+
+pub(super) async fn forward_pool_state_broadcast(
+    daemon: &Arc<crate::daemon::Daemon>,
+    peer_id: &str,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    result: Result<(), broadcast::error::RecvError>,
+) -> anyhow::Result<bool> {
+    match result {
+        Ok(()) => {
+            send_pool_sync_update(daemon, pool_peer_state, writer, "pool-broadcast").await?;
+        }
+        Err(broadcast::error::RecvError::Lagged(n)) => {
+            debug!(
+                "[notebook-sync] Peer {} lagged {} pool state updates",
+                peer_id, n
+            );
+            send_pool_sync_update(daemon, pool_peer_state, writer, "pool-broadcast-lagged").await?;
+        }
+        Err(broadcast::error::RecvError::Closed) => {
+            // Pool doc channel closed — daemon is shutting down.
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn send_pool_sync_update(
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    label: &str,
+) -> anyhow::Result<()> {
+    let encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, label)
+    };
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
+    }
+    Ok(())
+}
+
+fn generate_pool_sync_message(
+    pool_doc: &mut notebook_doc::pool_state::PoolDoc,
+    pool_peer_state: &mut sync::State,
+    label: &str,
+) -> Option<Vec<u8>> {
+    match catch_automerge_panic(label, || {
+        pool_doc
+            .generate_sync_message(pool_peer_state)
+            .map(|msg| msg.encode())
+    }) {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            warn!("{}", e);
+            pool_doc.rebuild_from_save();
+            *pool_peer_state = sync::State::new();
+            pool_doc
+                .generate_sync_message(pool_peer_state)
+                .map(|msg| msg.encode())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract PoolDoc peer sync handling from peer.rs into peer_pool_sync.rs
- Move initial pool sync, client pool-sync replies, and pool broadcast catch-up into focused helpers
- Keep the PR stacked on #2355 while the presence split is open

## Verification
- cargo fmt --check
- cargo check -p runtimed
- cargo clippy -p runtimed --lib -- -D warnings
- cargo test -p runtimed sanitize_peer_label
- git diff --check