### PR TITLE
refactor(runtimed): split peer runtime sync module

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -55,6 +55,7 @@ mod metadata;
 mod nbformat_convert;
 mod path_index;
 mod peer;
+mod peer_pool_sync;
 mod peer_presence;
 mod peer_writer;
 mod persist;

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -57,6 +57,7 @@ mod path_index;
 mod peer;
 mod peer_pool_sync;
 mod peer_presence;
+mod peer_runtime_sync;
 mod peer_writer;
 mod persist;
 mod project_context;
@@ -73,6 +74,7 @@ pub use path_index::{PathIndex, PathIndexError};
 pub(crate) use peer::*;
 #[cfg(test)]
 pub(crate) use peer_presence::sanitize_peer_label;
+pub(crate) use peer_runtime_sync::notebook_execution_context_id;
 pub(crate) use persist::*;
 pub(crate) use project_context::refresh_project_context_on_save_as;
 pub(crate) use room::*;

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -5,6 +5,9 @@ use super::peer_presence::{
     cleanup_presence_on_disconnect, forward_presence_broadcast, handle_presence_frame,
     prune_stale_presence, send_initial_presence_snapshot,
 };
+use super::peer_runtime_sync::{
+    forward_runtime_state_broadcast, handle_runtime_state_frame, persist_terminal_execution_records,
+};
 use super::peer_writer::{
     queue_request_error, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
     PeerWriter, RequestEnqueueError,
@@ -1188,6 +1191,9 @@ where
         String,
         runtimed_client::execution_store::ExecutionRecord,
     > = std::collections::HashMap::new();
+    let execution_store = runtimed_client::execution_store::ExecutionStore::new(
+        daemon.config.execution_store_dir.clone(),
+    );
 
     // Initial RuntimeStateDoc sync — encode inside lock, send outside.
     // Uses bounded generation to compact atomically if the message would exceed
@@ -1522,74 +1528,18 @@ where
                             }
 
                             NotebookFrameType::RuntimeStateSync => {
-                                // Client sync — accept changes (frontend may write
-                                // to comms/*/state/* for widget state updates).
-                                let message = sync::Message::decode(&frame.payload)
-                                    .map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
-                                // None signals "continue" (receive failed, skip reply)
-                                let reply_encoded: Option<Option<Vec<u8>>> = room.state.with_doc(|state_doc| {
-                                    let recv_result = catch_automerge_panic("state-receive-sync", || {
-                                        state_doc.receive_sync_message_with_changes(
-                                            &mut state_peer_state,
-                                            message,
-                                        )
-                                    });
-                                    let had_changes = match recv_result {
-                                        Ok(Ok(changed)) => changed,
-                                        Ok(Err(e)) => {
-                                            warn!("[notebook-sync] state receive_sync_message error: {}", e);
-                                            return Ok(None); // signal continue
-                                        }
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            state_doc.rebuild_from_save();
-                                            state_peer_state = sync::State::new();
-                                            return Ok(None); // signal continue
-                                        }
-                                    };
-
-                                    // If client sent changes, notification is automatic
-                                    // via heads comparison in with_doc.
-                                    // But if had_changes is true from receive, heads
-                                    // will differ and with_doc notifies automatically.
-                                    let _ = had_changes; // heads-based notification handles this
-
-                                    let encoded = match catch_automerge_panic("state-sync-reply", || {
-                                        state_doc
-                                            .generate_sync_message(&mut state_peer_state)
-                                            .map(|msg| msg.encode())
-                                    }) {
-                                        Ok(encoded) => encoded,
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            state_doc.rebuild_from_save();
-                                            state_peer_state = sync::State::new();
-                                            state_doc
-                                                .generate_sync_message(&mut state_peer_state)
-                                                .map(|msg| msg.encode())
-                                        }
-                                    };
-                                    Ok(Some(encoded))
-                                }).ok().flatten();
-                                let reply_encoded = match reply_encoded {
-                                    Some(encoded) => encoded,
-                                    None => continue, // receive failed
-                                };
-                                if let Some(encoded) = reply_encoded {
-                                    peer_writer.send_frame(
-                                        NotebookFrameType::RuntimeStateSync,
-                                        encoded,
-                                    )?;
-                                }
-
-                                persist_terminal_execution_records(
+                                if !handle_runtime_state_frame(
                                     room,
-                                    &runtimed_client::execution_store::ExecutionStore::new(
-                                        daemon.config.execution_store_dir.clone(),
-                                    ),
+                                    &mut state_peer_state,
+                                    &peer_writer,
+                                    &frame.payload,
+                                    &execution_store,
                                     &mut persisted_execution_records,
                                 )
-                                .await;
+                                .await?
+                                {
+                                    continue;
+                                }
 
                                 if runtime_state_phase
                                     != notebook_protocol::protocol::RuntimeStatePhaseWire::Ready
@@ -1679,66 +1629,16 @@ where
 
             // RuntimeStateDoc changed — push update to this client
             result = state_changed_rx.recv() => {
-                match result {
-                    Ok(()) => {
-                        let encoded = room.state.with_doc(|state_doc| {
-                            match catch_automerge_panic("state-broadcast", || {
-                                state_doc
-                                    .generate_sync_message(&mut state_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => Ok(encoded),
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    state_doc.rebuild_from_save();
-                                    state_peer_state = sync::State::new();
-                                    Ok(state_doc
-                                        .generate_sync_message(&mut state_peer_state)
-                                        .map(|msg| msg.encode()))
-                                }
-                            }
-                        }).ok().flatten();
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::RuntimeStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::debug!(
-                            "[notebook-sync] Peer {} lagged {} runtime state updates",
-                            peer_id, n
-                        );
-                        // Send a full sync to catch up
-                        let encoded = room.state.with_doc(|state_doc| {
-                            match catch_automerge_panic("state-broadcast-lagged", || {
-                                state_doc
-                                    .generate_sync_message(&mut state_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => Ok(encoded),
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    state_doc.rebuild_from_save();
-                                    state_peer_state = sync::State::new();
-                                    Ok(state_doc
-                                        .generate_sync_message(&mut state_peer_state)
-                                        .map(|msg| msg.encode()))
-                                }
-                            }
-                        }).ok().flatten();
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::RuntimeStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        // State change channel closed — room is being evicted
-                        return Ok(());
-                    }
+                if !forward_runtime_state_broadcast(
+                    room,
+                    peer_id,
+                    &mut state_peer_state,
+                    &peer_writer,
+                    result,
+                )
+                .await?
+                {
+                    return Ok(());
                 }
             }
 
@@ -1833,71 +1733,4 @@ async fn queue_doc_sync(
         writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
     }
     Ok(())
-}
-
-async fn persist_terminal_execution_records(
-    room: &NotebookRoom,
-    store: &runtimed_client::execution_store::ExecutionStore,
-    persisted_records: &mut std::collections::HashMap<
-        String,
-        runtimed_client::execution_store::ExecutionRecord,
-    >,
-) {
-    let notebook_path = room
-        .identity
-        .path
-        .read()
-        .await
-        .as_ref()
-        .map(|p| p.to_string_lossy().to_string());
-    let context_id = notebook_execution_context_id(room, notebook_path.as_deref());
-    let records = room
-        .state
-        .read(|sd| {
-            sd.read_state()
-                .executions
-                .into_iter()
-                .filter_map(|(execution_id, exec)| {
-                    if !matches!(exec.status.as_str(), "done" | "error") {
-                        return None;
-                    }
-                    Some(
-                        runtimed_client::execution_store::ExecutionRecord::from_execution_state(
-                            &execution_id,
-                            "notebook",
-                            context_id.clone(),
-                            notebook_path.clone(),
-                            &exec,
-                        ),
-                    )
-                })
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    for record in records {
-        if persisted_records
-            .get(&record.execution_id)
-            .is_some_and(|existing| existing.payload_matches(&record))
-        {
-            continue;
-        }
-        if let Err(e) = store.write_record(record.clone()).await {
-            warn!(
-                "[execution-store] Failed to persist execution record: {}",
-                e
-            );
-        } else {
-            persisted_records.insert(record.execution_id.clone(), record);
-        }
-    }
-}
-
-pub(crate) fn notebook_execution_context_id(
-    room: &NotebookRoom,
-    notebook_path: Option<&str>,
-) -> String {
-    notebook_path
-        .map(str::to_string)
-        .unwrap_or_else(|| room.id.to_string())
 }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -9,8 +9,8 @@ use super::peer_runtime_sync::{
     forward_runtime_state_broadcast, handle_runtime_state_frame, persist_terminal_execution_records,
 };
 use super::peer_writer::{
-    queue_request_error, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
-    PeerWriter, RequestEnqueueError,
+    enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
+    PeerWriter,
 };
 use super::*;
 use runtime_doc::RuntimeLifecycle;
@@ -1478,48 +1478,13 @@ where
                             }
 
                             NotebookFrameType::Request => {
-                                // Decode and enqueue the request, then return to
-                                // frame reads. The per-peer request worker preserves
-                                // request order and echoes the id on the response.
-                                let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
-                                    serde_json::from_slice(&frame.payload)?;
-                                debug!(
-                                    "[notebook-sync] Enqueuing {} id={} peer={} notebook={}",
-                                    metadata::request_label(&envelope.request),
-                                    envelope.id.as_deref().unwrap_or("-"),
+                                enqueue_notebook_request(
+                                    &request_worker,
+                                    &peer_writer,
+                                    &frame.payload,
+                                    &notebook_id,
                                     peer_id,
-                                    notebook_id,
-                                );
-                                if let Err(e) = request_worker.enqueue(envelope) {
-                                    match e {
-                                        RequestEnqueueError::Full(envelope) => {
-                                            warn!(
-                                                "[notebook-sync] Peer request queue full for {} (peer_id={})",
-                                                notebook_id, peer_id
-                                            );
-                                            queue_request_error(
-                                                &peer_writer,
-                                                envelope.id,
-                                                "Peer request queue full",
-                                            )?;
-                                        }
-                                        RequestEnqueueError::Closed(envelope) => {
-                                            warn!(
-                                                "[notebook-sync] Peer request worker stopped for {} (peer_id={})",
-                                                notebook_id, peer_id
-                                            );
-                                            queue_request_error(
-                                                &peer_writer,
-                                                envelope.id,
-                                                "Peer request worker stopped",
-                                            )?;
-                                            return Err(anyhow::anyhow!(
-                                                "peer request worker stopped for {}",
-                                                notebook_id
-                                            ));
-                                        }
-                                    }
-                                }
+                                )?;
                             }
 
                             NotebookFrameType::Presence => {

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1,3 +1,6 @@
+use super::peer_pool_sync::{
+    forward_pool_state_broadcast, handle_pool_state_frame, send_initial_pool_sync,
+};
 use super::peer_presence::{
     cleanup_presence_on_disconnect, forward_presence_broadcast, handle_presence_frame,
     prune_stale_presence, send_initial_presence_snapshot,
@@ -1296,29 +1299,7 @@ where
         }
     }
 
-    // Initial PoolDoc sync — global pool state
-    let initial_pool_encoded = {
-        let mut pool_doc = daemon.pool_doc.write().await;
-        match catch_automerge_panic("initial-pool-sync", || {
-            pool_doc
-                .generate_sync_message(&mut pool_peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
-            Err(e) => {
-                warn!("{}", e);
-                pool_doc.rebuild_from_save();
-                pool_peer_state = sync::State::new();
-                pool_doc
-                    .generate_sync_message(&mut pool_peer_state)
-                    .map(|msg| msg.encode())
-            }
-        }
-    };
-    if let Some(encoded) = initial_pool_encoded {
-        connection::send_typed_frame(&mut writer, NotebookFrameType::PoolStateSync, &encoded)
-            .await?;
-    }
+    send_initial_pool_sync(&mut writer, &daemon, &mut pool_peer_state).await?;
 
     // Phase 1.5 (removed): CommSync broadcast is no longer needed.
     // Late joiners receive widget state via RuntimeStateDoc CRDT sync,
@@ -1627,53 +1608,15 @@ where
                             }
 
                             NotebookFrameType::PoolStateSync => {
-                                // Client's pool sync reply — apply with change stripping
-                                let message = sync::Message::decode(&frame.payload)
-                                    .map_err(|e| anyhow::anyhow!("decode pool sync: {}", e))?;
-                                let reply_encoded = {
-                                    let mut pool_doc = daemon.pool_doc.write().await;
-
-                                    let recv_result = catch_automerge_panic("pool-receive-sync", || {
-                                        pool_doc.receive_sync_message(
-                                            &mut pool_peer_state,
-                                            message,
-                                        )
-                                    });
-                                    match recv_result {
-                                        Ok(Ok(())) => {}
-                                        Ok(Err(e)) => {
-                                            warn!("[notebook-sync] pool receive_sync_message error: {}", e);
-                                            continue;
-                                        }
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            pool_doc.rebuild_from_save();
-                                            pool_peer_state = sync::State::new();
-                                            continue;
-                                        }
-                                    }
-
-                                    match catch_automerge_panic("pool-sync-reply", || {
-                                        pool_doc
-                                            .generate_sync_message(&mut pool_peer_state)
-                                            .map(|msg| msg.encode())
-                                    }) {
-                                        Ok(encoded) => encoded,
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            pool_doc.rebuild_from_save();
-                                            pool_peer_state = sync::State::new();
-                                            pool_doc
-                                                .generate_sync_message(&mut pool_peer_state)
-                                                .map(|msg| msg.encode())
-                                        }
-                                    }
-                                };
-                                if let Some(encoded) = reply_encoded {
-                                    peer_writer.send_frame(
-                                        NotebookFrameType::PoolStateSync,
-                                        encoded,
-                                    )?;
+                                if !handle_pool_state_frame(
+                                    &daemon,
+                                    &mut pool_peer_state,
+                                    &peer_writer,
+                                    &frame.payload,
+                                )
+                                .await?
+                                {
+                                    continue;
                                 }
                             }
 
@@ -1801,67 +1744,16 @@ where
 
             // PoolDoc changed — push update to this client
             result = pool_changed_rx.recv() => {
-                match result {
-                    Ok(()) => {
-                        let encoded = {
-                            let mut pool_doc = daemon.pool_doc.write().await;
-                            match catch_automerge_panic("pool-broadcast", || {
-                                pool_doc
-                                    .generate_sync_message(&mut pool_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => encoded,
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    pool_doc.rebuild_from_save();
-                                    pool_peer_state = sync::State::new();
-                                    pool_doc
-                                        .generate_sync_message(&mut pool_peer_state)
-                                        .map(|msg| msg.encode())
-                                }
-                            }
-                        };
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::PoolStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::debug!(
-                            "[notebook-sync] Peer {} lagged {} pool state updates",
-                            peer_id, n
-                        );
-                        let encoded = {
-                            let mut pool_doc = daemon.pool_doc.write().await;
-                            match catch_automerge_panic("pool-broadcast-lagged", || {
-                                pool_doc
-                                    .generate_sync_message(&mut pool_peer_state)
-                                    .map(|msg| msg.encode())
-                            }) {
-                                Ok(encoded) => encoded,
-                                Err(e) => {
-                                    warn!("{}", e);
-                                    pool_doc.rebuild_from_save();
-                                    pool_peer_state = sync::State::new();
-                                    pool_doc
-                                        .generate_sync_message(&mut pool_peer_state)
-                                        .map(|msg| msg.encode())
-                                }
-                            }
-                        };
-                        if let Some(encoded) = encoded {
-                            peer_writer.send_frame(
-                                NotebookFrameType::PoolStateSync,
-                                encoded,
-                            )?;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        // Pool doc channel closed — daemon is shutting down
-                        return Ok(());
-                    }
+                if !forward_pool_state_broadcast(
+                    &daemon,
+                    peer_id,
+                    &mut pool_peer_state,
+                    &peer_writer,
+                    result,
+                )
+                .await?
+                {
+                    return Ok(());
                 }
             }
 

--- a/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use automerge::sync;
+use tokio::io::AsyncWrite;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::connection::{self, NotebookFrameType};
+
+use super::catch_automerge_panic;
+use super::peer_writer::PeerWriter;
+
+pub(super) async fn send_initial_pool_sync<W>(
+    writer: &mut W,
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let initial_pool_encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+        match catch_automerge_panic("initial-pool-sync", || {
+            pool_doc
+                .generate_sync_message(pool_peer_state)
+                .map(|msg| msg.encode())
+        }) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                warn!("{}", e);
+                pool_doc.rebuild_from_save();
+                *pool_peer_state = sync::State::new();
+                pool_doc
+                    .generate_sync_message(pool_peer_state)
+                    .map(|msg| msg.encode())
+            }
+        }
+    };
+    if let Some(encoded) = initial_pool_encoded {
+        connection::send_typed_frame(writer, NotebookFrameType::PoolStateSync, &encoded).await?;
+    }
+    Ok(())
+}
+
+pub(super) async fn handle_pool_state_frame(
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    payload: &[u8],
+) -> anyhow::Result<bool> {
+    let message =
+        sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode pool sync: {}", e))?;
+    let reply_encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+
+        let recv_result = catch_automerge_panic("pool-receive-sync", || {
+            pool_doc.receive_sync_message(pool_peer_state, message)
+        });
+        match recv_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!("[notebook-sync] pool receive_sync_message error: {}", e);
+                return Ok(false);
+            }
+            Err(e) => {
+                warn!("{}", e);
+                pool_doc.rebuild_from_save();
+                *pool_peer_state = sync::State::new();
+                return Ok(false);
+            }
+        }
+
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, "pool-sync-reply")
+    };
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
+    }
+    Ok(true)
+}
+
+pub(super) async fn forward_pool_state_broadcast(
+    daemon: &Arc<crate::daemon::Daemon>,
+    peer_id: &str,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    result: Result<(), broadcast::error::RecvError>,
+) -> anyhow::Result<bool> {
+    match result {
+        Ok(()) => {
+            send_pool_sync_update(daemon, pool_peer_state, writer, "pool-broadcast").await?;
+        }
+        Err(broadcast::error::RecvError::Lagged(n)) => {
+            debug!(
+                "[notebook-sync] Peer {} lagged {} pool state updates",
+                peer_id, n
+            );
+            send_pool_sync_update(daemon, pool_peer_state, writer, "pool-broadcast-lagged").await?;
+        }
+        Err(broadcast::error::RecvError::Closed) => {
+            // Pool doc channel closed — daemon is shutting down.
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn send_pool_sync_update(
+    daemon: &Arc<crate::daemon::Daemon>,
+    pool_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    label: &str,
+) -> anyhow::Result<()> {
+    let encoded = {
+        let mut pool_doc = daemon.pool_doc.write().await;
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, label)
+    };
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
+    }
+    Ok(())
+}
+
+fn generate_pool_sync_message(
+    pool_doc: &mut notebook_doc::pool_state::PoolDoc,
+    pool_peer_state: &mut sync::State,
+    label: &str,
+) -> Option<Vec<u8>> {
+    match catch_automerge_panic(label, || {
+        pool_doc
+            .generate_sync_message(pool_peer_state)
+            .map(|msg| msg.encode())
+    }) {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            warn!("{}", e);
+            pool_doc.rebuild_from_save();
+            *pool_peer_state = sync::State::new();
+            pool_doc
+                .generate_sync_message(pool_peer_state)
+                .map(|msg| msg.encode())
+        }
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+
+use automerge::sync;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::connection::NotebookFrameType;
+
+use super::catch_automerge_panic;
+use super::peer_writer::PeerWriter;
+use super::NotebookRoom;
+
+type PersistedExecutionRecords = HashMap<String, runtimed_client::execution_store::ExecutionRecord>;
+
+pub(super) async fn handle_runtime_state_frame(
+    room: &NotebookRoom,
+    state_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    payload: &[u8],
+    store: &runtimed_client::execution_store::ExecutionStore,
+    persisted_records: &mut PersistedExecutionRecords,
+) -> anyhow::Result<bool> {
+    let message =
+        sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
+
+    let reply_encoded: Option<Option<Vec<u8>>> = room
+        .state
+        .with_doc(|state_doc| {
+            let recv_result = catch_automerge_panic("state-receive-sync", || {
+                state_doc.receive_sync_message_with_changes(state_peer_state, message)
+            });
+            let had_changes = match recv_result {
+                Ok(Ok(changed)) => changed,
+                Ok(Err(e)) => {
+                    warn!("[notebook-sync] state receive_sync_message error: {}", e);
+                    return Ok(None);
+                }
+                Err(e) => {
+                    warn!("{}", e);
+                    state_doc.rebuild_from_save();
+                    *state_peer_state = sync::State::new();
+                    return Ok(None);
+                }
+            };
+
+            // If the client sent changes, notification is automatic via the
+            // heads comparison in RuntimeStateDoc::with_doc.
+            let _ = had_changes;
+
+            Ok(Some(generate_runtime_state_sync_message(
+                state_doc,
+                state_peer_state,
+                "state-sync-reply",
+            )))
+        })
+        .ok()
+        .flatten();
+
+    let reply_encoded = match reply_encoded {
+        Some(encoded) => encoded,
+        None => return Ok(false),
+    };
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
+    }
+
+    persist_terminal_execution_records(room, store, persisted_records).await;
+    Ok(true)
+}
+
+pub(super) async fn forward_runtime_state_broadcast(
+    room: &NotebookRoom,
+    peer_id: &str,
+    state_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    result: Result<(), broadcast::error::RecvError>,
+) -> anyhow::Result<bool> {
+    match result {
+        Ok(()) => {
+            send_runtime_state_sync_update(room, state_peer_state, writer, "state-broadcast")?;
+        }
+        Err(broadcast::error::RecvError::Lagged(n)) => {
+            debug!(
+                "[notebook-sync] Peer {} lagged {} runtime state updates",
+                peer_id, n
+            );
+            send_runtime_state_sync_update(
+                room,
+                state_peer_state,
+                writer,
+                "state-broadcast-lagged",
+            )?;
+        }
+        Err(broadcast::error::RecvError::Closed) => {
+            // State change channel closed — room is being evicted.
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn send_runtime_state_sync_update(
+    room: &NotebookRoom,
+    state_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    label: &str,
+) -> anyhow::Result<()> {
+    let encoded = room
+        .state
+        .with_doc(|state_doc| {
+            Ok(generate_runtime_state_sync_message(
+                state_doc,
+                state_peer_state,
+                label,
+            ))
+        })
+        .ok()
+        .flatten();
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
+    }
+    Ok(())
+}
+
+fn generate_runtime_state_sync_message(
+    state_doc: &mut runtime_doc::RuntimeStateDoc,
+    state_peer_state: &mut sync::State,
+    label: &str,
+) -> Option<Vec<u8>> {
+    match catch_automerge_panic(label, || {
+        state_doc
+            .generate_sync_message(state_peer_state)
+            .map(|msg| msg.encode())
+    }) {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            warn!("{}", e);
+            state_doc.rebuild_from_save();
+            *state_peer_state = sync::State::new();
+            state_doc
+                .generate_sync_message(state_peer_state)
+                .map(|msg| msg.encode())
+        }
+    }
+}
+
+pub(super) async fn persist_terminal_execution_records(
+    room: &NotebookRoom,
+    store: &runtimed_client::execution_store::ExecutionStore,
+    persisted_records: &mut PersistedExecutionRecords,
+) {
+    let notebook_path = room
+        .identity
+        .path
+        .read()
+        .await
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string());
+    let context_id = notebook_execution_context_id(room, notebook_path.as_deref());
+    let records = room
+        .state
+        .read(|sd| {
+            sd.read_state()
+                .executions
+                .into_iter()
+                .filter_map(|(execution_id, exec)| {
+                    if !matches!(exec.status.as_str(), "done" | "error") {
+                        return None;
+                    }
+                    Some(
+                        runtimed_client::execution_store::ExecutionRecord::from_execution_state(
+                            &execution_id,
+                            "notebook",
+                            context_id.clone(),
+                            notebook_path.clone(),
+                            &exec,
+                        ),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    for record in records {
+        if persisted_records
+            .get(&record.execution_id)
+            .is_some_and(|existing| existing.payload_matches(&record))
+        {
+            continue;
+        }
+        if let Err(e) = store.write_record(record.clone()).await {
+            warn!(
+                "[execution-store] Failed to persist execution record: {}",
+                e
+            );
+        } else {
+            persisted_records.insert(record.execution_id.clone(), record);
+        }
+    }
+}
+
+pub(crate) fn notebook_execution_context_id(
+    room: &NotebookRoom,
+    notebook_path: Option<&str>,
+) -> String {
+    notebook_path
+        .map(str::to_string)
+        .unwrap_or_else(|| room.id.to_string())
+}

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tokio::io::AsyncWrite;
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::connection::{self, NotebookFrameType};
 
@@ -182,6 +182,45 @@ pub(super) fn spawn_peer_request_worker(
     PeerRequestWorker { tx, handle }
 }
 
+pub(super) fn enqueue_notebook_request(
+    request_worker: &PeerRequestWorker,
+    writer: &PeerWriter,
+    payload: &[u8],
+    notebook_id: &str,
+    peer_id: &str,
+) -> anyhow::Result<()> {
+    let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
+        serde_json::from_slice(payload)?;
+    debug!(
+        "[notebook-sync] Enqueuing {} id={} peer={} notebook={}",
+        request_label(&envelope.request),
+        envelope.id.as_deref().unwrap_or("-"),
+        peer_id,
+        notebook_id,
+    );
+
+    if let Err(e) = request_worker.enqueue(envelope) {
+        match e {
+            RequestEnqueueError::Full(envelope) => {
+                warn!(
+                    "[notebook-sync] Peer request queue full for {} (peer_id={})",
+                    notebook_id, peer_id
+                );
+                queue_request_error(writer, envelope.id, "Peer request queue full")?;
+            }
+            RequestEnqueueError::Closed(envelope) => {
+                warn!(
+                    "[notebook-sync] Peer request worker stopped for {} (peer_id={})",
+                    notebook_id, peer_id
+                );
+                queue_request_error(writer, envelope.id, "Peer request worker stopped")?;
+                anyhow::bail!("peer request worker stopped for {}", notebook_id);
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn queue_request_error(
     writer: &PeerWriter,
     id: Option<String>,
@@ -294,5 +333,100 @@ mod tests {
             "request enqueue should not wait for the busy worker"
         );
         assert!(matches!(err, RequestEnqueueError::Full(_)));
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_rejects_malformed_payload_without_reply() {
+        let (request_tx, _request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer_tx, mut writer_rx) = mpsc::channel::<OutboundFrame>(1);
+        let writer = PeerWriter { tx: writer_tx };
+
+        let err =
+            enqueue_notebook_request(&request_worker, &writer, b"not json", "notebook", "peer")
+                .expect_err("malformed request payload should fail");
+        assert!(err.to_string().contains("expected ident"));
+        assert!(
+            writer_rx.try_recv().is_err(),
+            "malformed envelopes have no request id to echo"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_reports_full_queue_to_peer() {
+        let (request_tx, _request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        request_tx
+            .try_send(notebook_protocol::protocol::NotebookRequestEnvelope {
+                id: Some("first".to_string()),
+                request: NotebookRequest::GetDocBytes {},
+            })
+            .expect("queue should accept first request");
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer_tx, mut writer_rx) = mpsc::channel::<OutboundFrame>(1);
+        let writer = PeerWriter { tx: writer_tx };
+
+        let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
+            id: Some("second".to_string()),
+            request: NotebookRequest::GetDocBytes {},
+        })
+        .unwrap();
+        enqueue_notebook_request(&request_worker, &writer, &payload, "notebook", "peer")
+            .expect("full queue should be reported to the peer without failing the loop");
+
+        let frame = writer_rx
+            .try_recv()
+            .expect("full queue should enqueue an error response");
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let reply: notebook_protocol::protocol::NotebookResponseEnvelope =
+            serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(reply.id.as_deref(), Some("second"));
+        assert!(matches!(
+            reply.response,
+            notebook_protocol::protocol::NotebookResponse::Error { ref error }
+                if error == "Peer request queue full"
+        ));
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_reports_closed_worker_then_fails() {
+        let (request_tx, request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        drop(request_rx);
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer_tx, mut writer_rx) = mpsc::channel::<OutboundFrame>(1);
+        let writer = PeerWriter { tx: writer_tx };
+
+        let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
+            id: Some("closed".to_string()),
+            request: NotebookRequest::GetDocBytes {},
+        })
+        .unwrap();
+        let err = enqueue_notebook_request(&request_worker, &writer, &payload, "notebook", "peer")
+            .expect_err("closed worker should stop the peer loop");
+        assert_eq!(err.to_string(), "peer request worker stopped for notebook");
+
+        let frame = writer_rx
+            .try_recv()
+            .expect("closed worker should enqueue an error response before failing");
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let reply: notebook_protocol::protocol::NotebookResponseEnvelope =
+            serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(reply.id.as_deref(), Some("closed"));
+        assert!(matches!(
+            reply.response,
+            notebook_protocol::protocol::NotebookResponse::Error { ref error }
+                if error == "Peer request worker stopped"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Extract RuntimeStateDoc peer sync handling from peer.rs into peer_runtime_sync.rs
- Move client RuntimeStateSync replies, runtime-state broadcast catch-up, and terminal execution record persistence into focused helpers
- Keep the PR stacked on #2356 while the PoolDoc sync split is open

## Verification
- cargo fmt --check
- cargo check -p runtimed
- cargo clippy -p runtimed --lib -- -D warnings
- cargo test -p runtimed sanitize_peer_label
- git diff --check