### PR TITLE
refactor(notebook-doc): clarify execution count ownership

### DIFF
--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -242,8 +242,8 @@ export function cellSnapshotsToNotebookCellsSync(
         .map((output) => resolveOutputSync(output, blobPort ?? null, cache))
         .filter((o): o is JupyterOutput => o !== null);
 
-      // Resolve execution_count from RuntimeState (source of truth) rather
-      // than the stale NotebookDoc field which is always "null".
+      // RuntimeState is the live source of truth. NotebookDoc carries the
+      // persisted nbformat history fallback for runtime-free reload/export.
       const runtimeCount = getExecutionCountFromRuntime(snap.id);
       const ec =
         runtimeCount ?? (Number.isNaN(executionCount) ? null : executionCount);
@@ -307,7 +307,8 @@ export async function cellSnapshotsToNotebookCells(
           )
         ).filter((o): o is JupyterOutput => o !== null);
 
-        // Resolve execution_count from RuntimeState (source of truth)
+        // RuntimeState is the live source of truth. NotebookDoc carries the
+        // persisted nbformat history fallback for runtime-free reload/export.
         const runtimeCount = getExecutionCountFromRuntime(snap.id);
         const ec =
           runtimeCount ??

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2943,8 +2943,8 @@ mod tests {
             10,
         );
 
-        // execution_count is now in RuntimeStateDoc, not NotebookDoc
-        // The sync test for execution_count is covered by RuntimeStateDoc tests
+        // Live execution_count is covered by RuntimeStateDoc tests. NotebookDoc
+        // keeps only the persisted nbformat-history fallback.
     }
 
     /// Tests three-peer sync: daemon + two clients.

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -481,7 +481,25 @@ impl DocHandle {
     }
 
     /// Get a single cell's execution count (e.g. "5" or "null").
+    ///
+    /// RuntimeStateDoc is authoritative while an execution is known. The
+    /// NotebookDoc cell field is a durable nbformat-history fallback for
+    /// reload/export paths where runtime state is unavailable.
     pub fn get_cell_execution_count(&self, cell_id: &str) -> Option<String> {
+        if let Ok(state) = self.doc.lock() {
+            if let Some(count) = state
+                .state_doc
+                .read_state()
+                .executions
+                .values()
+                .filter(|exec| exec.cell_id == cell_id)
+                .filter_map(|exec| exec.execution_count)
+                .max()
+            {
+                return Some(count.to_string());
+            }
+        }
+
         let snapshot = self.snapshot_rx.borrow();
         snapshot
             .cells

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -720,6 +720,45 @@ mod tests {
         }
     }
 
+    #[test]
+    fn get_cell_execution_count_falls_back_to_notebook_doc() {
+        let (handle, _shared, _rx, _cmd_rx) = test_handle_with_shared();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell_full("cell-1", "code", "80", "x = 1", "7", &serde_json::json!({}))
+                    .unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        assert_eq!(
+            handle.get_cell_execution_count("cell-1").as_deref(),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn get_cell_execution_count_prefers_runtime_state() {
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell_full("cell-1", "code", "80", "x = 1", "7", &serde_json::json!({}))
+                    .unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+        set_execution(&shared, "exec-1", "cell-1", "done", &[], Some(9));
+
+        assert_eq!(
+            handle.get_cell_execution_count("cell-1").as_deref(),
+            Some("9")
+        );
+    }
+
     #[tokio::test]
     async fn await_execution_terminal_returns_once_status_done() {
         use crate::execution_wait::{await_execution_terminal, ExecutionTerminalState};

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -858,8 +858,20 @@ impl NotebookHandle {
     }
 
     /// Get a cell's execution count.
+    ///
+    /// RuntimeStateDoc is authoritative while an execution is known. The
+    /// NotebookDoc cell field is a durable nbformat-history fallback for
+    /// reload/export paths where runtime state is unavailable.
     pub fn get_cell_execution_count(&self, cell_id: &str) -> Option<String> {
-        self.doc.get_cell_execution_count(cell_id)
+        self.state_doc
+            .read_state()
+            .executions
+            .values()
+            .filter(|exec| exec.cell_id == cell_id)
+            .filter_map(|exec| exec.execution_count)
+            .max()
+            .map(|count| count.to_string())
+            .or_else(|| self.doc.get_cell_execution_count(cell_id))
     }
 
     /// Get a cell's metadata as a native JS object.

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1392,7 +1392,7 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
     .await;
     assert!(changed, "Should detect execution_count change");
 
-    // execution_count is now in RuntimeStateDoc via synthetic execution_id
+    // Live execution_count is resolved from RuntimeStateDoc via synthetic execution_id.
     let doc = room.doc.read().await;
     let eid = doc.get_execution_id("cell-1");
     drop(doc);

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -667,9 +667,8 @@ async fn test_notebook_sync_cross_window_propagation() {
     assert!(cell.is_some(), "client2 should have cell c1");
     let cell = cell.unwrap();
     assert_eq!(cell.source, "x = 42");
-    // execution_count is now in RuntimeStateDoc, not NotebookDoc.
-    // The cell snapshot shows the default "null" — execution count
-    // is resolved from RuntimeStateDoc at save time and by the frontend.
+    // Live execution_count is resolved from RuntimeStateDoc at save time and
+    // by the frontend. NotebookDoc keeps only the persisted history fallback.
 
     // Shutdown
     pool_client.shutdown().await.ok();

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -231,7 +231,7 @@ ROOT/
     notebook_metadata: Str      <- Legacy JSON mirror (dual-written)
 ```
 
-Outputs live in `RuntimeStateDoc` (separate Automerge doc, frame type `0x05`) keyed by `execution_id`, with each manifest carrying an `output_id` UUID for addressable references. They are not stored in the notebook doc.
+Outputs live in `RuntimeStateDoc` (separate Automerge doc, frame type `0x05`) keyed by `execution_id`, with each manifest carrying an `output_id` UUID for addressable references. They are not stored in the notebook doc. Execution counts are duplicated intentionally: `RuntimeStateDoc` is authoritative for live sessions, while `NotebookDoc.execution_count` is the persisted nbformat-history fallback used when runtime state is unavailable.
 
 Cell ordering uses fractional indexing via the `position` field. Cells are sorted lexicographically by `position`, with `cell_id` as a tiebreaker for the (rare) case where two cells receive the same fractional index.
 

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -347,8 +347,8 @@ export function diffExecutions(
 /**
  * Resolve the most recent execution_count for a cell from RuntimeState.
  *
- * The daemon writes execution_count to RuntimeStateDoc (not NotebookDoc),
- * so the WASM handle's get_cell_execution_count always returns "null".
+ * RuntimeStateDoc is the live source of truth. NotebookDoc may carry a
+ * persisted nbformat-history fallback when runtime state is unavailable.
  * This mirrors runt-mcp's get_cell_execution_count_from_runtime: find
  * the most recent execution for the cell that has a count set.
  */

--- a/packages/runtimed/tests/wasm-harness.ts
+++ b/packages/runtimed/tests/wasm-harness.ts
@@ -185,9 +185,8 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
     },
 
     serverSetExecutionCount(_cellId: string, _count: string) {
-      // No-op: execution_count is now in RuntimeStateDoc, not NotebookDoc.
-      // The WASM set_execution_count method was removed. Tests that need
-      // to verify execution_count should use RuntimeStateDoc instead.
+      // No-op: live execution_count is sourced from RuntimeStateDoc. The WASM
+      // set_execution_count method was removed from NotebookDoc mutations.
     },
 
     serverClearOutputs(cellId: string) {

--- a/packages/runtimed/tests/wasm-integration.test.ts
+++ b/packages/runtimed/tests/wasm-integration.test.ts
@@ -74,9 +74,9 @@ describe("WASM integration: real frames through SyncEngine", { retry: 3 }, () =>
       expect(h.client.get_cell_type("md-cell")).toBe("markdown");
     });
 
-    it.skip("client sees execution count after sync — execution_count moved to RuntimeStateDoc", async () => {
-      // execution_count is now in RuntimeStateDoc, not NotebookDoc.
-      // The WASM set_execution_count method was removed.
+    it.skip("client sees live execution count after sync", async () => {
+      // Live execution_count is sourced from RuntimeStateDoc. The WASM
+      // set_execution_count method was removed from NotebookDoc mutations.
     });
   });
 


### PR DESCRIPTION
## Summary
- keep `NotebookDoc.execution_count` as the persisted nbformat-history fallback
- make `DocHandle` and `NotebookHandle` prefer live `RuntimeStateDoc` execution counts, falling back to notebook-doc only when runtime state is unavailable
- update comments/docs/tests so the ownership boundary is explicit

Part of #2340.

## Verification
- `cargo test -p notebook-sync get_cell_execution_count --lib`
- `cargo check -p notebook-sync -p runtimed-wasm`
- `pnpm --dir apps/notebook exec tsc --noEmit`
- `cargo clippy -p notebook-sync -p runtimed-wasm --lib -- -D warnings`
- `cargo xtask wasm runtimed`
- `pnpm test:run packages/runtimed/tests/fixture-integration.test.ts packages/runtimed/tests/wasm-integration.test.ts apps/notebook/src/lib/__tests__/materialize-cells.test.ts`
- `cargo xtask lint --fix`