### PR TITLE
fix(linux): sanitize AppImage daemon bootstrap

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -57,6 +57,45 @@ The first run downloads the MSVC CRT and Windows SDK into cargo-xwin's cache.
 `nasm` is required by `aws-lc-sys`, and Homebrew's LLVM provides the
 `clang-cl`/`lld-link` toolchain used by the cross build.
 
+## Linux Target Checks From macOS
+
+Use this for Linux-only `cfg` and type-check validation from macOS. It is a
+`cargo check` workflow, not a substitute for building release Linux artifacts on
+Linux: Homebrew OpenSSL gives `openssl-sys` the metadata and headers needed for
+checking, but the final link should still happen on a Linux host or CI image.
+
+Install the local tools:
+
+```bash
+brew tap messense/macos-cross-toolchains
+brew install x86_64-unknown-linux-gnu openssl@3 pkgconf
+rustup target add x86_64-unknown-linux-gnu
+```
+
+Then point Cargo and `pkg-config` at the target compiler and local OpenSSL
+metadata:
+
+```bash
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+export CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc
+export CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++
+export AR_x86_64_unknown_linux_gnu=x86_64-linux-gnu-ar
+export PKG_CONFIG_ALLOW_CROSS=1
+export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig"
+```
+
+Example check:
+
+```bash
+cargo check -p runtimed-client --target x86_64-unknown-linux-gnu
+```
+
+If the check reports `x86_64-linux-gnu-gcc: No such file or directory`, the
+cross compiler is missing or not on `PATH`. If `openssl-sys` reports that
+`pkg-config has not been configured to support cross-compilation`, confirm
+`PKG_CONFIG_ALLOW_CROSS` and `PKG_CONFIG_PATH` are exported in the same shell as
+the `cargo check` command.
+
 ## Choosing a Workflow
 
 ### `cargo xtask dev` — One Command Setup + Dev

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -15,9 +15,7 @@ use std::os::unix::fs::symlink;
 use std::os::unix::fs::PermissionsExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::ffi::OsStrExt;
-#[cfg(any(target_os = "windows", test))]
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::Manager;
 
 #[cfg(any(target_os = "windows", test))]
@@ -86,48 +84,40 @@ fn is_owned_windows_cmd_shim(contents: &str) -> bool {
         || contents.starts_with(&format!("@echo off\nrem {WINDOWS_CMD_SHIM_MARKER}\n"))
 }
 
-/// Get the path to the bundled runt binary.
-pub fn get_bundled_runt_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+fn bundled_runt_candidates(
+    resource_dir: Option<&Path>,
+    current_exe: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
     #[cfg(target_os = "macos")]
     {
-        if let Ok(exe_dir) = app.path().resource_dir() {
-            // resource_dir on macOS points to Contents/Resources
-            // The binary is in Contents/MacOS, which is ../MacOS from Resources
-            let macos_dir = exe_dir.parent()?.join("MacOS");
-            let bundled_path = macos_dir.join("runt");
-            if bundled_path.exists() {
-                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
-                return Some(bundled_path);
+        if let Some(resource_dir) = resource_dir {
+            if let Some(contents_dir) = resource_dir.parent() {
+                candidates.push(contents_dir.join("MacOS").join("runt"));
             }
-            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
         }
     }
 
     #[cfg(target_os = "linux")]
     {
-        if let Ok(resource_dir) = app.path().resource_dir() {
-            let bundled_path = resource_dir.join("runt");
-            if bundled_path.exists() {
-                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
-                return Some(bundled_path);
+        if let Some(resource_dir) = resource_dir {
+            candidates.push(resource_dir.join("runt"));
+        }
+        if let Some(exe_path) = current_exe {
+            if let Some(exe_dir) = exe_path.parent() {
+                candidates.push(exe_dir.join("runt"));
             }
-            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
         }
     }
 
     #[cfg(target_os = "windows")]
     {
-        if let Ok(resource_dir) = app.path().resource_dir() {
-            let bundled_path = resource_dir.join("runt.exe");
-            if bundled_path.exists() {
-                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
-                return Some(bundled_path);
-            }
-            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
+        if let Some(resource_dir) = resource_dir {
+            candidates.push(resource_dir.join("runt.exe"));
         }
     }
 
-    // Fallback: try the development path (target/*/binaries/runt-{target})
     let target = if cfg!(target_os = "macos") {
         if cfg!(target_arch = "aarch64") {
             "aarch64-apple-darwin"
@@ -150,16 +140,26 @@ pub fn get_bundled_runt_path(app: &tauri::AppHandle) -> Option<PathBuf> {
         format!("runt-{}", target)
     };
 
-    // Try to find it relative to the executable (for no-bundle dev builds)
-    if let Ok(exe_path) = std::env::current_exe() {
+    if let Some(exe_path) = current_exe {
         if let Some(exe_dir) = exe_path.parent() {
-            let dev_path = exe_dir.join("binaries").join(&binary_name);
-            if dev_path.exists() {
-                log::debug!("[cli_install] Found dev runt at {:?}", dev_path);
-                return Some(dev_path);
-            }
-            log::debug!("[cli_install] Dev runt not found at {:?}", dev_path);
+            candidates.push(exe_dir.join("binaries").join(binary_name));
         }
+    }
+
+    candidates
+}
+
+/// Get the path to the bundled runt binary.
+pub fn get_bundled_runt_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    let resource_dir = app.path().resource_dir().ok();
+    let current_exe = std::env::current_exe().ok();
+
+    for candidate in bundled_runt_candidates(resource_dir.as_deref(), current_exe.as_deref()) {
+        if candidate.exists() {
+            log::debug!("[cli_install] Found bundled runt at {:?}", candidate);
+            return Some(candidate);
+        }
+        log::debug!("[cli_install] Bundled runt not found at {:?}", candidate);
     }
 
     None
@@ -724,6 +724,24 @@ pub fn clear_windows_update_flag() {}
 /// - Linux AppImage mounts (`/tmp/.mount_*`)
 /// - General temp directories (`/tmp/`, `/var/folders/`)
 #[cfg(unix)]
+fn is_ephemeral_runt_path(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains("/private/var/folders/")
+        || path_str.contains("/AppTranslocation/")
+        || path_str.starts_with("/tmp/")
+        || path_str.starts_with("/var/folders/")
+        || path_str.contains("/tmp/.mount_")
+        || path_str.contains("/Downloads/")
+        || path_str.starts_with("/Volumes/")
+}
+
+#[cfg(target_os = "linux")]
+fn is_temporary_linux_runt_path(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.starts_with("/tmp/")
+}
+
+#[cfg(unix)]
 fn is_ephemeral_path(app: &tauri::AppHandle) -> bool {
     let bundled = match get_bundled_runt_path(app) {
         Some(p) => p,
@@ -731,14 +749,7 @@ fn is_ephemeral_path(app: &tauri::AppHandle) -> bool {
     };
 
     let path_str = bundled.to_string_lossy();
-
-    let ephemeral = path_str.contains("/private/var/folders/")
-        || path_str.contains("/AppTranslocation/")
-        || path_str.starts_with("/tmp/")
-        || path_str.starts_with("/var/folders/")
-        || path_str.contains("/tmp/.mount_")
-        || path_str.contains("/Downloads/")
-        || path_str.starts_with("/Volumes/");
+    let ephemeral = is_ephemeral_runt_path(&bundled);
 
     if ephemeral {
         log::info!(
@@ -957,6 +968,14 @@ pub fn is_cli_installed_legacy() -> bool {
 pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     let bundled_runt = get_bundled_runt_path(app)
         .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
+
+    #[cfg(target_os = "linux")]
+    if is_temporary_linux_runt_path(&bundled_runt) {
+        return Err(format!(
+            "Cannot install CLI from ephemeral AppImage path {}. Install the DEB/APT package or a standalone runt binary instead.",
+            bundled_runt.display()
+        ));
+    }
 
     let dir = install_dir();
 
@@ -1386,6 +1405,52 @@ fn escalate_shell_command(shell_cmd: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn appimage_mount_paths_are_ephemeral() {
+        let path = PathBuf::from("/tmp/.mount_nteracLoPFjM/usr/bin/runt");
+        assert!(is_ephemeral_runt_path(&path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persistent_local_paths_are_not_ephemeral() {
+        let path = PathBuf::from("/home/alice/.local/share/runt-nightly/bin/runt");
+        assert!(!is_ephemeral_runt_path(&path));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_appimage_mount_paths_are_temporary_runt_paths() {
+        let path = PathBuf::from("/tmp/.mount_nteracLoPFjM/usr/bin/runt");
+        assert!(is_temporary_linux_runt_path(&path));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_download_paths_are_not_temporary_runt_paths() {
+        let path = PathBuf::from("/home/alice/Downloads/nteract/usr/bin/runt");
+        assert!(!is_temporary_linux_runt_path(&path));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bundled_runt_candidates_include_sidecar_sibling() {
+        let resource_dir = Path::new("/tmp/.mount_nteracLoPFjM/usr/lib/nteract Nightly");
+        let current_exe = Path::new("/tmp/.mount_nteracLoPFjM/usr/bin/nteract");
+        let candidates = bundled_runt_candidates(Some(resource_dir), Some(current_exe));
+        let target = if cfg!(target_arch = "aarch64") {
+            "aarch64-unknown-linux-gnu"
+        } else {
+            "x86_64-unknown-linux-gnu"
+        };
+
+        assert!(candidates.contains(&PathBuf::from("/tmp/.mount_nteracLoPFjM/usr/bin/runt")));
+        assert!(candidates.contains(&PathBuf::from(format!(
+            "/tmp/.mount_nteracLoPFjM/usr/bin/binaries/runt-{target}"
+        ))));
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -24,6 +24,8 @@
 //! `~/Library/LaunchAgents/` and using `launchctl` directly.
 
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::process::Command;
 
 use log::info;
 use runt_workspace::cache_namespace;
@@ -141,6 +143,45 @@ pub enum ServiceError {
 /// Service manager for runtimed.
 pub struct ServiceManager {
     config: ServiceConfig,
+}
+
+#[cfg(target_os = "linux")]
+const APPIMAGE_HOST_ENV_VARS: &[&str] = &[
+    "APPDIR",
+    "APPIMAGE",
+    "ARGV0",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "LD_LIBRARY_PATH",
+    "LD_ORIGIN_PATH",
+    "LD_PRELOAD",
+    "OWD",
+];
+
+#[cfg(target_os = "linux")]
+fn systemctl_binary() -> &'static str {
+    // Prefer host systemctl so AppImage PATH entries cannot shadow it.
+    if Path::new("/usr/bin/systemctl").exists() {
+        "/usr/bin/systemctl"
+    } else if Path::new("/bin/systemctl").exists() {
+        "/bin/systemctl"
+    } else {
+        "systemctl"
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn strip_appimage_host_env(command: &mut Command) {
+    for var in APPIMAGE_HOST_ENV_VARS {
+        command.env_remove(var);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn systemctl_command() -> Command {
+    let mut command = Command::new(systemctl_binary());
+    strip_appimage_host_env(&mut command);
+    command
 }
 
 impl Default for ServiceManager {
@@ -542,7 +583,7 @@ impl ServiceManager {
                 std::fs::remove_file(&path)?;
                 info!("[service] Removed {:?}", path);
                 // Reload systemd
-                std::process::Command::new("systemctl")
+                systemctl_command()
                     .args(["--user", "daemon-reload"])
                     .output()
                     .ok();
@@ -709,12 +750,12 @@ WantedBy=default.target
         info!("[service] Created {:?}", service_file_path);
 
         // Reload systemd
-        std::process::Command::new("systemctl")
+        systemctl_command()
             .args(["--user", "daemon-reload"])
             .output()?;
 
         // Enable the service
-        std::process::Command::new("systemctl")
+        systemctl_command()
             .args(["--user", "enable"])
             .arg(systemd_service_unit_name())
             .output()?;
@@ -724,7 +765,7 @@ WantedBy=default.target
 
     #[cfg(target_os = "linux")]
     fn start_linux(&self) -> ServiceResult<()> {
-        let output = std::process::Command::new("systemctl")
+        let output = systemctl_command()
             .args(["--user", "start"])
             .arg(systemd_service_unit_name())
             .output()?;
@@ -740,7 +781,7 @@ WantedBy=default.target
 
     #[cfg(target_os = "linux")]
     fn stop_linux(&self) -> ServiceResult<()> {
-        let output = std::process::Command::new("systemctl")
+        let output = systemctl_command()
             .args(["--user", "stop"])
             .arg(systemd_service_unit_name())
             .output()?;
@@ -1147,6 +1188,20 @@ mod tests {
                 content.contains("Environment=HOME="),
                 "Installed systemd service should contain HOME env var"
             );
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn systemctl_command_strips_appimage_linker_env() {
+        let command = systemctl_command();
+        let env_overrides = command.get_envs().collect::<Vec<_>>();
+
+        for var in APPIMAGE_HOST_ENV_VARS {
+            let removed = env_overrides
+                .iter()
+                .any(|(key, value)| *key == std::ffi::OsStr::new(var) && value.is_none());
+            assert!(removed, "{var} should be removed for host systemctl");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Linux AppImage bootstrap path that left daemon/service management coupled to the AppImage runtime environment.

- find the bundled `runt` sidecar next to the Linux AppImage executable, matching the `/usr/bin/runt` layout seen in #2360 logs
- prevent persistent CLI symlinks from pointing into temporary AppImage mount paths
- run user `systemctl` commands through host `systemctl` while stripping AppImage/linker environment variables
- document macOS-to-Linux `cargo check` setup with the Homebrew Linux cross toolchain, OpenSSL metadata, and pkg-config env

## Validation

- `cargo test -p runtimed-client service::tests`
- `cargo test -p notebook cli_install::tests`
- `PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig" CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++ AR_x86_64_unknown_linux_gnu=x86_64-linux-gnu-ar cargo check -p runtimed-client --target x86_64-unknown-linux-gnu`
- `git diff --check origin/main..HEAD`

## Review

Claude Bedrock review was run before opening the PR. The first pass found two blocking issues, both fixed; the final pass reported no blocking findings.