### PR TITLE
fix(runtime): resolve execution counts by sequence

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -490,11 +490,7 @@ impl DocHandle {
             if let Some(count) = state
                 .state_doc
                 .read_state()
-                .executions
-                .values()
-                .filter(|exec| exec.cell_id == cell_id)
-                .filter_map(|exec| exec.execution_count)
-                .max()
+                .execution_count_for_cell(cell_id)
             {
                 return Some(count.to_string());
             }

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -698,9 +698,29 @@ mod tests {
         outputs: &[serde_json::Value],
         execution_count: Option<i64>,
     ) {
+        set_execution_with_seq(
+            shared,
+            execution_id,
+            cell_id,
+            status,
+            outputs,
+            execution_count,
+            0,
+        );
+    }
+
+    fn set_execution_with_seq(
+        shared: &Arc<Mutex<SharedDocState>>,
+        execution_id: &str,
+        cell_id: &str,
+        status: &str,
+        outputs: &[serde_json::Value],
+        execution_count: Option<i64>,
+        seq: u64,
+    ) {
         let mut st = shared.lock().unwrap();
         st.state_doc
-            .create_execution_with_source(execution_id, cell_id, "x = 1", 0)
+            .create_execution_with_source(execution_id, cell_id, "x = 1", seq)
             .unwrap();
         st.state_doc.set_execution_running(execution_id).unwrap();
         if let Some(count) = execution_count {
@@ -756,6 +776,19 @@ mod tests {
         assert_eq!(
             handle.get_cell_execution_count("cell-1").as_deref(),
             Some("9")
+        );
+    }
+
+    #[test]
+    fn get_cell_execution_count_prefers_latest_runtime_sequence() {
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+
+        set_execution_with_seq(&shared, "exec-old", "cell-1", "done", &[], Some(12), 1);
+        set_execution_with_seq(&shared, "exec-new", "cell-1", "done", &[], Some(1), 2);
+
+        assert_eq!(
+            handle.get_cell_execution_count("cell-1").as_deref(),
+            Some("1")
         );
     }
 

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -301,6 +301,29 @@ pub struct RuntimeState {
     pub project_context: ProjectContext,
 }
 
+impl RuntimeState {
+    /// Resolve the latest execution count for a cell from runtime state.
+    ///
+    /// `execution_count` is kernel-local and may reset after restart, so
+    /// numeric max is not a valid recency signal. Prefer the coordinator's
+    /// queue sequence number, falling back to the highest count only when
+    /// comparing legacy entries without sequence metadata.
+    pub fn execution_count_for_cell(&self, cell_id: &str) -> Option<i64> {
+        self.executions
+            .values()
+            .filter(|exec| exec.cell_id == cell_id)
+            .filter_map(|exec| Some((exec.seq, exec.execution_count?)))
+            // Keep in sync with packages/runtimed/src/runtime-state.ts.
+            .max_by(|(a_seq, a_count), (b_seq, b_count)| match (a_seq, b_seq) {
+                (Some(a), Some(b)) => a.cmp(b).then_with(|| a_count.cmp(b_count)),
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (None, None) => a_count.cmp(b_count),
+            })
+            .map(|(_, count)| count)
+    }
+}
+
 use crate::RuntimeStateError;
 
 // ── RuntimeStateDoc ─────────────────────────────────────────────────
@@ -3370,6 +3393,68 @@ mod tests {
         let e2 = &state.executions["exec-2"];
         assert_eq!(e2.cell_id, "cell-2");
         assert_eq!(e2.status, "queued");
+    }
+
+    #[test]
+    fn test_execution_count_for_cell_uses_latest_sequence() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution_with_source("exec-old", "cell-1", "x = 1", 1)
+            .unwrap();
+        doc.set_execution_count("exec-old", 12).unwrap();
+        doc.create_execution_with_source("exec-new", "cell-1", "x = 1", 2)
+            .unwrap();
+        doc.set_execution_count("exec-new", 1).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.execution_count_for_cell("cell-1"), Some(1));
+    }
+
+    #[test]
+    fn test_execution_count_for_cell_falls_back_to_highest_count_without_sequence() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1", "cell-1").unwrap();
+        doc.set_execution_count("exec-1", 2).unwrap();
+        doc.create_execution("exec-2", "cell-1").unwrap();
+        doc.set_execution_count("exec-2", 5).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.execution_count_for_cell("cell-1"), Some(5));
+    }
+
+    #[test]
+    fn test_execution_count_for_cell_prefers_zero_sequence_over_legacy() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-legacy", "cell-1").unwrap();
+        doc.set_execution_count("exec-legacy", 12).unwrap();
+        doc.create_execution_with_source("exec-current", "cell-1", "x = 1", 0)
+            .unwrap();
+        doc.set_execution_count("exec-current", 1).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.execution_count_for_cell("cell-1"), Some(1));
+    }
+
+    #[test]
+    fn test_execution_count_for_cell_prefers_any_sequence_over_legacy() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-legacy", "cell-1").unwrap();
+        doc.set_execution_count("exec-legacy", 100).unwrap();
+        doc.create_execution_with_source("exec-current", "cell-1", "x = 1", 5)
+            .unwrap();
+        doc.set_execution_count("exec-current", 1).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.execution_count_for_cell("cell-1"), Some(1));
+    }
+
+    #[test]
+    fn test_execution_count_for_cell_ignores_missing_counts() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution_with_source("exec-1", "cell-1", "x = 1", 1)
+            .unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.execution_count_for_cell("cell-1"), None);
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -865,11 +865,7 @@ impl NotebookHandle {
     pub fn get_cell_execution_count(&self, cell_id: &str) -> Option<String> {
         self.state_doc
             .read_state()
-            .executions
-            .values()
-            .filter(|exec| exec.cell_id == cell_id)
-            .filter_map(|exec| exec.execution_count)
-            .max()
+            .execution_count_for_cell(cell_id)
             .map(|count| count.to_string())
             .or_else(|| self.doc.get_cell_execution_count(cell_id))
     }

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -126,6 +126,8 @@ export interface ExecutionState {
   status: "queued" | "running" | "done" | "error";
   execution_count: number | null;
   success: boolean | null;
+  /** Queue sequence number from RuntimeStateDoc; used as execution recency. */
+  seq?: number | null;
   /**
    * Output manifests in emission order, as the WASM runtime-state snapshot
    * exposes them. Each entry is the raw on-the-wire manifest (un-narrowed,
@@ -353,13 +355,22 @@ export function diffExecutions(
  * the most recent execution for the cell that has a count set.
  */
 export function getExecutionCountForCell(state: RuntimeState, cellId: string): number | null {
-  let best: number | null = null;
+  let best: { count: number; seq: number | null } | null = null;
   for (const exec of Object.values(state.executions)) {
     if (exec.cell_id === cellId && exec.execution_count != null) {
-      if (best === null || exec.execution_count > best) {
-        best = exec.execution_count;
+      const seq = exec.seq ?? null;
+      // Keep in sync with RuntimeState::execution_count_for_cell in runtime-doc.
+      if (
+        best === null ||
+        (seq !== null &&
+          (best.seq === null ||
+            seq > best.seq ||
+            (seq === best.seq && exec.execution_count > best.count))) ||
+        (seq === null && best.seq === null && exec.execution_count > best.count)
+      ) {
+        best = { count: exec.execution_count, seq };
       }
     }
   }
-  return best;
+  return best?.count ?? null;
 }

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -99,7 +99,13 @@ function interactiveStatus(): SessionStatus {
 function makeRuntimeState(
   executions: Record<
     string,
-    { cell_id: string; status: string; execution_count: number | null; success: boolean | null }
+    {
+      cell_id: string;
+      status: string;
+      execution_count: number | null;
+      success: boolean | null;
+      seq?: number | null;
+    }
   >,
 ): RuntimeState {
   return {
@@ -2094,16 +2100,95 @@ describe("getExecutionCountForCell", () => {
     expect(getExecutionCountForCell(state, "c1")).toBe(3);
   });
 
-  it("returns the highest count when multiple executions exist", () => {
+  it("returns the latest count by sequence when multiple executions exist", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        e1: {
+          cell_id: "c1",
+          status: "done" as const,
+          execution_count: 12,
+          success: true,
+          seq: 1,
+        },
+        e2: {
+          cell_id: "c1",
+          status: "done" as const,
+          execution_count: 1,
+          success: true,
+          seq: 2,
+        },
+        e3: {
+          cell_id: "c1",
+          status: "running" as const,
+          execution_count: null,
+          success: null,
+          seq: 3,
+        },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBe(1);
+  });
+
+  it("falls back to the highest count for legacy executions without sequence", () => {
     const state = {
       ...baseState,
       executions: {
         e1: { cell_id: "c1", status: "done" as const, execution_count: 2, success: true },
         e2: { cell_id: "c1", status: "done" as const, execution_count: 5, success: true },
-        e3: { cell_id: "c1", status: "running" as const, execution_count: null, success: null },
       },
     };
     expect(getExecutionCountForCell(state, "c1")).toBe(5);
+  });
+
+  it("prefers seq zero over a legacy execution without sequence", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        legacy: { cell_id: "c1", status: "done" as const, execution_count: 12, success: true },
+        current: {
+          cell_id: "c1",
+          status: "done" as const,
+          execution_count: 1,
+          success: true,
+          seq: 0,
+        },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBe(1);
+  });
+
+  it("prefers any sequence over a legacy execution without sequence", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        legacy: { cell_id: "c1", status: "done" as const, execution_count: 100, success: true },
+        current: {
+          cell_id: "c1",
+          status: "done" as const,
+          execution_count: 1,
+          success: true,
+          seq: 5,
+        },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBe(1);
+  });
+
+  it("returns null when matching executions have no counts yet", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        e1: {
+          cell_id: "c1",
+          status: "running" as const,
+          execution_count: null,
+          success: null,
+          seq: 1,
+        },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBeNull();
   });
 
   it("ignores executions for other cells", () => {


### PR DESCRIPTION
## Summary
- resolve live execution counts by RuntimeStateDoc queue sequence instead of numeric max
- share the Rust resolver through `RuntimeState::execution_count_for_cell` for notebook-sync and WASM
- keep a highest-count fallback for legacy execution entries without sequence metadata, while treating real `seq = 0` as newer than missing sequence
- add Rust/TS regression coverage for restart-style lower counts, mixed legacy/current entries, and missing counts

Follow-up from Claude Bedrock review of #2362.

## Verification
- `cargo test -p runtime-doc execution_count_for_cell --lib`
- `cargo test -p notebook-sync get_cell_execution_count --lib`
- `pnpm test:run packages/runtimed/tests/sync-engine.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit`
- `cargo check -p runtime-doc -p notebook-sync -p runtimed-wasm`
- `cargo clippy -p runtime-doc -p notebook-sync -p runtimed-wasm --lib -- -D warnings`
- `cargo xtask wasm runtimed`
- `pnpm test:run packages/runtimed/tests/fixture-integration.test.ts packages/runtimed/tests/wasm-integration.test.ts packages/runtimed/tests/sync-engine.test.ts`
- `cargo xtask lint --fix`