### PR TITLE
ci(linux): smoke AppImage bootstrap on Fedora

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -853,6 +853,34 @@ jobs:
           path: crates/notebook/binaries/nteract-mcp-x86_64-unknown-linux-gnu
           if-no-files-found: error
 
+  smoke-fedora-appimage:
+    name: Smoke Fedora AppImage
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: [build-notebook-linux-x64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download Linux AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: nteract-linux-x64
+          path: artifacts
+
+      - name: Smoke AppImage in Fedora
+        run: |
+          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
+          APPIMAGE="artifacts/nteract-${CHANNEL}-linux-x64.AppImage"
+          docker run --rm \
+            -v "${PWD}:/workspace" \
+            -w /workspace \
+            fedora:latest \
+            bash -lc '
+              set -euo pipefail
+              dnf install -y coreutils findutils fuse-libs grep procps-ng systemd
+              bash scripts/ci/fedora-appimage-smoke.sh "$1"
+            ' bash "$APPIMAGE"
+
   build-nteract-package:
     name: Build nteract Package
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -1158,6 +1186,7 @@ jobs:
         build-notebook-macos-x64,
         build-notebook-windows-x64,
         build-notebook-linux-x64,
+        smoke-fedora-appimage,
         build-python-wheels,
         build-nteract-package,
         build-dx-package,

--- a/scripts/ci/fedora-appimage-smoke.sh
+++ b/scripts/ci/fedora-appimage-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPIMAGE=${1:?usage: fedora-appimage-smoke.sh <path-to-AppImage>}
+
+if [[ ! -f "$APPIMAGE" ]]; then
+  echo "AppImage not found: $APPIMAGE" >&2
+  exit 1
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+APPIMAGE_COPY="$WORKDIR/nteract.AppImage"
+cp "$APPIMAGE" "$APPIMAGE_COPY"
+chmod +x "$APPIMAGE_COPY"
+
+cd "$WORKDIR"
+
+echo "Extracting AppImage"
+"$APPIMAGE_COPY" --appimage-extract > appimage-extract.log
+
+RUNT="$WORKDIR/squashfs-root/usr/bin/runt"
+RUNTIMED="$WORKDIR/squashfs-root/usr/bin/runtimed"
+MCP="$WORKDIR/squashfs-root/usr/bin/nteract-mcp"
+
+for binary in "$RUNT" "$RUNTIMED" "$MCP"; do
+  if [[ ! -x "$binary" ]]; then
+    echo "Expected executable missing from AppImage: $binary" >&2
+    find "$WORKDIR/squashfs-root/usr/bin" -maxdepth 1 -type f -print >&2 || true
+    exit 1
+  fi
+done
+
+"$RUNT" --version
+"$RUNTIMED" --version
+
+export HOME="$WORKDIR/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_CACHE_HOME="$HOME/.cache"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+# Simulate the environment AppRun gives child processes. The daemon doctor
+# path should still call the host systemctl and should persist service files
+# outside the temporary AppImage mount.
+export APPDIR="$WORKDIR/squashfs-root"
+export APPIMAGE="$APPIMAGE_COPY"
+export ARGV0="$APPIMAGE_COPY"
+export OWD="$WORKDIR"
+export LD_LIBRARY_PATH="$APPDIR/usr/lib:$APPDIR/usr/lib/x86_64-linux-gnu"
+
+set +e
+"$RUNT" daemon doctor --fix --no-start --json > doctor.json 2> doctor.stderr
+doctor_status=$?
+set -e
+
+echo "=== daemon doctor stdout ==="
+cat doctor.json
+echo
+echo "=== daemon doctor stderr ==="
+cat doctor.stderr
+echo
+
+if grep -Eiq 'symbol lookup error|error while loading shared libraries|version `[^`]+'\'' not found|liblzma|libsystemd' doctor.stderr doctor.json; then
+  echo "daemon doctor appears to have used AppImage libraries for host systemctl" >&2
+  exit 1
+fi
+
+if [[ "$doctor_status" -ne 0 ]]; then
+  echo "daemon doctor failed with status $doctor_status" >&2
+  exit "$doctor_status"
+fi
+
+SERVICE_FILE=$(find "$XDG_CONFIG_HOME/systemd/user" -maxdepth 1 -name 'runtimed*.service' -print -quit 2>/dev/null || true)
+if [[ -z "$SERVICE_FILE" ]]; then
+  echo "daemon doctor did not write a user systemd service file" >&2
+  exit 1
+fi
+
+echo "=== user systemd service ==="
+cat "$SERVICE_FILE"
+echo
+
+if grep -Fq "$WORKDIR/squashfs-root" "$SERVICE_FILE"; then
+  echo "service file points into the temporary AppImage extraction" >&2
+  exit 1
+fi
+
+if ! grep -Fq "ExecStart=$XDG_DATA_HOME" "$SERVICE_FILE"; then
+  echo "service file does not point at the durable per-user data directory" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Environment=HOME=$HOME" "$SERVICE_FILE"; then
+  echo "service file does not preserve HOME" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds release-pipeline coverage for the next Linux support burndown item in #2361: Fedora smoke coverage for the AppImage daemon bootstrap path.

- adds a Fedora AppImage smoke job after the Linux AppImage artifact is built
- extracts the release AppImage inside `fedora:latest`
- verifies packaged `runt`, `runtimed`, and `nteract-mcp` sidecars are executable
- runs `runt daemon doctor --fix --no-start --json` under AppImage-like environment variables, including `APPDIR`, `APPIMAGE`, `ARGV0`, `OWD`, and AppImage-style `LD_LIBRARY_PATH`
- verifies the generated user systemd service points to the durable per-user data directory rather than the temporary AppImage extraction

## Validation

- `bash -n scripts/ci/fedora-appimage-smoke.sh`
- `actionlint .github/workflows/release-common.yml`
- `git diff --check origin/main..HEAD`

## Notes

The full smoke needs a freshly built Linux AppImage artifact from the release workflow, so local validation is limited to script/workflow syntax.