### PR TITLE
refactor(runtimed): split peer notebook sync handlers

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -45,7 +45,6 @@ use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
 use crate::paths::notebook_doc_filename;
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookResponse};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
-use notebook_doc::diff::diff_metadata_touched;
 use notebook_doc::presence::{self, PresenceState};
 use runtime_doc::RuntimeStateDoc;
 
@@ -55,6 +54,7 @@ mod metadata;
 mod nbformat_convert;
 mod path_index;
 mod peer;
+mod peer_notebook_sync;
 mod peer_pool_sync;
 mod peer_presence;
 mod peer_runtime_sync;

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1,3 +1,7 @@
+use super::peer_notebook_sync::{
+    finish_notebook_doc_frame, forward_notebook_doc_broadcast, handle_notebook_doc_frame,
+    queue_doc_sync, NotebookDocFrameOutcome,
+};
 use super::peer_pool_sync::{
     forward_pool_state_broadcast, handle_pool_state_frame, send_initial_pool_sync,
 };
@@ -11,7 +15,6 @@ use super::peer_runtime_sync::{
 use super::peer_session::{send_initial_notebook_doc_sync, send_session_status, InitialSyncState};
 use super::peer_writer::{
     enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
-    PeerWriter,
 };
 use super::*;
 use runtime_doc::RuntimeLifecycle;
@@ -1291,75 +1294,17 @@ where
                 };
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
-                                // Handle Automerge sync message
-                                let message = sync::Message::decode(&frame.payload)
-                                    .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
-
-                                // Complete all document mutations inside the lock, encode the
-                                // reply, then release the lock before performing async I/O.
-                                let (persist_bytes, reply_encoded, metadata_changed) = {
-                                    let mut doc = room.doc.write().await;
-
-                                    let heads_before = doc.get_heads();
-
-                                    // Guard receive_sync_message against automerge panics
-                                    let recv_result = catch_automerge_panic("doc-receive-sync", || {
-                                        doc.receive_sync_message(&mut peer_state, message)
-                                    });
-                                    match recv_result {
-                                        Ok(Ok(())) => {}
-                                        Ok(Err(e)) => {
-                                            warn!("[notebook-sync] receive_sync_message error: {}", e);
-                                            continue;
-                                        }
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            doc.rebuild_from_save();
-                                            peer_state = sync::State::new();
-                                            continue;
-                                        }
-                                    }
-
-                                    let heads_after = doc.get_heads();
-                                    let metadata_changed = diff_metadata_touched(
-                                        doc.doc_mut(),
-                                        &heads_before,
-                                        &heads_after,
-                                    );
-
-                                    let bytes = doc.save();
-
-                                    // Notify other peers in this room
-                                    let _ = room.broadcasts.changed_tx.send(());
-
-                                    let encoded = match catch_automerge_panic("doc-sync-reply", || {
-                                        doc.generate_sync_message(&mut peer_state)
-                                            .map(|reply| reply.encode())
-                                    }) {
-                                        Ok(encoded) => encoded,
-                                        Err(e) => {
-                                            warn!("{}", e);
-                                            peer_state = sync::State::new();
-                                            if doc.rebuild_from_save() {
-                                                doc.generate_sync_message(&mut peer_state)
-                                                    .map(|reply| reply.encode())
-                                            } else {
-                                                None
-                                            }
-                                        }
-                                    };
-
-                                    (bytes, encoded, metadata_changed)
+                                let notebook_doc_effects = match handle_notebook_doc_frame(
+                                    room,
+                                    &mut peer_state,
+                                    &peer_writer,
+                                    &frame.payload,
+                                )
+                                .await?
+                                {
+                                    NotebookDocFrameOutcome::Applied(effects) => effects,
+                                    NotebookDocFrameOutcome::Skipped => continue,
                                 };
-
-                                // Queue the reply outside the lock so other peers can
-                                // acquire it while the writer task drains the socket.
-                                if let Some(encoded) = reply_encoded {
-                                    peer_writer.send_frame(
-                                        NotebookFrameType::AutomergeSync,
-                                        encoded,
-                                    )?;
-                                }
 
                                 if notebook_doc_phase
                                     != notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
@@ -1376,21 +1321,9 @@ where
                                     }
                                 }
 
-                                // Send to debounced persistence task
-                                if let Some(ref d) = room.persistence.debouncer {
-                                    let _ = d.persist_tx.send(Some(persist_bytes));
-                                }
-
-                                // Check if metadata changed and kernel is running - broadcast sync state
-                                if metadata_changed {
-                                    check_and_broadcast_sync_state(room).await;
-                                }
-
-                                // Re-verify trust from doc metadata (detects trust approval)
-                                check_and_update_trust_state(room).await;
-
-                                // Rebuild markdown asset refs after source sync.
-                                process_markdown_assets(room).await;
+                                // Keep session status queued before these awaits so the sync reply
+                                // and readiness transition remain adjacent on the peer writer.
+                                finish_notebook_doc_frame(room, notebook_doc_effects).await;
                             }
 
                             NotebookFrameType::Request => {
@@ -1465,30 +1398,7 @@ where
 
             // Another peer changed the document — push update to this client
             _ = changed_rx.recv() => {
-                // Encode inside the lock, send outside it to avoid holding the
-                // write lock across async I/O.
-                let encoded = {
-                    let mut doc = room.doc.write().await;
-                    match catch_automerge_panic("doc-broadcast", || {
-                        doc.generate_sync_message(&mut peer_state)
-                            .map(|msg| msg.encode())
-                    }) {
-                        Ok(encoded) => encoded,
-                        Err(e) => {
-                            warn!("{}", e);
-                            peer_state = sync::State::new();
-                            if doc.rebuild_from_save() {
-                                doc.generate_sync_message(&mut peer_state)
-                                    .map(|msg| msg.encode())
-                            } else {
-                                None
-                            }
-                        }
-                    }
-                };
-                if let Some(encoded) = encoded {
-                    peer_writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
-                }
+                forward_notebook_doc_broadcast(room, &mut peer_state, &peer_writer).await?;
 
                 if matches!(
                     initial_load_phase,
@@ -1582,36 +1492,4 @@ where
             }
         }
     }
-}
-
-/// Queue a doc sync message to a peer if there are pending changes.
-///
-/// Generates an Automerge sync message from the room's doc and hands it to the
-/// ordered peer writer. Used before forwarding ExecutionDone (to ensure outputs
-/// are synced) and after broadcast lag recovery.
-async fn queue_doc_sync(
-    room: &NotebookRoom,
-    peer_state: &mut automerge::sync::State,
-    writer: &PeerWriter,
-) -> anyhow::Result<()> {
-    let encoded = {
-        let mut doc = room.doc.write().await;
-        match catch_automerge_panic("broadcast-doc-changes", || {
-            doc.generate_sync_message(peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
-            Err(e) => {
-                warn!("{}", e);
-                doc.rebuild_from_save();
-                *peer_state = sync::State::new();
-                doc.generate_sync_message(peer_state)
-                    .map(|msg| msg.encode())
-            }
-        }
-    };
-    if let Some(encoded) = encoded {
-        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
-    }
-    Ok(())
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -1,0 +1,172 @@
+use automerge::sync;
+use tracing::warn;
+
+use crate::connection::NotebookFrameType;
+
+use super::catch_automerge_panic;
+use super::peer_writer::PeerWriter;
+use super::{
+    check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
+    NotebookRoom,
+};
+use notebook_doc::diff::diff_metadata_touched;
+
+pub(super) async fn handle_notebook_doc_frame(
+    room: &NotebookRoom,
+    peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    payload: &[u8],
+) -> anyhow::Result<NotebookDocFrameOutcome> {
+    let message =
+        sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
+
+    // Complete all document mutations inside the lock, encode the reply, then
+    // release the lock before performing async I/O.
+    let (persist_bytes, reply_encoded, metadata_changed) = {
+        let mut doc = room.doc.write().await;
+
+        let heads_before = doc.get_heads();
+
+        let recv_result = catch_automerge_panic("doc-receive-sync", || {
+            doc.receive_sync_message(peer_state, message)
+        });
+        match recv_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!("[notebook-sync] receive_sync_message error: {}", e);
+                return Ok(NotebookDocFrameOutcome::Skipped);
+            }
+            Err(e) => {
+                warn!("{}", e);
+                doc.rebuild_from_save();
+                *peer_state = sync::State::new();
+                return Ok(NotebookDocFrameOutcome::Skipped);
+            }
+        }
+
+        let heads_after = doc.get_heads();
+        let metadata_changed = diff_metadata_touched(doc.doc_mut(), &heads_before, &heads_after);
+
+        let bytes = doc.save();
+
+        // Notify other peers in this room.
+        let _ = room.broadcasts.changed_tx.send(());
+
+        let encoded = match catch_automerge_panic("doc-sync-reply", || {
+            doc.generate_sync_message(peer_state)
+                .map(|reply| reply.encode())
+        }) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                warn!("{}", e);
+                *peer_state = sync::State::new();
+                if doc.rebuild_from_save() {
+                    doc.generate_sync_message(peer_state)
+                        .map(|reply| reply.encode())
+                } else {
+                    None
+                }
+            }
+        };
+
+        (bytes, encoded, metadata_changed)
+    };
+
+    // Queue the reply outside the lock so other peers can acquire it while the
+    // writer task drains the socket.
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
+    }
+
+    Ok(NotebookDocFrameOutcome::Applied(NotebookDocSideEffects {
+        persist_bytes,
+        metadata_changed,
+    }))
+}
+
+pub(super) enum NotebookDocFrameOutcome {
+    Applied(NotebookDocSideEffects),
+    Skipped,
+}
+
+pub(super) struct NotebookDocSideEffects {
+    persist_bytes: Vec<u8>,
+    metadata_changed: bool,
+}
+
+pub(super) async fn finish_notebook_doc_frame(
+    room: &NotebookRoom,
+    effects: NotebookDocSideEffects,
+) {
+    if let Some(ref d) = room.persistence.debouncer {
+        let _ = d.persist_tx.send(Some(effects.persist_bytes));
+    }
+
+    if effects.metadata_changed {
+        check_and_broadcast_sync_state(room).await;
+    }
+
+    check_and_update_trust_state(room).await;
+    process_markdown_assets(room).await;
+}
+
+pub(super) async fn forward_notebook_doc_broadcast(
+    room: &NotebookRoom,
+    peer_state: &mut sync::State,
+    writer: &PeerWriter,
+) -> anyhow::Result<()> {
+    let encoded = {
+        let mut doc = room.doc.write().await;
+        match catch_automerge_panic("doc-broadcast", || {
+            doc.generate_sync_message(peer_state)
+                .map(|msg| msg.encode())
+        }) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                warn!("{}", e);
+                *peer_state = sync::State::new();
+                if doc.rebuild_from_save() {
+                    doc.generate_sync_message(peer_state)
+                        .map(|msg| msg.encode())
+                } else {
+                    None
+                }
+            }
+        }
+    };
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
+    }
+    Ok(())
+}
+
+/// Queue a doc sync message to a peer if there are pending changes.
+///
+/// Generates an Automerge sync message from the room's doc and hands it to the
+/// ordered peer writer after broadcast lag recovery.
+pub(super) async fn queue_doc_sync(
+    room: &NotebookRoom,
+    peer_state: &mut sync::State,
+    writer: &PeerWriter,
+) -> anyhow::Result<()> {
+    let encoded = {
+        let mut doc = room.doc.write().await;
+        match catch_automerge_panic("broadcast-doc-changes", || {
+            doc.generate_sync_message(peer_state)
+                .map(|msg| msg.encode())
+        }) {
+            Ok(encoded) => encoded,
+            Err(e) => {
+                warn!("{}", e);
+                doc.rebuild_from_save();
+                *peer_state = sync::State::new();
+                doc.generate_sync_message(peer_state)
+                    .map(|msg| msg.encode())
+            }
+        }
+    };
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Move NotebookDoc AutomergeSync receive/reply handling into `peer_notebook_sync.rs`
- Move NotebookDoc broadcast forwarding and lag catch-up sync generation into the same module
- Keep peer.rs responsible for connection loop phase transitions and session status updates

Part of #2340.

## Verification

- `cargo check -p runtimed`
- `cargo clippy -p runtimed --lib -- -D warnings`
- `cargo test -p runtimed peer_writer --lib`
- `cargo xtask lint --fix`