### PR TITLE
fix(build): clean wasm build warnings

### DIFF
--- a/apps/notebook/vite-plugin-raw-lib.ts
+++ b/apps/notebook/vite-plugin-raw-lib.ts
@@ -20,7 +20,11 @@ const SOURCEMAP_JS = /\/\/[#@]\s*sourceMappingURL=\S+/g;
 /** Matches CSS-style sourceMappingURL comments: /*# sourceMappingURL=foo.css.map *​/ */
 const SOURCEMAP_CSS = /\/\*[#@]\s*sourceMappingURL=\S+\s*\*\//g;
 
-const PREFIX = "\0raw-lib:";
+const JS_SUFFIX = ".js";
+// Resolve to a path-shaped ID instead of a virtual/protocol-like ID. The
+// synthetic JS suffix keeps CSS files out of Vite's CSS pipeline, while the
+// query lets Vitest dynamic imports stay inside Vite's loader.
+const QUERY = "?raw-lib";
 
 export function rawLibPlugin(nodeModulesDir: string): Plugin {
   const mapping: Record<string, string> = {
@@ -36,16 +40,13 @@ export function rawLibPlugin(nodeModulesDir: string): Plugin {
     name: "raw-lib",
     resolveId(source) {
       const filePath = mapping[source];
-      // Always resolve with a .js suffix so Vite treats the virtual module
-      // as JavaScript — without this, .css paths get routed through Vite's
-      // CSS pipeline which chokes on the `export default` wrapper.
-      if (filePath) return `${PREFIX}${filePath}.js`;
+      if (filePath) return `${filePath}${JS_SUFFIX}${QUERY}`;
       return null;
     },
     async load(id) {
-      if (!id.startsWith(PREFIX)) return null;
-      // Strip the .js suffix we added in resolveId to recover the real path
-      const filePath = id.slice(PREFIX.length, -".js".length);
+      const suffix = `${JS_SUFFIX}${QUERY}`;
+      if (!id.endsWith(suffix)) return null;
+      const filePath = id.slice(0, -suffix.length);
       let content = await fs.readFile(filePath, "utf-8");
       content = content.replace(SOURCEMAP_JS, "").replace(SOURCEMAP_CSS, "");
       return `export default ${JSON.stringify(content)};`;

--- a/crates/runtimed-wasm/LICENSE
+++ b/crates/runtimed-wasm/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, runtimed
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/sift-wasm/LICENSE
+++ b/crates/sift-wasm/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, runtimed
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1580,6 +1580,8 @@ impl<'a> Cursor<'a> {
 }
 
 fn verify_plugin_against_wasm(plugin_js: &Path, wasm_path: &Path) -> Result<usize, String> {
+    const WASM_URL_SENTINEL: &str = "__wasm_loaded_via_setWasmUrl__";
+
     if !plugin_js.exists() {
         return Err(format!("plugin bundle missing: {}", plugin_js.display()));
     }
@@ -1600,6 +1602,13 @@ fn verify_plugin_against_wasm(plugin_js: &Path, wasm_path: &Path) -> Result<usiz
 
     let bundle = fs::read_to_string(plugin_js)
         .map_err(|e| format!("failed to read {}: {e}", plugin_js.display()))?;
+
+    if !bundle.contains(WASM_URL_SENTINEL) {
+        return Err(format!(
+            "plugin bundle does not contain {WASM_URL_SENTINEL:?}; \
+             exclude-wasm-inline may not have rewritten the wasm-bindgen URL"
+        ));
+    }
 
     let mut missing = Vec::new();
     for name in &imports {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nteract-desktop",
   "private": true,
+  "type": "module",
   "packageManager": "pnpm@10.30.0",
   "scripts": {
     "build": "pnpm --dir apps/notebook build",

--- a/scripts/build-renderer-plugins.ts
+++ b/scripts/build-renderer-plugins.ts
@@ -22,6 +22,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { build } from "vite-plus";
 import {
   buildAllRendererPlugins,
+  RENDERER_ROLLDOWN_CHECKS,
   RENDERER_PLUGINS,
 } from "../src/build/renderer-plugin-builder.ts";
 import { wrapForMcpApp } from "../apps/mcp-app/src/lib/wrap-plugin.js";
@@ -68,6 +69,7 @@ async function buildCoreIIFE(): Promise<{ code: string; css: string }> {
         fileName: () => "isolated-renderer.js",
       },
       rolldownOptions: {
+        checks: RENDERER_ROLLDOWN_CHECKS,
         output: { assetFileNames: "isolated-renderer.[ext]" },
         external: [
           "@tauri-apps/api",

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -48,6 +48,11 @@ function getSrcDir(): string {
 }
 
 const srcDir = getSrcDir();
+export const RENDERER_ROLLDOWN_CHECKS = {
+  // These programmatic artifact builds intentionally bundle CSS-heavy renderer
+  // plugins; Rolldown's relative plugin timing diagnostics are noisy here.
+  pluginTimings: false,
+} as const;
 
 export const RENDERER_PLUGINS: RendererPluginDef[] = [
   { name: "markdown", entry: path.resolve(srcDir, "isolated-renderer/markdown-renderer.tsx") },
@@ -120,14 +125,20 @@ export function extractBuildOutput(result: unknown, label: string): { code: stri
  * dummy string, preventing the inline.
  */
 function excludeWasmInline(): import("vite-plus").Plugin {
+  const wasmGlueId = /sift_wasm/;
   return {
     name: "exclude-wasm-inline",
-    transform(code, id) {
-      if (!id.includes("sift_wasm") || !code.includes("sift_wasm_bg.wasm")) return;
-      return code.replace(
-        /new URL\(['"]sift_wasm_bg\.wasm['"],\s*import\.meta\.url\)/g,
-        `"__wasm_loaded_via_setWasmUrl__"`,
-      );
+    transform: {
+      filter: {
+        id: wasmGlueId,
+      },
+      handler(code) {
+        if (!code.includes("sift_wasm_bg.wasm")) return;
+        return code.replace(
+          /new URL\(['"]sift_wasm_bg\.wasm['"],\s*import\.meta\.url\)/g,
+          `"__wasm_loaded_via_setWasmUrl__"`,
+        );
+      },
     },
   };
 }
@@ -164,6 +175,7 @@ export async function buildRendererPlugin(
         fileName: () => `${pluginName}.js`,
       },
       rolldownOptions: {
+        checks: RENDERER_ROLLDOWN_CHECKS,
         external: ["react", "react/jsx-runtime"],
         output: {
           assetFileNames: `${pluginName}.[ext]`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ["./src/**/*.{ts,tsx}", "./apps/*/src/**/*.{ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- make the root package explicitly ESM and convert the root Tailwind config to ESM so Node no longer reparses the TS renderer build script
- disable Rolldown plugin timing diagnostics for intentional generated renderer artifact builds
- add a hook filter for the sift wasm inline rewrite and crate-local license files for wasm-pack packaging

## Validation
- cargo xtask wasm
- cargo xtask renderer-plugins
- cargo xtask verify-plugins
- cargo xtask lint
