### PR TITLE
docs(linux): document apt.runtimed.com installs

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1414,10 +1414,14 @@ jobs:
           CLI_NAME="runt"
           DAEMON_NAME="runtimed"
           MCP_NAME="nteract-mcp"
+          APT_PACKAGE="nteract"
+          APT_LIST_NAME="nteract"
           if [ "$VERSION_SUFFIX" = "nightly" ]; then
             CLI_NAME="runt-nightly"
             DAEMON_NAME="runtimed-nightly"
             MCP_NAME="nteract-mcp-nightly"
+            APT_PACKAGE="nteract-nightly"
+            APT_LIST_NAME="nteract-nightly"
           fi
           {
             echo "$RELEASE_INTRO"
@@ -1449,13 +1453,13 @@ jobs:
             echo '```bash'
             echo '# Add the nteract signing key'
             echo "curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \\"
-            echo '  | sudo gpg --dearmor -o /usr/share/keyrings/nteract-keyring.gpg'
+            echo '  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg'
             echo ''
             echo '# Add the repository'
             echo "echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com ${VERSION_SUFFIX} main\" \\"
-            echo '  | sudo tee /etc/apt/sources.list.d/nteract.list'
+            echo "  | sudo tee /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
             echo ''
-            echo "sudo apt update && sudo apt install nteract-${VERSION_SUFFIX}"
+            echo "sudo apt update && sudo apt install ${APT_PACKAGE}"
             echo '```'
             echo ''
             echo "## ${CLI_NAME} (CLI)"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Built on [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol
 
 Download the latest release from [GitHub Releases](https://github.com/nteract/desktop/releases).
 
+Linux users on Debian or Ubuntu should prefer the APT repository at
+`https://apt.runtimed.com`; see [Linux install options](docs/linux.md).
+
 The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
 
 The `runt` CLI and `runtimed` Python bindings ship with the app and stay up to date automatically. For nightly builds, use `runt-nightly` instead.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,103 @@
+# Linux Install Options
+
+nteract publishes Linux desktop builds through GitHub Releases and the APT
+repository at `https://apt.runtimed.com`.
+
+## Debian and Ubuntu
+
+Use APT for Debian and Ubuntu systems. Native packages are the recommended
+Linux install path because they integrate with the desktop and the per-user
+`runtimed` systemd service.
+
+### Stable
+
+```bash
+curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
+  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com stable main" \
+  | sudo tee /etc/apt/sources.list.d/nteract.list
+
+sudo apt update
+sudo apt install nteract
+```
+
+### Nightly
+
+Nightly builds install side-by-side with stable builds and use the
+`nteract-nightly`, `runt-nightly`, and `runtimed-nightly` names.
+
+```bash
+curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
+  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com nightly main" \
+  | sudo tee /etc/apt/sources.list.d/nteract-nightly.list
+
+sudo apt update
+sudo apt install nteract-nightly
+```
+
+You can enable both channels by keeping both source-list files.
+
+## Direct Downloads
+
+GitHub Releases include:
+
+- `.deb` packages for direct Debian/Ubuntu installs when you do not want to add
+  the APT repository.
+- AppImage builds for desktop Linux systems outside the Debian/Ubuntu family.
+
+For direct `.deb` installs:
+
+```bash
+sudo apt install ./nteract-stable-linux-x64.deb
+```
+
+For AppImage:
+
+```bash
+chmod +x nteract-stable-linux-x64.AppImage
+./nteract-stable-linux-x64.AppImage
+```
+
+The AppImage is a portable fallback. It can run the app and bootstrap the
+daemon, but persistent CLI installation from the temporary AppImage mount is
+intentionally skipped. Use the APT or `.deb` package when you want the `runt`
+CLI and system service to stay integrated across upgrades.
+
+## Headless Runtime Installs
+
+For headless Linux machines that need only the runtime stack, use the release
+installer script with GitHub release artifacts from a checkout of this
+repository:
+
+```bash
+./scripts/install-nightly-release --tag v2.3.5-nightly.YYYYMMDDHHMM
+```
+
+For source-built nightly installs on Linux development machines:
+
+```bash
+./scripts/install-nightly
+```
+
+Both scripts install channel-specific `runt`, `runtimed`, and `nteract-mcp`
+binaries under `~/.local/share/` and configure a user-level systemd service.
+
+## Troubleshooting
+
+Check the daemon state:
+
+```bash
+runt daemon doctor --json
+```
+
+For nightly builds:
+
+```bash
+runt-nightly daemon doctor --json
+```
+
+Daemon logs live under `~/.cache/runt/` for stable and
+`~/.cache/runt-nightly/` for nightly.

--- a/scripts/apt/README.md
+++ b/scripts/apt/README.md
@@ -1,6 +1,8 @@
 # APT Repository Publisher
 
-Publishes nteract `.deb` packages to a Cloudflare R2-backed APT repository at `apt.nteract.io`. Supports `nightly` and `stable` channels in the same bucket using standard Debian repository layout.
+Publishes nteract `.deb` packages to the Cloudflare R2-backed APT repository at
+`https://apt.runtimed.com`. Supports `nightly` and `stable` channels in the
+same bucket using standard Debian repository layout.
 
 ## Files
 
@@ -74,7 +76,7 @@ AWS_ACCESS_KEY_ID=your-r2-access-key-id
 AWS_SECRET_ACCESS_KEY=your-r2-secret-access-key
 AWS_DEFAULT_REGION=auto
 R2_BUCKET_NAME=your-bucket-name
-R2_PUBLIC_URL=https://apt.nteract.io
+R2_PUBLIC_URL=https://apt.runtimed.com
 GPG_KEY_ID=YOUR_FINGERPRINT
 GPG_PRIVATE_KEY=<output of the base64 export command above>
 ```
@@ -142,12 +144,40 @@ apt install nteract
 
 Note: the app requires a display (GTK) and will crash with a GTK error if you try to run it inside the container — that's expected. A clean `apt install` with no errors is sufficient to confirm the repository is working.
 
+## User install commands
+
+Stable:
+
+```bash
+curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
+  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com stable main" \
+  | sudo tee /etc/apt/sources.list.d/nteract.list
+
+sudo apt update
+sudo apt install nteract
+```
+
+Nightly:
+
+```bash
+curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
+  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com nightly main" \
+  | sudo tee /etc/apt/sources.list.d/nteract-nightly.list
+
+sudo apt update
+sudo apt install nteract-nightly
+```
+
 ---
 
 ## Repository layout in R2
 
 ```
-bucket root  (https://apt.nteract.io)
+bucket root  (https://apt.runtimed.com)
 │
 ├── nteract-keyring.gpg
 │
@@ -168,4 +198,3 @@ bucket root  (https://apt.nteract.io)
     └── stable/
         └── ...
 ```
-

--- a/scripts/apt/publish-apt.sh
+++ b/scripts/apt/publish-apt.sh
@@ -129,6 +129,13 @@ if [[ -z "$VERSION" ]]; then
 fi
 echo "    Version: $VERSION"
 
+INSTALL_PACKAGE="nteract"
+APT_LIST_NAME="nteract"
+if [[ "$CHANNEL" == "nightly" ]]; then
+  INSTALL_PACKAGE="nteract-nightly"
+  APT_LIST_NAME="nteract-nightly"
+fi
+
 # ---------------------------------------------------------------------------
 # Step 4: Derive the versioned pool filename
 # ---------------------------------------------------------------------------
@@ -341,15 +348,15 @@ fi
 # Step 19: Print user setup instructions
 # ---------------------------------------------------------------------------
 echo ""
-echo "Done! Published nteract-${CHANNEL} ${VERSION}"
+echo "Done! Published ${INSTALL_PACKAGE} ${VERSION}"
 echo ""
 echo "Users can install with:"
 echo ""
 echo "  curl -fsSL ${R2_PUBLIC_URL}/nteract-keyring.gpg \\"
-echo "    | sudo gpg --dearmor -o /usr/share/keyrings/nteract-keyring.gpg"
+echo "    | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg"
 echo ""
 echo "  echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] \\"
 echo "    ${R2_PUBLIC_URL} ${CHANNEL} main\" \\"
-echo "    | sudo tee /etc/apt/sources.list.d/nteract.list"
+echo "    | sudo tee /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
 echo ""
-echo "  sudo apt update && sudo apt install nteract-${CHANNEL}"
+echo "  sudo apt update && sudo apt install ${INSTALL_PACKAGE}"


### PR DESCRIPTION
## Summary

- adds a user-facing Linux install guide for stable/nightly APT, direct DEB/AppImage downloads, headless runtime installs, and daemon troubleshooting
- updates the APT publisher docs from apt.nteract.io to apt.runtimed.com and includes stable/nightly user install commands
- fixes generated release-note and publisher output so stable installs use the real `nteract` package while nightly uses `nteract-nightly`

Part of #2361.

## Validation

- `curl -fsSL https://apt.runtimed.com/dists/stable/Release`
- `curl -fsSL https://apt.runtimed.com/dists/nightly/Release`
- verified stable Packages exposes `Package: nteract` and nightly exposes `Package: nteract-nightly`
- `actionlint .github/workflows/release-common.yml`
- `bash -n scripts/apt/publish-apt.sh`
- `git diff --check`
- `cargo xtask lint --fix`
- Claude Bedrock reviewer: `global.anthropic.claude-opus-4-6-v1`, final pass found no actionable correctness issues
