### PR TITLE
fix(runtimed): keep cell outputs across save during run

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -246,6 +246,10 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 }
                             }
                             if state_changed {
+                                // Output / execution-count / terminal-status
+                                // changes from the kernel arrive here; signal
+                                // autosave to flush them to the .ipynb.
+                                let _ = room.broadcasts.notebook_file_dirty_tx.send(());
                                 persist_terminal_execution_records(
                                     &room,
                                     &execution_store,

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -23,7 +23,7 @@ pub(super) async fn handle_runtime_state_frame(
     let message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
 
-    let reply_encoded: Option<Option<Vec<u8>>> = room
+    let result: Option<(Option<Vec<u8>>, bool)> = room
         .state
         .with_doc(|state_doc| {
             let recv_result = catch_automerge_panic("state-receive-sync", || {
@@ -43,25 +43,28 @@ pub(super) async fn handle_runtime_state_frame(
                 }
             };
 
-            // If the client sent changes, notification is automatic via the
-            // heads comparison in RuntimeStateDoc::with_doc.
-            let _ = had_changes;
-
-            Ok(Some(generate_runtime_state_sync_message(
+            let reply = generate_runtime_state_sync_message(
                 state_doc,
                 state_peer_state,
                 "state-sync-reply",
-            )))
+            );
+            Ok(Some((reply, had_changes)))
         })
         .ok()
         .flatten();
 
-    let reply_encoded = match reply_encoded {
-        Some(encoded) => encoded,
+    let (reply_encoded, had_changes) = match result {
+        Some(pair) => pair,
         None => return Ok(false),
     };
     if let Some(encoded) = reply_encoded {
         writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
+    }
+
+    if had_changes {
+        // Save-relevant state arrived from a peer (kernel agent forwarding
+        // outputs, or another notebook client). Wake the autosave debouncer.
+        let _ = room.broadcasts.notebook_file_dirty_tx.send(());
     }
 
     persist_terminal_execution_records(room, store, persisted_records).await;

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -96,23 +96,32 @@ pub(crate) async fn save_notebook_to_disk(
     };
 
     // Read outputs and execution_count from RuntimeStateDoc keyed by execution_id.
+    //
+    // When a cell is re-queued, `set_execution_id` rewrites the cell's pointer
+    // to the new execution before the kernel produces outputs. Saving with the
+    // queued/running eid would clobber the previous outputs with an empty list.
+    // Fall back to the most recent terminal execution for the cell so an
+    // explicit Cmd+S during a run (or a racing autosave) preserves what's on
+    // disk until the live run completes. Cleared cells (`execution_id = None`)
+    // skip the fall-back and write empty outputs.
     let (cell_outputs, cell_execution_counts): (
         HashMap<String, Vec<serde_json::Value>>,
         HashMap<String, Option<i64>>,
     ) = room
         .state
         .read(|sd| {
+            let snapshot = sd.read_state();
             let mut outputs_map = HashMap::new();
             let mut ec_map = HashMap::new();
             for (cell_id, eid) in &cell_execution_ids {
-                if let Some(eid) = eid.as_ref() {
-                    let outputs = sd.get_outputs(eid);
-                    if !outputs.is_empty() {
-                        outputs_map.insert(cell_id.clone(), outputs);
-                    }
-                    if let Some(exec) = sd.get_execution(eid) {
-                        ec_map.insert(cell_id.clone(), exec.execution_count);
-                    }
+                let Some(eid) = eid.as_ref() else { continue };
+                let resolved_eid = resolve_save_execution_id(&snapshot, cell_id, eid);
+                let outputs = sd.get_outputs(&resolved_eid);
+                if !outputs.is_empty() {
+                    outputs_map.insert(cell_id.clone(), outputs);
+                }
+                if let Some(exec) = snapshot.executions.get(&resolved_eid) {
+                    ec_map.insert(cell_id.clone(), exec.execution_count);
                 }
             }
             (outputs_map, ec_map)
@@ -378,6 +387,40 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     );
 }
 
+/// Pick which execution_id save should read outputs from.
+///
+/// If the cell's current execution is queued or running with no outputs yet,
+/// fall back to the most recent done/error execution for the same cell. The
+/// fall-back applies only when the in-flight execution would yield empty
+/// outputs; once any output lands at the new id we use it (partial-but-live
+/// is preferred over stale-but-complete the moment the kernel speaks).
+fn resolve_save_execution_id(
+    snapshot: &runtime_doc::RuntimeState,
+    cell_id: &str,
+    current_eid: &str,
+) -> String {
+    let current = snapshot.executions.get(current_eid);
+    let in_flight_with_no_outputs = current
+        .map(|exec| {
+            (exec.status == "queued" || exec.status == "running") && exec.outputs.is_empty()
+        })
+        .unwrap_or(false);
+    if !in_flight_with_no_outputs {
+        return current_eid.to_string();
+    }
+    snapshot
+        .executions
+        .iter()
+        .filter(|(eid, exec)| {
+            eid.as_str() != current_eid
+                && exec.cell_id == cell_id
+                && (exec.status == "done" || exec.status == "error")
+        })
+        .max_by_key(|(_, exec)| exec.seq.unwrap_or(0))
+        .map(|(eid, _)| eid.clone())
+        .unwrap_or_else(|| current_eid.to_string())
+}
+
 /// Resolve a single cell output — handles both manifest hashes and raw JSON.
 async fn resolve_cell_output(
     output: &serde_json::Value,
@@ -614,6 +657,12 @@ impl Default for AutosaveDebouncerConfig {
 /// Spawn a debounced autosave task that writes the `.ipynb` file to disk
 /// whenever the Automerge document changes. Only for saved (non-untitled)
 /// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
+///
+/// Subscribes to both `room.broadcasts.changed_tx` (NotebookDoc edits) and
+/// `room.state.subscribe()` (RuntimeStateDoc edits) so output arrivals from
+/// the kernel drive a re-save. Without the state subscription, outputs that
+/// land after the cell's NotebookDoc edit window would never reach disk and
+/// the .ipynb would carry stale `outputs: []` for the lifetime of the room.
 pub(crate) fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
     spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default());
 }
@@ -625,6 +674,7 @@ fn spawn_autosave_debouncer_with_config(
     config: AutosaveDebouncerConfig,
 ) {
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+    let mut state_changed_rx = room.state.subscribe();
     spawn_supervised(
         "autosave-debouncer",
         async move {
@@ -667,6 +717,22 @@ fn spawn_autosave_debouncer_with_config(
                                 // Missed some updates, treat as a change
                                 debug!("[autosave] Lagged {} messages", n);
                                 last_receive = Some(Instant::now());
+                            }
+                        }
+                    }
+                    state_result = state_changed_rx.recv() => {
+                        match state_result {
+                            Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                                last_receive = Some(Instant::now());
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                // RuntimeStateHandle dropped before the room.
+                                // Stop watching state but keep serving NotebookDoc
+                                // edits via changed_rx. Replace the receiver with
+                                // a never-ready one so the select! arm still
+                                // compiles but never fires.
+                                let (_tx, rx) = broadcast::channel(1);
+                                state_changed_rx = rx;
                             }
                         }
                     }

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -658,11 +658,13 @@ impl Default for AutosaveDebouncerConfig {
 /// whenever the Automerge document changes. Only for saved (non-untitled)
 /// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
 ///
-/// Subscribes to both `room.broadcasts.changed_tx` (NotebookDoc edits) and
-/// `room.state.subscribe()` (RuntimeStateDoc edits) so output arrivals from
-/// the kernel drive a re-save. Without the state subscription, outputs that
-/// land after the cell's NotebookDoc edit window would never reach disk and
-/// the .ipynb would carry stale `outputs: []` for the lifetime of the room.
+/// Subscribes to two narrow signals: `room.broadcasts.changed_tx` for
+/// NotebookDoc edits, and `room.broadcasts.notebook_file_dirty_tx` for
+/// RuntimeStateDoc mutations that affect serialized .ipynb bytes (kernel
+/// outputs, execution counts, terminal status flips). The full state
+/// notifier on `RuntimeStateHandle` is intentionally NOT subscribed: it
+/// fires on every heads change including `last_saved`, which the autosave
+/// itself writes after each successful flush.
 pub(crate) fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
     spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default());
 }
@@ -674,7 +676,7 @@ fn spawn_autosave_debouncer_with_config(
     config: AutosaveDebouncerConfig,
 ) {
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
-    let mut state_changed_rx = room.state.subscribe();
+    let mut file_dirty_rx = room.broadcasts.notebook_file_dirty_tx.subscribe();
     spawn_supervised(
         "autosave-debouncer",
         async move {
@@ -720,19 +722,17 @@ fn spawn_autosave_debouncer_with_config(
                             }
                         }
                     }
-                    state_result = state_changed_rx.recv() => {
-                        match state_result {
+                    file_dirty_result = file_dirty_rx.recv() => {
+                        match file_dirty_result {
                             Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
                                 last_receive = Some(Instant::now());
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                // RuntimeStateHandle dropped before the room.
-                                // Stop watching state but keep serving NotebookDoc
-                                // edits via changed_rx. Replace the receiver with
-                                // a never-ready one so the select! arm still
-                                // compiles but never fires.
+                                // Sender side dropped before the room. Swap in a
+                                // never-ready receiver so select! still compiles
+                                // and we keep serving NotebookDoc edits.
                                 let (_tx, rx) = broadcast::channel(1);
-                                state_changed_rx = rx;
+                                file_dirty_rx = rx;
                             }
                         }
                     }
@@ -764,14 +764,24 @@ fn spawn_autosave_debouncer_with_config(
                                     // Check if changes arrived during the save. If so,
                                     // keep last_receive set so we flush again soon —
                                     // don't stamp last_saved while the file is stale.
-                                    let changed_during_save =
-                                        matches!(changed_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
-                                    if changed_during_save {
+                                    let notebook_changed = matches!(
+                                        changed_rx.try_recv(),
+                                        Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_))
+                                    );
+                                    let file_dirty = matches!(
+                                        file_dirty_rx.try_recv(),
+                                        Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_))
+                                    );
+                                    if notebook_changed || file_dirty {
                                         last_receive = Some(Instant::now());
                                     } else {
                                         last_receive = None;
                                         // Stamp last_saved on the runtime-state doc.
                                         // Frontends compute dirty = local_edit_at > last_saved.
+                                        // Safe to write here without echoing back into
+                                        // autosave: this listener watches
+                                        // `notebook_file_dirty_tx`, not the full state
+                                        // notifier, so set_last_saved doesn't re-arm us.
                                         let now = chrono::Utc::now().to_rfc3339();
                                         if let Err(e) = room.state.with_doc(|sd| {
                                             sd.set_last_saved(Some(&now))

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -34,13 +34,21 @@ impl RoomIdentity {
 
 /// Per-room broadcast fan-out.
 ///
-/// Groups the four channels that distribute room-scoped events to peer sync
-/// loops: document-change notifications, kernel broadcasts (EnvProgress,
-/// Comm), and presence traffic. `presence`
-/// holds the per-peer state that `presence_tx` relays between connections.
+/// Groups the channels that distribute room-scoped events to peer sync loops:
+/// document-change notifications, save-relevant runtime-state changes, kernel
+/// broadcasts (EnvProgress, Comm), and presence traffic. `presence` holds the
+/// per-peer state that `presence_tx` relays between connections.
 pub struct RoomBroadcasts {
     /// Broadcast channel to notify all peers in this room of doc changes.
     pub changed_tx: broadcast::Sender<()>,
+    /// Broadcast channel signaling that a runtime-state mutation could change
+    /// the serialized .ipynb bytes (kernel outputs, execution counts, terminal
+    /// status flips). The autosave debouncer listens here. `state_changed_tx`
+    /// (on `RuntimeStateHandle`) fires on any heads change including
+    /// `last_saved`, kernel lifecycle, and project context — those are
+    /// peer-sync concerns, not save concerns. Keeping the two signals
+    /// separate prevents an autosave -> set_last_saved -> autosave loop.
+    pub notebook_file_dirty_tx: broadcast::Sender<()>,
     /// Broadcast channel for kernel events: EnvProgress and Comm (widget messages).
     pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     /// Broadcast channel for presence frames (cursor, selection, kernel state).
@@ -54,10 +62,12 @@ pub struct RoomBroadcasts {
 impl Default for RoomBroadcasts {
     fn default() -> Self {
         let (changed_tx, _) = broadcast::channel(16);
+        let (notebook_file_dirty_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (presence_tx, _) = broadcast::channel(64);
         Self {
             changed_tx,
+            notebook_file_dirty_tx,
             kernel_broadcast_tx,
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7088,10 +7088,10 @@ async fn test_save_writes_empty_outputs_when_cell_execution_id_cleared() {
     );
 }
 
-/// `RuntimeStateDoc` mutations (output arrivals) must wake the autosave
-/// debouncer. Otherwise, when iopub flushes outputs after the
-/// autosave-trigger window has expired, the .ipynb is never updated to
-/// reflect them and disappears in the cell list at restart.
+/// Save-relevant runtime-state changes (output arrivals) must wake the
+/// autosave debouncer via `notebook_file_dirty_tx`. Otherwise, when iopub
+/// flushes outputs after the cell's NotebookDoc edit window has expired,
+/// the .ipynb is never updated and the user sees `outputs: []` on disk.
 #[tokio::test(start_paused = true)]
 async fn test_autosave_fires_on_runtime_state_change() {
     use std::time::Duration;
@@ -7146,6 +7146,9 @@ async fn test_autosave_fires_on_runtime_state_change() {
     );
 
     // Output arrives in RuntimeStateDoc only - no NotebookDoc change.
+    // The peer.rs RuntimeStateSync handler is what fires this signal in
+    // production when the runtime agent forwards outputs; we fire it
+    // directly here since the test bypasses the peer-sync machinery.
     room.state
         .with_doc(|sd| {
             let output = serde_json::json!({
@@ -7159,6 +7162,7 @@ async fn test_autosave_fires_on_runtime_state_change() {
             Ok(())
         })
         .unwrap();
+    let _ = room.broadcasts.notebook_file_dirty_tx.send(());
 
     // Poll for autosave to flush. Each sleep advances the paused clock so
     // the 2s debounce + 500ms check interval can elapse.
@@ -7179,4 +7183,113 @@ async fn test_autosave_fires_on_runtime_state_change() {
             serde_json::to_string_pretty(&nb).unwrap()
         );
     }
+}
+
+/// `set_last_saved` is a runtime-state mutation, but the autosave's own
+/// stamp must not feed back into the autosave subscription. The narrow
+/// `notebook_file_dirty_tx` signal stays silent on metadata writes like
+/// `last_saved`, so a single output arrival should produce exactly one
+/// flush, not an indefinite save-stamp-save loop.
+#[tokio::test(start_paused = true)]
+async fn test_autosave_does_not_self_trigger_after_state_save() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let uuid = Uuid::new_v4();
+    let room = Arc::new(NotebookRoom::new_fresh(
+        uuid, None, &docs_dir, blob_store, false,
+    ));
+
+    let eid = "exec-1";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hi')").unwrap();
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution_with_source(eid, "cell1", "print('hi')", 1)?;
+            Ok(())
+        })
+        .unwrap();
+
+    let save_path = tmp.path().join("loop.ipynb");
+    let written = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let canonical = tokio::fs::canonicalize(&written)
+        .await
+        .unwrap_or_else(|_| PathBuf::from(&written));
+    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    try_claim_path(&path_index, &canonical, room.id)
+        .await
+        .expect("path claim should succeed");
+    finalize_untitled_promotion(&room, canonical.clone()).await;
+
+    // One real state mutation: kernel produces an output.
+    room.state
+        .with_doc(|sd| {
+            sd.append_output(
+                eid,
+                &serde_json::json!({
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": ["hi\n"]
+                }),
+            )?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+    let _ = room.broadcasts.notebook_file_dirty_tx.send(());
+
+    // Wait for autosave to flush the output and stamp `last_saved`.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+        let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+        if nb["cells"][0]["outputs"]
+            .as_array()
+            .map(|o| !o.is_empty())
+            .unwrap_or(false)
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "autosave never flushed the output"
+        );
+    }
+
+    // Snapshot the `last_saved` stamp the autosave just wrote.
+    let stamp_after_first_save = room
+        .state
+        .read(|sd| sd.read_state().last_saved.clone())
+        .unwrap();
+    assert!(
+        stamp_after_first_save.is_some(),
+        "autosave should stamp last_saved after a successful flush"
+    );
+
+    // Idle for several debounce windows. If `set_last_saved` is feeding back
+    // into the autosave subscription, the stamp will keep ticking forward
+    // even with no real mutations. It must stay frozen.
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    let stamp_after_idle = room
+        .state
+        .read(|sd| sd.read_state().last_saved.clone())
+        .unwrap();
+    assert_eq!(
+        stamp_after_idle, stamp_after_first_save,
+        "autosave self-triggered: last_saved advanced without any real state change",
+    );
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6970,3 +6970,213 @@ async fn reset_starting_state_error_variant_writes_details() {
     // but present so readers can skip typed-reason branches cleanly.
     assert_eq!(state.kernel.error_reason.as_deref(), Some(""));
 }
+
+// ── Regression tests for #2351: outputs not serialized to notebook ───
+
+/// When a cell is re-queued for execution, `set_execution_id` rewrites the
+/// cell's pointer to the NEW execution_id before the kernel produces any
+/// outputs. If save fires in this window, the previous outputs must NOT
+/// be clobbered with empty `[]`. Save falls back to the most recent
+/// terminal (done/error) execution for the cell.
+#[tokio::test]
+async fn test_save_preserves_outputs_when_execution_in_flight() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "in_flight.ipynb");
+
+    let old_eid = "exec-old-done";
+    let new_eid = "exec-new-queued";
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hello')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hello\n"]
+            });
+            sd.create_execution_with_source(old_eid, "cell1", "print('hello')", 1)?;
+            sd.set_outputs(old_eid, &[output])?;
+            sd.set_execution_count(old_eid, 1)?;
+            sd.set_execution_done(old_eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(old_eid)).unwrap();
+    }
+
+    // Simulate `queue_cell_if_current`: rewrite cell.execution_id to a new
+    // queued execution that has not produced outputs yet.
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution_with_source(new_eid, "cell1", "print('hello')", 2)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(new_eid)).unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let cell = &nb["cells"][0];
+    let outputs = cell["outputs"].as_array().expect("outputs array");
+    assert_eq!(
+        outputs.len(),
+        1,
+        "previous outputs must be preserved during in-flight execution; got: {}",
+        serde_json::to_string_pretty(cell).unwrap()
+    );
+    assert_eq!(outputs[0]["name"], "stdout");
+    assert_eq!(
+        cell["execution_count"], 1,
+        "previous execution_count preserved when current execution has no count yet"
+    );
+}
+
+/// When a cell's `execution_id` is `None` (cleared via ClearOutputs), save
+/// must write empty outputs. The clear is intentional - we don't fall back
+/// to historical executions.
+#[tokio::test]
+async fn test_save_writes_empty_outputs_when_cell_execution_id_cleared() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "cleared.ipynb");
+
+    let eid = "exec-done";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hello')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hello\n"]
+            });
+            sd.create_execution_with_source(eid, "cell1", "print('hello')", 1)?;
+            sd.set_outputs(eid, &[output])?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+        doc.set_execution_id("cell1", None).unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let outputs = nb["cells"][0]["outputs"].as_array().expect("outputs array");
+    assert!(
+        outputs.is_empty(),
+        "cleared cell must have empty outputs; got: {}",
+        serde_json::to_string_pretty(&nb["cells"][0]).unwrap()
+    );
+}
+
+/// `RuntimeStateDoc` mutations (output arrivals) must wake the autosave
+/// debouncer. Otherwise, when iopub flushes outputs after the
+/// autosave-trigger window has expired, the .ipynb is never updated to
+/// reflect them and disappears in the cell list at restart.
+#[tokio::test(start_paused = true)]
+async fn test_autosave_fires_on_runtime_state_change() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let uuid = Uuid::new_v4();
+    let room = Arc::new(NotebookRoom::new_fresh(
+        uuid, None, &docs_dir, blob_store, false,
+    ));
+
+    let eid = "exec-1";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hi')").unwrap();
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution_with_source(eid, "cell1", "print('hi')", 1)?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Promote to file-backed; this spawns the autosave debouncer.
+    let save_path = tmp.path().join("auto.ipynb");
+    let written = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let canonical = tokio::fs::canonicalize(&written)
+        .await
+        .unwrap_or_else(|_| PathBuf::from(&written));
+    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    try_claim_path(&path_index, &canonical, room.id)
+        .await
+        .expect("path claim should succeed");
+    finalize_untitled_promotion(&room, canonical.clone()).await;
+
+    // Initial file: cell with no outputs (execution still queued, no fall-back).
+    let initial = tokio::fs::read_to_string(&save_path).await.unwrap();
+    let initial_nb: serde_json::Value = serde_json::from_str(&initial).unwrap();
+    assert!(
+        initial_nb["cells"][0]["outputs"]
+            .as_array()
+            .map(|o| o.is_empty())
+            .unwrap_or(true),
+        "baseline file must start with empty outputs"
+    );
+
+    // Output arrives in RuntimeStateDoc only - no NotebookDoc change.
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hi\n"]
+            });
+            sd.append_output(eid, &output)?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Poll for autosave to flush. Each sleep advances the paused clock so
+    // the 2s debounce + 500ms check interval can elapse.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+        let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+        if let Some(outputs) = nb["cells"][0]["outputs"].as_array() {
+            if !outputs.is_empty() {
+                assert_eq!(outputs[0]["name"], "stdout");
+                break;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for autosave to flush state-change outputs; got: {}",
+            serde_json::to_string_pretty(&nb).unwrap()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2351.

## Diagnosis

Lined up the saved `tldr.ipynb` (4 code cells, `execution_count` 2/5/6/5, every cell `outputs: []`) against the runtimed log:

```
21:03:46 Enqueuing RunAllCells
21:03:46 Queuing cell ... execution_id=d5dfe6aa-...   (×4)
21:03:46 [save] save_notebook_to_disk entered
21:03:46 [notebook-sync] Saved notebook to disk ... (4 cells)
```

Autosave fired in the same tick the cells got queued, before any output landed.

`save_notebook_to_disk` reads outputs from `RuntimeStateDoc` keyed by the cell's current `execution_id`. `requests/execute_cell.rs::queue_cell_if_current` rewrites that pointer at queue time. Old outputs sit at `executions[OLD_EID]`; the cell now points at `NEW_EID` where `get_outputs` returns `[]` until iopub flushes. With "Run All" every cell flips simultaneously, which matches the all-empty shape on disk.

The recovery path was also broken: outputs land in `RuntimeStateDoc`, which notifies via `room.state.subscribe()`, not `room.broadcasts.changed_tx`. The autosave debouncer only subscribed to `changed_tx`, so it never woke up to re-save once outputs landed. The .ipynb stays at the empty snapshot until the next NotebookDoc edit.

## Fix

Three parts so an explicit Cmd+S during a run is also safe and the autosave can't self-trigger:

1. **`save_notebook_to_disk` falls back to the previous terminal execution.** New `resolve_save_execution_id` helper: if the cell's current eid is `queued`/`running` with no outputs yet, save reads from the most recent done/error execution for the same cell. Once any output lands at the new id, it wins. Cleared cells (`execution_id = None`) skip the fall-back and still write empty outputs.
2. **Narrow `notebook_file_dirty_tx` signal on `RoomBroadcasts`.** The two `RuntimeStateSync` handlers (`peer.rs` for the runtime agent, `peer_runtime_sync.rs` for notebook clients) fire it whenever a sync message brings real changes - the path kernel outputs travel. Daemon-internal metadata writes (`set_last_saved`, kernel lifecycle, env progress) bypass this signal because they don't go through `receive_sync_message_with_changes`.
3. **Autosave subscribes to `changed_tx` plus the narrow signal.** No more "every state mutation is a save candidate." The autosave's own post-flush `set_last_saved` no longer feeds back into its own subscription, so the previous design's self-trigger loop is closed by construction rather than by draining.

The maintainer-friendly contract: autosave wakes on changes that can alter serialized `.ipynb` bytes.

## Behavioral coverage

| Scenario | Before | After |
|----------|--------|-------|
| Re-run cell, save during queue/run window | `outputs: []` written | Previous outputs preserved |
| Cell finishes, no NotebookDoc edit since, autosave window expired | File never updates | Autosave wakes via `notebook_file_dirty_tx`, writes outputs |
| `ClearOutputs` + save | `outputs: []` written | `outputs: []` written (unchanged) |
| Cell finishes, save | Live outputs written | Live outputs written (unchanged) |
| Idle after save (no new outputs) | Idle | Idle (no self-trigger loop) |

## Test plan

- [x] `test_save_preserves_outputs_when_execution_in_flight` covers the in-flight save case
- [x] `test_save_writes_empty_outputs_when_cell_execution_id_cleared` guards the fall-back from over-firing on cleared cells
- [x] `test_autosave_fires_on_runtime_state_change` covers the wakeup-on-state path via the narrow signal
- [x] `test_autosave_does_not_self_trigger_after_state_save` snapshots `last_saved` after one flush, idles 15 debounce windows, asserts the stamp didn't advance
- [x] `cargo test -p runtimed --lib notebook_sync_server` – 237 passed
- [x] `cargo test -p runtime-doc --lib` – 158 passed
- [x] `cargo xtask lint --fix` and `cargo xtask clippy` clean
- [x] End-to-end repro via `nteract-dev`: create notebook, run cell, save, confirm outputs land in .ipynb
