### PR TITLE
fix(e2e): bound sync flush before deno execution

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -842,7 +842,10 @@ function AppContent() {
     // Reset any previous error state before attempting
     envProgress.reset();
 
-    await flushSync();
+    if (!(await flushSync())) {
+      logger.warn("[App] handleSyncDeps: source sync failed, skipping");
+      return false;
+    }
     const blockedAction = captureSyncTrustAction();
 
     // Check trust first - required before any package installation (hot-sync or restart)
@@ -884,7 +887,10 @@ function AppContent() {
     runAllInFlightRef.current = true;
     try {
       // Flush pending source sync so daemon has latest code
-      await flushSync();
+      if (!(await flushSync())) {
+        logger.warn("[App] restartAndRunAll: source sync failed, skipping");
+        return;
+      }
 
       // Shutdown existing kernel
       await shutdownKernel();
@@ -1126,7 +1132,10 @@ function AppContent() {
         // Flush pending source sync so daemon has latest code before executing.
         // flushAndWait() guarantees any in-flight debounced flush has landed,
         // then sends remaining changes and awaits delivery.
-        await flushSync();
+        if (!(await flushSync())) {
+          logger.warn("[App] handleExecuteCell: source sync failed, skipping");
+          return;
+        }
 
         // No explicit ClearOutputs IPC needed — the daemon clears outputs
         // on execute_input and the SyncEngine injects a clear changeset
@@ -1217,7 +1226,10 @@ function AppContent() {
     runAllInFlightRef.current = true;
     try {
       // Flush pending source sync so daemon has latest code
-      await flushSync();
+      if (!(await flushSync())) {
+        logger.warn("[App] handleRunAllCells: source sync failed, skipping");
+        return;
+      }
 
       // Start kernel via daemon if not running or awaiting trust
       if (
@@ -1793,6 +1805,7 @@ function AppContent() {
             isLoading={isLoading}
             loadError={loadError}
             runtime={runtime}
+            sessionRuntimeState={sessionStatus?.runtime_state ?? null}
             onFocusCell={setFocusedCellId}
             onExecuteCell={handleExecuteCell}
             onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -39,6 +39,7 @@ interface NotebookViewProps {
   isLoading?: boolean;
   loadError?: string | null;
   runtime?: Runtime | null;
+  sessionRuntimeState?: string | null;
   onFocusCell: (cellId: string) => void;
   onExecuteCell: (cellId: string) => void;
   onInterruptKernel: () => void;
@@ -345,6 +346,7 @@ function NotebookViewContent({
   isLoading = false,
   loadError = null,
   runtime = "python",
+  sessionRuntimeState = null,
   onFocusCell,
   onExecuteCell,
   onInterruptKernel,
@@ -757,6 +759,8 @@ function NotebookViewContent({
       className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
       style={{ contain: "paint", overflowAnchor: "none" }}
       data-notebook-synced={!isLoading && cellIds.length > 0}
+      data-session-runtime-state={sessionRuntimeState ?? "unknown"}
+      data-session-ready={sessionRuntimeState === "ready"}
       data-cell-count={cellIds.length}
     >
       {loadError ? (

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -611,9 +611,9 @@ export function useAutomergeNotebook() {
     const engine = engineRef.current;
     if (!engine) {
       logger.debug("[flushSync] skipped: no engine");
-      return;
+      return true;
     }
-    await engine.flushAndWait();
+    return await engine.flushAndWait();
   }, []);
 
   // ── File operations ────────────────────────────────────────────────

--- a/apps/notebook/src/lib/notebook-file-ops.ts
+++ b/apps/notebook/src/lib/notebook-file-ops.ts
@@ -32,11 +32,12 @@ const IPYNB_FILTER = { name: "Jupyter Notebook", extensions: ["ipynb"] };
  */
 export async function saveNotebook(
   host: NotebookHost,
-  flushSync: () => Promise<void>,
+  flushSync: () => Promise<boolean | void>,
   hasPath: boolean,
 ): Promise<boolean> {
   try {
-    await flushSync();
+    const flushed = await flushSync();
+    if (flushed === false) return false;
 
     if (hasPath) {
       const client = new NotebookClient({ transport: host.transport });

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2642,9 +2642,11 @@ async fn send_frame_bytes(
         return Err("Empty frame".to_string());
     }
 
-    let notebook_sync = notebook_sync_for_window(window, registry.inner())?;
-    let guard = notebook_sync.lock().await;
-    let handle = guard.as_ref().ok_or("Not connected to daemon")?;
+    let handle = {
+        let notebook_sync = notebook_sync_for_window(window, registry.inner())?;
+        let guard = notebook_sync.lock().await;
+        guard.as_ref().cloned().ok_or("Not connected to daemon")?
+    };
 
     use notebook_doc::frame_types;
 

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -57,6 +57,42 @@ export async function waitForNotebookSynced(timeout = 15000) {
 }
 
 /**
+ * Wait for the daemon session-control runtime gate to match the app's
+ * execution readiness check.
+ *
+ * Kernel toolbar state comes from RuntimeStateDoc; ExecuteCell is still
+ * fail-closed until SessionControl reports runtime_state=ready.
+ */
+export async function waitForSessionReady(timeout = 30000) {
+  await waitForNotebookSynced(timeout);
+  try {
+    await browser.waitUntil(
+      async () => {
+        return await browser.execute(() => {
+          const el = document.querySelector("[data-session-ready]");
+          return el?.getAttribute("data-session-ready") === "true";
+        });
+      },
+      {
+        timeout,
+        interval: 300,
+        timeoutMsg: `Session runtime not ready within ${timeout / 1000}s`,
+      },
+    );
+  } catch (error) {
+    const state = await browser.execute(() => {
+      const el = document.querySelector("[data-session-runtime-state]");
+      return el?.getAttribute("data-session-runtime-state") ?? "missing";
+    });
+    throw new Error(
+      error instanceof Error
+        ? `${error.message} (state=${state})`
+        : `Session runtime not ready within ${timeout / 1000}s (state=${state})`,
+    );
+  }
+}
+
+/**
  * Wait for a specific number of code cells to be loaded.
  * Use this in fixture tests where the notebook has pre-populated cells.
  */

--- a/e2e/specs/deno.spec.js
+++ b/e2e/specs/deno.spec.js
@@ -15,6 +15,7 @@ import {
   waitForCellOutput,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForSessionReady,
 } from "../helpers.js";
 
 describe("Deno Kernel", () => {
@@ -31,6 +32,7 @@ describe("Deno Kernel", () => {
 
   it("should execute TypeScript and show output", async () => {
     await waitForNotebookSynced();
+    await waitForSessionReady();
 
     const codeCell = await $('[data-cell-type="code"]');
     await codeCell.waitForExist({ timeout: 10000 });

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -64,6 +64,9 @@ const COALESCE_MS = 32;
 /** Debounce interval for outbound source sync (ms). */
 const FLUSH_DEBOUNCE_MS = 20;
 
+/** Maximum wait for a host transport to accept an outbound sync frame. */
+const DEFAULT_FLUSH_DELIVERY_TIMEOUT_MS = 5000;
+
 // ── Logger interface ─────────────────────────────────────────────────
 
 export interface SyncEngineLogger {
@@ -219,6 +222,15 @@ export interface SyncEngineOptions {
 
   /** Optional RxJS scheduler for time-based operators (for testing). */
   scheduler?: SchedulerLike;
+
+  /**
+   * Maximum time to wait for outbound sync frame delivery.
+   *
+   * Cell execution calls flushAndWait() before sending ExecuteCell. Keeping
+   * this bounded prevents a stuck host transport from permanently consuming
+   * an execute click without ever sending the request.
+   */
+  flushDeliveryTimeoutMs?: number;
 }
 
 // ── SyncEngine ───────────────────────────────────────────────────────
@@ -226,6 +238,7 @@ export interface SyncEngineOptions {
 export class SyncEngine {
   private readonly opts: Required<Pick<SyncEngineOptions, "getHandle" | "transport" | "logger">> &
     Pick<SyncEngineOptions, "scheduler">;
+  private readonly flushDeliveryTimeoutMs: number;
   private subscription: Subscription | null = null;
   private latestSessionStatus: SessionStatus | null = null;
   private prevExecutions: Record<string, ExecutionState> = {};
@@ -247,7 +260,7 @@ export class SyncEngine {
   private readonly flushRequest$ = new Subject<void>();
 
   /** Promise for the most recent fire-and-forget flush (debounced path). */
-  private inflightFlush: Promise<void> | null = null;
+  private inflightFlush: Promise<boolean> | null = null;
 
   // ── Public observables ───────────────────────────────────────────
 
@@ -345,6 +358,7 @@ export class SyncEngine {
       logger: opts.logger ?? nullLogger,
       scheduler: opts.scheduler,
     };
+    this.flushDeliveryTimeoutMs = opts.flushDeliveryTimeoutMs ?? DEFAULT_FLUSH_DELIVERY_TIMEOUT_MS;
 
     // Expose as readonly Observable (hide Subject internals)
     this.cellChanges$ = this._cellChanges$.asObservable();
@@ -973,12 +987,11 @@ export class SyncEngine {
     const msg = handle.flush_local_changes();
     if (msg) {
       this.opts.logger.debug(`[sync-engine] flushing sync message (${msg.byteLength}B)`);
-      const done = this.opts.transport
-        .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
-        .catch((e: unknown) => {
-          handle.cancel_last_flush();
-          this.opts.logger.warn("[sync-engine] sync to relay failed:", e);
-        });
+      const done = this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg),
+        "sync to relay",
+        () => handle.cancel_last_flush(),
+      );
       // Track the in-flight flush so flushAndWait() can await it.
       this.inflightFlush = done;
     }
@@ -1013,55 +1026,99 @@ export class SyncEngine {
    *    changes from `flush_local_changes()`.
    * 2. Flushes any remaining local changes and awaits delivery.
    *
-   * Use before execute/save to guarantee the daemon has the latest source.
+   * Returns false if source delivery failed or timed out. Use before
+   * execute/save to guarantee the daemon has the latest source.
    */
-  async flushAndWait(): Promise<void> {
+  async flushAndWait(): Promise<boolean> {
     // Drain all in-flight debounced flushes. A new debounced flush can
     // start while we're awaiting the current one (the 20ms timer fires
     // independently), so loop until stable.
     while (this.inflightFlush) {
       const current = this.inflightFlush;
-      await current;
+      const delivered = await current;
       // Only clear if no newer flush replaced it while we awaited.
       if (this.inflightFlush === current) {
         this.inflightFlush = null;
       }
+      if (!delivered) {
+        return false;
+      }
     }
 
     const handle = this.opts.getHandle();
-    if (!handle) return;
+    if (!handle) return true;
 
     // Flush any remaining notebook doc changes (may be none if debounce got them).
     const msg = handle.flush_local_changes();
     if (msg) {
       this.opts.logger.debug(`[sync-engine] flushAndWait: sending ${msg.byteLength}B sync message`);
-      try {
-        await this.opts.transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
-      } catch (e) {
-        handle.cancel_last_flush();
-        this.opts.logger.warn("[sync-engine] flushAndWait: sync to relay failed:", e);
+      const delivered = await this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg),
+        "flushAndWait sync to relay",
+        () => handle.cancel_last_flush(),
+      );
+      if (!delivered) {
+        return false;
       }
     }
 
     // Also flush RuntimeStateDoc sync.
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
-      try {
-        await this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg);
-      } catch (e) {
-        handle.cancel_last_runtime_state_flush();
-        this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
+      const delivered = await this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg),
+        "flushAndWait runtime state sync",
+        () => handle.cancel_last_runtime_state_flush(),
+      );
+      if (!delivered) {
+        return false;
       }
     }
 
     // Also flush PoolDoc sync.
     const poolMsg = handle.flush_pool_state_sync();
     if (poolMsg) {
-      try {
-        await this.opts.transport.sendFrame(FrameType.POOL_STATE_SYNC, poolMsg);
-      } catch (e) {
-        handle.cancel_last_pool_state_flush();
-        this.opts.logger.warn("[sync-engine] flushAndWait: pool state sync failed:", e);
+      const delivered = await this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.POOL_STATE_SYNC, poolMsg),
+        "flushAndWait pool state sync",
+        () => handle.cancel_last_pool_state_flush(),
+      );
+      if (!delivered) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private async awaitFrameDelivery(
+    delivery: Promise<void>,
+    label: string,
+    onFailure: () => void,
+  ): Promise<boolean> {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const result = await Promise.race([
+        delivery.then(() => "ok" as const),
+        new Promise<"timeout">((resolve) => {
+          timeoutId = setTimeout(() => resolve("timeout"), this.flushDeliveryTimeoutMs);
+        }),
+      ]);
+
+      if (result === "timeout") {
+        onFailure();
+        this.opts.logger.warn(
+          `[sync-engine] ${label} timed out after ${this.flushDeliveryTimeoutMs}ms; rolled back sync state`,
+        );
+        return false;
+      }
+      return true;
+    } catch (e) {
+      onFailure();
+      this.opts.logger.warn(`[sync-engine] ${label} failed; rolled back sync state:`, e);
+      return false;
+    } finally {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
       }
     }
   }

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -170,11 +170,15 @@ describe("SyncEngine", () => {
   });
 
   /** Helper: create engine with the VirtualTimeScheduler injected */
-  function createEngine(opts?: { getHandle?: () => SyncableHandle | null }): SyncEngine {
+  function createEngine(opts?: {
+    getHandle?: () => SyncableHandle | null;
+    flushDeliveryTimeoutMs?: number;
+  }): SyncEngine {
     return new SyncEngine({
       getHandle: opts?.getHandle ?? (() => handle),
       transport,
       scheduler,
+      flushDeliveryTimeoutMs: opts?.flushDeliveryTimeoutMs,
     });
   }
 
@@ -835,10 +839,61 @@ describe("SyncEngine", () => {
       engine.start();
       engine.flush();
 
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(handle.cancel_last_flush).toHaveBeenCalled();
       engine.stop();
     });
+
+    it.each([
+      {
+        name: "notebook doc",
+        frameType: FrameType.AUTOMERGE_SYNC,
+        flush: () =>
+          (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+            new Uint8Array([1, 2, 3]),
+          ),
+        cancel: () => handle.cancel_last_flush,
+      },
+      {
+        name: "runtime state",
+        frameType: FrameType.RUNTIME_STATE_SYNC,
+        flush: () =>
+          (handle.flush_runtime_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(
+            new Uint8Array([4, 5, 6]),
+          ),
+        cancel: () => handle.cancel_last_runtime_state_flush,
+      },
+      {
+        name: "pool state",
+        frameType: FrameType.POOL_STATE_SYNC,
+        flush: () =>
+          (handle.flush_pool_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(
+            new Uint8Array([7, 8, 9]),
+          ),
+        cancel: () => handle.cancel_last_pool_state_flush,
+      },
+    ])(
+      "flushAndWait() times out stuck $name frame delivery",
+      async ({ frameType, flush, cancel }) => {
+        flush();
+        vi.spyOn(transport, "sendFrame").mockImplementation((actualFrameType) => {
+          if (actualFrameType === frameType) return new Promise(() => {});
+          return Promise.resolve();
+        });
+
+        const engine = createEngine({ flushDeliveryTimeoutMs: 5 });
+        engine.start();
+
+        const result = await Promise.race([
+          engine.flushAndWait(),
+          new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 100)),
+        ]);
+
+        expect(result).toBe(false);
+        expect(cancel()).toHaveBeenCalled();
+        engine.stop();
+      },
+    );
 
     it("scheduleFlush() debounces at 20ms", () => {
       const syncMsg = new Uint8Array([1]);


### PR DESCRIPTION
## Summary
- add a bounded SyncEngine flush delivery wait so ExecuteCell cannot be permanently blocked by a stuck sync frame
- avoid holding the notebook relay mutex while awaiting forwarded frames from Tauri
- expose session runtime readiness for E2E diagnostics and wait for it in the Deno execution spec

## Investigation
The failing CI run showed Deno auto-launch completing and the edited cell source autosaving, but no daemon ExecuteCell request afterward. That points at the frontend/session-sync boundary before execute dispatch, not the Deno kernel startup path.

## Verification
- cargo xtask lint --fix
- pnpm test:run packages/runtimed/tests/sync-engine.test.ts
- cargo check -p notebook
- cargo xtask e2e build
- cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/10-deno.ipynb e2e/specs/deno.spec.js
