### PR TITLE
fix(runtimed): autosave runtime outputs explicitly

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -5,7 +5,7 @@ use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFram
 use notebook_protocol::protocol::RuntimeAgentResponse;
 use tracing::{debug, info, warn};
 
-use super::peer_runtime_sync::persist_terminal_execution_records;
+use super::peer_runtime_sync::{persist_terminal_execution_records, runtime_file_save_fingerprint};
 use super::peer_writer::spawn_peer_writer;
 use super::{NotebookRoom, RuntimeAgentMessage, STATE_SYNC_COMPACT_THRESHOLD};
 
@@ -202,12 +202,17 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     NotebookFrameType::RuntimeStateSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                             let mut state_changed = false;
+                            let mut runtime_file_dirty = false;
                             let reply_encoded = room.state.with_doc(|sd| {
+                                let before = runtime_file_save_fingerprint(sd);
                                 if let Ok(changed) = sd.receive_sync_message_with_changes(
                                     &mut state_sync_state, msg,
                                 ) {
                                     if changed {
                                         state_changed = true;
+                                        if runtime_file_save_fingerprint(sd) != before {
+                                            runtime_file_dirty = true;
+                                        }
                                         // Notification handled by with_doc heads check
                                     }
                                 }
@@ -224,6 +229,9 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 }
                             }
                             if state_changed {
+                                if runtime_file_dirty {
+                                    let _ = room.broadcasts.file_dirty_tx.send(());
+                                }
                                 persist_terminal_execution_records(
                                     &room,
                                     &execution_store,

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -12,6 +12,60 @@ use super::NotebookRoom;
 
 type PersistedExecutionRecords = HashMap<String, runtimed_client::execution_store::ExecutionRecord>;
 
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct RuntimeFileSaveFingerprint {
+    executions: Vec<RuntimeExecutionSaveFingerprint>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeExecutionSaveFingerprint {
+    execution_id: String,
+    cell_id: String,
+    phase: RuntimeExecutionSavePhase,
+    execution_count: Option<i64>,
+    seq: Option<u64>,
+    outputs: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeExecutionSavePhase {
+    InFlightEmpty,
+    TerminalEmpty,
+    HasOutputs,
+    Other,
+}
+
+pub(super) fn runtime_file_save_fingerprint(
+    state_doc: &runtime_doc::RuntimeStateDoc,
+) -> RuntimeFileSaveFingerprint {
+    let mut executions = state_doc
+        .read_state()
+        .executions
+        .into_iter()
+        .map(|(execution_id, exec)| {
+            let phase = if !exec.outputs.is_empty() {
+                RuntimeExecutionSavePhase::HasOutputs
+            } else if exec.status == "queued" || exec.status == "running" {
+                RuntimeExecutionSavePhase::InFlightEmpty
+            } else if exec.status == "done" || exec.status == "error" {
+                RuntimeExecutionSavePhase::TerminalEmpty
+            } else {
+                RuntimeExecutionSavePhase::Other
+            };
+            RuntimeExecutionSaveFingerprint {
+                execution_id,
+                cell_id: exec.cell_id,
+                phase,
+                execution_count: exec.execution_count,
+                seq: exec.seq,
+                outputs: exec.outputs,
+            }
+        })
+        .collect::<Vec<_>>();
+    executions.sort_by(|a, b| a.execution_id.cmp(&b.execution_id));
+    RuntimeFileSaveFingerprint { executions }
+}
+
 pub(super) async fn handle_runtime_state_frame(
     room: &NotebookRoom,
     state_peer_state: &mut sync::State,
@@ -22,10 +76,12 @@ pub(super) async fn handle_runtime_state_frame(
 ) -> anyhow::Result<bool> {
     let message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
+    let mut runtime_file_dirty = false;
 
     let reply_encoded: Option<Option<Vec<u8>>> = room
         .state
         .with_doc(|state_doc| {
+            let before = runtime_file_save_fingerprint(state_doc);
             let recv_result = catch_automerge_panic("state-receive-sync", || {
                 state_doc.receive_sync_message_with_changes(state_peer_state, message)
             });
@@ -45,7 +101,9 @@ pub(super) async fn handle_runtime_state_frame(
 
             // If the client sent changes, notification is automatic via the
             // heads comparison in RuntimeStateDoc::with_doc.
-            let _ = had_changes;
+            if had_changes && runtime_file_save_fingerprint(state_doc) != before {
+                runtime_file_dirty = true;
+            }
 
             Ok(Some(generate_runtime_state_sync_message(
                 state_doc,
@@ -62,6 +120,9 @@ pub(super) async fn handle_runtime_state_frame(
     };
     if let Some(encoded) = reply_encoded {
         writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
+    }
+    if runtime_file_dirty {
+        let _ = room.broadcasts.file_dirty_tx.send(());
     }
 
     persist_terminal_execution_records(room, store, persisted_records).await;

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -96,23 +96,32 @@ pub(crate) async fn save_notebook_to_disk(
     };
 
     // Read outputs and execution_count from RuntimeStateDoc keyed by execution_id.
+    //
+    // When a cell is re-queued, `set_execution_id` rewrites the cell's pointer
+    // to the new execution before the kernel produces outputs. Saving with the
+    // queued/running eid would clobber the previous outputs with an empty list.
+    // Fall back to the most recent terminal execution for the cell so an
+    // explicit Cmd+S during a run (or a racing autosave) preserves what's on
+    // disk until the live run completes. Cleared cells (`execution_id = None`)
+    // skip the fall-back and write empty outputs.
     let (cell_outputs, cell_execution_counts): (
         HashMap<String, Vec<serde_json::Value>>,
         HashMap<String, Option<i64>>,
     ) = room
         .state
         .read(|sd| {
+            let snapshot = sd.read_state();
             let mut outputs_map = HashMap::new();
             let mut ec_map = HashMap::new();
             for (cell_id, eid) in &cell_execution_ids {
-                if let Some(eid) = eid.as_ref() {
-                    let outputs = sd.get_outputs(eid);
-                    if !outputs.is_empty() {
-                        outputs_map.insert(cell_id.clone(), outputs);
-                    }
-                    if let Some(exec) = sd.get_execution(eid) {
-                        ec_map.insert(cell_id.clone(), exec.execution_count);
-                    }
+                let Some(eid) = eid.as_ref() else { continue };
+                let resolved_eid = resolve_save_execution_id(&snapshot, cell_id, eid);
+                let outputs = sd.get_outputs(&resolved_eid);
+                if !outputs.is_empty() {
+                    outputs_map.insert(cell_id.clone(), outputs);
+                }
+                if let Some(exec) = snapshot.executions.get(&resolved_eid) {
+                    ec_map.insert(cell_id.clone(), exec.execution_count);
                 }
             }
             (outputs_map, ec_map)
@@ -378,6 +387,40 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     );
 }
 
+/// Pick which execution_id save should read outputs from.
+///
+/// If the cell's current execution is queued or running with no outputs yet,
+/// fall back to the most recent done/error execution for the same cell. The
+/// fall-back applies only when the in-flight execution would yield empty
+/// outputs; once any output lands at the new id we use it (partial-but-live
+/// is preferred over stale-but-complete the moment the kernel speaks).
+fn resolve_save_execution_id(
+    snapshot: &runtime_doc::RuntimeState,
+    cell_id: &str,
+    current_eid: &str,
+) -> String {
+    let current = snapshot.executions.get(current_eid);
+    let in_flight_with_no_outputs = current
+        .map(|exec| {
+            (exec.status == "queued" || exec.status == "running") && exec.outputs.is_empty()
+        })
+        .unwrap_or(false);
+    if !in_flight_with_no_outputs {
+        return current_eid.to_string();
+    }
+    snapshot
+        .executions
+        .iter()
+        .filter(|(eid, exec)| {
+            eid.as_str() != current_eid
+                && exec.cell_id == cell_id
+                && (exec.status == "done" || exec.status == "error")
+        })
+        .max_by_key(|(_, exec)| exec.seq.unwrap_or(0))
+        .map(|(eid, _)| eid.clone())
+        .unwrap_or_else(|| current_eid.to_string())
+}
+
 /// Resolve a single cell output — handles both manifest hashes and raw JSON.
 async fn resolve_cell_output(
     output: &serde_json::Value,
@@ -612,8 +655,14 @@ impl Default for AutosaveDebouncerConfig {
 }
 
 /// Spawn a debounced autosave task that writes the `.ipynb` file to disk
-/// whenever the Automerge document changes. Only for saved (non-untitled)
+/// whenever serialized notebook content changes. Only for saved (non-untitled)
 /// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
+///
+/// NotebookDoc edits arrive on `changed_tx`; runtime changes that can affect
+/// `.ipynb` bytes, such as outputs and execution counts, arrive on
+/// `file_dirty_tx`. Generic RuntimeStateDoc broadcasts are intentionally not
+/// autosave triggers because they also carry session/UI fields like
+/// `last_saved`, lifecycle, path, and project context.
 pub(crate) fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
     spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default());
 }
@@ -625,6 +674,7 @@ fn spawn_autosave_debouncer_with_config(
     config: AutosaveDebouncerConfig,
 ) {
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+    let mut file_dirty_rx = room.broadcasts.file_dirty_tx.subscribe();
     spawn_supervised(
         "autosave-debouncer",
         async move {
@@ -670,6 +720,20 @@ fn spawn_autosave_debouncer_with_config(
                             }
                         }
                     }
+                    file_dirty_result = file_dirty_rx.recv() => {
+                        match file_dirty_result {
+                            Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                                last_receive = Some(Instant::now());
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                // Room teardown is already represented by
+                                // changed_rx closing. Stop watching this
+                                // auxiliary signal if it disappears first.
+                                let (_tx, rx) = broadcast::channel(1);
+                                file_dirty_rx = rx;
+                            }
+                        }
+                    }
                     _ = check_interval.tick() => {
                         let should_flush = if let Some(recv) = last_receive {
                             let debounce_ready = recv.elapsed() >= debounce_duration;
@@ -700,7 +764,9 @@ fn spawn_autosave_debouncer_with_config(
                                     // don't stamp last_saved while the file is stale.
                                     let changed_during_save =
                                         matches!(changed_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
-                                    if changed_during_save {
+                                    let file_dirty_during_save =
+                                        matches!(file_dirty_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
+                                    if changed_during_save || file_dirty_during_save {
                                         last_receive = Some(Instant::now());
                                     } else {
                                         last_receive = None;

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -41,6 +41,11 @@ impl RoomIdentity {
 pub struct RoomBroadcasts {
     /// Broadcast channel to notify all peers in this room of doc changes.
     pub changed_tx: broadcast::Sender<()>,
+    /// Broadcast channel to notify autosave that runtime state changed data
+    /// serialized into the `.ipynb` file, such as cell outputs or execution
+    /// counts. This deliberately excludes generic RuntimeStateDoc updates like
+    /// lifecycle, project context, path, and last_saved.
+    pub file_dirty_tx: broadcast::Sender<()>,
     /// Broadcast channel for kernel events: EnvProgress and Comm (widget messages).
     pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     /// Broadcast channel for presence frames (cursor, selection, kernel state).
@@ -54,10 +59,12 @@ pub struct RoomBroadcasts {
 impl Default for RoomBroadcasts {
     fn default() -> Self {
         let (changed_tx, _) = broadcast::channel(16);
+        let (file_dirty_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (presence_tx, _) = broadcast::channel(64);
         Self {
             changed_tx,
+            file_dirty_tx,
             kernel_broadcast_tx,
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6970,3 +6970,230 @@ async fn reset_starting_state_error_variant_writes_details() {
     // but present so readers can skip typed-reason branches cleanly.
     assert_eq!(state.kernel.error_reason.as_deref(), Some(""));
 }
+
+// ── Regression tests for #2351: outputs not serialized to notebook ───
+
+/// When a cell is re-queued for execution, `set_execution_id` rewrites the
+/// cell's pointer to the NEW execution_id before the kernel produces any
+/// outputs. If save fires in this window, the previous outputs must not be
+/// clobbered with empty `[]`. Save falls back to the most recent terminal
+/// execution for the cell.
+#[tokio::test]
+async fn test_save_preserves_outputs_when_execution_in_flight() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "in_flight.ipynb");
+
+    let old_eid = "exec-old-done";
+    let new_eid = "exec-new-queued";
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hello')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hello\n"]
+            });
+            sd.create_execution_with_source(old_eid, "cell1", "print('hello')", 1)?;
+            sd.set_outputs(old_eid, &[output])?;
+            sd.set_execution_count(old_eid, 1)?;
+            sd.set_execution_done(old_eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(old_eid)).unwrap();
+    }
+
+    // Simulate `queue_cell_if_current`: rewrite cell.execution_id to a new
+    // queued execution that has not produced outputs yet.
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution_with_source(new_eid, "cell1", "print('hello')", 2)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(new_eid)).unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let cell = &nb["cells"][0];
+    let outputs = cell["outputs"].as_array().expect("outputs array");
+    assert_eq!(
+        outputs.len(),
+        1,
+        "previous outputs must be preserved during in-flight execution; got: {}",
+        serde_json::to_string_pretty(cell).unwrap()
+    );
+    assert_eq!(outputs[0]["name"], "stdout");
+    assert_eq!(
+        cell["execution_count"], 1,
+        "previous execution_count preserved when current execution has no count yet"
+    );
+}
+
+/// When a cell's `execution_id` is `None` (cleared via ClearOutputs), save
+/// must write empty outputs. The clear is intentional - we don't fall back
+/// to historical executions.
+#[tokio::test]
+async fn test_save_writes_empty_outputs_when_cell_execution_id_cleared() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "cleared.ipynb");
+
+    let eid = "exec-done";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hello')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hello\n"]
+            });
+            sd.create_execution_with_source(eid, "cell1", "print('hello')", 1)?;
+            sd.set_outputs(eid, &[output])?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+        doc.set_execution_id("cell1", None).unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let outputs = nb["cells"][0]["outputs"].as_array().expect("outputs array");
+    assert!(
+        outputs.is_empty(),
+        "cleared cell must have empty outputs; got: {}",
+        serde_json::to_string_pretty(&nb["cells"][0]).unwrap()
+    );
+}
+
+/// RuntimeStateDoc mutations only wake autosave through the explicit
+/// file-dirty channel. Autosave's own `last_saved` write must not trigger a
+/// follow-on autosave loop.
+#[tokio::test(start_paused = true)]
+async fn test_autosave_fires_on_runtime_file_dirty_without_self_loop() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        &docs_dir,
+        blob_store,
+        false,
+    ));
+
+    let eid = "exec-1";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "print('hi')").unwrap();
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution_with_source(eid, "cell1", "print('hi')", 1)?;
+            Ok(())
+        })
+        .unwrap();
+
+    let save_path = tmp.path().join("auto.ipynb");
+    let written = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let canonical = tokio::fs::canonicalize(&written)
+        .await
+        .unwrap_or_else(|_| PathBuf::from(&written));
+    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    try_claim_path(&path_index, &canonical, room.id)
+        .await
+        .expect("path claim should succeed");
+    finalize_untitled_promotion(&room, canonical).await;
+
+    let initial = tokio::fs::read_to_string(&save_path).await.unwrap();
+    let initial_nb: serde_json::Value = serde_json::from_str(&initial).unwrap();
+    assert!(
+        initial_nb["cells"][0]["outputs"]
+            .as_array()
+            .map(|o| o.is_empty())
+            .unwrap_or(true),
+        "baseline file must start with empty outputs"
+    );
+
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["hi\n"]
+            });
+            sd.append_output(eid, &output)?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+
+    let _ = room.broadcasts.file_dirty_tx.send(());
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let first_last_saved = loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+        let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let outputs_saved = nb["cells"][0]["outputs"]
+            .as_array()
+            .is_some_and(|outputs| !outputs.is_empty());
+        let last_saved = room
+            .state
+            .read(|sd| sd.read_state().last_saved)
+            .unwrap_or_default();
+        if outputs_saved {
+            assert_eq!(nb["cells"][0]["outputs"][0]["name"], "stdout");
+            if let Some(last_saved) = last_saved {
+                break last_saved;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for autosave to flush state-change outputs; got: {}",
+            serde_json::to_string_pretty(&nb).unwrap()
+        );
+    };
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let second_last_saved = room
+        .state
+        .read(|sd| sd.read_state().last_saved)
+        .unwrap_or_default()
+        .expect("autosave should have stamped last_saved");
+    assert_eq!(
+        first_last_saved, second_last_saved,
+        "last_saved changed without a new file-dirty or NotebookDoc signal"
+    );
+}


### PR DESCRIPTION
## Summary

- preserve previous cell outputs when saving during a newly queued or running execution with no outputs yet
- add a narrow file-dirty autosave signal for runtime execution data instead of subscribing autosave to all RuntimeStateDoc broadcasts
- notify that signal from RuntimeStateSync merges only when execution data that can affect .ipynb serialization changes
- cover clear-output behavior, in-flight save fallback, and the autosave last_saved self-loop case

## Why

This is an alternative to #2372 that keeps autosave scoped to changes that can alter serialized notebook bytes. Generic runtime-state updates like last_saved, lifecycle, path, project context, or env progress should not wake autosave.

## Validation

- cargo xtask wasm
- cargo test -p runtimed test_save_
- cargo test -p runtimed test_autosave_fires_on_runtime_file_dirty_without_self_loop
- cargo xtask lint --fix
