### PR TITLE
fix(e2e): handle sync delivery timeouts

### DIFF
--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1002,19 +1002,21 @@ export class SyncEngine {
     // stuck on "not_started" (#runtime-state-race).
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
-      this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg).catch((e: unknown) => {
-        handle.cancel_last_runtime_state_flush();
-        this.opts.logger.warn("[sync-engine] runtime state sync to relay failed:", e);
-      });
+      void this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg),
+        "runtime state sync to relay",
+        () => handle.cancel_last_runtime_state_flush(),
+      );
     }
 
     // Also flush PoolDoc sync so the daemon sends pool state.
     const poolMsg = handle.flush_pool_state_sync();
     if (poolMsg) {
-      this.opts.transport.sendFrame(FrameType.POOL_STATE_SYNC, poolMsg).catch((e: unknown) => {
-        handle.cancel_last_pool_state_flush();
-        this.opts.logger.warn("[sync-engine] pool state sync to relay failed:", e);
-      });
+      void this.awaitFrameDelivery(
+        this.opts.transport.sendFrame(FrameType.POOL_STATE_SYNC, poolMsg),
+        "pool state sync to relay",
+        () => handle.cancel_last_pool_state_flush(),
+      );
     }
   }
 
@@ -1098,16 +1100,27 @@ export class SyncEngine {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     try {
       const result = await Promise.race([
-        delivery.then(() => "ok" as const),
-        new Promise<"timeout">((resolve) => {
-          timeoutId = setTimeout(() => resolve("timeout"), this.flushDeliveryTimeoutMs);
+        delivery.then(
+          () => ({ status: "ok" as const }),
+          (error: unknown) => ({ status: "error" as const, error }),
+        ),
+        new Promise<{ status: "timeout" }>((resolve) => {
+          timeoutId = setTimeout(() => resolve({ status: "timeout" }), this.flushDeliveryTimeoutMs);
         }),
       ]);
 
-      if (result === "timeout") {
+      if (result.status === "timeout") {
         onFailure();
         this.opts.logger.warn(
           `[sync-engine] ${label} timed out after ${this.flushDeliveryTimeoutMs}ms; rolled back sync state`,
+        );
+        return false;
+      }
+      if (result.status === "error") {
+        onFailure();
+        this.opts.logger.warn(
+          `[sync-engine] ${label} failed; rolled back sync state:`,
+          result.error,
         );
         return false;
       }

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -846,6 +846,41 @@ describe("SyncEngine", () => {
 
     it.each([
       {
+        name: "runtime state",
+        frameType: FrameType.RUNTIME_STATE_SYNC,
+        flush: () =>
+          (handle.flush_runtime_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(
+            new Uint8Array([4, 5, 6]),
+          ),
+        cancel: () => handle.cancel_last_runtime_state_flush,
+      },
+      {
+        name: "pool state",
+        frameType: FrameType.POOL_STATE_SYNC,
+        flush: () =>
+          (handle.flush_pool_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(
+            new Uint8Array([7, 8, 9]),
+          ),
+        cancel: () => handle.cancel_last_pool_state_flush,
+      },
+    ])("flush() times out stuck $name frame delivery", async ({ frameType, flush, cancel }) => {
+      flush();
+      vi.spyOn(transport, "sendFrame").mockImplementation((actualFrameType) => {
+        if (actualFrameType === frameType) return new Promise(() => {});
+        return Promise.resolve();
+      });
+
+      const engine = createEngine({ flushDeliveryTimeoutMs: 5 });
+      engine.start();
+      engine.flush();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(cancel()).toHaveBeenCalled();
+      engine.stop();
+    });
+
+    it.each([
+      {
         name: "notebook doc",
         frameType: FrameType.AUTOMERGE_SYNC,
         flush: () =>
@@ -894,6 +929,30 @@ describe("SyncEngine", () => {
         engine.stop();
       },
     );
+
+    it("flushAndWait() consumes delivery rejections that arrive after timeout", async () => {
+      const syncMsg = new Uint8Array([1, 2, 3]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+      let rejectDelivery: (reason?: unknown) => void = () => {};
+      vi.spyOn(transport, "sendFrame").mockReturnValue(
+        new Promise((_, reject) => {
+          rejectDelivery = reject;
+        }),
+      );
+
+      const engine = createEngine({ flushDeliveryTimeoutMs: 5 });
+      engine.start();
+      const result = await engine.flushAndWait();
+
+      expect(result).toBe(false);
+      expect(handle.cancel_last_flush).toHaveBeenCalledTimes(1);
+
+      rejectDelivery(new Error("late send failure"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(handle.cancel_last_flush).toHaveBeenCalledTimes(1);
+      engine.stop();
+    });
 
     it("scheduleFlush() debounces at 20ms", () => {
       const syncMsg = new Uint8Array([1]);


### PR DESCRIPTION
## Summary
- bound fire-and-forget runtime and pool state sync delivery with the same timeout/rollback path used by notebook flushes
- consume late send rejections after a timeout so they do not surface as unhandled promise rejections
- add SyncEngine coverage for runtime/pool timeout rollback and late rejection handling

## Verification
- pnpm test:run packages/runtimed/tests/sync-engine.test.ts
- cargo xtask lint --fix