### PR TITLE
fix(runtimed): flush autosave on room eviction

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -103,7 +103,7 @@ pub async fn get_or_create_room(
         // Spawn autosave debouncer to keep .ipynb on disk current.
         let path_str = notebook_path.to_string_lossy().to_string();
         let shutdown_tx = spawn_autosave_debouncer(path_str, room.clone());
-        *room.persistence.autosave_shutdown_tx.lock().await = Some(shutdown_tx);
+        install_autosave_shutdown_tx(&room, shutdown_tx).await;
     }
 
     room

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -102,7 +102,8 @@ pub async fn get_or_create_room(
 
         // Spawn autosave debouncer to keep .ipynb on disk current.
         let path_str = notebook_path.to_string_lossy().to_string();
-        spawn_autosave_debouncer(path_str, room.clone());
+        let shutdown_tx = spawn_autosave_debouncer(path_str, room.clone());
+        *room.persistence.autosave_shutdown_tx.lock().await = Some(shutdown_tx);
     }
 
     room

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -8,8 +8,8 @@ use crate::task_supervisor::spawn_best_effort;
 
 use super::{
     flush_launched_deps_to_metadata, rename_env_dir_to_unified_hash, save_notebook_to_disk,
-    send_runtime_agent_request, should_preserve_env_on_eviction, CapturedEnvRuntime, NotebookRoom,
-    NotebookRooms,
+    send_runtime_agent_request, should_preserve_env_on_eviction, shutdown_autosave_debouncer,
+    CapturedEnvRuntime, NotebookRoom, NotebookRooms,
 };
 
 pub(super) async fn handle_peer_disconnect(
@@ -329,6 +329,21 @@ pub(super) async fn handle_peer_disconnect(
                             env_source
                         );
                     }
+                }
+
+                const AUTOSAVE_SHUTDOWN_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_secs(5);
+                let autosave_shutdown_ok = shutdown_autosave_debouncer(
+                    &room_for_eviction,
+                    &notebook_id_for_eviction,
+                    AUTOSAVE_SHUTDOWN_TIMEOUT,
+                )
+                .await;
+                if !autosave_shutdown_ok {
+                    warn!(
+                        "[notebook-sync] Autosave shutdown did not complete final .ipynb save for {}; continuing eviction after .automerge flush",
+                        notebook_id_for_eviction
+                    );
                 }
 
                 // Rename the env dir to match the post-flush unified

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -363,7 +363,7 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     // Spawn autosave debouncer so subsequent edits persist to .ipynb.
     let shutdown_tx =
         spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
-    *room.persistence.autosave_shutdown_tx.lock().await = Some(shutdown_tx);
+    install_autosave_shutdown_tx(room, shutdown_tx).await;
 
     // Clear ephemeral markers.
     room.identity.is_ephemeral.store(false, Ordering::Relaxed);
@@ -674,6 +674,23 @@ pub(crate) fn spawn_autosave_debouncer(
     spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default())
 }
 
+pub(crate) async fn install_autosave_shutdown_tx(
+    room: &NotebookRoom,
+    shutdown_tx: mpsc::UnboundedSender<AutosaveShutdownRequest>,
+) {
+    let previous_tx = room
+        .persistence
+        .autosave_shutdown_tx
+        .lock()
+        .await
+        .replace(shutdown_tx);
+
+    if let Some(previous_tx) = previous_tx {
+        let (ack_tx, _ack_rx) = oneshot::channel::<bool>();
+        let _ = previous_tx.send(ack_tx);
+    }
+}
+
 /// Request one final autosave and stop the `.ipynb` autosave task.
 ///
 /// The task owns a room `Arc`, so room eviction cannot rely on broadcast
@@ -774,7 +791,13 @@ fn spawn_autosave_debouncer_with_config(
                         }
                     }
                     Some(ack_tx) = shutdown_rx.recv() => {
-                        let ok = if !is_untitled_notebook(&notebook_id) && !room.is_loading() {
+                        let ok = if room.is_loading() {
+                            warn!(
+                                "[autosave] Final save on shutdown skipped while {} is loading",
+                                notebook_id
+                            );
+                            false
+                        } else if !is_untitled_notebook(&notebook_id) {
                             match save_notebook_to_disk(&room, None).await {
                                 Ok(path) => {
                                     info!("[autosave] Final save on shutdown: {}", path);

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -361,7 +361,9 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     }
 
     // Spawn autosave debouncer so subsequent edits persist to .ipynb.
-    spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
+    let shutdown_tx =
+        spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
+    *room.persistence.autosave_shutdown_tx.lock().await = Some(shutdown_tx);
 
     // Clear ephemeral markers.
     room.identity.is_ephemeral.store(false, Ordering::Relaxed);
@@ -654,6 +656,8 @@ impl Default for AutosaveDebouncerConfig {
     }
 }
 
+pub(crate) type AutosaveShutdownRequest = oneshot::Sender<bool>;
+
 /// Spawn a debounced autosave task that writes the `.ipynb` file to disk
 /// whenever serialized notebook content changes. Only for saved (non-untitled)
 /// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
@@ -663,8 +667,55 @@ impl Default for AutosaveDebouncerConfig {
 /// `file_dirty_tx`. Generic RuntimeStateDoc broadcasts are intentionally not
 /// autosave triggers because they also carry session/UI fields like
 /// `last_saved`, lifecycle, path, and project context.
-pub(crate) fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
-    spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default());
+pub(crate) fn spawn_autosave_debouncer(
+    notebook_id: String,
+    room: Arc<NotebookRoom>,
+) -> mpsc::UnboundedSender<AutosaveShutdownRequest> {
+    spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default())
+}
+
+/// Request one final autosave and stop the `.ipynb` autosave task.
+///
+/// The task owns a room `Arc`, so room eviction cannot rely on broadcast
+/// channels closing to signal shutdown. This helper consumes the stored
+/// lifecycle channel and waits for an explicit save acknowledgement.
+pub(crate) async fn shutdown_autosave_debouncer(
+    room: &NotebookRoom,
+    notebook_id: &str,
+    timeout: std::time::Duration,
+) -> bool {
+    let shutdown_tx = room.persistence.autosave_shutdown_tx.lock().await.take();
+    let Some(shutdown_tx) = shutdown_tx else {
+        return true;
+    };
+
+    let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+    if shutdown_tx.send(ack_tx).is_err() {
+        debug!(
+            "[autosave] Shutdown skipped for {} (autosave task already exited)",
+            notebook_id
+        );
+        return true;
+    }
+
+    match tokio::time::timeout(timeout, ack_rx).await {
+        Ok(Ok(true)) => true,
+        Ok(Ok(false)) => false,
+        Ok(Err(_)) => {
+            warn!(
+                "[autosave] Shutdown ack dropped for {} before final save completed",
+                notebook_id
+            );
+            false
+        }
+        Err(_) => {
+            warn!(
+                "[autosave] Shutdown timed out for {} after {:?}",
+                notebook_id, timeout
+            );
+            false
+        }
+    }
 }
 
 /// Spawn autosave debouncer with custom timing configuration (for testing).
@@ -672,9 +723,10 @@ fn spawn_autosave_debouncer_with_config(
     notebook_id: String,
     room: Arc<NotebookRoom>,
     config: AutosaveDebouncerConfig,
-) {
+) -> mpsc::UnboundedSender<AutosaveShutdownRequest> {
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
     let mut file_dirty_rx = room.broadcasts.file_dirty_tx.subscribe();
+    let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
     spawn_supervised(
         "autosave-debouncer",
         async move {
@@ -698,19 +750,6 @@ fn spawn_autosave_debouncer_with_config(
                                 last_receive = Some(Instant::now());
                             }
                             Err(broadcast::error::RecvError::Closed) => {
-                                // Room is being evicted — do a final autosave
-                                if !is_untitled_notebook(&notebook_id)
-                                    && !room.is_loading()
-                                {
-                                    match save_notebook_to_disk(&room, None).await {
-                                        Ok(path) => {
-                                            info!("[autosave] Final save on room close: {}", path);
-                                        }
-                                        Err(e) => {
-                                            warn!("[autosave] Final save failed: {}", e);
-                                        }
-                                    }
-                                }
                                 break;
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -733,6 +772,33 @@ fn spawn_autosave_debouncer_with_config(
                                 file_dirty_rx = rx;
                             }
                         }
+                    }
+                    Some(ack_tx) = shutdown_rx.recv() => {
+                        let ok = if !is_untitled_notebook(&notebook_id) && !room.is_loading() {
+                            match save_notebook_to_disk(&room, None).await {
+                                Ok(path) => {
+                                    info!("[autosave] Final save on shutdown: {}", path);
+                                    let now = chrono::Utc::now().to_rfc3339();
+                                    if let Err(e) = room.state.with_doc(|sd| {
+                                        sd.set_last_saved(Some(&now))
+                                    }) {
+                                        warn!(
+                                            "[autosave] set_last_saved failed during shutdown: {}",
+                                            e
+                                        );
+                                    }
+                                    true
+                                }
+                                Err(e) => {
+                                    warn!("[autosave] Final save on shutdown failed: {}", e);
+                                    false
+                                }
+                            }
+                        } else {
+                            true
+                        };
+                        let _ = ack_tx.send(ok);
+                        break;
                     }
                     _ = check_interval.tick() => {
                         let should_flush = if let Some(recv) = last_receive {
@@ -802,6 +868,7 @@ fn spawn_autosave_debouncer_with_config(
             trigger_global_shutdown();
         },
     );
+    shutdown_tx
 }
 
 /// Actually persist bytes to disk, logging if it takes too long.

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -686,8 +686,22 @@ pub(crate) async fn install_autosave_shutdown_tx(
         .replace(shutdown_tx);
 
     if let Some(previous_tx) = previous_tx {
-        let (ack_tx, _ack_rx) = oneshot::channel::<bool>();
-        let _ = previous_tx.send(ack_tx);
+        let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+        if previous_tx.send(ack_tx).is_err() {
+            return;
+        }
+        match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
+                warn!("[autosave] Replaced autosave task reported failed shutdown");
+            }
+            Ok(Err(_)) => {
+                warn!("[autosave] Replaced autosave task dropped shutdown ack");
+            }
+            Err(_) => {
+                warn!("[autosave] Timed out waiting for replaced autosave task shutdown");
+            }
+        }
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -104,6 +104,12 @@ pub struct RoomPersistence {
     /// Shutdown signal for the file watcher task.
     /// Sent when the room is evicted to stop the watcher.
     pub watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Shutdown/flush request channel for the `.ipynb` autosave task.
+    ///
+    /// The autosave task owns an `Arc<NotebookRoom>`, so broadcast-channel
+    /// closure is not a reliable room-lifecycle signal. Eviction uses this
+    /// channel to request one acknowledged final save before the task exits.
+    pub autosave_shutdown_tx: Mutex<Option<mpsc::UnboundedSender<AutosaveShutdownRequest>>>,
     /// Shutdown signal for the project-file watcher task.
     ///
     /// Separate from `watcher_shutdown_tx` (which watches the `.ipynb`)
@@ -150,6 +156,7 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             watcher_shutdown_tx: Mutex::new(None),
+            autosave_shutdown_tx: Mutex::new(None),
             project_file_watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
@@ -169,6 +176,7 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             watcher_shutdown_tx: Mutex::new(None),
+            autosave_shutdown_tx: Mutex::new(None),
             project_file_watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7290,13 +7290,15 @@ async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
     install_autosave_shutdown_tx(&room, old_tx).await;
 
     let (new_tx, mut new_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
+    let replaced_ack_task = tokio::spawn(async move {
+        let ack_tx = old_rx
+            .recv()
+            .await
+            .expect("replacing the handle should signal the old task");
+        let _ = ack_tx.send(true);
+    });
     install_autosave_shutdown_tx(&room, new_tx).await;
-
-    let replaced_ack = tokio::time::timeout(Duration::from_millis(500), old_rx.recv()).await;
-    assert!(
-        matches!(replaced_ack, Ok(Some(_))),
-        "replacing the autosave shutdown handle should signal the old task: {replaced_ack:?}"
-    );
+    replaced_ack_task.await.unwrap();
     assert!(
         new_rx.try_recv().is_err(),
         "new shutdown handle should remain installed until explicit shutdown"
@@ -7314,4 +7316,64 @@ async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
         "explicit shutdown should receive ack from the new handle"
     );
     ack_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_autosave_shutdown_during_loading_returns_false_without_write() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        &docs_dir,
+        blob_store,
+        false,
+    ));
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "before = 1").unwrap();
+    }
+
+    let save_path = tmp.path().join("loading.ipynb");
+    let written = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let canonical = tokio::fs::canonicalize(&written)
+        .await
+        .unwrap_or_else(|_| PathBuf::from(&written));
+    *room.identity.path.write().await = Some(canonical.clone());
+    let shutdown_tx =
+        spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(&room));
+    install_autosave_shutdown_tx(&room, shutdown_tx).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(1, "cell-2", "code").unwrap();
+        doc.update_source("cell-2", "after = 2").unwrap();
+    }
+    let _ = room.broadcasts.changed_tx.send(());
+
+    assert!(room.try_start_loading(), "test should mark room as loading");
+    assert!(
+        !shutdown_autosave_debouncer(&room, &canonical.to_string_lossy(), Duration::from_secs(5))
+            .await,
+        "shutdown while loading should report that no final save happened"
+    );
+    room.finish_loading();
+
+    let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let cells = nb["cells"].as_array().expect("cells array");
+    assert_eq!(
+        cells.len(),
+        1,
+        "shutdown while loading should not write pending edits to disk"
+    );
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7274,3 +7274,44 @@ async fn test_autosave_shutdown_flushes_pending_doc_change() {
         "shutdown should consume the autosave lifecycle handle"
     );
 }
+
+#[tokio::test]
+async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let room = NotebookRoom::new_fresh(Uuid::new_v4(), None, &docs_dir, blob_store, false);
+
+    let (old_tx, mut old_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
+    install_autosave_shutdown_tx(&room, old_tx).await;
+
+    let (new_tx, mut new_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
+    install_autosave_shutdown_tx(&room, new_tx).await;
+
+    let replaced_ack = tokio::time::timeout(Duration::from_millis(500), old_rx.recv()).await;
+    assert!(
+        matches!(replaced_ack, Ok(Some(_))),
+        "replacing the autosave shutdown handle should signal the old task: {replaced_ack:?}"
+    );
+    assert!(
+        new_rx.try_recv().is_err(),
+        "new shutdown handle should remain installed until explicit shutdown"
+    );
+
+    let ack_task = tokio::spawn(async move {
+        let ack_tx = new_rx
+            .recv()
+            .await
+            .expect("explicit shutdown should use the new handle");
+        let _ = ack_tx.send(true);
+    });
+    assert!(
+        shutdown_autosave_debouncer(&room, "fake.ipynb", Duration::from_millis(500)).await,
+        "explicit shutdown should receive ack from the new handle"
+    );
+    ack_task.await.unwrap();
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7197,3 +7197,80 @@ async fn test_autosave_fires_on_runtime_file_dirty_without_self_loop() {
         "last_saved changed without a new file-dirty or NotebookDoc signal"
     );
 }
+
+#[tokio::test(start_paused = true)]
+async fn test_autosave_shutdown_flushes_pending_doc_change() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        &docs_dir,
+        blob_store,
+        false,
+    ));
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "before = 1").unwrap();
+    }
+
+    let save_path = tmp.path().join("auto.ipynb");
+    let written = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let canonical = tokio::fs::canonicalize(&written)
+        .await
+        .unwrap_or_else(|_| PathBuf::from(&written));
+    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    try_claim_path(&path_index, &canonical, room.id)
+        .await
+        .expect("path claim should succeed");
+    finalize_untitled_promotion(&room, canonical.clone()).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(1, "cell-2", "code").unwrap();
+        doc.update_source("cell-2", "after = 2").unwrap();
+    }
+    let _ = room.broadcasts.changed_tx.send(());
+
+    assert!(
+        shutdown_autosave_debouncer(&room, &canonical.to_string_lossy(), Duration::from_secs(5))
+            .await,
+        "autosave shutdown should complete its final save"
+    );
+
+    let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let cells = nb["cells"].as_array().expect("cells array");
+    assert_eq!(
+        cells.len(),
+        2,
+        "shutdown final save should persist the pending doc edit"
+    );
+    let sources: Vec<String> = cells
+        .iter()
+        .map(|c| match &c["source"] {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(arr) => {
+                arr.iter().filter_map(|v| v.as_str()).collect::<String>()
+            }
+            other => panic!("unexpected source shape: {other:?}"),
+        })
+        .collect();
+    assert!(
+        sources.iter().any(|source| source == "after = 2"),
+        "shutdown final save should include the edit made inside the debounce window; got: {sources:?}"
+    );
+    assert!(
+        room.persistence.autosave_shutdown_tx.lock().await.is_none(),
+        "shutdown should consume the autosave lifecycle handle"
+    );
+}


### PR DESCRIPTION
## Summary
- store an explicit shutdown channel for each .ipynb autosave task
- request an acknowledged final autosave during room eviction instead of relying on broadcast channel closure
- add a regression test for edits pending inside the debounce window at shutdown

## Verification
- cargo test -p runtimed autosave
- cargo test -p runtimed --test tokio_mutex_lint
- cargo xtask lint --fix