### PR TITLE
refactor(runtimed): split runtime state session bootstrap

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -11,7 +11,10 @@ use super::peer_presence::{
     prune_stale_presence, send_initial_presence_snapshot,
 };
 use super::peer_runtime_sync::{forward_runtime_state_broadcast, handle_runtime_state_frame};
-use super::peer_session::{send_initial_notebook_doc_sync, send_session_status, InitialSyncState};
+use super::peer_session::{
+    send_initial_notebook_doc_sync, send_initial_runtime_state_sync, send_session_status,
+    InitialSyncState,
+};
 use super::peer_writer::{
     enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
 };
@@ -332,41 +335,7 @@ where
         daemon.config.execution_store_dir.clone(),
     );
 
-    // Initial RuntimeStateDoc sync — encode inside lock, send outside.
-    // Uses bounded generation to compact atomically if the message would exceed
-    // the 100 MiB frame limit.
-    let initial_state_encoded = room
-        .state
-        .with_doc(|state_doc| {
-            // Safety net: compact before initial sync if the doc grew too large.
-            // 80 MiB leaves headroom under the 100 MiB frame limit.
-            const COMPACTION_THRESHOLD: usize = 80 * 1024 * 1024;
-            if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
-                info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
-            }
-            match catch_automerge_panic("initial-state-sync", || {
-                state_doc.generate_sync_message_bounded_encoded(
-                    &mut state_peer_state,
-                    STATE_SYNC_COMPACT_THRESHOLD,
-                )
-            }) {
-                Ok(encoded) => Ok(encoded),
-                Err(e) => {
-                    warn!("{}", e);
-                    state_doc.rebuild_from_save();
-                    state_peer_state = sync::State::new();
-                    Ok(state_doc
-                        .generate_sync_message(&mut state_peer_state)
-                        .map(|msg| msg.encode()))
-                }
-            }
-        })
-        .ok()
-        .flatten();
-    if let Some(encoded) = initial_state_encoded {
-        connection::send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded)
-            .await?;
-    }
+    send_initial_runtime_state_sync(&mut writer, room, &mut state_peer_state).await?;
     runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Syncing;
     if client_protocol_version >= 3 {
         send_session_status(

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use automerge::sync;
 use tokio::io::AsyncWrite;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::connection::{self, NotebookFrameType};
 
-use super::{catch_automerge_panic, NotebookRoom};
+use super::{catch_automerge_panic, NotebookRoom, STATE_SYNC_COMPACT_THRESHOLD};
 
 pub(crate) async fn send_session_status<W>(
     writer: &mut W,
@@ -91,4 +91,53 @@ where
     }
 
     Ok(sync_state)
+}
+
+/// Generate and send the initial RuntimeStateDoc sync frame.
+///
+/// The caller owns `state_peer_state` because the steady-state peer loop uses
+/// the same sync state to compute later RuntimeStateDoc deltas.
+pub(crate) async fn send_initial_runtime_state_sync<W>(
+    writer: &mut W,
+    room: &Arc<NotebookRoom>,
+    state_peer_state: &mut sync::State,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    // Encode inside the RuntimeStateDoc lock, then send outside it to avoid
+    // holding state while awaiting socket I/O.
+    let initial_state_encoded = room
+        .state
+        .with_doc(|state_doc| {
+            // Safety net: compact before initial sync if the doc grew too large.
+            // 80 MiB leaves headroom under the 100 MiB frame limit.
+            const COMPACTION_THRESHOLD: usize = 80 * 1024 * 1024;
+            if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
+                info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
+            }
+            match catch_automerge_panic("initial-state-sync", || {
+                state_doc.generate_sync_message_bounded_encoded(
+                    state_peer_state,
+                    STATE_SYNC_COMPACT_THRESHOLD,
+                )
+            }) {
+                Ok(encoded) => Ok(encoded),
+                Err(e) => {
+                    warn!("{}", e);
+                    state_doc.rebuild_from_save();
+                    *state_peer_state = sync::State::new();
+                    Ok(state_doc
+                        .generate_sync_message(state_peer_state)
+                        .map(|msg| msg.encode()))
+                }
+            }
+        })
+        .ok()
+        .flatten();
+    if let Some(encoded) = initial_state_encoded {
+        connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- move initial RuntimeStateDoc sync frame generation/sending into peer_session.rs
- keep the peer loop responsible for phase transitions while session bootstrap owns the initial state frame
- preserve bounded RuntimeStateDoc sync generation, compaction, Automerge panic recovery, and sync-state reuse behavior

## Verification
- cargo check -p runtimed
- cargo clippy -p runtimed --lib -- -D warnings
- cargo test -p runtimed test_notebook_sync_path_handshake_reuses_existing_room --lib
- cargo test -p runtimed test_room_peer_counting --lib
- cargo xtask lint --fix

Note: cargo test -p runtimed runtime_state --lib compiled cleanly but matched 0 tests, so it is not counted as coverage.

Refs #2340