### PR TITLE
ci(release): retry sccache startup probe

### DIFF
--- a/.github/actions/sccache-warmup/action.yml
+++ b/.github/actions/sccache-warmup/action.yml
@@ -1,0 +1,34 @@
+name: Warm up sccache
+description: >-
+  Probe sccache startup with retry to absorb transient GHA cache flakes.
+  Runs `sccache rustc --version` (the same path cargo takes when first wrapping
+  rustc), retrying up to 3 times with a 10s backoff. Once the daemon is up it
+  serves the rest of the job, so downstream cargo steps never see the startup
+  flake. Caller must have installed the Rust toolchain and sccache already.
+runs:
+  using: composite
+  steps:
+    - name: Probe sccache startup
+      shell: bash
+      run: |
+        set +e
+        max_attempts=3
+        delay=10
+        attempt=1
+        while [ "$attempt" -le "$max_attempts" ]; do
+          echo "::group::sccache startup probe (attempt $attempt/$max_attempts)"
+          sccache rustc --version
+          rc=$?
+          echo "::endgroup::"
+          if [ "$rc" -eq 0 ]; then
+            sccache --show-stats || true
+            exit 0
+          fi
+          if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "Probe failed (rc=$rc), retrying in ${delay}s..."
+            sleep "$delay"
+          fi
+          attempt=$((attempt + 1))
+        done
+        echo "::error::sccache startup probe failed after $max_attempts attempts"
+        exit 1

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -198,6 +201,9 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -261,6 +267,9 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -439,6 +448,9 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -613,6 +625,9 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -759,6 +774,9 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4
@@ -992,6 +1010,9 @@ jobs:
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Warm up sccache
+        uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What

Adds a composite action (`.github/actions/sccache-warmup`) that probes sccache startup with retry and wires it in after every `Install sccache` step in `release-common.yml` (7 sites — Linux x64, macOS x64, macOS ARM, Windows x64, plus the runtime-artifact and python-wheel jobs).

## Why

The Windows nightly job [25122410855](https://github.com/nteract/desktop/actions/runs/25122410855/job/73626557286) died on the `Generate Icons` step with:

```
sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => send http request
   url: https://productionresultssa12.blob.core.windows.net/actions-cache/...
   service: ghac
   path: .sccache_check
   ...
   client error (Connect): An existing connection was forcibly closed by the remote host. (os error 10054)
```

That's a transient Azure blob hiccup. `Generate Icons` is just the canary - it's the first step in that job that invokes `cargo`, which means the first `sccache rustc` call, which means the first time sccache's daemon contacts the GHA cache backend to read `.sccache_check`. When that single read fails, sccache exits 2, cargo exits, and the whole job dies before any real build work happens.

## How

The composite action runs `sccache rustc --version` (the same path cargo takes when first wrapping rustc) up to 3 times with a 10s backoff. Once the daemon is up, it serves the rest of the job, so downstream cargo steps never see the startup flake.

If all 3 attempts fail, the warmup step itself fails with a clear `::error::` message - which is still a strict improvement: the failure is attributed to sccache rather than masquerading as a `cargo xtask icons` error 80 lines into a build step, and it fails fast rather than after several minutes of build setup.

## Test plan

- [ ] Nightly run picks up the new step and shows a `Warm up sccache` step right after `Install sccache` in every Rust-building job.
- [ ] On a clean run, the probe completes in seconds and `sccache --show-stats` prints baseline counters.
- [ ] If the GHA cache flakes again, the `attempt 2/3` line appears in the log and the build continues.
