### PR TITLE
ci: speed up PR feedback loops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,13 +635,74 @@ jobs:
             > e2e-logs/daemon.log 2>&1 &
           DAEMON_PID=$!
 
-          # Wait for pool warm-up (skip for tests with no pool)
+          RUNT=$(find target/release/binaries -maxdepth 1 -name 'runt-*' -print -quit)
+          if [ -z "$RUNT" ]; then
+            echo "Could not find runt binary"
+            exit 1
+          fi
+
+          wait_for_daemon() {
+            local timeout="$1"
+            for i in $(seq 1 "$timeout"); do
+              kill -0 "$DAEMON_PID" 2>/dev/null || {
+                echo "Daemon died while waiting for readiness"
+                cat e2e-logs/daemon.log
+                exit 1
+              }
+
+              STATUS=$(env -u UV_CACHE_DIR -u UV_PYTHON_INSTALL_DIR \
+                RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+                "$RUNT" daemon status --json 2>/dev/null || true)
+
+              if [ -n "$STATUS" ] && STATUS_JSON="$STATUS" \
+                UV_POOL="${{ matrix.uv_pool }}" \
+                CONDA_POOL="${{ matrix.conda_pool }}" \
+                python3 <<'PY'
+          import json
+          import os
+          import sys
+
+          status = json.loads(os.environ["STATUS_JSON"])
+          if not status.get("running"):
+              sys.exit(1)
+
+          pool = status.get("pool_stats") or {}
+
+          def ready(name, requested):
+              if int(requested) <= 0:
+                  return True
+              state = pool.get(name) or {}
+              return int(state.get("available") or 0) > 0
+
+          sys.exit(
+              0
+              if ready("uv", os.environ["UV_POOL"])
+              and ready("conda", os.environ["CONDA_POOL"])
+              else 1
+          )
+          PY
+              then
+                echo "Daemon ready after ${i}s"
+                echo "$STATUS"
+                return 0
+              fi
+
+              sleep 1
+            done
+
+            echo "Daemon was not ready within ${timeout}s"
+            echo "Last daemon status:"
+            echo "${STATUS:-<none>}"
+            echo "Daemon log:"
+            cat e2e-logs/daemon.log
+            exit 1
+          }
+
+          # Wait for daemon readiness and, when requested, at least one warm pool entry.
           if [ "${{ matrix.uv_pool }}" = "0" ] && [ "${{ matrix.conda_pool }}" = "0" ]; then
-            echo "No pool to warm, sleeping 5s..."
-            sleep 5
+            wait_for_daemon 30
           else
-            echo "Waiting for daemon pool to warm (90s on cold CI)..."
-            sleep 90
+            wait_for_daemon 120
           fi
 
           # Start the app (with notebook if specified)
@@ -786,6 +847,8 @@ jobs:
           export RUNTIMED_BINARY="${GITHUB_WORKSPACE}/target/release/runtimed"
           export RUNTIMED_LOG_LEVEL=debug
           export RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
+          export RUNTIMED_TEST_UV_POOL_SIZE=1
+          export RUNTIMED_TEST_CONDA_POOL_SIZE=0
           # Tells the test fixture to copy daemon.log into the artifact
           # dir on teardown so a post-mortem has the daemon's side of any
           # failure (see #2290).
@@ -798,9 +861,13 @@ jobs:
           # timeout = 600). uv-installed bindings landed in
           # ${GITHUB_WORKSPACE}/.venv via VIRTUAL_ENV in the previous step.
           export VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv"
+          export RUNTIMED_PYTEST_WORKERS=6
           uv run pytest \
             tests/test_daemon_integration.py \
             tests/test_dx_integration.py \
+            -n "${RUNTIMED_PYTEST_WORKERS}" \
+            --dist loadscope \
+            --durations=25 \
             -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
 
           exit "${FAIL:-0}"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -400,7 +400,7 @@ jobs:
 
   linux-smoke:
     name: Linux (build + smoke)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -51,6 +51,7 @@ use notebook_protocol::protocol::LaunchedEnvConfig;
 /// to clash with common services on a developer machine.
 const DEFAULT_KERNEL_PORT_RANGE: std::ops::RangeInclusive<u16> = 9000..=9999;
 const TEST_KERNEL_PORT_RANGE_SIZE: u16 = 100;
+static NEXT_KERNEL_PORT_OFFSET: AtomicU64 = AtomicU64::new(0);
 
 fn kernel_port_range() -> std::ops::RangeInclusive<u16> {
     match std::env::var("RUNTIMED_TEST_KERNEL_PORT_RANGE_START") {
@@ -68,6 +69,19 @@ fn kernel_port_range() -> std::ops::RangeInclusive<u16> {
         },
         Err(_) => DEFAULT_KERNEL_PORT_RANGE,
     }
+}
+
+fn kernel_port_candidates(num: usize) -> Vec<u16> {
+    let range = kernel_port_range();
+    let start = u32::from(*range.start());
+    let end = u32::from(*range.end());
+    let len = (end - start + 1) as usize;
+    let offset = NEXT_KERNEL_PORT_OFFSET.fetch_add(num as u64, Ordering::Relaxed) as usize % len;
+
+    (0..len)
+        .map(|i| start + ((offset + i) % len) as u32)
+        .filter_map(|port| u16::try_from(port).ok())
+        .collect()
 }
 
 /// Reserve `num` TCP ports for a kernel's ZMQ sockets.
@@ -90,7 +104,7 @@ async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<T
     let mut ports: Vec<u16> = Vec::with_capacity(num);
     let mut listeners: Vec<TcpListener> = Vec::with_capacity(num);
 
-    for port in kernel_port_range() {
+    for port in kernel_port_candidates(num) {
         if ports.len() == num {
             break;
         }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -49,7 +49,26 @@ use notebook_protocol::protocol::LaunchedEnvConfig;
 /// also `ip_local_port_range` start, typically 32768). 9000-9999 is in the
 /// IANA user-port range, far from any default ephemeral pool, and unlikely
 /// to clash with common services on a developer machine.
-const KERNEL_PORT_RANGE: std::ops::RangeInclusive<u16> = 9000..=9999;
+const DEFAULT_KERNEL_PORT_RANGE: std::ops::RangeInclusive<u16> = 9000..=9999;
+const TEST_KERNEL_PORT_RANGE_SIZE: u16 = 100;
+
+fn kernel_port_range() -> std::ops::RangeInclusive<u16> {
+    match std::env::var("RUNTIMED_TEST_KERNEL_PORT_RANGE_START") {
+        Ok(raw) => match raw.parse::<u16>() {
+            Ok(start) => {
+                let end = start.saturating_add(TEST_KERNEL_PORT_RANGE_SIZE - 1);
+                start..=end
+            }
+            Err(e) => {
+                warn!(
+                    "[jupyter-kernel] Ignoring invalid RUNTIMED_TEST_KERNEL_PORT_RANGE_START={raw:?}: {e}"
+                );
+                DEFAULT_KERNEL_PORT_RANGE
+            }
+        },
+        Err(_) => DEFAULT_KERNEL_PORT_RANGE,
+    }
+}
 
 /// Reserve `num` TCP ports for a kernel's ZMQ sockets.
 ///
@@ -71,7 +90,7 @@ async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<T
     let mut ports: Vec<u16> = Vec::with_capacity(num);
     let mut listeners: Vec<TcpListener> = Vec::with_capacity(num);
 
-    for port in KERNEL_PORT_RANGE {
+    for port in kernel_port_range() {
         if ports.len() == num {
             break;
         }
@@ -84,7 +103,7 @@ async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<T
 
     if ports.len() == num {
         debug!(
-            "[jupyter-kernel] Reserved {} ports from KERNEL_PORT_RANGE: {:?}",
+            "[jupyter-kernel] Reserved {} ports from configured range: {:?}",
             num, ports
         );
         return Ok((ports, listeners));

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-timeout>=2.0",
+    "pytest-xdist>=3.6",
     "ipykernel>=6.0",
 ]
 

--- a/python/runtimed/tests/conftest.py
+++ b/python/runtimed/tests/conftest.py
@@ -47,6 +47,9 @@ def pytest_report_header(config):
     else:
         lines.append("runtimed: dev mode (expects running daemon)")
 
+    if worker := os.environ.get("PYTEST_XDIST_WORKER"):
+        lines.append(f"pytest-xdist worker: {worker}")
+
     # Check for custom socket path
     if "RUNTIMED_SOCKET_PATH" in os.environ:
         lines.append(f"runtimed socket: {os.environ['RUNTIMED_SOCKET_PATH']}")

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -414,6 +414,9 @@ def daemon_process(request):
     log_level = os.environ.get("RUNTIMED_LOG_LEVEL", "info")
 
     xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    xdist_worker_index = (
+        int(xdist_worker.removeprefix("gw")) if xdist_worker.startswith("gw") else 0
+    )
 
     # Create a temp directory for this test run
     # ignore_cleanup_errors=True prevents OSError when ipykernel leaves behind
@@ -446,6 +449,8 @@ def daemon_process(request):
             uv_pool_size,
             "--conda-pool-size",
             conda_pool_size,
+            "--pixi-pool-size",
+            "0",
         ]
 
         print(f"\n[test] Starting daemon: {' '.join(cmd)}", file=sys.stderr)
@@ -457,6 +462,7 @@ def daemon_process(request):
             env = os.environ.copy()
             env["RUST_LOG"] = log_level
             env["RUNTIMED_WORKSPACE_PATH"] = str(workspace_dir)
+            env["RUNTIMED_TEST_KERNEL_PORT_RANGE_START"] = str(9000 + xdist_worker_index * 100)
 
             proc = subprocess.Popen(
                 cmd,

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -413,16 +413,24 @@ def daemon_process(request):
     binary = _find_runtimed_binary()
     log_level = os.environ.get("RUNTIMED_LOG_LEVEL", "info")
 
+    xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+
     # Create a temp directory for this test run
     # ignore_cleanup_errors=True prevents OSError when ipykernel leaves behind
     # directories like 'magics' that aren't empty during cleanup
-    with tempfile.TemporaryDirectory(prefix="runtimed-test-", ignore_cleanup_errors=True) as tmpdir:
+    with tempfile.TemporaryDirectory(
+        prefix=f"runtimed-test-{xdist_worker}-", ignore_cleanup_errors=True
+    ) as tmpdir:
         tmpdir = Path(tmpdir)
         socket_path = tmpdir / "runtimed.sock"
         cache_dir = tmpdir / "cache"
         blob_dir = tmpdir / "blobs"
+        workspace_dir = tmpdir / "workspace"
         cache_dir.mkdir()
         blob_dir.mkdir()
+        workspace_dir.mkdir()
+        uv_pool_size = os.environ.get("RUNTIMED_TEST_UV_POOL_SIZE", "3")
+        conda_pool_size = os.environ.get("RUNTIMED_TEST_CONDA_POOL_SIZE", "1")
 
         # Build command
         cmd = [
@@ -435,9 +443,9 @@ def daemon_process(request):
             "--blob-store-dir",
             str(blob_dir),
             "--uv-pool-size",
-            "3",  # Reduced from 6 — CI runners are slow to warm large pools
+            uv_pool_size,
             "--conda-pool-size",
-            "1",  # Reduced from 3 — one env is enough, tests run sequentially
+            conda_pool_size,
         ]
 
         print(f"\n[test] Starting daemon: {' '.join(cmd)}", file=sys.stderr)
@@ -448,6 +456,7 @@ def daemon_process(request):
         with open(log_file, "w") as log_f:
             env = os.environ.copy()
             env["RUST_LOG"] = log_level
+            env["RUNTIMED_WORKSPACE_PATH"] = str(workspace_dir)
 
             proc = subprocess.Popen(
                 cmd,
@@ -475,8 +484,8 @@ def daemon_process(request):
         # Wait for pools to warm up before running tests.
         # We poll the daemon log file for pool-ready messages since
         # a reachable socket doesn't guarantee pools are warmed.
-        uv_ready = False
-        conda_ready = False
+        uv_ready = uv_pool_size == "0"
+        conda_ready = conda_pool_size == "0"
         import re
 
         # Match either format:
@@ -557,7 +566,7 @@ def daemon_process(request):
                 dest_dir = Path(artifact_dir)
                 dest_dir.mkdir(parents=True, exist_ok=True)
                 module_name = request.module.__name__.replace(".", "_")
-                dest = dest_dir / f"daemon-{module_name}.log"
+                dest = dest_dir / f"daemon-{module_name}-{xdist_worker}.log"
                 shutil.copy2(log_file, dest)
                 print(f"[test] Copied daemon log to {dest}", file=sys.stderr)
 


### PR DESCRIPTION
## What changed

- Runs `runtimed-py` integration tests with `pytest-xdist` using 6 loadscope workers and `--durations=25`.
- Makes the spawned Python integration daemon xdist-aware: unique temp workspace identity, worker-specific log artifact names, configurable pool sizes.
- Reduces per-worker integration daemon prewarm pressure to 1 UV env and 0 conda prewarm envs.
- Replaces E2E's fixed 90s daemon/pool sleep with `runt daemon status --json` readiness polling.
- Moves the PR Linux smoke runner from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404`.

## Why

Recent PR Build runs are still wall-clock limited by `runtimed-py Integration Tests`, and E2E UV-pool shards pay a fixed 90s sleep even when the daemon is ready earlier. This keeps the first-pass signal intact while making the slow paths more data-driven and less idle.

## Validation

- `cargo xtask lint --fix`
- YAML parse check for `.github/workflows/build.yml` and `.github/workflows/smoke.yml`
- `bash -n` on the embedded Build workflow E2E and Python integration shell blocks
- `uv run --directory python/runtimed python -m py_compile tests/conftest.py tests/test_daemon_integration.py`
- `uv run --directory python/runtimed pytest tests/test_daemon_integration.py tests/test_dx_integration.py --collect-only -n 2 --dist loadscope -q`
- `actionlint` against the changed workflows

## External review

Claude Bedrock reviewer found one confirmed issue in the first pass: xdist-spawned daemons would inherit the same `RUNTIMED_WORKSPACE_PATH` and share workspace-derived singleton/log state. Fixed by assigning each spawned daemon a temp workspace path.

The same review noted possible worker over-provisioning/load. I kept `-n 6` to preserve the intended class-level batching, but reduced per-worker pool pressure to 1 UV env and 0 conda prewarm envs. A second Claude review retry hung without producing output, so this PR should use CI timing data to tune worker count if needed.
