### PR TITLE
fix(runtimed): clean partial streaming load state

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -85,7 +85,7 @@ use automerge::{
     ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     KernelActivity, KernelErrorReason, ProjectContext, ProjectFile, ProjectFileExtras,
@@ -1526,6 +1526,43 @@ impl RuntimeStateDoc {
         self.doc.put(&entry, "execution_count", ScalarValue::Null)?;
         self.doc.put(&entry, "success", ScalarValue::Null)?;
         Ok(true)
+    }
+
+    /// Remove all execution entries associated with the given cell ids.
+    ///
+    /// Used when a failed notebook load rolls back newly added cells before
+    /// they become durable notebook state.
+    pub fn remove_executions_for_cells(
+        &mut self,
+        cell_ids: &[String],
+    ) -> Result<usize, RuntimeStateError> {
+        if cell_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let Some(executions) = self.get_map("executions") else {
+            return Ok(0);
+        };
+
+        let cell_ids: HashSet<&str> = cell_ids.iter().map(String::as_str).collect();
+        let execution_ids: Vec<String> = self
+            .doc
+            .keys(&executions)
+            .filter(|execution_id| {
+                let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten()
+                else {
+                    return false;
+                };
+                cell_ids.contains(self.read_str(&entry, "cell_id").as_str())
+            })
+            .collect();
+
+        for execution_id in &execution_ids {
+            self.doc.delete(&executions, execution_id.as_str())?;
+            self.remove_display_index_entries_for_execution(execution_id);
+        }
+
+        Ok(execution_ids.len())
     }
 
     // ── display_index management ─────────────────────────────────────
@@ -3455,6 +3492,36 @@ mod tests {
 
         let state = doc.read_state();
         assert_eq!(state.execution_count_for_cell("cell-1"), None);
+    }
+
+    #[test]
+    fn test_remove_executions_for_cells_removes_matching_executions_and_indexes() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-a", "cell-a").unwrap();
+        doc.create_execution("exec-b", "cell-b").unwrap();
+        doc.create_execution("exec-c", "cell-a").unwrap();
+        doc.add_display_index_entry("display-1", "exec-a", "output-a");
+        doc.add_display_index_entry("display-1", "exec-b", "output-b");
+        doc.add_display_index_entry("display-2", "exec-a", "output-c");
+
+        let removed = doc
+            .remove_executions_for_cells(&["cell-a".to_string()])
+            .unwrap();
+
+        assert_eq!(removed, 2);
+        let state = doc.read_state();
+        assert!(!state.executions.contains_key("exec-a"));
+        assert!(state.executions.contains_key("exec-b"));
+        assert!(!state.executions.contains_key("exec-c"));
+        assert_eq!(
+            doc.get_display_index_entries("display-1"),
+            vec![("exec-b".to_string(), "output-b".to_string())],
+            "display index entries for removed executions should be cleared"
+        );
+        assert!(
+            doc.get_display_index_entries("display-2").is_empty(),
+            "all display ids for removed executions should be cleared"
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -207,11 +207,35 @@ where
             Ok(initial_load_phase)
         }
         Err(e) => {
-            room.finish_loading();
-            {
+            let cell_ids = {
                 let mut doc = room.doc.write().await;
-                let _ = doc.clear_all_cells();
+                let cell_ids = doc
+                    .get_cells()
+                    .into_iter()
+                    .map(|cell| cell.id)
+                    .collect::<Vec<_>>();
+                if let Err(err) = doc.clear_all_cells() {
+                    warn!(
+                        "[notebook-sync] Failed to clear partial load cells for {}: {}",
+                        load_path.display(),
+                        err
+                    );
+                }
+                cell_ids
+            };
+            if !cell_ids.is_empty() {
+                if let Err(err) = room
+                    .state
+                    .with_doc(|state_doc| state_doc.remove_executions_for_cells(&cell_ids))
+                {
+                    warn!(
+                        "[notebook-sync] Failed to remove partial load executions for {}: {}",
+                        load_path.display(),
+                        err
+                    );
+                }
             }
+            room.finish_loading();
             let _ = room.broadcasts.changed_tx.send(());
             warn!(
                 "[notebook-sync] Streaming load failed for {}: {}",
@@ -229,5 +253,538 @@ where
             }
             Err(anyhow::anyhow!("Streaming load failed: {}", e))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    use notebook_protocol::protocol::{
+        InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire, SessionControlMessage,
+    };
+    use tokio::io::AsyncWrite;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::blob_store::BlobStore;
+
+    #[derive(Default)]
+    struct CaptureWriter {
+        bytes: Vec<u8>,
+    }
+
+    impl AsyncWrite for CaptureWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Default)]
+    struct FailFirstWrite {
+        bytes: Vec<u8>,
+        failed: bool,
+        partial_room: Option<Arc<NotebookRoom>>,
+        observed_partial_doc: bool,
+        observed_partial_executions: bool,
+    }
+
+    impl FailFirstWrite {
+        fn expecting_partial_state(room: &Arc<NotebookRoom>) -> Self {
+            Self {
+                partial_room: Some(Arc::clone(room)),
+                ..Self::default()
+            }
+        }
+    }
+
+    impl AsyncWrite for FailFirstWrite {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            if !self.failed {
+                self.failed = true;
+                if let Some(room) = self.partial_room.clone() {
+                    let doc = room
+                        .doc
+                        .try_read()
+                        .expect("notebook doc lock should be released before socket write");
+                    assert!(
+                        doc.cell_count() > 0,
+                        "injected write failure should happen after partial cells are loaded"
+                    );
+                    drop(doc);
+                    self.observed_partial_doc = true;
+
+                    let observed_partial_executions = room
+                        .state
+                        .with_doc(|state_doc| Ok(!state_doc.read_state().executions.is_empty()))
+                        .expect("runtime state doc should be readable before injected failure");
+                    assert!(
+                        observed_partial_executions,
+                        "injected write failure should happen after partial executions are loaded"
+                    );
+                    self.observed_partial_executions = true;
+                }
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "injected first write failure",
+                )));
+            }
+            self.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn test_room(tmp: &tempfile::TempDir) -> Arc<NotebookRoom> {
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        Arc::new(NotebookRoom::new_fresh(
+            Uuid::new_v4(),
+            None,
+            tmp.path(),
+            blob_store,
+            true,
+        ))
+    }
+
+    async fn write_one_cell_notebook(path: &Path) {
+        tokio::fs::write(
+            path,
+            r##"{
+                "nbformat": 4,
+                "nbformat_minor": 5,
+                "metadata": {},
+                "cells": [
+                    {
+                        "id": "loaded-cell",
+                        "cell_type": "code",
+                        "metadata": {},
+                        "source": "x = 1",
+                        "execution_count": 7,
+                        "outputs": [
+                            {
+                                "output_type": "stream",
+                                "name": "stdout",
+                                "text": "hello\n"
+                            }
+                        ]
+                    }
+                ]
+            }"##,
+        )
+        .await
+        .unwrap();
+    }
+
+    fn frame_types(bytes: &[u8]) -> Vec<NotebookFrameType> {
+        let mut types = Vec::new();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let len = u32::from_be_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .expect("frame length prefix"),
+            ) as usize;
+            offset += 4;
+            let frame = &bytes[offset..offset + len];
+            offset += len;
+            types.push(NotebookFrameType::try_from(frame[0]).expect("known frame type"));
+        }
+        types
+    }
+
+    fn decode_session_statuses(bytes: &[u8]) -> Vec<SessionControlMessage> {
+        let mut statuses = Vec::new();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let len = u32::from_be_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .expect("frame length prefix"),
+            ) as usize;
+            offset += 4;
+            let frame = &bytes[offset..offset + len];
+            offset += len;
+
+            if frame[0] == NotebookFrameType::SessionControl as u8 {
+                statuses.push(serde_json::from_slice(&frame[1..]).expect("session control json"));
+            }
+        }
+        statuses
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_contention_leaves_owner_loading_state_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("missing-but-not-read.ipynb");
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        assert!(room.try_start_loading(), "first peer owns streaming load");
+
+        let phase = stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect("contending peer should not fail");
+
+        assert_eq!(phase, InitialLoadPhaseWire::Streaming);
+        assert!(
+            writer.bytes.is_empty(),
+            "contending peer must not emit Ready/Failed before the owner finishes loading"
+        );
+        assert!(
+            room.is_loading(),
+            "contending peer must leave the owner loading marker intact"
+        );
+
+        room.finish_loading();
+        assert!(
+            !room.is_loading(),
+            "steady-state changed_rx readiness check can now promote Streaming to Ready"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_failure_emits_failed_status_and_clears_partial_doc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+        let mut reader = tokio::io::empty();
+        let mut writer = FailFirstWrite::expecting_partial_state(&room);
+        let mut peer_state = sync::State::new();
+
+        let err = stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect_err("missing file should fail streaming load");
+
+        assert!(
+            err.to_string()
+                .contains("Failed to send sync message: injected first write failure"),
+            "error should preserve the peer-loop failure prefix"
+        );
+        assert!(writer.observed_partial_doc);
+        assert!(writer.observed_partial_executions);
+        assert!(
+            !room.is_loading(),
+            "failure cleanup must release the loading marker"
+        );
+        assert_eq!(
+            room.doc.read().await.cell_count(),
+            0,
+            "failure cleanup must clear partially loaded cells"
+        );
+        room.state
+            .with_doc(|state_doc| {
+                assert!(
+                    state_doc.read_state().executions.is_empty(),
+                    "failure cleanup must remove executions for rolled-back cells"
+                );
+                Ok(())
+            })
+            .unwrap();
+        changed_rx
+            .try_recv()
+            .expect("failure cleanup should broadcast document change");
+        assert!(
+            changed_rx.try_recv().is_err(),
+            "failure cleanup should emit exactly one cleanup broadcast"
+        );
+
+        let statuses = decode_session_statuses(&writer.bytes);
+        assert_eq!(statuses.len(), 1);
+        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        assert_eq!(status.notebook_doc, NotebookDocPhaseWire::Syncing);
+        assert_eq!(status.runtime_state, RuntimeStatePhaseWire::Syncing);
+        match &status.initial_load {
+            InitialLoadPhaseWire::Failed { reason } => {
+                assert!(
+                    reason.contains("Failed to send sync message"),
+                    "failed status should include the load failure reason: {reason}"
+                );
+            }
+            other => panic!("expected failed initial load status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_v2_client_suppresses_session_status_frames() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        let phase = stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            2,
+        )
+        .await
+        .expect("valid notebook should stream successfully");
+
+        assert_eq!(phase, InitialLoadPhaseWire::Ready);
+        let emitted_frame_types = frame_types(&writer.bytes);
+        assert!(
+            !emitted_frame_types.is_empty(),
+            "pre-v3 success must still emit document sync frames"
+        );
+        assert!(
+            decode_session_statuses(&writer.bytes).is_empty(),
+            "pre-v3 clients must not receive SessionControl frames"
+        );
+        assert!(
+            emitted_frame_types
+                .iter()
+                .all(|frame_type| *frame_type == NotebookFrameType::AutomergeSync),
+            "pre-v3 success should only emit Automerge sync frames"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_v2_failure_suppresses_failed_status_frame() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let mut reader = tokio::io::empty();
+        let mut writer = FailFirstWrite::expecting_partial_state(&room);
+        let mut peer_state = sync::State::new();
+
+        stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            2,
+        )
+        .await
+        .expect_err("injected write failure should fail streaming load");
+
+        assert!(writer.observed_partial_doc);
+        assert!(writer.observed_partial_executions);
+        assert!(
+            writer.bytes.is_empty(),
+            "pre-v3 failure must not emit SessionControl frames"
+        );
+        assert!(!room.is_loading());
+        assert_eq!(room.doc.read().await.cell_count(), 0);
+        room.state
+            .with_doc(|state_doc| {
+                assert!(
+                    state_doc.read_state().executions.is_empty(),
+                    "pre-v3 failure cleanup must remove rolled-back executions"
+                );
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_missing_file_emits_failed_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("does-not-exist.ipynb");
+        let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        let err = stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect_err("missing file should fail streaming load");
+
+        assert!(
+            err.to_string()
+                .contains("Streaming load failed: Failed to read notebook"),
+            "missing file should preserve the load failure reason"
+        );
+        changed_rx
+            .try_recv()
+            .expect("missing-file cleanup should broadcast document change");
+        assert!(changed_rx.try_recv().is_err());
+
+        let statuses = decode_session_statuses(&writer.bytes);
+        assert_eq!(statuses.len(), 1);
+        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        match &status.initial_load {
+            InitialLoadPhaseWire::Failed { reason } => {
+                assert!(
+                    reason.contains("Failed to read notebook"),
+                    "failed status should include the missing-file reason: {reason}"
+                );
+            }
+            other => panic!("expected failed initial load status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_success_orders_doc_sync_before_ready_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        let phase = stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect("valid notebook should stream successfully");
+
+        assert_eq!(phase, InitialLoadPhaseWire::Ready);
+        assert!(!room.is_loading(), "successful load should finish loading");
+        let cells = room.doc.read().await.get_cells();
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "loaded-cell");
+        assert_eq!(cells[0].source, "x = 1");
+
+        let frame_types = frame_types(&writer.bytes);
+        assert!(
+            frame_types.len() >= 2,
+            "success should emit at least one doc sync followed by Ready"
+        );
+        assert_eq!(
+            frame_types.last(),
+            Some(&NotebookFrameType::SessionControl),
+            "Ready must be the final bootstrap frame"
+        );
+        assert!(
+            frame_types[..frame_types.len() - 1]
+                .iter()
+                .all(|frame_type| *frame_type == NotebookFrameType::AutomergeSync),
+            "all frames before Ready must be document sync frames"
+        );
+
+        let statuses = decode_session_statuses(&writer.bytes);
+        assert_eq!(statuses.len(), 1);
+        let SessionControlMessage::SyncStatus(status) = &statuses[0];
+        assert_eq!(status.notebook_doc, NotebookDocPhaseWire::Syncing);
+        assert_eq!(status.runtime_state, RuntimeStatePhaseWire::Syncing);
+        assert_eq!(status.initial_load, InitialLoadPhaseWire::Ready);
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_success_records_non_null_execution_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect("valid notebook should stream successfully");
+
+        room.state
+            .with_doc(|state_doc| {
+                let state = state_doc.read_state();
+                let execution = state
+                    .executions
+                    .values()
+                    .find(|execution| execution.cell_id == "loaded-cell")
+                    .expect("loaded code cell should have an execution record");
+                assert_eq!(execution.execution_count, Some(7));
+                Ok(())
+            })
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- add focused stream_initial_load coverage for success, load contention, missing-file failure, partial-write failure cleanup, pre-v3 SessionControl gating, and non-null execution_count propagation
- add RuntimeStateDoc cleanup for executions belonging to cells rolled back after failed notebook streaming load
- keep failed-load cleanup consistent by clearing partial cells, removing matching runtime executions/display_index entries, and only then releasing the loading marker
- ran Claude Bedrock Opus 4.7 review loops; final pass found no concrete bugs or regressions

## Verification
- cargo fmt --check
- cargo test -p runtime-doc remove_executions_for_cells --lib
- cargo test -p runtimed stream_initial_load --lib
- cargo check -p runtimed
- cargo clippy -p runtimed --lib -- -D warnings
- cargo xtask lint --fix

Refs #2340