### PR TITLE
chore(deps): update zeromq to master via runtimelib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2133,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,7 +3296,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
-source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
+source = "git+https://github.com/quillaid/runtimed.git?rev=7473fe4b3b57d324a9558e873de84c4ecf85a059#7473fe4b3b57d324a9558e873de84c4ecf85a059"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3804,7 +3804,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4267,7 +4267,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "nbformat"
 version = "3.0.0"
-source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
+source = "git+https://github.com/quillaid/runtimed.git?rev=7473fe4b3b57d324a9558e873de84c4ecf85a059#7473fe4b3b57d324a9558e873de84c4ecf85a059"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4629,7 +4629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7165,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
-source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
+source = "git+https://github.com/quillaid/runtimed.git?rev=7473fe4b3b57d324a9558e873de84c4ecf85a059#7473fe4b3b57d324a9558e873de84c4ecf85a059"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7254,7 +7254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8023,7 +8023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8947,7 +8947,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10283,7 +10283,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11138,8 +11138,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 [[package]]
 name = "zeromq"
 version = "0.6.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06ccf13d2d6709a7463d175b88598c88a5dc63c8907ffb6f32a8a16baf77c1f"
+source = "git+https://github.com/zeromq/zmq.rs.git#bdfd4d88412be7ff688e6fa9dcac8616cf385546"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2133,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3296,7 +3296,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#6938d702b43192a933cee7f168e2176e85bf93d9"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#1650c4e0582940c2658e18cb6c17d3a9e50e4068"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3820,7 +3820,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4283,7 +4283,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4646,7 +4646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5122,7 +5122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7182,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#6938d702b43192a933cee7f168e2176e85bf93d9"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#1650c4e0582940c2658e18cb6c17d3a9e50e4068"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7271,7 +7271,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8040,7 +8040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8964,7 +8964,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10300,7 +10300,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2133,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3804,7 +3804,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4267,7 +4267,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4629,7 +4629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7254,7 +7254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8023,7 +8023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8947,7 +8947,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10283,7 +10283,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11138,7 +11138,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 [[package]]
 name = "zeromq"
 version = "0.6.0-pre.1"
-source = "git+https://github.com/zeromq/zmq.rs.git#bdfd4d88412be7ff688e6fa9dcac8616cf385546"
+source = "git+https://github.com/zeromq/zmq.rs.git#770bb20cf117cc53a95ddfce3c5221b76a3389a9"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,20 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "jupyter-protocol"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c8c5887974082be34e2bdac6b9b9dd8ad89951cae918b197959035b0673f6f"
 dependencies = [
@@ -4377,7 +4391,7 @@ checksum = "b2c06543f305caee515923b125a737c4d58079c063e25701f93f45077bb8d622"
 dependencies = [
  "anyhow",
  "chrono",
- "jupyter-protocol",
+ "jupyter-protocol 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6914,7 +6928,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
- "jupyter-protocol",
+ "jupyter-protocol 2.0.0",
  "kernel-env",
  "libc",
  "notebook-doc",
@@ -7033,7 +7047,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jiter",
- "jupyter-protocol",
+ "jupyter-protocol 2.0.0",
  "kernel-env",
  "kernel-launch",
  "libc",
@@ -7167,8 +7181,6 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a95a93931b98c47a6201d5edd6e5b3545758fb475703bc797ba866b089ee6dd"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7178,7 +7190,7 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
- "jupyter-protocol",
+ "jupyter-protocol 2.0.0",
  "serde",
  "serde_json",
  "shellexpand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2133,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3296,7 +3296,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3728,23 +3728,7 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c8c5887974082be34e2bdac6b9b9dd8ad89951cae918b197959035b0673f6f"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "jupyter-protocol"
-version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#bc7fa469a3d64ac2cab633fad8eceb284de825dd"
+source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3820,7 +3804,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4283,7 +4267,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4387,12 +4371,11 @@ dependencies = [
 [[package]]
 name = "nbformat"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c06543f305caee515923b125a737c4d58079c063e25701f93f45077bb8d622"
+source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
 dependencies = [
  "anyhow",
  "chrono",
- "jupyter-protocol 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jupyter-protocol",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4646,7 +4629,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6929,7 +6912,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
- "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
+ "jupyter-protocol",
  "kernel-env",
  "libc",
  "notebook-doc",
@@ -7048,7 +7031,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jiter",
- "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
+ "jupyter-protocol",
  "kernel-env",
  "kernel-launch",
  "libc",
@@ -7182,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#bc7fa469a3d64ac2cab633fad8eceb284de825dd"
+source = "git+https://github.com/runtimed/runtimed.git?rev=2849523ef299d09b6a1ed838e2398ecf6ad74e70#2849523ef299d09b6a1ed838e2398ecf6ad74e70"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7192,7 +7175,7 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
- "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
+ "jupyter-protocol",
  "serde",
  "serde_json",
  "shellexpand",
@@ -7271,7 +7254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8040,7 +8023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8964,7 +8947,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10300,7 +10283,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,8 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c8c5887974082be34e2bdac6b9b9dd8ad89951cae918b197959035b0673f6f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3742,8 +3744,7 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c8c5887974082be34e2bdac6b9b9dd8ad89951cae918b197959035b0673f6f"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#6938d702b43192a933cee7f168e2176e85bf93d9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6928,7 +6929,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
- "jupyter-protocol 2.0.0",
+ "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
  "kernel-env",
  "libc",
  "notebook-doc",
@@ -7047,7 +7048,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jiter",
- "jupyter-protocol 2.0.0",
+ "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
  "kernel-env",
  "kernel-launch",
  "libc",
@@ -7181,6 +7182,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#6938d702b43192a933cee7f168e2176e85bf93d9"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7190,7 +7192,7 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
- "jupyter-protocol 2.0.0",
+ "jupyter-protocol 2.0.0 (git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport)",
  "serde",
  "serde_json",
  "shellexpand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2133,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,7 +3296,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "jupyter-protocol"
 version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#1650c4e0582940c2658e18cb6c17d3a9e50e4068"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#bc7fa469a3d64ac2cab633fad8eceb284de825dd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3820,7 +3820,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4283,7 +4283,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4646,7 +4646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7182,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "2.0.0"
-source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#1650c4e0582940c2658e18cb6c17d3a9e50e4068"
+source = "git+https://github.com/quillaid/runtimed.git?branch=feat%2Fipc-transport#bc7fa469a3d64ac2cab633fad8eceb284de825dd"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -7271,7 +7271,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8040,7 +8040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8964,7 +8964,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10300,7 +10300,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70", default-features = false }
-jupyter-protocol = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70" }
-nbformat = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70" }
+runtimelib = { git = "https://github.com/quillaid/runtimed.git", rev = "7473fe4b3b57d324a9558e873de84c4ecf85a059", default-features = false }
+jupyter-protocol = { git = "https://github.com/quillaid/runtimed.git", rev = "7473fe4b3b57d324a9558e873de84c4ecf85a059" }
+nbformat = { git = "https://github.com/quillaid/runtimed.git", rev = "7473fe4b3b57d324a9558e873de84c4ecf85a059" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { git = "https://github.com/quillaid/runtimed.git", branch = "feat/ipc-transport", default-features = false }
-jupyter-protocol = { git = "https://github.com/quillaid/runtimed.git", branch = "feat/ipc-transport" }
-nbformat = "3.0.0"
+runtimelib = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70", default-features = false }
+jupyter-protocol = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70" }
+nbformat = { git = "https://github.com/runtimed/runtimed.git", rev = "2849523ef299d09b6a1ed838e2398ecf6ad74e70" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "2.0.0", default-features = false }
-jupyter-protocol = "2.0.0"
+runtimelib = { path = "../runtimed/crates/runtimelib", default-features = false }
+jupyter-protocol = { path = "../runtimed/crates/jupyter-protocol" }
 nbformat = "3.0.0"
 thiserror = "2"
 schemars = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { path = "../runtimed/crates/runtimelib", default-features = false }
-jupyter-protocol = { path = "../runtimed/crates/jupyter-protocol" }
+runtimelib = { git = "https://github.com/quillaid/runtimed.git", branch = "feat/ipc-transport", default-features = false }
+jupyter-protocol = { git = "https://github.com/quillaid/runtimed.git", branch = "feat/ipc-transport" }
 nbformat = "3.0.0"
 thiserror = "2"
 schemars = "1"

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -240,6 +240,26 @@ pub fn default_notebook_docs_dir() -> PathBuf {
     daemon_base_dir().join("notebook-docs")
 }
 
+/// Base directory for kernel IPC (Unix domain) socket files.
+///
+/// Uses `/tmp/` to stay within the macOS 104-byte `sun_path` limit —
+/// paths under `~/.cache/` can exceed it with long usernames. In dev
+/// mode each worktree gets its own subdirectory so concurrent worktree
+/// daemons never collide.
+///
+/// Layout: `/tmp/{cache_namespace}/` (e.g. `/tmp/runt-nightly/`).
+/// Kernel socket files are `kernel-{id}-ipc-{1..5}` inside this dir.
+#[cfg(unix)]
+pub fn ipc_socket_dir() -> PathBuf {
+    let base = PathBuf::from("/tmp").join(cache_namespace());
+    if is_dev_mode() {
+        if let Some(worktree) = get_workspace_path() {
+            return base.join(format!("wt-{}", worktree_hash(&worktree)));
+        }
+    }
+    base
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -243,21 +243,41 @@ pub fn default_notebook_docs_dir() -> PathBuf {
 /// Base directory for kernel IPC (Unix domain) socket files.
 ///
 /// Uses `/tmp/` to stay within the macOS 104-byte `sun_path` limit —
-/// paths under `~/.cache/` can exceed it with long usernames. In dev
-/// mode each worktree gets its own subdirectory so concurrent worktree
-/// daemons never collide.
+/// paths under `~/.cache/` can exceed it with long usernames. The UID
+/// is embedded in the directory name so that different OS users on the
+/// same machine get private, non-overlapping socket roots (the daemon
+/// singleton lock is per-user, but `/tmp/` is world-writable). The
+/// directory is created with mode `0o700` by `ensure_ipc_socket_dir`.
 ///
-/// Layout: `/tmp/{cache_namespace}/` (e.g. `/tmp/runt-nightly/`).
+/// Layout: `/tmp/{cache_namespace}-{uid}/` (e.g. `/tmp/runt-nightly-1000/`).
+/// In dev mode a worktree hash is appended so concurrent worktree
+/// daemons never collide.
 /// Kernel socket files are `kernel-{id}-ipc-{1..5}` inside this dir.
 #[cfg(unix)]
 pub fn ipc_socket_dir() -> PathBuf {
-    let base = PathBuf::from("/tmp").join(cache_namespace());
+    // SAFETY: getuid() is always safe — it's a read-only syscall with no
+    // preconditions.
+    let uid = unsafe { libc::getuid() };
+    let base = PathBuf::from("/tmp").join(format!("{}-{}", cache_namespace(), uid));
     if is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
             return base.join(format!("wt-{}", worktree_hash(&worktree)));
         }
     }
     base
+}
+
+/// Create the IPC socket directory with owner-only permissions (`0o700`).
+///
+/// Call this before writing kernel socket files. The restricted mode
+/// prevents other local users from creating or removing sockets in
+/// our directory.
+#[cfg(unix)]
+pub fn ensure_ipc_socket_dir() -> std::io::Result<()> {
+    let dir = ipc_socket_dir();
+    std::fs::create_dir_all(&dir)?;
+    std::fs::set_permissions(&dir, std::os::unix::fs::PermissionsExt::from_mode(0o700))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1009,6 +1009,36 @@ impl Daemon {
             }
         }
 
+        // Sweep stale IPC socket files from a previous daemon session.
+        // The singleton lock guarantees no live kernels exist at this
+        // point, so any `kernel-*-ipc-*` files are leftovers from a
+        // crash and can be safely removed.
+        #[cfg(unix)]
+        {
+            let ipc_dir = runtimed_client::ipc_socket_dir();
+            if ipc_dir.is_dir() {
+                let mut swept = 0usize;
+                if let Ok(entries) = std::fs::read_dir(&ipc_dir) {
+                    for entry in entries.flatten() {
+                        if let Some(name) = entry.file_name().to_str() {
+                            if name.starts_with("kernel-")
+                                && name.contains("-ipc-")
+                                && std::fs::remove_file(entry.path()).is_ok()
+                            {
+                                swept += 1;
+                            }
+                        }
+                    }
+                }
+                if swept > 0 {
+                    info!(
+                        "[runtimed] Swept {} stale IPC socket file(s) from {:?}",
+                        swept, ipc_dir
+                    );
+                }
+            }
+        }
+
         // Register global shutdown trigger for notebook_sync_server debouncers.
         {
             let shutdown_daemon = self.clone();

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -778,9 +778,7 @@ impl KernelConnection for JupyterKernel {
         #[cfg(unix)]
         let ipc_prefix = {
             let prefix = ipc_path_prefix(&kernel_id);
-            if let Some(parent) = prefix.parent() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
+            crate::ensure_ipc_socket_dir()?;
             Some(prefix)
         };
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1198,28 +1198,49 @@ impl KernelConnection for JupyterKernel {
 
         // ── ZMQ connections and background tasks ─────────────────────────
 
-        // IPC: wait for the kernel to create socket files before connecting.
+        // IPC: wait for the kernel to create ALL socket files before connecting.
         // Unlike TCP (where connect can retry internally), zmq.rs IPC connect
         // fails immediately with ENOENT if the socket file doesn't exist yet.
-        // The kernel (ipykernel/Deno) needs time to start, parse the
-        // connection file, and call zmq.bind() which creates the socket files.
+        // The kernel (ipykernel) needs time to start, parse the connection
+        // file, and call zmq.bind() on each channel — which creates the socket
+        // files. We wait for all 5 (shell, iopub, stdin, control, hb) so no
+        // subsequent connect() races the kernel's bind().
         #[cfg(unix)]
         if connection_info.transport == jupyter_protocol::connection_info::Transport::IPC {
-            let shell_socket = format!("{}-{}", connection_info.ip, connection_info.shell_port);
+            let socket_paths: Vec<String> = [
+                connection_info.shell_port,
+                connection_info.iopub_port,
+                connection_info.stdin_port,
+                connection_info.control_port,
+                connection_info.hb_port,
+            ]
+            .iter()
+            .map(|port| format!("{}-{}", connection_info.ip, port))
+            .collect();
+
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
             loop {
-                if std::path::Path::new(&shell_socket).exists() {
-                    debug!("[jupyter-kernel] IPC socket ready: {}", shell_socket);
+                let all_exist = socket_paths
+                    .iter()
+                    .all(|p| std::path::Path::new(p).exists());
+                if all_exist {
+                    debug!(
+                        "[jupyter-kernel] All 5 IPC sockets ready (prefix={})",
+                        connection_info.ip
+                    );
                     break;
                 }
                 if std::time::Instant::now() >= deadline {
-                    // Clean up since we're about to fail
+                    let missing: Vec<_> = socket_paths
+                        .iter()
+                        .filter(|p| !std::path::Path::new(p.as_str()).exists())
+                        .collect();
                     if let Some(ref prefix) = ipc_prefix {
                         cleanup_ipc_sockets(prefix);
                     }
                     return Err(anyhow::anyhow!(
-                        "Kernel did not create IPC socket within 30s: {}",
-                        shell_socket
+                        "Kernel did not create IPC sockets within 30s. Missing: {:?}",
+                        missing
                     ));
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1079,6 +1079,34 @@ impl KernelConnection for JupyterKernel {
 
         // ── ZMQ connections and background tasks ─────────────────────────
 
+        // IPC: wait for the kernel to create socket files before connecting.
+        // Unlike TCP (where connect can retry internally), zmq.rs IPC connect
+        // fails immediately with ENOENT if the socket file doesn't exist yet.
+        // The kernel (ipykernel/Deno) needs time to start, parse the
+        // connection file, and call zmq.bind() which creates the socket files.
+        #[cfg(unix)]
+        if connection_info.transport == jupyter_protocol::connection_info::Transport::IPC {
+            let shell_socket = format!("{}-{}", connection_info.ip, connection_info.shell_port);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                if std::path::Path::new(&shell_socket).exists() {
+                    debug!("[jupyter-kernel] IPC socket ready: {}", shell_socket);
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    // Clean up since we're about to fail
+                    if let Some(ref prefix) = ipc_prefix {
+                        cleanup_ipc_sockets(prefix);
+                    }
+                    return Err(anyhow::anyhow!(
+                        "Kernel did not create IPC socket within 30s: {}",
+                        shell_socket
+                    ));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+
         // Create iopub connection and spawn listener
         let mut iopub =
             runtimelib::create_client_iopub_connection(&connection_info, "", &session_id).await?;

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -11,9 +11,9 @@
 use std::collections::{HashMap, VecDeque};
 #[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
 #[cfg(unix)]
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -9,7 +9,6 @@
 //! **not** hold queue, executing cell, or status — those live in `KernelState`.
 
 use std::collections::{HashMap, VecDeque};
-#[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 #[cfg(unix)]
 use std::path::Path;
@@ -25,7 +24,6 @@ use jupyter_protocol::{
     JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
 };
 use runtime_doc::{KernelActivity, RuntimeLifecycle};
-#[cfg(windows)]
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -125,7 +123,6 @@ fn kernel_port_candidates(num: usize) -> Vec<u16> {
 /// rarer on Linux/macOS and the reserved range is small enough that we
 /// might collide with something, so the fallback keeps developer machines
 /// working.
-#[cfg(windows)]
 async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<TcpListener>)> {
     let mut ports: Vec<u16> = Vec::with_capacity(num);
     let mut listeners: Vec<TcpListener> = Vec::with_capacity(num);
@@ -305,7 +302,6 @@ impl KernelConnection for JupyterKernel {
         // are no ports to reserve — the kernel_id uniqueness guarantees
         // collision-free socket paths. On Windows (TCP) ports are reserved
         // inside the spawn loop and the file is rewritten per attempt.
-        #[cfg(windows)]
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let conn_dir = crate::connections_dir();
         tokio::fs::create_dir_all(&conn_dir).await?;
@@ -775,18 +771,25 @@ impl KernelConnection for JupyterKernel {
             ConnectionInfo,
         );
 
+        // Deno's Jupyter kernel uses its own ZMQ implementation that
+        // does not support IPC transport. Use IPC only for Python kernels
+        // on Unix; everything else stays on TCP.
         #[cfg(unix)]
-        let ipc_prefix = {
+        let use_ipc = kernel_type != "deno";
+
+        #[cfg(unix)]
+        let ipc_prefix = if use_ipc {
             let prefix = ipc_path_prefix(&kernel_id);
             crate::ensure_ipc_socket_dir()?;
             Some(prefix)
+        } else {
+            None
         };
 
         let (mut process, _stderr_buffer, connection_info) = {
             // ── Unix: IPC transport (single attempt, no port race) ───────
             #[cfg(unix)]
-            {
-                let prefix = ipc_prefix.as_ref().unwrap();
+            if let Some(ref prefix) = ipc_prefix {
                 let connection_info = ConnectionInfo {
                     transport: jupyter_protocol::connection_info::Transport::IPC,
                     ip: prefix.display().to_string(),
@@ -904,6 +907,122 @@ impl KernelConnection for JupyterKernel {
                         // Process still running — good
                         (process, stderr_buffer, connection_info) as LaunchedKernel
                     }
+                }
+            } else {
+                // ── Unix TCP fallback (Deno) — single attempt, no retry ──
+                let (ports, listeners) = reserve_kernel_ports(ip, 5).await?;
+                let connection_info = ConnectionInfo {
+                    transport: jupyter_protocol::connection_info::Transport::TCP,
+                    ip: ip.to_string(),
+                    stdin_port: ports[0],
+                    control_port: ports[1],
+                    hb_port: ports[2],
+                    shell_port: ports[3],
+                    iopub_port: ports[4],
+                    signature_scheme: "hmac-sha256".to_string(),
+                    key: Uuid::new_v4().to_string(),
+                    kernel_name: Some(kernelspec_name.to_string()),
+                };
+                tokio::fs::write(
+                    &connection_file_path,
+                    serde_json::to_string_pretty(&connection_info)?,
+                )
+                .await?;
+
+                drop(listeners);
+                let mut process = cmd.spawn()?;
+
+                let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
+                    Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
+                let stderr_drain: Option<JoinHandle<()>> =
+                    if let Some(stderr) = process.stderr.take() {
+                        let kid = kernel_id.clone();
+                        let buffer = stderr_buffer.clone();
+                        Some(spawn_best_effort("kernel-stderr", async move {
+                            use tokio::io::{AsyncBufReadExt, BufReader};
+                            let mut lines = BufReader::new(stderr).lines();
+                            while let Ok(Some(line)) = lines.next_line().await {
+                                let lower = line.to_ascii_lowercase();
+                                if lower.contains("error") || lower.contains("traceback") {
+                                    warn!("[kernel-stderr:{}] {}", kid, line);
+                                } else {
+                                    debug!("[kernel-stderr:{}] {}", kid, line);
+                                }
+                                let mut queue = buffer.lock().unwrap();
+                                if queue.len() == STDERR_BUFFER_LINES {
+                                    queue.pop_front();
+                                }
+                                queue.push_back(line);
+                            }
+                        }))
+                    } else {
+                        None
+                    };
+
+                info!(
+                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=tcp, ports={:?})",
+                    process.id(),
+                    kernel_id,
+                    ports
+                );
+
+                const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
+                let startup_deadline = std::time::Instant::now() + STARTUP_CEILING;
+                let mut early_exit: Option<std::process::ExitStatus> = None;
+                let mut wait_err: Option<std::io::Error> = None;
+                loop {
+                    match process.try_wait() {
+                        Ok(Some(status)) => {
+                            early_exit = Some(status);
+                            break;
+                        }
+                        Ok(None) => {
+                            if std::time::Instant::now() >= startup_deadline {
+                                break;
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                        Err(e) => {
+                            wait_err = Some(e);
+                            break;
+                        }
+                    }
+                }
+
+                match (early_exit, wait_err) {
+                    (Some(exit_status), _) => {
+                        if let Some(handle) = stderr_drain {
+                            let _ =
+                                tokio::time::timeout(std::time::Duration::from_millis(500), handle)
+                                    .await;
+                        }
+                        let captured = {
+                            let queue = stderr_buffer.lock().unwrap();
+                            queue.iter().cloned().collect::<Vec<_>>().join("\n")
+                        };
+                        let stderr_tail = if captured.is_empty() {
+                            "(no stderr captured before exit)".to_string()
+                        } else {
+                            format!("stderr tail:\n{}", captured)
+                        };
+                        error!(
+                            "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={})\n{}",
+                            exit_status, kernel_id, stderr_tail
+                        );
+                        return Err(anyhow::anyhow!(
+                            "Kernel process exited immediately: {}\n{}",
+                            exit_status,
+                            stderr_tail
+                        ));
+                    }
+                    (None, Some(e)) => {
+                        warn!(
+                            "[jupyter-kernel] Could not check kernel process status: {}",
+                            e
+                        );
+                        (process, stderr_buffer, connection_info) as LaunchedKernel
+                    }
+                    (None, None) => (process, stderr_buffer, connection_info) as LaunchedKernel,
                 }
             }
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -11,7 +11,9 @@
 use std::collections::{HashMap, VecDeque};
 #[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+#[cfg(unix)]
+use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -9,8 +9,9 @@
 //! **not** hold queue, executing cell, or status — those live in `KernelState`.
 
 use std::collections::{HashMap, VecDeque};
+#[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -22,6 +23,7 @@ use jupyter_protocol::{
     JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
 };
 use runtime_doc::{KernelActivity, RuntimeLifecycle};
+#[cfg(windows)]
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -41,6 +43,27 @@ use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
 use notebook_protocol::protocol::LaunchedEnvConfig;
+
+/// IPC socket path prefix for a kernel.
+///
+/// Produces e.g. `/tmp/runt-nightly/kernel-fluffy-panther-ipc` which, with
+/// integer suffixes 1-5, yields unique collision-free socket files per
+/// kernel launch. The kernel_id is a petname or UUID, so paths never
+/// collide across concurrent launches.
+#[cfg(unix)]
+fn ipc_path_prefix(kernel_id: &str) -> PathBuf {
+    crate::ipc_socket_dir().join(format!("kernel-{}-ipc", kernel_id))
+}
+
+/// Remove IPC socket files for the 5 Jupyter ZMQ channels.
+///
+/// Best-effort: ignores errors (files may already be gone after kernel exit).
+#[cfg(unix)]
+pub(crate) fn cleanup_ipc_sockets(prefix: &Path) {
+    for port in 1..=5u16 {
+        let _ = std::fs::remove_file(format!("{}-{}", prefix.display(), port));
+    }
+}
 
 /// Reserved port range for Jupyter kernel ZMQ sockets.
 ///
@@ -100,6 +123,7 @@ fn kernel_port_candidates(num: usize) -> Vec<u16> {
 /// rarer on Linux/macOS and the reserved range is small enough that we
 /// might collide with something, so the fallback keeps developer machines
 /// working.
+#[cfg(windows)]
 async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<TcpListener>)> {
     let mut ports: Vec<u16> = Vec::with_capacity(num);
     let mut listeners: Vec<TcpListener> = Vec::with_capacity(num);
@@ -216,6 +240,11 @@ pub struct JupyterKernel {
     connection_file: Option<PathBuf>,
     /// Shell writer for sending execute requests.
     shell_writer: Option<runtimelib::DealerSendConnection>,
+    /// IPC socket path prefix for cleanup (Unix only).
+    /// When set, the 5 socket files `{prefix}-{1..5}` are removed on
+    /// shutdown and Drop.
+    #[cfg(unix)]
+    ipc_prefix: Option<PathBuf>,
     /// Kernel process PID for signal-based cleanup (Unix only).
     #[cfg(unix)]
     kernel_pid: Option<i32>,
@@ -270,11 +299,11 @@ impl KernelConnection for JupyterKernel {
             _ => &kernel_type,
         };
 
-        // Per-launch IP and stable connection-file path. Ports are
-        // (re-)reserved inside the spawn loop below so the file's contents
-        // can be rewritten with fresh port numbers on retry; the path itself
-        // is what the kernel command-line points at, so keeping it stable
-        // means we don't have to rebuild `cmd` between attempts.
+        // Per-launch connection-file path. On Unix (IPC transport) there
+        // are no ports to reserve — the kernel_id uniqueness guarantees
+        // collision-free socket paths. On Windows (TCP) ports are reserved
+        // inside the spawn loop and the file is rewritten per attempt.
+        #[cfg(windows)]
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let conn_dir = crate::connections_dir();
         tokio::fs::create_dir_all(&conn_dir).await?;
@@ -725,33 +754,47 @@ impl KernelConnection for JupyterKernel {
         // only "exit status: 1" with no clue why the kernel died.
         const STDERR_BUFFER_LINES: usize = 50;
 
-        // Spawn loop with retry on the Windows port-allocation race. The
-        // reserved 9000-9999 range from `reserve_kernel_ports` is outside
-        // the *default* Windows dynamic ephemeral range, but the dynamic
-        // range is `netsh`-configurable and at least the GitHub-hosted
-        // windows-latest runners overlap our reserved range. When that
-        // happens the kernel's bind() races the OS allocator and exits
-        // with `Address in use`. Retry up to a few times with fresh ports
-        // so a single unlucky pick doesn't sink the launch.
-        const MAX_LAUNCH_ATTEMPTS: usize = 4;
+        // ── Platform-specific kernel spawn ──────────────────────────────
+        //
+        // Unix: IPC transport. No port allocation, no TOCTOU race, no retry
+        // loop. The kernel_id (petname/UUID) is unique per launch, so the
+        // socket path `ipc:///tmp/runt-nightly/kernel-{id}-ipc-{1..5}` can
+        // never collide with another kernel.
+        //
+        // Windows: TCP transport with a retry loop. The reserved 9000-9999
+        // port range avoids most ephemeral conflicts, but the range is
+        // `netsh`-configurable and GitHub-hosted runners overlap it. Retry
+        // up to 4 times with fresh ports so a single unlucky pick doesn't
+        // sink the launch.
+
         type LaunchedKernel = (
             tokio::process::Child,
             Arc<StdMutex<VecDeque<String>>>,
             ConnectionInfo,
         );
+
+        #[cfg(unix)]
+        let ipc_prefix = {
+            let prefix = ipc_path_prefix(&kernel_id);
+            if let Some(parent) = prefix.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            Some(prefix)
+        };
+
         let (mut process, _stderr_buffer, connection_info) = {
-            let mut accepted: Option<LaunchedKernel> = None;
-            let mut last_failure: Option<anyhow::Error> = None;
-            for attempt in 1..=MAX_LAUNCH_ATTEMPTS {
-                let (ports, listeners) = reserve_kernel_ports(ip, 5).await?;
+            // ── Unix: IPC transport (single attempt, no port race) ───────
+            #[cfg(unix)]
+            {
+                let prefix = ipc_prefix.as_ref().unwrap();
                 let connection_info = ConnectionInfo {
-                    transport: jupyter_protocol::connection_info::Transport::TCP,
-                    ip: ip.to_string(),
-                    stdin_port: ports[0],
-                    control_port: ports[1],
-                    hb_port: ports[2],
-                    shell_port: ports[3],
-                    iopub_port: ports[4],
+                    transport: jupyter_protocol::connection_info::Transport::IPC,
+                    ip: prefix.display().to_string(),
+                    shell_port: 1,
+                    iopub_port: 2,
+                    stdin_port: 3,
+                    control_port: 4,
+                    hb_port: 5,
                     signature_scheme: "hmac-sha256".to_string(),
                     key: Uuid::new_v4().to_string(),
                     kernel_name: Some(kernelspec_name.to_string()),
@@ -762,29 +805,7 @@ impl KernelConnection for JupyterKernel {
                 )
                 .await?;
 
-                // Order the listener drop relative to spawn per platform.
-                //
-                // Windows: child processes inherit the parent's socket handles
-                // by default. If `cmd.spawn()` ran while the listeners were
-                // alive, the kernel would inherit handles for ports 9000-9004
-                // and ipykernel's first `s.bind('tcp://...:9003')` would fail
-                // with EADDRINUSE - the kernel itself already owns a listener
-                // on that port via inheritance. The 9000-9999 reserved range
-                // is outside the dynamic ephemeral pool, so the OS allocator
-                // can't reclaim a freed port between drop and the kernel's
-                // bind. Drop early.
-                //
-                // Linux/macOS: FD_CLOEXEC is the default, so the child can't
-                // inherit the listener. The risk is the opposite - on the
-                // fallback path where ports come from the OS ephemeral
-                // allocator, the OS could re-hand a freed port to some other
-                // process between drop and the kernel's bind. Hold the
-                // listeners across spawn so that window stays closed.
-                #[cfg(windows)]
-                drop(listeners);
                 let mut process = cmd.spawn()?;
-                #[cfg(not(windows))]
-                drop(listeners);
 
                 let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
                     Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
@@ -814,19 +835,13 @@ impl KernelConnection for JupyterKernel {
                     };
 
                 info!(
-                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, attempt={}/{}, ports={:?})",
+                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=ipc, prefix={})",
                     process.id(),
                     kernel_id,
-                    attempt,
-                    MAX_LAUNCH_ATTEMPTS,
-                    ports
+                    prefix.display(),
                 );
 
-                // Wait for kernel startup. ipykernel spends 1-3s on Windows
-                // (and macOS cold path) importing pyzmq/ipykernel and binding
-                // ZMQ sockets. Polling try_wait every 100ms inside the
-                // window catches an early exit (the EADDRINUSE case we're
-                // retrying for) without paying the full ceiling on success.
+                // Brief startup check — detect early crashes.
                 const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
                 let startup_deadline = std::time::Instant::now() + STARTUP_CEILING;
                 let mut early_exit: Option<std::process::ExitStatus> = None;
@@ -850,18 +865,8 @@ impl KernelConnection for JupyterKernel {
                     }
                 }
 
-                let outcome = match (early_exit, wait_err) {
-                    (Some(s), _) => Ok(Some(s)),
-                    (None, Some(e)) => Err(e),
-                    (None, None) => Ok(None),
-                };
-
-                // Early crash detection: did the process exit during startup?
-                match outcome {
-                    Ok(Some(exit_status)) => {
-                        // Wait for stderr EOF (the child is gone, the reader
-                        // task should finish promptly) so we read a complete
-                        // tail. Bound it so a stuck pipe can't hang launch.
+                match (early_exit, wait_err) {
+                    (Some(exit_status), _) => {
                         if let Some(handle) = stderr_drain {
                             let _ =
                                 tokio::time::timeout(std::time::Duration::from_millis(500), handle)
@@ -871,27 +876,16 @@ impl KernelConnection for JupyterKernel {
                             let queue = stderr_buffer.lock().unwrap();
                             queue.iter().cloned().collect::<Vec<_>>().join("\n")
                         };
-                        let port_race = captured.contains("Address in use")
-                            || captured.contains("Address already in use");
-                        if port_race && attempt < MAX_LAUNCH_ATTEMPTS {
-                            warn!(
-                                "[jupyter-kernel] Kernel hit port-allocation race on attempt {}/{}; retrying with fresh ports (kernel_id={}, exit={})",
-                                attempt, MAX_LAUNCH_ATTEMPTS, kernel_id, exit_status
-                            );
-                            last_failure = Some(anyhow::anyhow!(
-                                "kernel exited with port race: {}",
-                                exit_status
-                            ));
-                            continue;
-                        }
                         let stderr_tail = if captured.is_empty() {
                             "(no stderr captured before exit)".to_string()
                         } else {
                             format!("stderr tail:\n{}", captured)
                         };
+                        // Clean up socket files since the kernel never started.
+                        cleanup_ipc_sockets(prefix);
                         error!(
-                            "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={}, attempts={})\n{}",
-                            exit_status, kernel_id, attempt, stderr_tail
+                            "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={})\n{}",
+                            exit_status, kernel_id, stderr_tail
                         );
                         return Err(anyhow::anyhow!(
                             "Kernel process exited immediately: {}\n{}",
@@ -899,28 +893,181 @@ impl KernelConnection for JupyterKernel {
                             stderr_tail
                         ));
                     }
-                    Ok(None) => {
-                        // Process still running — good
-                        accepted = Some((process, stderr_buffer, connection_info));
-                        break;
-                    }
-                    Err(e) => {
+                    (None, Some(e)) => {
                         warn!(
                             "[jupyter-kernel] Could not check kernel process status: {}",
                             e
                         );
-                        accepted = Some((process, stderr_buffer, connection_info));
-                        break;
+                        (process, stderr_buffer, connection_info) as LaunchedKernel
+                    }
+                    (None, None) => {
+                        // Process still running — good
+                        (process, stderr_buffer, connection_info) as LaunchedKernel
                     }
                 }
             }
-            accepted.ok_or_else(|| {
-                last_failure.unwrap_or_else(|| {
-                    anyhow::anyhow!(
-                        "Kernel launch retry loop exhausted without success or recorded error"
+
+            // ── Windows: TCP transport with retry loop ───────────────────
+            #[cfg(windows)]
+            {
+                const MAX_LAUNCH_ATTEMPTS: usize = 4;
+                let mut accepted: Option<LaunchedKernel> = None;
+                let mut last_failure: Option<anyhow::Error> = None;
+                for attempt in 1..=MAX_LAUNCH_ATTEMPTS {
+                    let (ports, listeners) = reserve_kernel_ports(ip, 5).await?;
+                    let connection_info = ConnectionInfo {
+                        transport: jupyter_protocol::connection_info::Transport::TCP,
+                        ip: ip.to_string(),
+                        stdin_port: ports[0],
+                        control_port: ports[1],
+                        hb_port: ports[2],
+                        shell_port: ports[3],
+                        iopub_port: ports[4],
+                        signature_scheme: "hmac-sha256".to_string(),
+                        key: Uuid::new_v4().to_string(),
+                        kernel_name: Some(kernelspec_name.to_string()),
+                    };
+                    tokio::fs::write(
+                        &connection_file_path,
+                        serde_json::to_string_pretty(&connection_info)?,
                     )
-                })
-            })?
+                    .await?;
+
+                    // Windows: drop listeners before spawn so the child doesn't
+                    // inherit socket handles (which would cause EADDRINUSE on
+                    // the kernel's bind).
+                    drop(listeners);
+                    let mut process = cmd.spawn()?;
+
+                    let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
+                        Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
+                    let stderr_drain: Option<JoinHandle<()>> =
+                        if let Some(stderr) = process.stderr.take() {
+                            let kid = kernel_id.clone();
+                            let buffer = stderr_buffer.clone();
+                            Some(spawn_best_effort("kernel-stderr", async move {
+                                use tokio::io::{AsyncBufReadExt, BufReader};
+                                let mut lines = BufReader::new(stderr).lines();
+                                while let Ok(Some(line)) = lines.next_line().await {
+                                    let lower = line.to_ascii_lowercase();
+                                    if lower.contains("error") || lower.contains("traceback") {
+                                        warn!("[kernel-stderr:{}] {}", kid, line);
+                                    } else {
+                                        debug!("[kernel-stderr:{}] {}", kid, line);
+                                    }
+                                    let mut queue = buffer.lock().unwrap();
+                                    if queue.len() == STDERR_BUFFER_LINES {
+                                        queue.pop_front();
+                                    }
+                                    queue.push_back(line);
+                                }
+                            }))
+                        } else {
+                            None
+                        };
+
+                    info!(
+                        "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, attempt={}/{}, ports={:?})",
+                        process.id(),
+                        kernel_id,
+                        attempt,
+                        MAX_LAUNCH_ATTEMPTS,
+                        ports
+                    );
+
+                    const STARTUP_CEILING: std::time::Duration =
+                        std::time::Duration::from_millis(3000);
+                    let startup_deadline = std::time::Instant::now() + STARTUP_CEILING;
+                    let mut early_exit: Option<std::process::ExitStatus> = None;
+                    let mut wait_err: Option<std::io::Error> = None;
+                    loop {
+                        match process.try_wait() {
+                            Ok(Some(status)) => {
+                                early_exit = Some(status);
+                                break;
+                            }
+                            Ok(None) => {
+                                if std::time::Instant::now() >= startup_deadline {
+                                    break;
+                                }
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            }
+                            Err(e) => {
+                                wait_err = Some(e);
+                                break;
+                            }
+                        }
+                    }
+
+                    let outcome = match (early_exit, wait_err) {
+                        (Some(s), _) => Ok(Some(s)),
+                        (None, Some(e)) => Err(e),
+                        (None, None) => Ok(None),
+                    };
+
+                    match outcome {
+                        Ok(Some(exit_status)) => {
+                            if let Some(handle) = stderr_drain {
+                                let _ = tokio::time::timeout(
+                                    std::time::Duration::from_millis(500),
+                                    handle,
+                                )
+                                .await;
+                            }
+                            let captured = {
+                                let queue = stderr_buffer.lock().unwrap();
+                                queue.iter().cloned().collect::<Vec<_>>().join("\n")
+                            };
+                            let port_race = captured.contains("Address in use")
+                                || captured.contains("Address already in use");
+                            if port_race && attempt < MAX_LAUNCH_ATTEMPTS {
+                                warn!(
+                                    "[jupyter-kernel] Kernel hit port-allocation race on attempt {}/{}; retrying with fresh ports (kernel_id={}, exit={})",
+                                    attempt, MAX_LAUNCH_ATTEMPTS, kernel_id, exit_status
+                                );
+                                last_failure = Some(anyhow::anyhow!(
+                                    "kernel exited with port race: {}",
+                                    exit_status
+                                ));
+                                continue;
+                            }
+                            let stderr_tail = if captured.is_empty() {
+                                "(no stderr captured before exit)".to_string()
+                            } else {
+                                format!("stderr tail:\n{}", captured)
+                            };
+                            error!(
+                                "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={}, attempts={})\n{}",
+                                exit_status, kernel_id, attempt, stderr_tail
+                            );
+                            return Err(anyhow::anyhow!(
+                                "Kernel process exited immediately: {}\n{}",
+                                exit_status,
+                                stderr_tail
+                            ));
+                        }
+                        Ok(None) => {
+                            accepted = Some((process, stderr_buffer, connection_info));
+                            break;
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[jupyter-kernel] Could not check kernel process status: {}",
+                                e
+                            );
+                            accepted = Some((process, stderr_buffer, connection_info));
+                            break;
+                        }
+                    }
+                }
+                accepted.ok_or_else(|| {
+                    last_failure.unwrap_or_else(|| {
+                        anyhow::anyhow!(
+                            "Kernel launch retry loop exhausted without success or recorded error"
+                        )
+                    })
+                })?
+            }
         };
 
         #[cfg(unix)]
@@ -2402,6 +2549,8 @@ impl KernelConnection for JupyterKernel {
             connection_file: Some(connection_file_path),
             shell_writer: Some(shell_writer),
             #[cfg(unix)]
+            ipc_prefix,
+            #[cfg(unix)]
             kernel_pid,
             iopub_task: Some(iopub_task),
             shell_reader_task: Some(shell_reader_task),
@@ -2557,6 +2706,12 @@ impl KernelConnection for JupyterKernel {
 
         if let Some(ref path) = self.connection_file {
             let _ = std::fs::remove_file(path);
+        }
+
+        // Clean up IPC socket files (Unix only).
+        #[cfg(unix)]
+        if let Some(ref prefix) = self.ipc_prefix {
+            cleanup_ipc_sockets(prefix);
         }
 
         self.connection_info = None;
@@ -2838,6 +2993,12 @@ impl Drop for JupyterKernel {
         // Clean up connection file
         if let Some(ref path) = self.connection_file {
             let _ = std::fs::remove_file(path);
+        }
+
+        // Clean up IPC socket files (Unix only).
+        #[cfg(unix)]
+        if let Some(ref prefix) = self.ipc_prefix {
+            cleanup_ipc_sockets(prefix);
         }
 
         info!("[jupyter-kernel] JupyterKernel dropped - resources cleaned up");

--- a/crates/runtimed/src/runtime_agent_manifest.rs
+++ b/crates/runtimed/src/runtime_agent_manifest.rs
@@ -239,6 +239,17 @@ pub(crate) fn reap_manifest_dir(dir: &Path) -> usize {
 
 fn remove_manifest_path(path: &Path, manifest: &RuntimeAgentManifest) {
     if let Some(connection_file) = &manifest.connection_file {
+        // If the connection file specifies IPC transport, clean up the
+        // socket files. Parse best-effort — if the file is gone or
+        // malformed, skip silently.
+        #[cfg(unix)]
+        if let Ok(contents) = std::fs::read_to_string(connection_file) {
+            if let Ok(info) = serde_json::from_str::<jupyter_protocol::ConnectionInfo>(&contents) {
+                if info.transport == jupyter_protocol::connection_info::Transport::IPC {
+                    crate::jupyter_kernel::cleanup_ipc_sockets(std::path::Path::new(&info.ip));
+                }
+            }
+        }
         let _ = std::fs::remove_file(connection_file);
     }
     if let Err(e) = std::fs::remove_file(path) {


### PR DESCRIPTION
## Summary

- Updates runtimelib/jupyter-protocol/nbformat to pick up zeromq master (`bdfd4d8`) via [runtimed/runtimed#302](https://github.com/runtimed/runtimed/pull/302)
- Currently targeting `quillaid:feat/zmq-rs-master` — will repin to upstream commit once #302 merges

### What's new in zmq.rs master (since 0.6.0-pre.1)

- **Disconnect callbacks** on Dealer/Pull/Rep/Router/XPub — fair_queue disconnects now notify the socket backend, enabling correct `SocketEvent::Disconnected` delivery (previously silently lost)
- **XSubSocket** support + Sub backend refactor into shared `sub_backend.rs` with better subscription resync on reconnect
- `Clone` for `RouterSendHalf`
- MSRV bump to 1.85

### Why

The disconnect callback fix is the key change for nteract/desktop. Our Dealer (shell) and Sub (iopub) sockets now get proper notification when kernels disconnect, which improves crash detection and cleanup. This complements the IPC transport work in #2369.

## Test plan

- [x] `cargo check -p runtimed` — clean
- [x] `cargo xtask lint --fix` — clean
- [ ] Full CI suite