### PR TITLE
ci: smoke test linux rpm installs

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -763,7 +763,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev \
-            libssl-dev libayatana-appindicator3-dev librsvg2-dev
+            libssl-dev libayatana-appindicator3-dev librsvg2-dev rpm
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -843,7 +843,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: crates/notebook
-          args: --bundles appimage,deb --config '{"build":{"beforeBuildCommand":""}}'
+          args: --bundles appimage,deb,rpm --config '{"build":{"beforeBuildCommand":""}}'
           includeUpdaterJson: false
 
       - name: Collect artifacts
@@ -857,6 +857,8 @@ jobs:
           done
           DEB_PATH=$(find target/release/bundle/deb -name "*.deb" | head -1)
           cp "$DEB_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.deb"
+          RPM_PATH=$(find target/release/bundle/rpm -name "*.rpm" | head -1)
+          cp "$RPM_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.rpm"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -925,6 +927,33 @@ jobs:
               set -euo pipefail
               bash scripts/ci/ubuntu-deb-smoke.sh local "$1" "$2" "$3"
             ' bash "$DEB" "$CHANNEL" "${{ needs.compute-version.outputs.version }}"
+
+  smoke-fedora-rpm:
+    name: Smoke Fedora RPM
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: [compute-version, build-notebook-linux-x64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download Linux RPM
+        uses: actions/download-artifact@v4
+        with:
+          name: nteract-linux-x64
+          path: artifacts
+
+      - name: Smoke RPM in Fedora
+        run: |
+          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
+          RPM="artifacts/nteract-${CHANNEL}-linux-x64.rpm"
+          docker run --rm \
+            -v "${PWD}:/workspace" \
+            -w /workspace \
+            fedora:latest \
+            bash -lc '
+              set -euo pipefail
+              bash scripts/ci/fedora-rpm-smoke.sh "$1" "$2" "$3"
+            ' bash "$RPM" "$CHANNEL" "${{ needs.compute-version.outputs.version }}"
 
   build-nteract-package:
     name: Build nteract Package
@@ -1249,6 +1278,7 @@ jobs:
         build-notebook-linux-x64,
         smoke-fedora-appimage,
         smoke-ubuntu-deb,
+        smoke-fedora-rpm,
         build-python-wheels,
         build-nteract-package,
         build-dx-package,
@@ -1366,6 +1396,7 @@ jobs:
           cp "notebook-windows-x64/nteract-${CHANNEL}-windows-x64.exe" release-assets/
           cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.AppImage" release-assets/
           cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.deb" release-assets/
+          cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.rpm" release-assets/
           # Updater bundles + signatures
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz" release-assets/
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig" release-assets/
@@ -1532,8 +1563,9 @@ jobs:
             echo "| Windows | x64 | \`nteract-${VERSION_SUFFIX}-windows-x64.exe\` |"
             echo "| Linux | x64 | \`nteract-${VERSION_SUFFIX}-linux-x64.AppImage\` |"
             echo "| Linux | x64 (deb) | \`nteract-${VERSION_SUFFIX}-linux-x64.deb\` |"
+            echo "| Linux | x64 (rpm) | \`nteract-${VERSION_SUFFIX}-linux-x64.rpm\` |"
             echo ''
-            echo "macOS builds are signed and notarized. Windows is not code signed — expect a SmartScreen prompt. Linux AppImage: \`chmod +x\` and run. Linux DEB: \`sudo dpkg -i nteract-${VERSION_SUFFIX}-linux-x64.deb\`."
+            echo "macOS builds are signed and notarized. Windows is not code signed — expect a SmartScreen prompt. Linux AppImage: \`chmod +x\` and run. Linux DEB: \`sudo apt install ./nteract-${VERSION_SUFFIX}-linux-x64.deb\`. Linux RPM: \`sudo dnf install ./nteract-${VERSION_SUFFIX}-linux-x64.rpm\`."
             echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
@@ -1594,6 +1626,7 @@ jobs:
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage.sig
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.deb
+            ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.rpm
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.dmg
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.app.tar.gz
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.app.tar.gz.sig

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -46,12 +46,20 @@ GitHub Releases include:
 
 - `.deb` packages for direct Debian/Ubuntu installs when you do not want to add
   the APT repository.
+- `.rpm` packages for direct Fedora/RHEL/openSUSE-family installs while we
+  evaluate whether to add a signed RPM repository.
 - AppImage builds for desktop Linux systems outside the Debian/Ubuntu family.
 
 For direct `.deb` installs:
 
 ```bash
 sudo apt install ./nteract-stable-linux-x64.deb
+```
+
+For direct `.rpm` installs:
+
+```bash
+sudo dnf install ./nteract-stable-linux-x64.rpm
 ```
 
 For AppImage:

--- a/scripts/ci/fedora-rpm-smoke.sh
+++ b/scripts/ci/fedora-rpm-smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: fedora-rpm-smoke.sh <path-to-rpm> <stable|nightly> [expected-version]" >&2
+}
+
+RPM_PATH=${1:-}
+CHANNEL=${2:-}
+EXPECTED_VERSION=${3:-}
+
+if [[ -z "$RPM_PATH" || -z "$CHANNEL" ]]; then
+  usage
+  exit 2
+fi
+
+case "$CHANNEL" in
+  stable)
+    PACKAGE_NAME="nteract"
+    CLI_NAME="runt"
+    DAEMON_NAME="runtimed"
+    MCP_NAME="nteract-mcp"
+    APP_NAME="nteract"
+    ;;
+  nightly)
+    PACKAGE_NAME="nteract-nightly"
+    CLI_NAME="runt-nightly"
+    DAEMON_NAME="runtimed-nightly"
+    MCP_NAME="nteract-mcp-nightly"
+    APP_NAME="nteract-nightly"
+    ;;
+  *)
+    echo "Unsupported channel: $CHANNEL" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$RPM_PATH" ]]; then
+  echo "RPM package not found: $RPM_PATH" >&2
+  exit 1
+fi
+
+dnf install -y coreutils file findutils grep procps-ng rpm systemd
+
+echo "=== RPM package metadata ==="
+file "$RPM_PATH"
+rpm -qip "$RPM_PATH"
+rpm -qp --queryformat 'Name: %{NAME}\nVersion: %{VERSION}\nRelease: %{RELEASE}\nArchitecture: %{ARCH}\n' "$RPM_PATH"
+echo
+
+ACTUAL_PACKAGE=$(rpm -qp --queryformat '%{NAME}' "$RPM_PATH")
+if [[ "$ACTUAL_PACKAGE" != "$PACKAGE_NAME" ]]; then
+  echo "Expected package $PACKAGE_NAME, got $ACTUAL_PACKAGE" >&2
+  exit 1
+fi
+
+if [[ -n "$EXPECTED_VERSION" ]]; then
+  echo "Expected release workflow version: $EXPECTED_VERSION"
+fi
+
+echo "=== RPM package files ==="
+rpm -qpl "$RPM_PATH" | sort
+
+dnf install -y "$RPM_PATH"
+
+INSTALLED_NEVRA=$(rpm -q "$PACKAGE_NAME")
+echo "Installed RPM: $INSTALLED_NEVRA"
+
+echo "=== Installed package files ==="
+rpm -ql "$PACKAGE_NAME" | sort
+
+for command_name in "$CLI_NAME" "$DAEMON_NAME" "$MCP_NAME"; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Expected command missing from PATH: $command_name" >&2
+    exit 1
+  fi
+  "$command_name" --version
+done
+
+for binary_name in "$CLI_NAME" "$DAEMON_NAME" "$MCP_NAME"; do
+  if ! rpm -ql "$PACKAGE_NAME" | grep -E "/${binary_name}$" >/dev/null; then
+    echo "Expected packaged binary missing: $binary_name" >&2
+    exit 1
+  fi
+done
+
+if ! rpm -ql "$PACKAGE_NAME" | grep -E "/${APP_NAME}\.desktop$" >/dev/null; then
+  echo "Expected desktop file missing for $APP_NAME" >&2
+  exit 1
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+export HOME="$WORKDIR/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_CACHE_HOME="$HOME/.cache"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+set +e
+"$CLI_NAME" daemon doctor --fix --no-start --json > "$WORKDIR/doctor.json" 2> "$WORKDIR/doctor.stderr"
+doctor_status=$?
+set -e
+
+echo "=== daemon doctor stdout ==="
+cat "$WORKDIR/doctor.json"
+echo
+echo "=== daemon doctor stderr ==="
+cat "$WORKDIR/doctor.stderr"
+echo
+
+if [[ "$doctor_status" -ne 0 ]]; then
+  echo "daemon doctor failed with status $doctor_status" >&2
+  exit "$doctor_status"
+fi
+
+SERVICE_FILE=$(find "$XDG_CONFIG_HOME/systemd/user" -maxdepth 1 -name 'runtimed*.service' -print -quit 2>/dev/null || true)
+if [[ -z "$SERVICE_FILE" ]]; then
+  echo "daemon doctor did not write a user systemd service file" >&2
+  exit 1
+fi
+
+echo "=== user systemd service ==="
+cat "$SERVICE_FILE"
+echo
+
+if ! grep -Fq "ExecStart=" "$SERVICE_FILE"; then
+  echo "service file has no ExecStart" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$XDG_DATA_HOME" "$SERVICE_FILE"; then
+  echo "service file does not point at durable per-user data" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Environment=HOME=$HOME" "$SERVICE_FILE"; then
+  echo "service file does not preserve HOME" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- build Linux RPM artifacts alongside AppImage and DEB packages
- add Fedora RPM smoke coverage for direct package install, expected binaries, desktop file, and daemon doctor service wiring
- publish the RPM as a GitHub release asset and document direct RPM installs as the current Fedora/RHEL/openSUSE-family path

Tracks #2361.

## Verification

- `cargo xtask lint --fix`
- `bash -n scripts/ci/fedora-rpm-smoke.sh`
- `shellcheck scripts/ci/fedora-rpm-smoke.sh`
- `actionlint .github/workflows/release-common.yml`
- `git diff --check`
