### PR TITLE
feat(runtimed): add daemon-owned settings rpc channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7080,6 +7080,7 @@ dependencies = [
 name = "runtimed-client"
 version = "2.3.5"
 dependencies = [
+ "anyhow",
  "automerge",
  "base64 0.22.1",
  "chrono",

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -6,6 +6,7 @@
 mod env;
 mod framing;
 mod handshake;
+mod settings_rpc;
 
 pub use env::{EnvSource, LaunchSpec, PackageManager};
 
@@ -18,6 +19,8 @@ pub use framing::{
 pub use handshake::{
     Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4, PROTOCOL_VERSION,
 };
+
+pub use settings_rpc::{SettingsRpcClientMessage, SettingsRpcServerMessage};
 
 #[cfg(test)]
 mod tests {

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -17,7 +17,8 @@ pub use framing::{
 };
 
 pub use handshake::{
-    Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4, PROTOCOL_VERSION,
+    Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4, PROTOCOL_V5,
+    PROTOCOL_VERSION,
 };
 
 pub use settings_rpc::{SettingsRpcClientMessage, SettingsRpcServerMessage};
@@ -156,6 +157,10 @@ mod tests {
         let json = serde_json::to_string(&Handshake::SettingsSync).unwrap();
         assert_eq!(json, r#"{"channel":"settings_sync"}"#);
 
+        // SettingsRpc
+        let json = serde_json::to_string(&Handshake::SettingsRpc).unwrap();
+        assert_eq!(json, r#"{"channel":"settings_rpc"}"#);
+
         // NotebookSync (without protocol - should omit the field)
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
@@ -166,30 +171,30 @@ mod tests {
         .unwrap();
         assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
 
-        // NotebookSync with v4 protocol
+        // NotebookSync with v5 protocol
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
-            protocol: Some(PROTOCOL_V4.into()),
+            protocol: Some(PROTOCOL_V5.into()),
             working_dir: None,
             initial_metadata: None,
         })
         .unwrap();
         assert_eq!(
             json,
-            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v4"}"#
+            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v5"}"#
         );
 
         // NotebookSync with working_dir for untitled notebook
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
-            protocol: Some(PROTOCOL_V4.into()),
+            protocol: Some(PROTOCOL_V5.into()),
             working_dir: Some("/home/user/project".into()),
             initial_metadata: None,
         })
         .unwrap();
         assert_eq!(
             json,
-            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v4","working_dir":"/home/user/project"}"#
+            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v5","working_dir":"/home/user/project"}"#
         );
 
         // Blob
@@ -253,7 +258,7 @@ mod tests {
     fn test_notebook_connection_info_serialization() {
         // Success case (minimal - no optional fields)
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
+            protocol: PROTOCOL_V5.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "/home/user/notebook.ipynb".into(),
@@ -266,12 +271,12 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
             json,
-            r#"{"protocol":"v4","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false,"ephemeral":false}"#
+            r#"{"protocol":"v5","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false,"ephemeral":false}"#
         );
 
         // With version info
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
+            protocol: PROTOCOL_V5.into(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some("0.1.0+abc123".into()),
             notebook_id: "/home/user/notebook.ipynb".into(),
@@ -287,7 +292,7 @@ mod tests {
 
         // With trust approval needed
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
+            protocol: PROTOCOL_V5.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
@@ -302,7 +307,7 @@ mod tests {
 
         // Error case
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
+            protocol: PROTOCOL_V5.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: String::new(),
@@ -317,7 +322,7 @@ mod tests {
 
         // With notebook_path
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
+            protocol: PROTOCOL_V5.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),

--- a/crates/notebook-protocol/src/connection/framing.rs
+++ b/crates/notebook-protocol/src/connection/framing.rs
@@ -114,7 +114,7 @@ pub(super) fn frame_size_limits(type_byte: u8) -> FrameSizeLimits {
     }
 }
 
-/// Minimum protocol version accepted by v4 daemons.
+/// Minimum protocol version accepted by current daemons.
 pub const MIN_PROTOCOL_VERSION: u32 = 4;
 
 /// Magic bytes identifying the runtimed protocol.

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -96,13 +96,15 @@ pub enum Handshake {
 }
 
 pub const PROTOCOL_V4: &str = "v4";
+pub const PROTOCOL_V5: &str = "v5";
 
 /// Numeric protocol version for version negotiation.
 /// Increment this when making breaking protocol changes.
 ///
 /// Protocol v4 removes legacy environment-sync request/response variants and
 /// is not wire-compatible with v3 clients.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// Protocol v5 adds the daemon-owned `SettingsRpc` handshake channel.
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Server response indicating protocol capabilities.
 ///
@@ -110,7 +112,7 @@ pub const PROTOCOL_VERSION: u32 = 4;
 /// Used by the `NotebookSync` handshake variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Protocol version string (currently always "v4").
+    /// Protocol version string (currently always "v5").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     /// Clients can compare this against their expected version.
@@ -128,7 +130,7 @@ pub struct ProtocolCapabilities {
 /// Contains notebook_id derived by the daemon (from path or generated env_id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version string (currently always "v4").
+    /// Protocol version string (currently always "v5").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -12,6 +12,12 @@ pub enum Handshake {
     Pool,
     /// Automerge settings sync.
     SettingsSync,
+    /// RPC settings channel: full snapshot push, scalar `SetSetting` writes.
+    ///
+    /// Opt-in alternative to `SettingsSync`. The daemon owns `settings.json`;
+    /// clients send `SetSetting { key, value }` against the daemon's current
+    /// snapshot rather than pushing CRDT state. Prototype for issue #1598.
+    SettingsRpc,
     /// Automerge notebook sync (per-notebook room).
     ///
     /// The optional `protocol` field is accepted for version negotiation.

--- a/crates/notebook-protocol/src/connection/settings_rpc.rs
+++ b/crates/notebook-protocol/src/connection/settings_rpc.rs
@@ -1,0 +1,109 @@
+//! Wire types for the `Handshake::SettingsRpc` channel.
+//!
+//! Prototype for the design described in nteract/desktop#1598. The daemon
+//! owns `settings.json` as canonical state; clients receive a full snapshot
+//! whenever it changes and send scalar `SetSetting` writes against the
+//! daemon's current view.
+//!
+//! Only the fields that matter on the wire live here. The `SyncedSettings`
+//! shape itself is defined in `runtimed-client::settings_doc` and rides this
+//! channel as opaque JSON to avoid pulling that crate into the protocol
+//! crate.
+
+use serde::{Deserialize, Serialize};
+
+/// Server -> Client. Sent on connect and on every settings change.
+///
+/// `settings` carries a serialized `SyncedSettings` snapshot. The shape is
+/// defined by the daemon; clients deserialize against their own
+/// `SyncedSettings` definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SettingsRpcServerMessage {
+    /// Full settings snapshot.
+    Snapshot {
+        /// Serialized `SyncedSettings` JSON object.
+        settings: serde_json::Value,
+    },
+    /// Acknowledgement of a `SetSetting` request.
+    SetSettingAck {
+        /// True if the write was applied. False on validation/persist error.
+        ok: bool,
+        /// Human-readable error description on failure.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+}
+
+/// Client -> Server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SettingsRpcClientMessage {
+    /// Set a single scalar setting against the daemon's current snapshot.
+    ///
+    /// `key` may be a top-level field (`"theme"`) or a dotted path into a
+    /// nested map (`"uv.default_packages"`), matching the existing
+    /// `SettingsDoc::put_value` accepted shapes.
+    SetSetting {
+        key: String,
+        value: serde_json::Value,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_snapshot_serializes_with_type_tag() {
+        let msg = SettingsRpcServerMessage::Snapshot {
+            settings: serde_json::json!({"theme": "dark"}),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"snapshot""#));
+        assert!(json.contains(r#""theme":"dark""#));
+    }
+
+    #[test]
+    fn server_ack_omits_none_error() {
+        let msg = SettingsRpcServerMessage::SetSettingAck {
+            ok: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(json, r#"{"type":"set_setting_ack","ok":true}"#);
+    }
+
+    #[test]
+    fn server_ack_round_trips_error() {
+        let msg = SettingsRpcServerMessage::SetSettingAck {
+            ok: false,
+            error: Some("invalid value".into()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: SettingsRpcServerMessage = serde_json::from_str(&json).unwrap();
+        match back {
+            SettingsRpcServerMessage::SetSettingAck { ok, error } => {
+                assert!(!ok);
+                assert_eq!(error.as_deref(), Some("invalid value"));
+            }
+            _ => panic!("expected ack"),
+        }
+    }
+
+    #[test]
+    fn client_set_setting_round_trip() {
+        let msg = SettingsRpcClientMessage::SetSetting {
+            key: "theme".into(),
+            value: serde_json::Value::String("dark".into()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: SettingsRpcClientMessage = serde_json::from_str(&json).unwrap();
+        match back {
+            SettingsRpcClientMessage::SetSetting { key, value } => {
+                assert_eq!(key, "theme");
+                assert_eq!(value, serde_json::Value::String("dark".into()));
+            }
+        }
+    }
+}

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -25,7 +25,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
-    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
+    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V5,
 };
 use notebook_protocol::protocol::NotebookBroadcast;
 
@@ -180,7 +180,7 @@ pub async fn connect_with_options(
     // Send handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V4.to_string()),
+        protocol: Some(PROTOCOL_V5.to_string()),
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         initial_metadata: initial_metadata.clone(),
     };
@@ -559,7 +559,7 @@ pub async fn connect_relay(
     // Send notebook sync handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V4.to_string()),
+        protocol: Some(PROTOCOL_V5.to_string()),
         initial_metadata: None,
         working_dir: None,
     };
@@ -567,7 +567,7 @@ pub async fn connect_relay(
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive protocol capabilities (v4 handshake)
+    // Receive protocol capabilities.
     let caps_data = connection::recv_frame(&mut reader)
         .await?
         .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 ts-bindings = ["dep:ts-rs"]
 
 [dependencies]
+anyhow = { workspace = true }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -38,6 +38,7 @@ pub mod protocol;
 pub mod runtime;
 pub mod service;
 pub mod settings_doc;
+pub mod settings_rpc_client;
 pub mod singleton;
 pub mod sync_client;
 pub mod telemetry;

--- a/crates/runtimed-client/src/settings_rpc_client.rs
+++ b/crates/runtimed-client/src/settings_rpc_client.rs
@@ -1,0 +1,234 @@
+//! Client for the `Handshake::SettingsRpc` channel.
+//!
+//! Prototype for the design described in nteract/desktop#1598. The daemon
+//! owns `settings.json` as canonical state; this client receives a full
+//! snapshot whenever it changes and sends scalar `SetSetting` writes
+//! against the daemon's current view.
+//!
+//! This is a separate code path from `SyncClient` (Automerge). Both speak
+//! over the same Unix-domain socket using different `Handshake` variants.
+//! Until the new shape is the default, callers wire it up explicitly.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use log::info;
+use notebook_protocol::connection::{
+    self, Handshake, SettingsRpcClientMessage, SettingsRpcServerMessage,
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::settings_doc::SyncedSettings;
+
+/// Errors from the settings RPC client.
+#[derive(Debug, thiserror::Error)]
+pub enum SettingsRpcError {
+    #[error("Failed to connect: {0}")]
+    ConnectionFailed(#[from] std::io::Error),
+
+    #[error("Connection timeout")]
+    Timeout,
+
+    #[error("Disconnected")]
+    Disconnected,
+
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    #[error("Daemon rejected SetSetting: {0}")]
+    Rejected(String),
+}
+
+impl From<anyhow::Error> for SettingsRpcError {
+    fn from(err: anyhow::Error) -> Self {
+        // The framing helpers return io errors verbatim through `anyhow`.
+        // Surface them as `ConnectionFailed` so disconnects come through
+        // with the right kind; everything else is a protocol decode error.
+        if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+            return SettingsRpcError::ConnectionFailed(std::io::Error::new(
+                io_err.kind(),
+                io_err.to_string(),
+            ));
+        }
+        SettingsRpcError::Protocol(err.to_string())
+    }
+}
+
+/// Client for the RPC settings channel.
+///
+/// Holds the most recently received `SyncedSettings` snapshot. Use
+/// `recv_snapshot` to wait for the next update from the daemon, or
+/// `set_setting` to request a write.
+pub struct SettingsRpcClient<S> {
+    snapshot: SyncedSettings,
+    stream: S,
+}
+
+#[cfg(unix)]
+impl SettingsRpcClient<tokio::net::UnixStream> {
+    /// Connect to the daemon's unified socket.
+    pub async fn connect(socket_path: PathBuf) -> Result<Self, SettingsRpcError> {
+        Self::connect_with_timeout(socket_path, Duration::from_secs(2)).await
+    }
+
+    /// Connect with a custom timeout.
+    pub async fn connect_with_timeout(
+        socket_path: PathBuf,
+        timeout: Duration,
+    ) -> Result<Self, SettingsRpcError> {
+        let stream = tokio::time::timeout(timeout, tokio::net::UnixStream::connect(&socket_path))
+            .await
+            .map_err(|_| SettingsRpcError::Timeout)?
+            .map_err(SettingsRpcError::ConnectionFailed)?;
+
+        info!("[settings-rpc-client] Connected to {:?}", socket_path);
+
+        Self::init(stream).await
+    }
+}
+
+#[cfg(windows)]
+impl SettingsRpcClient<tokio::net::windows::named_pipe::NamedPipeClient> {
+    /// Connect to the daemon's unified socket.
+    pub async fn connect(socket_path: PathBuf) -> Result<Self, SettingsRpcError> {
+        Self::connect_with_timeout(socket_path, Duration::from_secs(2)).await
+    }
+
+    pub async fn connect_with_timeout(
+        socket_path: PathBuf,
+        timeout: Duration,
+    ) -> Result<Self, SettingsRpcError> {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        const ERROR_PIPE_BUSY: i32 = 231;
+        let client = tokio::time::timeout(timeout, async {
+            let mut attempts = 0;
+            loop {
+                match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
+                    Ok(client) => return Ok(client),
+                    Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
+                        attempts += 1;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+        .await
+        .map_err(|_| SettingsRpcError::Timeout)?
+        .map_err(SettingsRpcError::ConnectionFailed)?;
+
+        info!("[settings-rpc-client] Connected to {}", pipe_name);
+
+        Self::init(client).await
+    }
+}
+
+impl<S> SettingsRpcClient<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Send the preamble + `SettingsRpc` handshake and consume the initial
+    /// snapshot frame.
+    async fn init(mut stream: S) -> Result<Self, SettingsRpcError> {
+        connection::send_preamble(&mut stream).await?;
+        connection::send_json_frame(&mut stream, &Handshake::SettingsRpc).await?;
+
+        // The daemon sends the initial snapshot first.
+        let snapshot = expect_snapshot(&mut stream).await?;
+        info!(
+            "[settings-rpc-client] Initial snapshot received: theme={:?}",
+            snapshot.theme
+        );
+        Ok(Self { snapshot, stream })
+    }
+
+    /// Cached most-recent snapshot.
+    pub fn get_snapshot(&self) -> &SyncedSettings {
+        &self.snapshot
+    }
+
+    /// Wait for the next snapshot push from the daemon.
+    ///
+    /// Stray `SetSettingAck` frames here would only happen if the daemon
+    /// is misbehaving, so surface them as a protocol error rather than
+    /// silently swallowing.
+    pub async fn recv_snapshot(&mut self) -> Result<SyncedSettings, SettingsRpcError> {
+        match recv_server_message(&mut self.stream).await? {
+            SettingsRpcServerMessage::Snapshot { settings } => {
+                let parsed: SyncedSettings = serde_json::from_value(settings)
+                    .map_err(|e| SettingsRpcError::Protocol(format!("snapshot decode: {e}")))?;
+                self.snapshot = parsed.clone();
+                Ok(parsed)
+            }
+            SettingsRpcServerMessage::SetSettingAck { ok, error } => {
+                Err(SettingsRpcError::Protocol(format!(
+                    "unexpected ack while waiting for snapshot: ok={ok} error={error:?}"
+                )))
+            }
+        }
+    }
+
+    /// Send `SetSetting` and wait for the daemon's ack.
+    ///
+    /// Snapshot pushes that arrive before the ack are applied to the
+    /// cached snapshot in-line so callers don't lose updates that happen
+    /// to land on the same socket between request and reply.
+    pub async fn set_setting(
+        &mut self,
+        key: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), SettingsRpcError> {
+        let req = SettingsRpcClientMessage::SetSetting {
+            key: key.to_string(),
+            value: value.clone(),
+        };
+        connection::send_json_frame(&mut self.stream, &req).await?;
+
+        loop {
+            match recv_server_message(&mut self.stream).await? {
+                SettingsRpcServerMessage::Snapshot { settings } => {
+                    let parsed: SyncedSettings = serde_json::from_value(settings)
+                        .map_err(|e| SettingsRpcError::Protocol(format!("snapshot decode: {e}")))?;
+                    self.snapshot = parsed;
+                    // Keep waiting for the ack — the daemon broadcasts the
+                    // snapshot on `settings_changed`, which fires before
+                    // the ack on the writer's own connection.
+                }
+                SettingsRpcServerMessage::SetSettingAck { ok, error } => {
+                    return if ok {
+                        Ok(())
+                    } else {
+                        Err(SettingsRpcError::Rejected(
+                            error.unwrap_or_else(|| "unknown".into()),
+                        ))
+                    };
+                }
+            }
+        }
+    }
+}
+
+async fn expect_snapshot<S>(stream: &mut S) -> Result<SyncedSettings, SettingsRpcError>
+where
+    S: AsyncRead + Unpin,
+{
+    match recv_server_message(stream).await? {
+        SettingsRpcServerMessage::Snapshot { settings } => serde_json::from_value(settings)
+            .map_err(|e| SettingsRpcError::Protocol(format!("snapshot decode: {e}"))),
+        SettingsRpcServerMessage::SetSettingAck { ok, error } => Err(SettingsRpcError::Protocol(
+            format!("expected initial snapshot, got ack ok={ok} error={error:?}"),
+        )),
+    }
+}
+
+async fn recv_server_message<S>(
+    stream: &mut S,
+) -> Result<SettingsRpcServerMessage, SettingsRpcError>
+where
+    S: AsyncRead + Unpin,
+{
+    match connection::recv_json_frame::<_, SettingsRpcServerMessage>(stream).await? {
+        Some(msg) => Ok(msg),
+        None => Err(SettingsRpcError::Disconnected),
+    }
+}

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -711,7 +711,7 @@ impl SyncEnvironmentResult {
 #[pyclass(get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version (currently "v4").
+    /// Protocol version (currently "v5").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     pub protocol_version: Option<u32>,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1682,6 +1682,21 @@ impl Daemon {
                 )
                 .await
             }
+            Handshake::SettingsRpc => {
+                let (reader, writer) = tokio::io::split(stream);
+                let changed_tx = self.settings_changed.clone();
+                let changed_rx = self.settings_changed.subscribe();
+                crate::sync_server::handle_settings_rpc_connection(
+                    reader,
+                    writer,
+                    self.settings.clone(),
+                    changed_tx,
+                    changed_rx,
+                    self.config.resolved_settings_doc_path(),
+                    self.config.resolved_settings_json_path(),
+                )
+                .await
+            }
             Handshake::NotebookSync {
                 notebook_id,
                 protocol,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1706,7 +1706,7 @@ impl Daemon {
                 info!(
                     "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
                     notebook_id,
-                    protocol.as_deref().unwrap_or("v4"),
+                    protocol.as_deref().unwrap_or("v5"),
                     working_dir
                 );
                 let docs_dir = self.config.notebook_docs_dir.clone();
@@ -1869,7 +1869,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V5, PROTOCOL_VERSION,
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
@@ -1899,7 +1899,7 @@ impl Daemon {
             writer: &mut W,
             error: String,
         ) -> anyhow::Result<()> {
-            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
+            let (proto_str, proto_ver) = (PROTOCOL_V5, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
                 protocol: proto_str.to_string(),
                 protocol_version: Some(proto_ver),
@@ -2152,7 +2152,7 @@ impl Daemon {
         // `notebook_id` variable in this handler is the canonical path string
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
+        let (proto_str, proto_ver) = (PROTOCOL_V5, PROTOCOL_VERSION);
         let response = NotebookConnectionInfo {
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),
@@ -2211,7 +2211,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V5, PROTOCOL_VERSION,
         };
 
         info!(
@@ -2290,7 +2290,7 @@ impl Daemon {
                 );
             }
             let (mut reader, mut writer) = tokio::io::split(stream);
-            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
+            let (proto_str, proto_ver) = (PROTOCOL_V5, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
                 protocol: proto_str.to_string(),
                 protocol_version: Some(proto_ver),
@@ -2312,7 +2312,7 @@ impl Daemon {
         // Always send the room's UUID on the wire, even when the caller
         // provided a notebook_id_hint — room.id is the canonical source.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
+        let (proto_str, proto_ver) = (PROTOCOL_V5, PROTOCOL_VERSION);
         let notebook_path = room
             .identity
             .path

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -206,7 +206,7 @@ where
 
     // Send capabilities response unless already sent via NotebookConnectionInfo.
     if !skip_capabilities {
-        let (proto_str, proto_ver) = (connection::PROTOCOL_V4, connection::PROTOCOL_VERSION);
+        let (proto_str, proto_ver) = (connection::PROTOCOL_V5, connection::PROTOCOL_VERSION);
         let caps = connection::ProtocolCapabilities {
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -8,9 +8,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use automerge::sync;
+use notebook_protocol::connection::{SettingsRpcClientMessage, SettingsRpcServerMessage};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::connection;
 use crate::settings_doc::SettingsDoc;
@@ -115,11 +116,192 @@ where
 }
 
 /// Persist the settings document to disk (both Automerge binary and JSON mirror).
+///
+/// The Automerge sync path treats persist failures as best-effort warnings
+/// (the in-memory CRDT is still authoritative; the next change retries).
+/// The RPC path needs the failure surfaced to the writing client, so it
+/// uses `try_persist_settings` instead.
 fn persist_settings(doc: &mut SettingsDoc, automerge_path: &Path, json_path: &Path) {
     if let Err(e) = doc.save_to_file(automerge_path) {
         warn!("[sync] Failed to save Automerge doc: {}", e);
     }
     if let Err(e) = doc.save_json_mirror(json_path) {
         warn!("[sync] Failed to write JSON mirror: {}", e);
+    }
+}
+
+/// Persist the settings document, surfacing the first failure as `Err`.
+///
+/// Used by the RPC `SetSetting` path so the ack can carry `ok: false`
+/// when the on-disk write fails. The in-memory doc is left as the
+/// caller wrote it; rollback is the caller's call. We still attempt
+/// both writes so a partially recoverable state (Automerge ok, JSON
+/// mirror failed) doesn't silently leave only one side persisted.
+fn try_persist_settings(
+    doc: &mut SettingsDoc,
+    automerge_path: &Path,
+    json_path: &Path,
+) -> Result<(), String> {
+    let mut first_error: Option<String> = None;
+    if let Err(e) = doc.save_to_file(automerge_path) {
+        let msg = format!("save Automerge doc: {e}");
+        warn!("[settings-rpc] {msg}");
+        first_error.get_or_insert(msg);
+    }
+    if let Err(e) = doc.save_json_mirror(json_path) {
+        let msg = format!("write JSON mirror: {e}");
+        warn!("[settings-rpc] {msg}");
+        first_error.get_or_insert(msg);
+    }
+    match first_error {
+        None => Ok(()),
+        Some(msg) => Err(msg),
+    }
+}
+
+/// Build a `Snapshot` server message from the current `SettingsDoc`.
+fn build_snapshot_message(doc: &SettingsDoc) -> anyhow::Result<SettingsRpcServerMessage> {
+    let snapshot = doc.get_all();
+    let value = serde_json::to_value(&snapshot)?;
+    Ok(SettingsRpcServerMessage::Snapshot { settings: value })
+}
+
+/// Handle a single `Handshake::SettingsRpc` client.
+///
+/// Prototype channel for nteract/desktop#1598. Runs alongside the existing
+/// Automerge `SettingsSync` handler against the same `SettingsDoc` and the
+/// same `settings_changed` broadcast. The Automerge path is the source of
+/// truth for now; this channel is opt-in and additive.
+///
+/// Wire shape:
+/// 1. On connect: server sends one `Snapshot`.
+/// 2. Loop: select between client `SetSetting` requests and `settings_changed`
+///    broadcast ticks. Each `SetSetting` is applied via
+///    `SettingsDoc::put_value`, persisted, broadcast, and acked. Each
+///    broadcast tick causes a fresh `Snapshot` to go out.
+pub async fn handle_settings_rpc_connection<R, W>(
+    mut reader: R,
+    mut writer: W,
+    settings: Arc<RwLock<SettingsDoc>>,
+    changed_tx: broadcast::Sender<()>,
+    mut changed_rx: broadcast::Receiver<()>,
+    automerge_path: PathBuf,
+    json_path: PathBuf,
+) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    info!("[settings-rpc] New client connected");
+
+    // Initial snapshot. Build with a short read lock so we don't hold the
+    // guard across the socket write.
+    let initial = {
+        let doc = settings.read().await;
+        build_snapshot_message(&doc)?
+    };
+    connection::send_json_frame(&mut writer, &initial).await?;
+
+    loop {
+        tokio::select! {
+            // Inbound client message.
+            result = connection::recv_json_frame::<_, SettingsRpcClientMessage>(&mut reader) => {
+                match result? {
+                    Some(SettingsRpcClientMessage::SetSetting { key, value }) => {
+                        debug!("[settings-rpc] SetSetting key={key} value={value}");
+
+                        // Apply + persist + build the post-write snapshot
+                        // under a single write-lock scope. Don't hold the
+                        // RwLock guard across `.await`. Compare heads so
+                        // no-op writes (same value, unsupported value
+                        // shape silently ignored by `put_value`) don't
+                        // wake the `settings_changed` subscribers — the
+                        // existing Automerge handler enforces the same
+                        // invariant against pool-warming churn (#2120).
+                        type ApplyOk = (SettingsRpcServerMessage, bool);
+                        let apply_result: Result<ApplyOk, String> = {
+                            let mut doc = settings.write().await;
+                            let before = doc.heads();
+                            doc.put_value(&key, &value);
+                            let after = doc.heads();
+                            let doc_changed = before != after;
+
+                            let persist_result = if doc_changed {
+                                try_persist_settings(&mut doc, &automerge_path, &json_path)
+                            } else {
+                                Ok(())
+                            };
+                            persist_result.and_then(|()| {
+                                build_snapshot_message(&doc)
+                                    .map(|snapshot| (snapshot, doc_changed))
+                                    .map_err(|e| e.to_string())
+                            })
+                        };
+
+                        match apply_result {
+                            Ok((snapshot, doc_changed)) => {
+                                // Always echo the post-write snapshot to the
+                                // writer so set-and-read patterns see a
+                                // consistent view, even on no-op writes.
+                                connection::send_json_frame(&mut writer, &snapshot).await?;
+                                if doc_changed {
+                                    // Fan out to peers; our own broadcast
+                                    // tick will fire on the next select
+                                    // iteration and resend the same
+                                    // snapshot — harmless, the client
+                                    // treats a duplicate snapshot as a
+                                    // no-op refresh.
+                                    let _ = changed_tx.send(());
+                                }
+                                let ack = SettingsRpcServerMessage::SetSettingAck {
+                                    ok: true,
+                                    error: None,
+                                };
+                                connection::send_json_frame(&mut writer, &ack).await?;
+                            }
+                            Err(e) => {
+                                let ack = SettingsRpcServerMessage::SetSettingAck {
+                                    ok: false,
+                                    error: Some(e),
+                                };
+                                connection::send_json_frame(&mut writer, &ack).await?;
+                            }
+                        }
+                    }
+                    None => {
+                        info!("[settings-rpc] Client disconnected");
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Settings changed elsewhere (this client's own write, the
+            // Automerge sync handler, or the `settings.json` watcher).
+            // Push a fresh snapshot.
+            tick = changed_rx.recv() => {
+                match tick {
+                    Ok(()) => {
+                        let snapshot = {
+                            let doc = settings.read().await;
+                            build_snapshot_message(&doc)?
+                        };
+                        connection::send_json_frame(&mut writer, &snapshot).await?;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        // Broadcast queue overflowed. Resync with current
+                        // state instead of giving up.
+                        debug!("[settings-rpc] broadcast lagged by {n}, resyncing");
+                        let snapshot = {
+                            let doc = settings.read().await;
+                            build_snapshot_message(&doc)?
+                        };
+                        connection::send_json_frame(&mut writer, &snapshot).await?;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Ok(());
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -14,7 +14,31 @@ use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, info, warn};
 
 use crate::connection;
-use crate::settings_doc::SettingsDoc;
+use crate::settings_doc::{
+    SettingsDoc, SyncedSettings, MAX_KEEP_ALIVE_SECS, MAX_POOL_SIZE, MIN_KEEP_ALIVE_SECS,
+};
+
+const SETTINGS_RPC_KEYS: &[&str] = &[
+    "theme",
+    "color_theme",
+    "default_runtime",
+    "default_python_env",
+    "uv.default_packages",
+    "conda.default_packages",
+    "pixi.default_packages",
+    "keep_alive_secs",
+    "onboarding_completed",
+    "uv_pool_size",
+    "conda_pool_size",
+    "pixi_pool_size",
+    "bootstrap_dx",
+    "install_id",
+    "telemetry_enabled",
+    "telemetry_consent_recorded",
+    "telemetry_last_daemon_ping_at",
+    "telemetry_last_app_ping_at",
+    "telemetry_last_mcp_ping_at",
+];
 
 /// Check if an error is just a normal connection close.
 pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {
@@ -166,6 +190,104 @@ fn build_snapshot_message(doc: &SettingsDoc) -> anyhow::Result<SettingsRpcServer
     Ok(SettingsRpcServerMessage::Snapshot { settings: value })
 }
 
+fn validate_settings_rpc_write(
+    doc: &SettingsDoc,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<bool, String> {
+    if !SETTINGS_RPC_KEYS.contains(&key) {
+        return Err(format!(
+            "unknown setting '{key}'. Valid keys: {}",
+            SETTINGS_RPC_KEYS.join(", ")
+        ));
+    }
+
+    validate_field_constraints(key, value)?;
+
+    let current = serde_json::to_value(doc.get_all()).map_err(|e| e.to_string())?;
+    let mut candidate = current.clone();
+    set_json_setting(&mut candidate, key, value.clone())?;
+    serde_json::from_value::<SyncedSettings>(candidate.clone())
+        .map_err(|e| format!("invalid value for setting '{key}': {e}"))?;
+
+    Ok(candidate != current)
+}
+
+fn validate_field_constraints(key: &str, value: &serde_json::Value) -> Result<(), String> {
+    match key {
+        "keep_alive_secs" => {
+            let secs = value
+                .as_u64()
+                .ok_or_else(|| "keep_alive_secs must be an unsigned integer".to_string())?;
+            if !(MIN_KEEP_ALIVE_SECS..=MAX_KEEP_ALIVE_SECS).contains(&secs) {
+                return Err(format!(
+                    "keep_alive_secs must be between {MIN_KEEP_ALIVE_SECS} and {MAX_KEEP_ALIVE_SECS}"
+                ));
+            }
+        }
+        "uv_pool_size" | "conda_pool_size" | "pixi_pool_size" => {
+            let size = value
+                .as_u64()
+                .ok_or_else(|| format!("{key} must be an unsigned integer"))?;
+            if size > MAX_POOL_SIZE {
+                return Err(format!("{key} must be between 0 and {MAX_POOL_SIZE}"));
+            }
+        }
+        "uv.default_packages" | "conda.default_packages" | "pixi.default_packages" => {
+            let packages = value
+                .as_array()
+                .ok_or_else(|| format!("{key} must be an array of package strings"))?;
+            for package in packages {
+                let package = package
+                    .as_str()
+                    .ok_or_else(|| format!("{key} must be an array of package strings"))?;
+                notebook_doc::metadata::validate_package_specifier(package)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        "telemetry_last_daemon_ping_at"
+        | "telemetry_last_app_ping_at"
+        | "telemetry_last_mcp_ping_at" => {
+            if !(value.is_null() || value.as_u64().is_some()) {
+                return Err(format!(
+                    "{key} must be null or an unsigned integer timestamp"
+                ));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn set_json_setting(
+    root: &mut serde_json::Value,
+    key: &str,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err("setting key must not contain empty path segments".to_string());
+    }
+
+    let mut current = root;
+    for part in &parts[..parts.len().saturating_sub(1)] {
+        current = current
+            .as_object_mut()
+            .ok_or_else(|| format!("expected object while setting '{key}'"))?
+            .entry((*part).to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    }
+
+    let leaf = parts
+        .last()
+        .ok_or_else(|| "setting key must not be empty".to_string())?;
+    current
+        .as_object_mut()
+        .ok_or_else(|| format!("expected object while setting '{key}'"))?
+        .insert((*leaf).to_string(), value);
+    Ok(())
+}
+
 /// Handle a single `Handshake::SettingsRpc` client.
 ///
 /// Prototype channel for nteract/desktop#1598. Runs alongside the existing
@@ -221,21 +343,34 @@ where
                         type ApplyOk = (SettingsRpcServerMessage, bool);
                         let apply_result: Result<ApplyOk, String> = {
                             let mut doc = settings.write().await;
-                            let before = doc.heads();
-                            doc.put_value(&key, &value);
-                            let after = doc.heads();
-                            let doc_changed = before != after;
+                            match validate_settings_rpc_write(&doc, &key, &value) {
+                                Err(e) => Err(e),
+                                Ok(expected_change) => {
+                                    let before = doc.heads();
+                                    if expected_change {
+                                        doc.put_value(&key, &value);
+                                    }
+                                    let after = doc.heads();
+                                    let doc_changed = before != after;
 
-                            let persist_result = if doc_changed {
-                                try_persist_settings(&mut doc, &automerge_path, &json_path)
-                            } else {
-                                Ok(())
-                            };
-                            persist_result.and_then(|()| {
-                                build_snapshot_message(&doc)
-                                    .map(|snapshot| (snapshot, doc_changed))
-                                    .map_err(|e| e.to_string())
-                            })
+                                    if expected_change && !doc_changed {
+                                        Err(format!(
+                                            "setting '{key}' is valid but is not supported by the SettingsDoc writer"
+                                        ))
+                                    } else {
+                                        let persist_result = if doc_changed {
+                                            try_persist_settings(&mut doc, &automerge_path, &json_path)
+                                        } else {
+                                            Ok(())
+                                        };
+                                        persist_result.and_then(|()| {
+                                            build_snapshot_message(&doc)
+                                                .map(|snapshot| (snapshot, doc_changed))
+                                                .map_err(|e| e.to_string())
+                                        })
+                                    }
+                                }
+                            }
                         };
 
                         match apply_result {
@@ -303,5 +438,101 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings_doc::{ColorTheme, ThemeMode};
+
+    fn validation_error(key: &str, value: serde_json::Value) -> String {
+        let doc = SettingsDoc::new();
+        validate_settings_rpc_write(&doc, key, &value).expect_err("write should be rejected")
+    }
+
+    #[test]
+    fn settings_rpc_validation_accepts_supported_changes() {
+        let doc = SettingsDoc::new();
+
+        assert!(
+            validate_settings_rpc_write(&doc, "theme", &serde_json::json!("dark")).unwrap(),
+            "changing a scalar enum should report a document change"
+        );
+        assert!(
+            validate_settings_rpc_write(
+                &doc,
+                "uv.default_packages",
+                &serde_json::json!(["numpy", "pandas"])
+            )
+            .unwrap(),
+            "changing a package list should report a document change"
+        );
+        assert!(
+            validate_settings_rpc_write(&doc, "keep_alive_secs", &serde_json::json!(60)).unwrap(),
+            "changing a bounded number should report a document change"
+        );
+    }
+
+    #[test]
+    fn settings_rpc_validation_detects_no_op_writes() {
+        let doc = SettingsDoc::new();
+
+        assert!(
+            !validate_settings_rpc_write(&doc, "theme", &serde_json::json!(ThemeMode::System))
+                .unwrap(),
+            "writing the current theme should be a no-op"
+        );
+        assert!(
+            !validate_settings_rpc_write(
+                &doc,
+                "color_theme",
+                &serde_json::json!(ColorTheme::Classic)
+            )
+            .unwrap(),
+            "writing the current color theme should be a no-op"
+        );
+    }
+
+    #[test]
+    fn settings_rpc_validation_rejects_unknown_keys_and_bad_types() {
+        let unknown = validation_error("theme.typo", serde_json::json!("dark"));
+        assert!(unknown.contains("unknown setting"));
+
+        let bad_theme = validation_error("theme", serde_json::json!("midnight"));
+        assert!(bad_theme.contains("invalid value"));
+
+        let bad_bool = validation_error("telemetry_enabled", serde_json::json!("false"));
+        assert!(bad_bool.contains("invalid value"));
+
+        let bad_timestamp =
+            validation_error("telemetry_last_app_ping_at", serde_json::json!("yesterday"));
+        assert!(bad_timestamp.contains("must be null or an unsigned integer timestamp"));
+    }
+
+    #[test]
+    fn settings_rpc_validation_rejects_out_of_range_numbers() {
+        let too_short = validation_error("keep_alive_secs", serde_json::json!(1));
+        assert!(too_short.contains("keep_alive_secs must be between"));
+
+        let too_large_pool = validation_error("uv_pool_size", serde_json::json!(MAX_POOL_SIZE + 1));
+        assert!(too_large_pool.contains("uv_pool_size must be between"));
+
+        let wrong_pool_type = validation_error("conda_pool_size", serde_json::json!("3"));
+        assert!(wrong_pool_type.contains("conda_pool_size must be an unsigned integer"));
+    }
+
+    #[test]
+    fn settings_rpc_validation_rejects_malformed_package_lists() {
+        let not_array = validation_error("uv.default_packages", serde_json::json!("numpy"));
+        assert!(not_array.contains("must be an array of package strings"));
+
+        let non_string =
+            validation_error("conda.default_packages", serde_json::json!(["numpy", 123]));
+        assert!(non_string.contains("must be an array of package strings"));
+
+        let invalid_spec =
+            validation_error("pixi.default_packages", serde_json::json!(["[\"numpy\""]));
+        assert!(!invalid_spec.is_empty());
     }
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -476,7 +476,7 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
 #[tokio::test]
 async fn test_settings_rpc_set_setting_round_trip() {
     use runtimed::settings_doc::{SyncedSettings, ThemeMode};
-    use runtimed::settings_rpc_client::SettingsRpcClient;
+    use runtimed::settings_rpc_client::{SettingsRpcClient, SettingsRpcError};
 
     let temp_dir = TempDir::new().unwrap();
     let mut config = test_config(&temp_dir);
@@ -502,9 +502,13 @@ async fn test_settings_rpc_set_setting_round_trip() {
 
     // Connect via the new RPC handshake and read the initial snapshot.
     let mut rpc_client =
-        SettingsRpcClient::connect_with_timeout(socket_path, Duration::from_secs(2))
+        SettingsRpcClient::connect_with_timeout(socket_path.clone(), Duration::from_secs(2))
             .await
             .expect("SettingsRpcClient should connect via unified socket");
+    let mut peer_client =
+        SettingsRpcClient::connect_with_timeout(socket_path, Duration::from_secs(2))
+            .await
+            .expect("second SettingsRpcClient should connect via unified socket");
 
     assert_eq!(
         rpc_client.get_snapshot().theme,
@@ -525,6 +529,35 @@ async fn test_settings_rpc_set_setting_round_trip() {
         rpc_client.get_snapshot().theme,
         ThemeMode::Dark,
         "snapshot push from broadcast should reflect the new theme"
+    );
+    let peer_snapshot = tokio::time::timeout(Duration::from_secs(2), peer_client.recv_snapshot())
+        .await
+        .expect("peer should receive settings_changed broadcast")
+        .expect("peer snapshot should decode");
+    assert_eq!(
+        peer_snapshot.theme,
+        ThemeMode::Dark,
+        "peer snapshot should reflect the RPC write"
+    );
+
+    let rejected = rpc_client
+        .set_setting("theme.typo", &serde_json::Value::String("light".into()))
+        .await
+        .expect_err("unknown setting keys must be rejected");
+    assert!(
+        matches!(rejected, SettingsRpcError::Rejected(_)),
+        "unknown setting should produce a daemon rejection, got {rejected:?}"
+    );
+
+    rpc_client
+        .set_setting("theme", &serde_json::Value::String("dark".into()))
+        .await
+        .expect("same-value set_setting should still be acked");
+    let no_peer_snapshot =
+        tokio::time::timeout(Duration::from_millis(300), peer_client.recv_snapshot()).await;
+    assert!(
+        no_peer_snapshot.is_err(),
+        "same-value write should not broadcast to peers"
     );
 
     // The on-disk JSON mirror must reflect the change too. Without the

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -474,6 +474,71 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
 }
 
 #[tokio::test]
+async fn test_settings_rpc_set_setting_round_trip() {
+    use runtimed::settings_doc::{SyncedSettings, ThemeMode};
+    use runtimed::settings_rpc_client::SettingsRpcClient;
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let settings_dir = temp_dir.path().canonicalize().unwrap();
+    let settings_doc_path = settings_dir.join("settings.automerge");
+    let settings_json_path = settings_dir.join("settings.json");
+    config.settings_doc_path = Some(settings_doc_path);
+    config.settings_json_path = Some(settings_json_path.clone());
+
+    // Seed a default `settings.json` so the daemon hydrates a known
+    // baseline (theme: System).
+    let initial = serde_json::to_string_pretty(&SyncedSettings::default()).unwrap();
+    std::fs::write(&settings_json_path, initial).unwrap();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    // Connect via the new RPC handshake and read the initial snapshot.
+    let mut rpc_client =
+        SettingsRpcClient::connect_with_timeout(socket_path, Duration::from_secs(2))
+            .await
+            .expect("SettingsRpcClient should connect via unified socket");
+
+    assert_eq!(
+        rpc_client.get_snapshot().theme,
+        ThemeMode::System,
+        "initial snapshot should match seeded settings"
+    );
+
+    // Issue a scalar write. The daemon applies it under its write lock,
+    // persists, broadcasts, and acks. The ack happens after the broadcast
+    // tick on this same connection, so the snapshot we cached during
+    // `set_setting` already reflects the new value.
+    rpc_client
+        .set_setting("theme", &serde_json::Value::String("dark".into()))
+        .await
+        .expect("set_setting should be acked");
+
+    assert_eq!(
+        rpc_client.get_snapshot().theme,
+        ThemeMode::Dark,
+        "snapshot push from broadcast should reflect the new theme"
+    );
+
+    // The on-disk JSON mirror must reflect the change too. Without the
+    // mirror write, an external editor reading `settings.json` after the
+    // RPC would see a stale value.
+    let saved_json = std::fs::read_to_string(&settings_json_path).unwrap();
+    let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
+    assert_eq!(saved.theme, ThemeMode::Dark);
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_blob_server_health() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);


### PR DESCRIPTION
Adds a `Handshake::SettingsRpc` channel as a hardened slice of the settings ownership design in #1598. The daemon owns its in-memory `SettingsDoc` and `settings.json`; RPC clients receive a full `SyncedSettings` snapshot on connect and on every change, and send `SetSetting { key, value }` writes against the daemon's current state instead of pushing CRDT state.

Both channels run against the same `Arc<RwLock<SettingsDoc>>` and the same `settings_changed` broadcast, so peers on either side see each other's writes. The existing Automerge `SettingsSync` path is unchanged and remains the default for the app.

Refs #1598.

## Design decisions

- **Same `SettingsDoc`, two channels.** The new RPC handler shares the existing daemon settings document and persistence paths with `SettingsSync`, so RPC writes and Automerge writes converge through the same daemon-owned state.
- **Validate before mutating.** `SetSetting` now rejects unknown keys, bad scalar types, out-of-range durations/pool sizes, and malformed package lists before touching the shared document. If a key is valid in `SyncedSettings` but unsupported by the current `SettingsDoc::put_value` writer, the daemon returns a rejected ack instead of silently succeeding.
- **Snapshot push on the writer's own connection, before the ack.** The writer receives the post-write `Snapshot` before `SetSettingAck`, so set-and-read callers do not observe stale cached settings. Peers receive the same update through `settings_changed`.
- **Heads-equality guard.** Same-value writes do not persist or broadcast. This mirrors the Automerge path's guard against settings churn waking pool warmers unnecessarily.
- **Persist failures fail the ack.** RPC writes attempt both the Automerge binary and JSON mirror writes. The first persistence failure is surfaced as `SetSettingAck { ok: false, error }`.
- **Protocol version reflects the new handshake.** The wire protocol reports v5 for the added `SettingsRpc` channel while keeping v4 as the minimum accepted daemon protocol for upgrade compatibility.
- **Upgrade window closes Settings before daemon replacement.** The app's upgrade flow closes every webview except the upgrade window before upgrading the daemon, so an open Settings window does not keep a stale settings socket alive across the daemon swap.
- **Opt-in.** Existing Tauri/React settings code still uses `SyncClient`/`SettingsSync`; this PR adds the RPC path without flipping callers.

## Files

- `crates/notebook-protocol/src/connection/handshake.rs` - new `Handshake::SettingsRpc` variant and protocol v5 constant.
- `crates/notebook-protocol/src/connection/settings_rpc.rs` - `SettingsRpcServerMessage::{Snapshot, SetSettingAck}` and `SettingsRpcClientMessage::SetSetting`.
- `crates/runtimed/src/sync_server.rs` - `handle_settings_rpc_connection`, validation, snapshot fanout, and persistence error handling.
- `crates/runtimed/src/daemon.rs` - dispatch for the new handshake variant.
- `crates/runtimed-client/src/settings_rpc_client.rs` - `SettingsRpcClient` with `connect`, `get_snapshot`, `recv_snapshot`, and `set_setting`.
- `crates/runtimed/tests/integration.rs` - RPC round-trip coverage, peer broadcast coverage, JSON persistence coverage, and rejected-write coverage.

## Test plan

- [x] `cargo test -p runtimed sync_server::tests --lib`
- [x] `cargo test -p notebook-protocol connection::`
- [x] `cargo test -p runtimed test_settings_rpc_set_setting_round_trip --test integration`
- [x] `cargo clippy -p runtimed --test integration -- -D warnings`
- [x] `cargo xtask lint --fix`

## Out of scope

- No on-disk migration. Both `settings.automerge` and `settings.json` still get written.
- No Tauri/React caller migration. The app still uses the existing `SettingsSync` path.
- No telemetry-state split into `runtime-state.json`. The full canonical-JSON migration in #1598 covers that larger move.


