### PR TITLE
fix(runtimed): reserve kernel ports in daemon

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -606,6 +606,15 @@ pub enum NotebookBroadcast {
 /// The coordinator mediates between frontend requests and the runtime agent.
 /// Environment preparation happens in the coordinator; the runtime agent
 /// receives a ready-to-launch configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KernelPorts {
+    pub stdin: u16,
+    pub control: u16,
+    pub hb: u16,
+    pub shell: u16,
+    pub iopub: u16,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)]
@@ -618,6 +627,7 @@ pub enum RuntimeAgentRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         notebook_path: Option<String>,
         launched_config: LaunchedEnvConfig,
+        kernel_ports: KernelPorts,
         /// Environment variables to set for the kernel process.
         #[serde(default)]
         env_vars: std::collections::HashMap<String, String>,
@@ -639,6 +649,7 @@ pub enum RuntimeAgentRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         notebook_path: Option<String>,
         launched_config: LaunchedEnvConfig,
+        kernel_ports: KernelPorts,
         #[serde(default)]
         env_vars: std::collections::HashMap<String, String>,
     },
@@ -1306,6 +1317,58 @@ mod tests {
     }
 
     #[test]
+    fn runtime_agent_launch_and_restart_include_kernel_ports() {
+        let ports = KernelPorts {
+            stdin: 9000,
+            control: 9001,
+            hb: 9002,
+            shell: 9003,
+            iopub: 9004,
+        };
+        let launch = RuntimeAgentRequest::LaunchKernel {
+            kernel_type: "python".into(),
+            env_source: EnvSource::Prewarmed(crate::connection::PackageManager::Uv),
+            notebook_path: None,
+            launched_config: Default::default(),
+            kernel_ports: ports,
+            env_vars: Default::default(),
+        };
+        let json = serde_json::to_value(&launch).unwrap();
+        assert_eq!(json["kernel_ports"]["stdin"], 9000);
+        assert_eq!(json["kernel_ports"]["control"], 9001);
+        assert_eq!(json["kernel_ports"]["hb"], 9002);
+        assert_eq!(json["kernel_ports"]["shell"], 9003);
+        assert_eq!(json["kernel_ports"]["iopub"], 9004);
+
+        let parsed: RuntimeAgentRequest = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            parsed,
+            RuntimeAgentRequest::LaunchKernel {
+                kernel_ports,
+                ..
+            } if kernel_ports == ports
+        ));
+
+        let restart = RuntimeAgentRequest::RestartKernel {
+            kernel_type: "python".into(),
+            env_source: EnvSource::Inline(crate::connection::PackageManager::Conda),
+            notebook_path: None,
+            launched_config: Default::default(),
+            kernel_ports: ports,
+            env_vars: Default::default(),
+        };
+        let json = serde_json::to_value(&restart).unwrap();
+        let parsed: RuntimeAgentRequest = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            parsed,
+            RuntimeAgentRequest::RestartKernel {
+                kernel_ports,
+                ..
+            } if kernel_ports == ports
+        ));
+    }
+
+    #[test]
     fn runtime_agent_is_command() {
         assert!(RuntimeAgentRequest::InterruptExecution.is_command());
         assert!(!RuntimeAgentRequest::ShutdownKernel.is_command());
@@ -1338,6 +1401,13 @@ mod tests {
             env_source: EnvSource::Prewarmed(crate::connection::PackageManager::Uv),
             notebook_path: None,
             launched_config: Default::default(),
+            kernel_ports: KernelPorts {
+                stdin: 9000,
+                control: 9001,
+                hb: 9002,
+                shell: 9003,
+                iopub: 9004,
+            },
             env_vars: Default::default(),
         }
         .is_command());
@@ -1346,6 +1416,13 @@ mod tests {
             env_source: EnvSource::Inline(crate::connection::PackageManager::Conda),
             notebook_path: None,
             launched_config: Default::default(),
+            kernel_ports: KernelPorts {
+                stdin: 9005,
+                control: 9006,
+                hb: 9007,
+                shell: 9008,
+                iopub: 9009,
+            },
             env_vars: Default::default(),
         }
         .is_command());

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -40,98 +40,21 @@ use crate::stream_terminal::{StreamOutputState, StreamTerminals};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
-use notebook_protocol::protocol::LaunchedEnvConfig;
+use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig};
 
-/// Reserved port range for Jupyter kernel ZMQ sockets.
-///
-/// Outside the Windows dynamic ephemeral range (49152-65535) and the IANA
-/// registered range (the conventional ceiling for system ports on Linux is
-/// also `ip_local_port_range` start, typically 32768). 9000-9999 is in the
-/// IANA user-port range, far from any default ephemeral pool, and unlikely
-/// to clash with common services on a developer machine.
-const DEFAULT_KERNEL_PORT_RANGE: std::ops::RangeInclusive<u16> = 9000..=9999;
-const TEST_KERNEL_PORT_RANGE_SIZE: u16 = 100;
-static NEXT_KERNEL_PORT_OFFSET: AtomicU64 = AtomicU64::new(0);
-
-fn kernel_port_range() -> std::ops::RangeInclusive<u16> {
-    match std::env::var("RUNTIMED_TEST_KERNEL_PORT_RANGE_START") {
-        Ok(raw) => match raw.parse::<u16>() {
-            Ok(start) => {
-                let end = start.saturating_add(TEST_KERNEL_PORT_RANGE_SIZE - 1);
-                start..=end
-            }
-            Err(e) => {
-                warn!(
-                    "[jupyter-kernel] Ignoring invalid RUNTIMED_TEST_KERNEL_PORT_RANGE_START={raw:?}: {e}"
-                );
-                DEFAULT_KERNEL_PORT_RANGE
-            }
-        },
-        Err(_) => DEFAULT_KERNEL_PORT_RANGE,
+async fn bind_kernel_port_listeners(ip: IpAddr, ports: KernelPorts) -> Result<Vec<TcpListener>> {
+    let port_numbers = [
+        ports.stdin,
+        ports.control,
+        ports.hb,
+        ports.shell,
+        ports.iopub,
+    ];
+    let mut listeners = Vec::with_capacity(port_numbers.len());
+    for port in port_numbers {
+        listeners.push(TcpListener::bind(SocketAddr::new(ip, port)).await?);
     }
-}
-
-fn kernel_port_candidates(num: usize) -> Vec<u16> {
-    let range = kernel_port_range();
-    let start = u32::from(*range.start());
-    let end = u32::from(*range.end());
-    let len = (end - start + 1) as usize;
-    let offset = NEXT_KERNEL_PORT_OFFSET.fetch_add(num as u64, Ordering::Relaxed) as usize % len;
-
-    (0..len)
-        .map(|i| start + ((offset + i) % len) as u32)
-        .filter_map(|port| u16::try_from(port).ok())
-        .collect()
-}
-
-/// Reserve `num` TCP ports for a kernel's ZMQ sockets.
-///
-/// Wraps `runtimelib::peek_ports_with_listeners` to address a TOCTOU race
-/// observed on Windows: that function binds to port 0, asks the OS for a
-/// port (in the dynamic ephemeral range on Windows: 49152-65535), then
-/// drops the listener and tells the kernel to bind that same port. The
-/// 100-200ms window between drop and the kernel's bind is long enough on
-/// Windows for the OS to hand the port to another process as an outbound
-/// ephemeral source - the kernel's bind() then fails with EADDRINUSE and
-/// the daemon sees it as `Codec Error: WSAECONNRESET (10054)`.
-///
-/// We try the reserved range 9000-9999 first. If we can't fill `num` from
-/// the reserved range, fall back to the OS-assigned ports - the race is
-/// rarer on Linux/macOS and the reserved range is small enough that we
-/// might collide with something, so the fallback keeps developer machines
-/// working.
-async fn reserve_kernel_ports(ip: IpAddr, num: usize) -> Result<(Vec<u16>, Vec<TcpListener>)> {
-    let mut ports: Vec<u16> = Vec::with_capacity(num);
-    let mut listeners: Vec<TcpListener> = Vec::with_capacity(num);
-
-    for port in kernel_port_candidates(num) {
-        if ports.len() == num {
-            break;
-        }
-        let addr = SocketAddr::new(ip, port);
-        if let Ok(listener) = TcpListener::bind(addr).await {
-            ports.push(port);
-            listeners.push(listener);
-        }
-    }
-
-    if ports.len() == num {
-        debug!(
-            "[jupyter-kernel] Reserved {} ports from configured range: {:?}",
-            num, ports
-        );
-        return Ok((ports, listeners));
-    }
-
-    warn!(
-        "[jupyter-kernel] Reserved range exhausted ({}/{} filled); falling back to OS-assigned",
-        ports.len(),
-        num
-    );
-    drop(listeners);
-    runtimelib::peek_ports_with_listeners(ip, num)
-        .await
-        .map_err(Into::into)
+    Ok(listeners)
 }
 
 /// Type alias for pending completion response channels.
@@ -725,203 +648,141 @@ impl KernelConnection for JupyterKernel {
         // only "exit status: 1" with no clue why the kernel died.
         const STDERR_BUFFER_LINES: usize = 50;
 
-        // Spawn loop with retry on the Windows port-allocation race. The
-        // reserved 9000-9999 range from `reserve_kernel_ports` is outside
-        // the *default* Windows dynamic ephemeral range, but the dynamic
-        // range is `netsh`-configurable and at least the GitHub-hosted
-        // windows-latest runners overlap our reserved range. When that
-        // happens the kernel's bind() races the OS allocator and exits
-        // with `Address in use`. Retry up to a few times with fresh ports
-        // so a single unlucky pick doesn't sink the launch.
-        const MAX_LAUNCH_ATTEMPTS: usize = 4;
-        type LaunchedKernel = (
-            tokio::process::Child,
-            Arc<StdMutex<VecDeque<String>>>,
-            ConnectionInfo,
-        );
-        let (mut process, _stderr_buffer, connection_info) = {
-            let mut accepted: Option<LaunchedKernel> = None;
-            let mut last_failure: Option<anyhow::Error> = None;
-            for attempt in 1..=MAX_LAUNCH_ATTEMPTS {
-                let (ports, listeners) = reserve_kernel_ports(ip, 5).await?;
-                let connection_info = ConnectionInfo {
-                    transport: jupyter_protocol::connection_info::Transport::TCP,
-                    ip: ip.to_string(),
-                    stdin_port: ports[0],
-                    control_port: ports[1],
-                    hb_port: ports[2],
-                    shell_port: ports[3],
-                    iopub_port: ports[4],
-                    signature_scheme: "hmac-sha256".to_string(),
-                    key: Uuid::new_v4().to_string(),
-                    kernel_name: Some(kernelspec_name.to_string()),
-                };
-                tokio::fs::write(
-                    &connection_file_path,
-                    serde_json::to_string_pretty(&connection_info)?,
-                )
-                .await?;
+        let kernel_ports = config.kernel_ports;
+        let ports = [
+            kernel_ports.stdin,
+            kernel_ports.control,
+            kernel_ports.hb,
+            kernel_ports.shell,
+            kernel_ports.iopub,
+        ];
+        let connection_info = ConnectionInfo {
+            transport: jupyter_protocol::connection_info::Transport::TCP,
+            ip: ip.to_string(),
+            stdin_port: kernel_ports.stdin,
+            control_port: kernel_ports.control,
+            hb_port: kernel_ports.hb,
+            shell_port: kernel_ports.shell,
+            iopub_port: kernel_ports.iopub,
+            signature_scheme: "hmac-sha256".to_string(),
+            key: Uuid::new_v4().to_string(),
+            kernel_name: Some(kernelspec_name.to_string()),
+        };
+        tokio::fs::write(
+            &connection_file_path,
+            serde_json::to_string_pretty(&connection_info)?,
+        )
+        .await?;
 
-                // Order the listener drop relative to spawn per platform.
-                //
-                // Windows: child processes inherit the parent's socket handles
-                // by default. If `cmd.spawn()` ran while the listeners were
-                // alive, the kernel would inherit handles for ports 9000-9004
-                // and ipykernel's first `s.bind('tcp://...:9003')` would fail
-                // with EADDRINUSE - the kernel itself already owns a listener
-                // on that port via inheritance. The 9000-9999 reserved range
-                // is outside the dynamic ephemeral pool, so the OS allocator
-                // can't reclaim a freed port between drop and the kernel's
-                // bind. Drop early.
-                //
-                // Linux/macOS: FD_CLOEXEC is the default, so the child can't
-                // inherit the listener. The risk is the opposite - on the
-                // fallback path where ports come from the OS ephemeral
-                // allocator, the OS could re-hand a freed port to some other
-                // process between drop and the kernel's bind. Hold the
-                // listeners across spawn so that window stays closed.
-                #[cfg(windows)]
-                drop(listeners);
-                let mut process = cmd.spawn()?;
-                #[cfg(not(windows))]
-                drop(listeners);
+        let listeners = bind_kernel_port_listeners(ip, kernel_ports).await?;
 
-                let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
-                    Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
-                let stderr_drain: Option<JoinHandle<()>> =
-                    if let Some(stderr) = process.stderr.take() {
-                        let kid = kernel_id.clone();
-                        let buffer = stderr_buffer.clone();
-                        Some(spawn_best_effort("kernel-stderr", async move {
-                            use tokio::io::{AsyncBufReadExt, BufReader};
-                            let mut lines = BufReader::new(stderr).lines();
-                            while let Ok(Some(line)) = lines.next_line().await {
-                                let lower = line.to_ascii_lowercase();
-                                if lower.contains("error") || lower.contains("traceback") {
-                                    warn!("[kernel-stderr:{}] {}", kid, line);
-                                } else {
-                                    debug!("[kernel-stderr:{}] {}", kid, line);
-                                }
-                                let mut queue = buffer.lock().unwrap();
-                                if queue.len() == STDERR_BUFFER_LINES {
-                                    queue.pop_front();
-                                }
-                                queue.push_back(line);
-                            }
-                        }))
+        // Keep the previous listener handoff behavior, but bind only the
+        // daemon-assigned ports. Windows child processes can inherit socket
+        // handles, so listeners must be dropped before spawn there. Unix
+        // descriptors are close-on-exec by default, so keep them through spawn
+        // to narrow the handoff window.
+        #[cfg(windows)]
+        drop(listeners);
+        let mut process = cmd.spawn()?;
+        #[cfg(not(windows))]
+        drop(listeners);
+
+        let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
+            Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
+        let stderr_drain: Option<JoinHandle<()>> = if let Some(stderr) = process.stderr.take() {
+            let kid = kernel_id.clone();
+            let buffer = stderr_buffer.clone();
+            Some(spawn_best_effort("kernel-stderr", async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    let lower = line.to_ascii_lowercase();
+                    if lower.contains("error") || lower.contains("traceback") {
+                        warn!("[kernel-stderr:{}] {}", kid, line);
                     } else {
-                        None
-                    };
-
-                info!(
-                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, attempt={}/{}, ports={:?})",
-                    process.id(),
-                    kernel_id,
-                    attempt,
-                    MAX_LAUNCH_ATTEMPTS,
-                    ports
-                );
-
-                // Wait for kernel startup. ipykernel spends 1-3s on Windows
-                // (and macOS cold path) importing pyzmq/ipykernel and binding
-                // ZMQ sockets. Polling try_wait every 100ms inside the
-                // window catches an early exit (the EADDRINUSE case we're
-                // retrying for) without paying the full ceiling on success.
-                const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
-                let startup_deadline = std::time::Instant::now() + STARTUP_CEILING;
-                let mut early_exit: Option<std::process::ExitStatus> = None;
-                let mut wait_err: Option<std::io::Error> = None;
-                loop {
-                    match process.try_wait() {
-                        Ok(Some(status)) => {
-                            early_exit = Some(status);
-                            break;
-                        }
-                        Ok(None) => {
-                            if std::time::Instant::now() >= startup_deadline {
-                                break;
-                            }
-                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                        }
-                        Err(e) => {
-                            wait_err = Some(e);
-                            break;
-                        }
+                        debug!("[kernel-stderr:{}] {}", kid, line);
                     }
+                    let mut queue = buffer.lock().unwrap();
+                    if queue.len() == STDERR_BUFFER_LINES {
+                        queue.pop_front();
+                    }
+                    queue.push_back(line);
                 }
+            }))
+        } else {
+            None
+        };
 
-                let outcome = match (early_exit, wait_err) {
-                    (Some(s), _) => Ok(Some(s)),
-                    (None, Some(e)) => Err(e),
-                    (None, None) => Ok(None),
-                };
+        info!(
+            "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, ports={:?})",
+            process.id(),
+            kernel_id,
+            ports
+        );
 
-                // Early crash detection: did the process exit during startup?
-                match outcome {
-                    Ok(Some(exit_status)) => {
-                        // Wait for stderr EOF (the child is gone, the reader
-                        // task should finish promptly) so we read a complete
-                        // tail. Bound it so a stuck pipe can't hang launch.
-                        if let Some(handle) = stderr_drain {
-                            let _ =
-                                tokio::time::timeout(std::time::Duration::from_millis(500), handle)
-                                    .await;
-                        }
-                        let captured = {
-                            let queue = stderr_buffer.lock().unwrap();
-                            queue.iter().cloned().collect::<Vec<_>>().join("\n")
-                        };
-                        let port_race = captured.contains("Address in use")
-                            || captured.contains("Address already in use");
-                        if port_race && attempt < MAX_LAUNCH_ATTEMPTS {
-                            warn!(
-                                "[jupyter-kernel] Kernel hit port-allocation race on attempt {}/{}; retrying with fresh ports (kernel_id={}, exit={})",
-                                attempt, MAX_LAUNCH_ATTEMPTS, kernel_id, exit_status
-                            );
-                            last_failure = Some(anyhow::anyhow!(
-                                "kernel exited with port race: {}",
-                                exit_status
-                            ));
-                            continue;
-                        }
-                        let stderr_tail = if captured.is_empty() {
-                            "(no stderr captured before exit)".to_string()
-                        } else {
-                            format!("stderr tail:\n{}", captured)
-                        };
-                        error!(
-                            "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={}, attempts={})\n{}",
-                            exit_status, kernel_id, attempt, stderr_tail
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Kernel process exited immediately: {}\n{}",
-                            exit_status,
-                            stderr_tail
-                        ));
-                    }
-                    Ok(None) => {
-                        // Process still running — good
-                        accepted = Some((process, stderr_buffer, connection_info));
+        // Wait for kernel startup. ipykernel spends 1-3s on Windows
+        // (and macOS cold path) importing pyzmq/ipykernel and binding
+        // ZMQ sockets. Polling try_wait every 100ms inside the window catches
+        // an early exit without paying the full ceiling on success.
+        const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
+        let startup_deadline = std::time::Instant::now() + STARTUP_CEILING;
+        let mut early_exit: Option<std::process::ExitStatus> = None;
+        let mut wait_err: Option<std::io::Error> = None;
+        loop {
+            match process.try_wait() {
+                Ok(Some(status)) => {
+                    early_exit = Some(status);
+                    break;
+                }
+                Ok(None) => {
+                    if std::time::Instant::now() >= startup_deadline {
                         break;
                     }
-                    Err(e) => {
-                        warn!(
-                            "[jupyter-kernel] Could not check kernel process status: {}",
-                            e
-                        );
-                        accepted = Some((process, stderr_buffer, connection_info));
-                        break;
-                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                Err(e) => {
+                    wait_err = Some(e);
+                    break;
                 }
             }
-            accepted.ok_or_else(|| {
-                last_failure.unwrap_or_else(|| {
-                    anyhow::anyhow!(
-                        "Kernel launch retry loop exhausted without success or recorded error"
-                    )
-                })
-            })?
-        };
+        }
+
+        match (early_exit, wait_err) {
+            (Some(exit_status), _) => {
+                // Wait for stderr EOF (the child is gone, the reader task
+                // should finish promptly) so we read a complete tail. Bound it
+                // so a stuck pipe can't hang launch.
+                if let Some(handle) = stderr_drain {
+                    let _ =
+                        tokio::time::timeout(std::time::Duration::from_millis(500), handle).await;
+                }
+                let captured = {
+                    let queue = stderr_buffer.lock().unwrap();
+                    queue.iter().cloned().collect::<Vec<_>>().join("\n")
+                };
+                let stderr_tail = if captured.is_empty() {
+                    "(no stderr captured before exit)".to_string()
+                } else {
+                    format!("stderr tail:\n{}", captured)
+                };
+                error!(
+                    "[jupyter-kernel] Kernel process exited immediately: {} (kernel_id={})\n{}",
+                    exit_status, kernel_id, stderr_tail
+                );
+                return Err(anyhow::anyhow!(
+                    "Kernel process exited immediately: {}\n{}",
+                    exit_status,
+                    stderr_tail
+                ));
+            }
+            (None, Some(e)) => {
+                warn!(
+                    "[jupyter-kernel] Could not check kernel process status: {}",
+                    e
+                );
+            }
+            (None, None) => {}
+        }
 
         #[cfg(unix)]
         let kernel_pid = process.id().map(|pid| pid as i32);
@@ -2870,5 +2731,31 @@ fn prepend_to_path(dir: &std::path::Path) -> String {
     match std::env::var("PATH") {
         Ok(existing) => format!("{}:{}", dir_str, existing),
         Err(_) => dir_str.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bind_kernel_port_listeners_uses_provided_ports() {
+        let ports = KernelPorts {
+            stdin: 19100,
+            control: 19101,
+            hb: 19102,
+            shell: 19103,
+            iopub: 19104,
+        };
+
+        let listeners = bind_kernel_port_listeners(IpAddr::V4(Ipv4Addr::LOCALHOST), ports)
+            .await
+            .expect("bind provided ports");
+        let bound_ports: Vec<_> = listeners
+            .iter()
+            .map(|listener| listener.local_addr().expect("local addr").port())
+            .collect();
+
+        assert_eq!(bound_ports, vec![19100, 19101, 19102, 19103, 19104]);
     }
 }

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -22,7 +22,7 @@ use crate::blob_store::BlobStore;
 use crate::output_prep::QueueCommand;
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::PooledEnv;
-use notebook_protocol::protocol::LaunchedEnvConfig;
+use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig};
 
 /// Configuration for launching a kernel.
 ///
@@ -38,6 +38,8 @@ pub struct KernelLaunchConfig {
     pub notebook_path: Option<PathBuf>,
     /// Environment configuration snapshot at launch time.
     pub launched_config: LaunchedEnvConfig,
+    /// Daemon-reserved TCP ports for the Jupyter kernel ZMQ sockets.
+    pub kernel_ports: KernelPorts,
     /// Extra environment variables to set in the kernel process.
     pub env_vars: Vec<(String, String)>,
     /// Prewarmed pool environment, if one was claimed.

--- a/crates/runtimed/src/kernel_ports.rs
+++ b/crates/runtimed/src/kernel_ports.rs
@@ -1,0 +1,303 @@
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::ops::RangeInclusive;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
+
+use anyhow::{Context, Result};
+use notebook_protocol::protocol::KernelPorts;
+use tokio::net::TcpListener;
+use tracing::{debug, warn};
+
+pub const DEFAULT_KERNEL_PORT_RANGE: RangeInclusive<u16> = 9000..=29999;
+pub const TEST_KERNEL_PORT_RANGE_SIZE: u16 = 1000;
+pub const MAX_KERNEL_PORT_LAUNCH_ATTEMPTS: usize = 4;
+
+const PORTS_PER_KERNEL: u16 = 5;
+static NEXT_KERNEL_PORT_BLOCK: AtomicU64 = AtomicU64::new(0);
+static RESERVED_KERNEL_PORTS: OnceLock<StdMutex<HashSet<u16>>> = OnceLock::new();
+
+fn reservations() -> &'static StdMutex<HashSet<u16>> {
+    RESERVED_KERNEL_PORTS.get_or_init(|| StdMutex::new(HashSet::new()))
+}
+
+fn lock_reservations() -> MutexGuard<'static, HashSet<u16>> {
+    match reservations().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[derive(Debug)]
+pub struct KernelPortReservation {
+    ports: KernelPorts,
+}
+
+impl KernelPortReservation {
+    pub fn ports(&self) -> KernelPorts {
+        self.ports
+    }
+}
+
+impl Drop for KernelPortReservation {
+    fn drop(&mut self) {
+        release_ports(kernel_ports_array(self.ports));
+    }
+}
+
+pub async fn reserve_kernel_ports() -> Result<KernelPortReservation> {
+    reserve_kernel_ports_for_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)).await
+}
+
+pub(crate) fn is_kernel_port_bind_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("address already in use")
+        || lower.contains("address in use")
+        || lower.contains("eaddrinuse")
+        || lower.contains("wsaeaddrinuse")
+        || lower.contains("winerror 10048")
+        || lower.contains("errno = 10048")
+        || lower.contains("os error 48")
+        || lower.contains("os error 98")
+        || lower.contains("os error 10048")
+}
+
+async fn reserve_kernel_ports_for_ip(ip: IpAddr) -> Result<KernelPortReservation> {
+    let range = kernel_port_range();
+    let blocks = candidate_blocks(range.clone());
+    reserve_from_blocks(ip, blocks)
+        .await
+        .with_context(|| format!("no available kernel port allocation in range {range:?}"))
+}
+
+fn kernel_port_range() -> RangeInclusive<u16> {
+    match std::env::var("RUNTIMED_TEST_KERNEL_PORT_RANGE_START") {
+        Ok(raw) => match raw.parse::<u16>() {
+            Ok(start) => test_kernel_port_range(start),
+            Err(e) => {
+                warn!(
+                    "[kernel-ports] Ignoring invalid RUNTIMED_TEST_KERNEL_PORT_RANGE_START={raw:?}: {e}"
+                );
+                DEFAULT_KERNEL_PORT_RANGE
+            }
+        },
+        Err(_) => DEFAULT_KERNEL_PORT_RANGE,
+    }
+}
+
+fn test_kernel_port_range(start: u16) -> RangeInclusive<u16> {
+    let end = start.saturating_add(TEST_KERNEL_PORT_RANGE_SIZE - 1);
+    start..=end
+}
+
+fn candidate_blocks(range: RangeInclusive<u16>) -> Vec<[u16; PORTS_PER_KERNEL as usize]> {
+    let start = u32::from(*range.start());
+    let end = u32::from(*range.end());
+    let len = end.saturating_sub(start) + 1;
+    let block_count = len / u32::from(PORTS_PER_KERNEL);
+    if block_count == 0 {
+        return Vec::new();
+    }
+
+    let offset = NEXT_KERNEL_PORT_BLOCK.fetch_add(1, Ordering::Relaxed) as u32 % block_count;
+    (0..block_count)
+        .filter_map(|i| {
+            let block_start = start + ((offset + i) % block_count) * u32::from(PORTS_PER_KERNEL);
+            let block = [
+                u16::try_from(block_start).ok()?,
+                u16::try_from(block_start + 1).ok()?,
+                u16::try_from(block_start + 2).ok()?,
+                u16::try_from(block_start + 3).ok()?,
+                u16::try_from(block_start + 4).ok()?,
+            ];
+            Some(block)
+        })
+        .collect()
+}
+
+async fn reserve_from_blocks(
+    ip: IpAddr,
+    blocks: Vec<[u16; PORTS_PER_KERNEL as usize]>,
+) -> Result<KernelPortReservation> {
+    let mut last_bind_error = None;
+
+    for block in blocks {
+        if !claim_ports(block) {
+            continue;
+        }
+
+        match probe_ports(ip, block).await {
+            Ok(()) => {
+                let ports = KernelPorts {
+                    stdin: block[0],
+                    control: block[1],
+                    hb: block[2],
+                    shell: block[3],
+                    iopub: block[4],
+                };
+                debug!("[kernel-ports] Reserved kernel ports: {:?}", ports);
+                return Ok(KernelPortReservation { ports });
+            }
+            Err(e) => {
+                release_ports(block);
+                last_bind_error = Some(e);
+            }
+        }
+    }
+
+    if let Some(e) = last_bind_error {
+        Err(e).context("all candidate kernel port blocks were unavailable")
+    } else {
+        anyhow::bail!("all candidate kernel port blocks are already reserved")
+    }
+}
+
+fn claim_ports(ports: [u16; PORTS_PER_KERNEL as usize]) -> bool {
+    let mut reserved = lock_reservations();
+    if ports.iter().any(|port| reserved.contains(port)) {
+        return false;
+    }
+    for port in ports {
+        reserved.insert(port);
+    }
+    true
+}
+
+fn release_ports(ports: [u16; PORTS_PER_KERNEL as usize]) {
+    let mut reserved = lock_reservations();
+    for port in ports {
+        reserved.remove(&port);
+    }
+}
+
+async fn probe_ports(ip: IpAddr, ports: [u16; PORTS_PER_KERNEL as usize]) -> Result<()> {
+    let mut listeners = Vec::with_capacity(PORTS_PER_KERNEL as usize);
+    for port in ports {
+        listeners.push(TcpListener::bind(SocketAddr::new(ip, port)).await?);
+    }
+    drop(listeners);
+    Ok(())
+}
+
+fn kernel_ports_array(ports: KernelPorts) -> [u16; PORTS_PER_KERNEL as usize] {
+    [
+        ports.stdin,
+        ports.control,
+        ports.hb,
+        ports.shell,
+        ports.iopub,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(start: u16) -> [u16; PORTS_PER_KERNEL as usize] {
+        [start, start + 1, start + 2, start + 3, start + 4]
+    }
+
+    fn reserved_contains_any(ports: [u16; PORTS_PER_KERNEL as usize]) -> bool {
+        let reserved = reservations()
+            .lock()
+            .expect("kernel port reservations poisoned");
+        ports.iter().any(|port| reserved.contains(port))
+    }
+
+    #[tokio::test]
+    async fn concurrent_allocations_from_same_daemon_do_not_overlap() {
+        let first = reserve_from_blocks(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            vec![block(19000), block(19005)],
+        )
+        .await
+        .expect("first allocation");
+        let second = reserve_from_blocks(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            vec![block(19000), block(19005)],
+        )
+        .await
+        .expect("second allocation");
+
+        let first_ports: HashSet<_> = kernel_ports_array(first.ports()).into_iter().collect();
+        let second_ports: HashSet<_> = kernel_ports_array(second.ports()).into_iter().collect();
+        assert!(first_ports.is_disjoint(&second_ports));
+    }
+
+    #[tokio::test]
+    async fn failed_partial_allocation_releases_all_claimed_ports() {
+        let occupied = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 19012))
+            .await
+            .expect("occupy port");
+        let failed_block = block(19010);
+
+        let result = reserve_from_blocks(IpAddr::V4(Ipv4Addr::LOCALHOST), vec![failed_block]).await;
+        assert!(result.is_err());
+        assert!(!reserved_contains_any(failed_block));
+
+        drop(occupied);
+    }
+
+    #[tokio::test]
+    async fn occupied_ports_are_skipped() {
+        let occupied = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 19022))
+            .await
+            .expect("occupy port");
+
+        let reservation = reserve_from_blocks(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            vec![block(19020), block(19025)],
+        )
+        .await
+        .expect("allocation should skip occupied block");
+
+        assert_eq!(reservation.ports().stdin, 19025);
+        drop(occupied);
+    }
+
+    #[tokio::test]
+    async fn successful_reservation_releases_on_drop() {
+        let reusable_block = block(19030);
+        let reservation =
+            reserve_from_blocks(IpAddr::V4(Ipv4Addr::LOCALHOST), vec![reusable_block])
+                .await
+                .expect("reservation");
+        assert!(reserved_contains_any(reusable_block));
+
+        drop(reservation);
+        assert!(!reserved_contains_any(reusable_block));
+
+        let second = reserve_from_blocks(IpAddr::V4(Ipv4Addr::LOCALHOST), vec![reusable_block])
+            .await
+            .expect("second reservation should reuse dropped block");
+        assert_eq!(second.ports().stdin, reusable_block[0]);
+    }
+
+    #[test]
+    fn test_range_slicing_uses_1000_port_window() {
+        assert_eq!(test_kernel_port_range(9000), 9000..=9999);
+        assert_eq!(test_kernel_port_range(14000), 14000..=14999);
+    }
+
+    #[test]
+    fn bind_error_matcher_covers_kernel_error_text() {
+        assert!(is_kernel_port_bind_error(
+            "Failed to launch kernel: Address already in use (os error 48)"
+        ));
+        assert!(is_kernel_port_bind_error(
+            "zmq.error.ZMQError: Address already in use"
+        ));
+        assert!(is_kernel_port_bind_error(
+            "OSError: [WinError 10048] Only one usage of each socket address is normally permitted"
+        ));
+        assert!(is_kernel_port_bind_error(
+            "zmq.error.ZMQError: bind failed with errno = WSAEADDRINUSE"
+        ));
+        assert!(is_kernel_port_bind_error(
+            "zmq.error.ZMQError: bind failed with errno = 10048"
+        ));
+        assert!(!is_kernel_port_bind_error(
+            "Failed to launch kernel: ModuleNotFoundError: No module named ipykernel"
+        ));
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -30,6 +30,7 @@ pub mod embedded_plugins;
 pub mod inline_env;
 pub mod jupyter_kernel;
 pub mod kernel_connection;
+pub(crate) mod kernel_ports;
 pub mod kernel_state;
 pub mod launcher_cache;
 pub mod markdown_assets;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3507,7 +3507,7 @@ pub(crate) async fn auto_launch_kernel(
                 }
 
                 // Send LaunchKernel RPC via the runtime agent's sync connection
-                let launch_request =
+                match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),
                         env_source: env_source.clone(),
@@ -3515,10 +3515,12 @@ pub(crate) async fn auto_launch_kernel(
                             .as_deref()
                             .map(|p| p.to_str().unwrap_or("").to_string()),
                         launched_config: launched_config.clone(),
+                        kernel_ports,
                         env_vars: Default::default(),
-                    };
-
-                match send_runtime_agent_request(room, launch_request).await {
+                    }
+                })
+                .await
+                {
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -64,3 +64,39 @@ pub(crate) async fn send_runtime_agent_request(
         send_runtime_agent_query(room, request).await
     }
 }
+
+/// Reserve daemon-owned kernel ports, send a launch/restart request, and retry
+/// with a fresh reservation if the runtime agent loses a port bind race.
+pub(crate) async fn send_runtime_agent_request_with_kernel_ports<F>(
+    room: &NotebookRoom,
+    mut build_request: F,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse>
+where
+    F: FnMut(
+        notebook_protocol::protocol::KernelPorts,
+    ) -> notebook_protocol::protocol::RuntimeAgentRequest,
+{
+    for attempt in 1..=crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS {
+        let port_reservation = crate::kernel_ports::reserve_kernel_ports().await?;
+        let response =
+            send_runtime_agent_request(room, build_request(port_reservation.ports())).await?;
+
+        match &response {
+            notebook_protocol::protocol::RuntimeAgentResponse::Error { error }
+                if crate::kernel_ports::is_kernel_port_bind_error(error)
+                    && attempt < crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS =>
+            {
+                warn!(
+                    "[notebook-sync] Runtime agent hit kernel port bind race on attempt {}/{}; retrying with fresh ports: {}",
+                    attempt,
+                    crate::kernel_ports::MAX_KERNEL_PORT_LAUNCH_ATTEMPTS,
+                    error
+                );
+                continue;
+            }
+            _ => return Ok(response),
+        }
+    }
+
+    unreachable!("kernel port launch retry loop must return from the final attempt")
+}

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -22,9 +22,10 @@ use crate::notebook_sync_server::{
     get_inline_conda_deps, get_inline_uv_deps, get_inline_uv_prerelease,
     missing_conda_env_yml_decision, project_environment_build_approved,
     promote_inline_deps_to_project, publish_kernel_state_presence, reset_starting_state,
-    reset_starting_state_with_outcome, resolve_metadata_snapshot, send_runtime_agent_request,
-    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, unified_env_on_disk,
-    CapturedEnvRuntime, NotebookRoom, ResetOutcome,
+    reset_starting_state_with_outcome, resolve_metadata_snapshot,
+    send_runtime_agent_request_with_kernel_ports, try_conda_pool_for_inline_deps,
+    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
+    ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -1237,16 +1238,20 @@ pub(crate) async fn handle(
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
             info!("[notebook-sync] Agent connected — sending RestartKernel");
-            let restart_request = notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
-                kernel_type: resolved_kernel_type.clone(),
-                env_source: resolved_env_source.clone(),
-                notebook_path: notebook_path
-                    .as_deref()
-                    .map(|p| p.to_str().unwrap_or("").to_string()),
-                launched_config: launched_config.clone(),
-                env_vars: Default::default(),
-            };
-            match send_runtime_agent_request(room, restart_request).await {
+            match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
+                notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
+                    kernel_type: resolved_kernel_type.clone(),
+                    env_source: resolved_env_source.clone(),
+                    notebook_path: notebook_path
+                        .as_deref()
+                        .map(|p| p.to_str().unwrap_or("").to_string()),
+                    launched_config: launched_config.clone(),
+                    kernel_ports,
+                    env_vars: Default::default(),
+                }
+            })
+            .await
+            {
                 Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelRestarted {
                     env_source: es,
                 }) => {
@@ -1379,7 +1384,7 @@ pub(crate) async fn handle(
                 }
 
                 // Send LaunchKernel RPC
-                let launch_request =
+                match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: resolved_kernel_type.clone(),
                         env_source: resolved_env_source.clone(),
@@ -1387,10 +1392,12 @@ pub(crate) async fn handle(
                             .as_deref()
                             .map(|p| p.to_str().unwrap_or("").to_string()),
                         launched_config: launched_config.clone(),
+                        kernel_ports,
                         env_vars: Default::default(),
-                    };
-
-                match send_runtime_agent_request(room, launch_request).await {
+                    }
+                })
+                .await
+                {
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -528,6 +528,7 @@ async fn handle_runtime_agent_request(
             env_source,
             notebook_path,
             launched_config,
+            kernel_ports,
             env_vars: _,
         } => {
             info!(
@@ -563,6 +564,7 @@ async fn handle_runtime_agent_request(
                 env_source: env_source.as_str().to_string(),
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
+                kernel_ports,
                 env_vars: vec![],
                 pooled_env,
             };
@@ -594,6 +596,7 @@ async fn handle_runtime_agent_request(
             env_source,
             notebook_path,
             launched_config,
+            kernel_ports,
             env_vars: _,
         } => {
             info!(
@@ -647,6 +650,7 @@ async fn handle_runtime_agent_request(
                 env_source: env_source.as_str().to_string(),
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
+                kernel_ports,
                 env_vars: vec![],
                 pooled_env,
             };

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use notebook_protocol::connection::EnvSource;
 use notebook_protocol::protocol::{
-    RuntimeAgentRequest, RuntimeAgentRequestEnvelope, RuntimeAgentResponse,
+    KernelPorts, RuntimeAgentRequest, RuntimeAgentRequestEnvelope, RuntimeAgentResponse,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -364,6 +364,13 @@ async fn shutdown_then_launch_serialized() {
             env_source: EnvSource::parse("conda:inline"),
             notebook_path: None,
             launched_config: Default::default(),
+            kernel_ports: KernelPorts {
+                stdin: 9000,
+                control: 9001,
+                hb: 9002,
+                shell: 9003,
+                iopub: 9004,
+            },
             env_vars: Default::default(),
         },
     )

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -462,7 +462,7 @@ def daemon_process(request):
             env = os.environ.copy()
             env["RUST_LOG"] = log_level
             env["RUNTIMED_WORKSPACE_PATH"] = str(workspace_dir)
-            env["RUNTIMED_TEST_KERNEL_PORT_RANGE_START"] = str(9000 + xdist_worker_index * 100)
+            env["RUNTIMED_TEST_KERNEL_PORT_RANGE_START"] = str(9000 + xdist_worker_index * 1000)
 
             proc = subprocess.Popen(
                 cmd,


### PR DESCRIPTION
## Summary
- add daemon-owned kernel port reservations over the 9000..=29999 range with 1000-port test worker slices
- pass explicit stdin/control/hb/shell/iopub ports through LaunchKernel and RestartKernel runtime-agent requests
- remove runtime-agent-side port selection while preserving the assigned-port listener handoff during Jupyter launch

Supersedes #2388's runtime-agent/local-lock approach.

## Validation
- cargo test -p notebook-protocol -p runtimed --lib
- cargo clippy -p runtimed --lib -- -D warnings
- cargo clippy -p runtimed --all-targets -- -D warnings
- cargo xtask lint --fix