### PR TITLE
refactor(runtimed): centralize frontend protocol helpers

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -246,8 +246,10 @@ function AppContent() {
   const {
     uvError: poolUvError,
     condaError: poolCondaError,
+    pixiError: poolPixiError,
     dismissUvError: dismissPoolUvError,
     dismissCondaError: dismissPoolCondaError,
+    dismissPixiError: dismissPoolPixiError,
   } = usePoolState();
 
   // Trust verification for notebook dependencies
@@ -1587,8 +1589,10 @@ function AppContent() {
         <PoolErrorBanner
           uvError={poolUvError}
           condaError={poolCondaError}
+          pixiError={poolPixiError}
           onDismissUv={dismissPoolUvError}
           onDismissConda={dismissPoolCondaError}
+          onDismissPixi={dismissPoolPixiError}
         />
         {needsApproval &&
           !trustApprovalHandoffPending &&

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -3,12 +3,12 @@ import { AlertTriangle, Clock, Settings, X } from "lucide-react";
 import type { PoolErrorWithTimestamp } from "../hooks/usePoolState";
 
 interface PoolErrorItemProps {
-  envType: "UV" | "Conda";
+  envType: "UV" | "Conda" | "Pixi";
   error: PoolErrorWithTimestamp;
   onDismiss: () => void;
 }
 
-function errorSubtitle(error: PoolErrorWithTimestamp, envType: "UV" | "Conda"): string {
+function errorSubtitle(error: PoolErrorWithTimestamp, envType: "UV" | "Conda" | "Pixi"): string {
   switch (error.error_kind) {
     case "timeout":
       return "Retrying automatically";
@@ -85,23 +85,27 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
 interface PoolErrorBannerProps {
   uvError: PoolErrorWithTimestamp | null;
   condaError: PoolErrorWithTimestamp | null;
+  pixiError: PoolErrorWithTimestamp | null;
   onDismissUv: () => void;
   onDismissConda: () => void;
+  onDismissPixi: () => void;
 }
 
 /**
  * Banner component showing pool warming errors.
  *
- * Displays amber warning banners for UV and/or Conda pool errors,
+ * Displays amber warning banners for UV, Conda, and Pixi pool errors,
  * with contextual messages based on error type.
  */
 export function PoolErrorBanner({
   uvError,
   condaError,
+  pixiError,
   onDismissUv,
   onDismissConda,
+  onDismissPixi,
 }: PoolErrorBannerProps) {
-  if (!uvError && !condaError) {
+  if (!uvError && !condaError && !pixiError) {
     return null;
   }
 
@@ -111,6 +115,7 @@ export function PoolErrorBanner({
       {condaError && (
         <PoolErrorItem envType="Conda" error={condaError} onDismiss={onDismissConda} />
       )}
+      {pixiError && <PoolErrorItem envType="Pixi" error={pixiError} onDismiss={onDismissPixi} />}
     </div>
   );
 }

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -24,7 +24,7 @@ function errorsEqual(
 }
 
 /** Extract error info from a RuntimePoolState, or null if healthy. */
-function extractError(pool: PoolState["uv"] | PoolState["conda"]): PoolErrorWithTimestamp | null {
+function extractError(pool: PoolState[keyof PoolState]): PoolErrorWithTimestamp | null {
   if (!pool.error) return null;
   return {
     message: pool.error,
@@ -48,13 +48,16 @@ export function usePoolState() {
   // Track dismissed errors so they don't reappear until state changes
   const [dismissedUv, setDismissedUv] = useState(false);
   const [dismissedConda, setDismissedConda] = useState(false);
+  const [dismissedPixi, setDismissedPixi] = useState(false);
 
   // Track previous errors to detect changes and reset dismiss state
   const prevUvErrorRef = useRef<PoolErrorWithTimestamp | null>(null);
   const prevCondaErrorRef = useRef<PoolErrorWithTimestamp | null>(null);
+  const prevPixiErrorRef = useRef<PoolErrorWithTimestamp | null>(null);
 
   const uvError = extractError(poolState.uv);
   const condaError = extractError(poolState.conda);
+  const pixiError = extractError(poolState.pixi);
 
   // Reset dismiss state when error changes
   if (!errorsEqual(uvError, prevUvErrorRef.current)) {
@@ -65,6 +68,10 @@ export function usePoolState() {
     prevCondaErrorRef.current = condaError;
     if (dismissedConda) setDismissedConda(false);
   }
+  if (!errorsEqual(pixiError, prevPixiErrorRef.current)) {
+    prevPixiErrorRef.current = pixiError;
+    if (dismissedPixi) setDismissedPixi(false);
+  }
 
   const dismissUvError = useCallback(() => {
     setDismissedUv(true);
@@ -74,17 +81,27 @@ export function usePoolState() {
     setDismissedConda(true);
   }, []);
 
+  const dismissPixiError = useCallback(() => {
+    setDismissedPixi(true);
+  }, []);
+
   const dismissAll = useCallback(() => {
     setDismissedUv(true);
     setDismissedConda(true);
+    setDismissedPixi(true);
   }, []);
 
   return {
     uvError: dismissedUv ? null : uvError,
     condaError: dismissedConda ? null : condaError,
-    hasErrors: (!dismissedUv && uvError !== null) || (!dismissedConda && condaError !== null),
+    pixiError: dismissedPixi ? null : pixiError,
+    hasErrors:
+      (!dismissedUv && uvError !== null) ||
+      (!dismissedConda && condaError !== null) ||
+      (!dismissedPixi && pixiError !== null),
     dismissUvError,
     dismissCondaError,
+    dismissPixiError,
     dismissAll,
   };
 }

--- a/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
+++ b/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  classifyCellChangesetMaterialization,
   type CellChangeset,
   type ChangedFields,
   mergeChangesets,
@@ -162,23 +163,9 @@ describe("CellChangeset helpers", () => {
 describe("CellChangeset classification", () => {
   it("source-only changeset", () => {
     const cs = sourceOnly("cell-1");
-    const isSourceOnly =
-      cs.added.length === 0 &&
-      cs.removed.length === 0 &&
-      !cs.order_changed &&
-      cs.changed.every((c) => {
-        const f = c.fields;
-        return (
-          f.source &&
-          !f.outputs &&
-          !f.execution_count &&
-          !f.cell_type &&
-          !f.metadata &&
-          !f.position &&
-          !f.resolved_assets
-        );
-      });
-    expect(isSourceOnly).toBe(true);
+    expect(classifyCellChangesetMaterialization(cs)).toEqual({
+      kind: "incremental",
+    });
   });
 
   it("structural changeset with added cells", () => {
@@ -187,16 +174,28 @@ describe("CellChangeset classification", () => {
       added: ["cell-new"],
       order_changed: true,
     };
-    const isStructural =
-      cs.added.length > 0 || cs.removed.length > 0 || cs.order_changed;
-    expect(isStructural).toBe(true);
+    expect(classifyCellChangesetMaterialization(cs)).toEqual({
+      kind: "full",
+      reason: "structural",
+    });
   });
 
   it("non-structural output change", () => {
     const cs = outputsOnly("cell-1");
-    const isStructural =
-      cs.added.length > 0 || cs.removed.length > 0 || cs.order_changed;
-    expect(isStructural).toBe(false);
+    expect(classifyCellChangesetMaterialization(cs)).toEqual({
+      kind: "incremental",
+    });
+  });
+
+  it("resolved asset changeset", () => {
+    const cs: CellChangeset = {
+      ...empty,
+      changed: [{ cell_id: "cell-1", fields: { resolved_assets: true } }],
+    };
+    expect(classifyCellChangesetMaterialization(cs)).toEqual({
+      kind: "full",
+      reason: "resolved_assets",
+    });
   });
 });
 

--- a/apps/notebook/src/lib/__tests__/pool-state.test.ts
+++ b/apps/notebook/src/lib/__tests__/pool-state.test.ts
@@ -35,12 +35,20 @@ describe("pool-state store", () => {
       retry_in_secs: 30,
       failed_package: "pandas",
     },
+    pixi: {
+      available: 1,
+      warming: 0,
+      pool_size: 1,
+      consecutive_failures: 0,
+      retry_in_secs: 0,
+    },
   };
 
   it("starts at DEFAULT_POOL_STATE with zeroed pools", () => {
     expect(getPoolState()).toEqual(DEFAULT_POOL_STATE);
     expect(getPoolState().uv.available).toBe(0);
     expect(getPoolState().conda.available).toBe(0);
+    expect(getPoolState().pixi.available).toBe(0);
     expect(getPoolState().uv.error).toBeUndefined();
   });
 
@@ -59,18 +67,35 @@ describe("pool-state store", () => {
   });
 
   it("DEFAULT_POOL_STATE's nested pools are independent objects", () => {
-    // If uv and conda aliased the same object (via module-level object
-    // literal share), a daemon update that only touched `uv` would
-    // silently mutate `conda` too — a real bug waiting to happen.
+    // If pool defaults aliased the same object (via module-level object
+    // literal share), a daemon update that only touched one manager would
+    // silently mutate the others too — a real bug waiting to happen.
     expect(DEFAULT_POOL_STATE.uv).not.toBe(DEFAULT_POOL_STATE.conda);
+    expect(DEFAULT_POOL_STATE.uv).not.toBe(DEFAULT_POOL_STATE.pixi);
+    expect(DEFAULT_POOL_STATE.conda).not.toBe(DEFAULT_POOL_STATE.pixi);
   });
 
   it("setPoolState keeps the reference, not a defensive copy", () => {
     // useSyncExternalStore re-renders only when the snapshot reference
     // changes. If we deep-cloned, callers would over-render. If we kept
-    // the old reference, callers would under-render. Pin: same-ref out.
+    // the old reference, callers would under-render. Pin: same-ref out
+    // for complete daemon snapshots.
     setPoolState(populated);
     expect(getPoolState()).toBe(populated);
+  });
+
+  it("normalizes stale pool snapshots that predate pixi", () => {
+    const stale = {
+      uv: populated.uv,
+      conda: populated.conda,
+    } as PoolState;
+
+    setPoolState(stale);
+
+    expect(getPoolState()).not.toBe(stale);
+    expect(getPoolState().uv).toBe(populated.uv);
+    expect(getPoolState().conda).toBe(populated.conda);
+    expect(getPoolState().pixi).toBe(DEFAULT_POOL_STATE.pixi);
   });
 
   it("successive setPoolState calls each replace the snapshot", () => {
@@ -109,6 +134,7 @@ describe("pool-state store", () => {
     const fresh: PoolState = {
       uv: { ...DEFAULT_POOL_STATE.uv, available: 5 },
       conda: { ...DEFAULT_POOL_STATE.conda },
+      pixi: { ...DEFAULT_POOL_STATE.pixi },
     };
     setPoolState(fresh);
     expect(getPoolState()).toBe(fresh);

--- a/apps/notebook/src/lib/cell-changeset.ts
+++ b/apps/notebook/src/lib/cell-changeset.ts
@@ -5,7 +5,9 @@
  * app imports (`../lib/cell-changeset`) continue to work without changes.
  */
 export {
+  classifyCellChangesetMaterialization,
   type CellChangeset,
+  type CellChangesetMaterialization,
   type ChangedCell,
   type ChangedFields,
   mergeChangesets,

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -10,6 +10,7 @@ import {
   needsPlugin,
   preWarmForMimes,
 } from "@/components/isolated/iframe-libraries";
+import { classifyCellChangesetMaterialization } from "runtimed";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort } from "./blob-port";
@@ -22,10 +23,14 @@ import { notifyMetadataChanged } from "./notebook-metadata";
 // Re-export CellChangeset types so existing consumers don't break.
 export type {
   CellChangeset,
+  CellChangesetMaterialization,
   ChangedCell,
   ChangedFields,
 } from "./cell-changeset";
-export { mergeChangesets } from "./cell-changeset";
+export {
+  classifyCellChangesetMaterialization,
+  mergeChangesets,
+} from "./cell-changeset";
 
 // ── Materialization dependencies ─────────────────────────────────────
 
@@ -91,35 +96,25 @@ export async function materializeChangeset(
 
   // ── Full materialization fallback ──────────────────────────────────
 
-  if (!changeset) {
-    logger.debug(
-      "[frame-pipeline] full materialization: no changeset from WASM",
-    );
+  const materialization = classifyCellChangesetMaterialization(changeset);
+  if (materialization.kind === "full") {
+    if (materialization.reason === "missing_changeset") {
+      logger.debug(
+        "[frame-pipeline] full materialization: no changeset from WASM",
+      );
+    } else {
+      logger.debug(
+        `[frame-pipeline] full materialization: +${changeset?.added.length ?? 0} -${changeset?.removed.length ?? 0} reorder=${changeset?.order_changed ?? false} reason=${materialization.reason}`,
+      );
+    }
     await deps.materializeCells(handle);
     notifyMetadataChanged();
     return;
   }
 
-  // Structural changes (cells added/removed/reordered) or resolved_assets
-  // changes require full materialization. resolved_assets are only available
-  // from get_cells_json() (full serialization), not per-cell WASM accessors,
-  // so the incremental path would serve stale values from the previous cell.
-  const hasResolvedAssetChanges = changeset.changed.some(
-    (c) => c.fields.resolved_assets,
-  );
-  if (
-    changeset.added.length > 0 ||
-    changeset.removed.length > 0 ||
-    changeset.order_changed ||
-    hasResolvedAssetChanges
-  ) {
-    logger.debug(
-      `[frame-pipeline] full materialization: +${changeset.added.length} -${changeset.removed.length} reorder=${changeset.order_changed} assets=${hasResolvedAssetChanges}`,
-    );
-    await deps.materializeCells(handle);
-    notifyMetadataChanged();
-    return;
-  }
+  // `classifyCellChangesetMaterialization(null)` always takes the full
+  // materialization branch above; this guard narrows the incremental path.
+  if (!changeset) return;
 
   // ── Per-cell incremental materialization ───────────────────────────
 

--- a/apps/notebook/src/lib/pool-state.ts
+++ b/apps/notebook/src/lib/pool-state.ts
@@ -8,31 +8,11 @@
  */
 
 import { useSyncExternalStore } from "react";
+import { DEFAULT_POOL_STATE, type PoolState } from "runtimed";
 
 // ── Types ────────────────────────────────────────────────────────────
 
-/** State of a single runtime pool (UV or Conda). */
-export interface RuntimePoolState {
-  available: number;
-  warming: number;
-  pool_size: number;
-  /** Human-readable error message (undefined if healthy). */
-  error?: string;
-  /** Package that failed to install (undefined if not identified). */
-  failed_package?: string;
-  /** Error classification: "timeout", "invalid_package", "import_error", "setup_failed". */
-  error_kind?: string;
-  /** Number of consecutive failures (0 if healthy). */
-  consecutive_failures: number;
-  /** Seconds until next retry (0 if retry is imminent or healthy). */
-  retry_in_secs: number;
-}
-
-/** Full pool state snapshot from the PoolDoc. */
-export interface PoolState {
-  uv: RuntimePoolState;
-  conda: RuntimePoolState;
-}
+export { DEFAULT_POOL_STATE, type PoolState, type RuntimePoolState } from "runtimed";
 
 /** Pool error info with timestamp, used by PoolErrorBanner. */
 export interface PoolErrorWithTimestamp {
@@ -45,23 +25,22 @@ export interface PoolErrorWithTimestamp {
   receivedAt: number;
 }
 
-const DEFAULT_RUNTIME_POOL: RuntimePoolState = {
-  available: 0,
-  warming: 0,
-  pool_size: 0,
-  consecutive_failures: 0,
-  retry_in_secs: 0,
-};
-
-export const DEFAULT_POOL_STATE: PoolState = {
-  uv: { ...DEFAULT_RUNTIME_POOL },
-  conda: { ...DEFAULT_RUNTIME_POOL },
-};
-
 // ── Store ────────────────────────────────────────────────────────────
 
 let currentState: PoolState = DEFAULT_POOL_STATE;
 const subscribers = new Set<() => void>();
+
+function normalizePoolState(state: PoolState): PoolState {
+  const partial = state as Partial<PoolState>;
+  if (partial.uv && partial.conda && partial.pixi) {
+    return state;
+  }
+  return {
+    uv: partial.uv ?? DEFAULT_POOL_STATE.uv,
+    conda: partial.conda ?? DEFAULT_POOL_STATE.conda,
+    pixi: partial.pixi ?? DEFAULT_POOL_STATE.pixi,
+  };
+}
 
 function notifySubscribers(): void {
   for (const cb of subscribers) {
@@ -75,7 +54,7 @@ function notifySubscribers(): void {
 
 /** Update the pool state snapshot. Called by the frame pipeline. */
 export function setPoolState(state: PoolState): void {
-  currentState = state;
+  currentState = normalizePoolState(state);
   notifySubscribers();
 }
 

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -34,6 +34,10 @@ export interface CellChangeset {
   order_changed: boolean;
 }
 
+export type CellChangesetMaterialization =
+  | { kind: "full"; reason: "missing_changeset" | "structural" | "resolved_assets" }
+  | { kind: "incremental" };
+
 // ── Utilities ────────────────────────────────────────────────────────
 
 /**
@@ -61,4 +65,27 @@ export function mergeChangesets(a: CellChangeset, b: CellChangeset): CellChanges
     removed: [...new Set([...a.removed, ...b.removed])],
     order_changed: a.order_changed || b.order_changed,
   };
+}
+
+/**
+ * Classify how a frontend projection should consume a coalesced changeset.
+ *
+ * Structural changes and `resolved_assets` updates require a full notebook
+ * materialization because per-cell WASM accessors do not expose every value the
+ * app-level cell snapshot needs. Pure cell chrome/output updates can use the
+ * incremental projection path.
+ */
+export function classifyCellChangesetMaterialization(
+  changeset: CellChangeset | null,
+): CellChangesetMaterialization {
+  if (!changeset) {
+    return { kind: "full", reason: "missing_changeset" };
+  }
+  if (changeset.added.length > 0 || changeset.removed.length > 0 || changeset.order_changed) {
+    return { kind: "full", reason: "structural" };
+  }
+  if (changeset.changed.some((c) => c.fields.resolved_assets)) {
+    return { kind: "full", reason: "resolved_assets" };
+  }
+  return { kind: "incremental" };
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -42,7 +42,9 @@ export type {
 
 // Cell changeset
 export {
+  classifyCellChangesetMaterialization,
   type CellChangeset,
+  type CellChangesetMaterialization,
   type ChangedCell,
   type ChangedFields,
   mergeChangesets,

--- a/packages/runtimed/src/pool-state.ts
+++ b/packages/runtimed/src/pool-state.ts
@@ -5,7 +5,7 @@
  * represent the deserialized snapshot from the WASM `PoolDoc::read_state()`.
  */
 
-/** State of a single runtime pool (UV or Conda). */
+/** State of a single runtime pool (UV, Conda, or Pixi). */
 export interface RuntimePoolState {
   available: number;
   warming: number;
@@ -26,6 +26,7 @@ export interface RuntimePoolState {
 export interface PoolState {
   uv: RuntimePoolState;
   conda: RuntimePoolState;
+  pixi: RuntimePoolState;
 }
 
 const DEFAULT_RUNTIME_POOL: RuntimePoolState = {
@@ -39,4 +40,5 @@ const DEFAULT_RUNTIME_POOL: RuntimePoolState = {
 export const DEFAULT_POOL_STATE: PoolState = {
   uv: { ...DEFAULT_RUNTIME_POOL },
   conda: { ...DEFAULT_RUNTIME_POOL },
+  pixi: { ...DEFAULT_RUNTIME_POOL },
 };

--- a/packages/runtimed/tests/cell-changeset.test.ts
+++ b/packages/runtimed/tests/cell-changeset.test.ts
@@ -1,0 +1,68 @@
+import {
+  classifyCellChangesetMaterialization,
+  type CellChangeset,
+  mergeChangesets,
+} from "runtimed";
+import { describe, expect, it } from "vite-plus/test";
+
+const empty: CellChangeset = {
+  changed: [],
+  added: [],
+  removed: [],
+  order_changed: false,
+};
+
+function outputsOnly(cellId: string): CellChangeset {
+  return {
+    changed: [{ cell_id: cellId, fields: { outputs: true } }],
+    added: [],
+    removed: [],
+    order_changed: false,
+  };
+}
+
+describe("CellChangeset helpers", () => {
+  it("merges sparse changed fields without mutating inputs", () => {
+    const source: CellChangeset = {
+      changed: [{ cell_id: "cell-1", fields: { source: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const outputs = outputsOnly("cell-1");
+    const originalSourceFields = { ...source.changed[0].fields };
+
+    expect(mergeChangesets(source, outputs)).toEqual({
+      changed: [{ cell_id: "cell-1", fields: { source: true, outputs: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    });
+    expect(source.changed[0].fields).toEqual(originalSourceFields);
+  });
+
+  it("classifies missing or structural changesets as full materialization", () => {
+    expect(classifyCellChangesetMaterialization(null)).toEqual({
+      kind: "full",
+      reason: "missing_changeset",
+    });
+    expect(
+      classifyCellChangesetMaterialization({
+        ...empty,
+        added: ["cell-new"],
+      }),
+    ).toEqual({ kind: "full", reason: "structural" });
+    expect(
+      classifyCellChangesetMaterialization({
+        ...empty,
+        changed: [{ cell_id: "cell-1", fields: { resolved_assets: true } }],
+      }),
+    ).toEqual({ kind: "full", reason: "resolved_assets" });
+  });
+
+  it("classifies non-structural cell updates as incremental materialization", () => {
+    expect(classifyCellChangesetMaterialization(outputsOnly("cell-1"))).toEqual({
+      kind: "incremental",
+    });
+  });
+});

--- a/packages/runtimed/tests/pool-state.test.ts
+++ b/packages/runtimed/tests/pool-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { DEFAULT_POOL_STATE, type PoolState, type RuntimePoolState } from "../src";
+
+describe("PoolDoc state contract", () => {
+  it("exports zeroed defaults for each runtime pool", () => {
+    expect(DEFAULT_POOL_STATE).toEqual({
+      uv: {
+        available: 0,
+        warming: 0,
+        pool_size: 0,
+        consecutive_failures: 0,
+        retry_in_secs: 0,
+      },
+      conda: {
+        available: 0,
+        warming: 0,
+        pool_size: 0,
+        consecutive_failures: 0,
+        retry_in_secs: 0,
+      },
+      pixi: {
+        available: 0,
+        warming: 0,
+        pool_size: 0,
+        consecutive_failures: 0,
+        retry_in_secs: 0,
+      },
+    });
+  });
+
+  it("keeps default pool snapshots independently addressable", () => {
+    expect(DEFAULT_POOL_STATE.uv).not.toBe(DEFAULT_POOL_STATE.conda);
+    expect(DEFAULT_POOL_STATE.uv).not.toBe(DEFAULT_POOL_STATE.pixi);
+    expect(DEFAULT_POOL_STATE.conda).not.toBe(DEFAULT_POOL_STATE.pixi);
+  });
+
+  it("accepts the daemon PoolDoc schema shape", () => {
+    const uv: RuntimePoolState = {
+      available: 2,
+      warming: 1,
+      pool_size: 3,
+      consecutive_failures: 0,
+      retry_in_secs: 0,
+    };
+    const conda: RuntimePoolState = {
+      available: 0,
+      warming: 0,
+      pool_size: 0,
+      error: "setup failed",
+      error_kind: "setup_failed",
+      failed_package: "pandas",
+      consecutive_failures: 2,
+      retry_in_secs: 30,
+    };
+    const pixi: RuntimePoolState = {
+      available: 1,
+      warming: 0,
+      pool_size: 1,
+      consecutive_failures: 0,
+      retry_in_secs: 0,
+    };
+    const state: PoolState = { uv, conda, pixi };
+
+    expect(state.uv.available).toBe(2);
+    expect(state.conda.failed_package).toBe("pandas");
+    expect(state.pixi.available).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- move CellChangeset materialization classification into `packages/runtimed`
- re-export PoolDoc state types/defaults from `packages/runtimed` so the app store no longer duplicates the schema
- align the shared TS PoolDoc shape with Rust by including the Pixi pool and surfacing Pixi pool errors in the app banner
- add package-level coverage for the shared CellChangeset and PoolDoc contracts

Refs #2340

## Test Plan
- `pnpm exec vp test run packages/runtimed/tests/cell-changeset.test.ts packages/runtimed/tests/pool-state.test.ts`
- `pnpm exec vp test run apps/notebook/src/lib/__tests__/cell-changeset.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts apps/notebook/src/lib/__tests__/pool-state.test.ts`
- `cargo xtask lint --fix`
- `pnpm test:run`