### PR TITLE
refactor(runtimed): centralize env progress broadcasts

### DIFF
--- a/apps/notebook/src/hooks/__tests__/useEnvProgress.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useEnvProgress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { EnvProgressEvent } from "../../types";
+import type { EnvProgressEvent } from "runtimed";
 import { getStatusText } from "../useEnvProgress";
 
 describe("getStatusText", () => {
@@ -11,5 +11,14 @@ describe("getStatusText", () => {
     };
 
     expect(getStatusText(event)).toBe("Environment error");
+  });
+
+  it("labels offline cache hits from the shared env progress phase union", () => {
+    const event: EnvProgressEvent = {
+      env_type: "pixi",
+      phase: "offline_hit",
+    };
+
+    expect(getStatusText(event)).toBe("Using cached packages");
   });
 });

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -16,6 +16,7 @@ import {
   deriveKernelInfo,
   deriveQueueState,
   type GuardedNotebookProvenance,
+  isEnvProgressBroadcast,
   type KernelStatus,
   type NotebookClient,
   type NotebookResponse,
@@ -33,7 +34,6 @@ import {
   resetRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
-import type { DaemonBroadcast } from "../types";
 
 // ── Hook types ──────────────────────────────────────────────────────
 
@@ -204,21 +204,19 @@ export function useDaemonKernel({
 
     const unsubscribeBroadcast = subscribeBroadcast((payload) => {
       if (cancelled) return;
-      const broadcast = payload as DaemonBroadcast;
+      // Custom comm messages (buttons, model.send()) are now handled
+      // by the SyncEngine.commBroadcasts$ subscriber in App.tsx.
+      if (isEnvProgressBroadcast(payload)) return;
 
-      switch (broadcast.event) {
-        // Custom comm messages (buttons, model.send()) are now handled
-        // by the SyncEngine.commBroadcasts$ subscriber in App.tsx.
-
-        case "env_progress":
-          break;
-
-        default: {
-          const event = (broadcast as { event?: string }).event;
-          if (event !== undefined) {
-            logger.debug(`[daemon-kernel] Unknown broadcast event: ${event}`);
-          }
-        }
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        "event" in payload &&
+        typeof (payload as { event: unknown }).event === "string"
+      ) {
+        logger.debug(
+          `[daemon-kernel] Unknown broadcast event: ${(payload as { event: string }).event}`,
+        );
       }
     });
 

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
+import {
+  type EnvProgressEnvType,
+  type EnvProgressEvent,
+  type EnvProgressPhase,
+  isEnvProgressBroadcast,
+} from "runtimed";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
-import type { DaemonBroadcast, EnvProgressEvent, EnvProgressPhase } from "../types";
 
 export interface EnvProgressState {
   /** Whether environment preparation is currently active */
@@ -8,7 +13,7 @@ export interface EnvProgressState {
   /** Current phase name */
   phase: string | null;
   /** Environment type (conda or uv) */
-  envType: "conda" | "uv" | null;
+  envType: EnvProgressEnvType | null;
   /** Error message if phase is "error" */
   error: string | null;
   /** Human-readable status text */
@@ -43,6 +48,8 @@ export function getStatusText(event: EnvProgressEvent): string {
       return "Using cached environment";
     case "lock_file_hit":
       return "Rebuilding from lock file";
+    case "offline_hit":
+      return "Using cached packages";
     case "fetching_repodata": {
       const e = event as Extract<EnvProgressPhase, { phase: "fetching_repodata" }>;
       return `Fetching package index (${e.channels.join(", ")})`;
@@ -180,11 +187,8 @@ export function useEnvProgress() {
     // Subscribe to broadcast events with env_progress via the frame bus
     // (from daemon-managed environment preparation during kernel launch)
     const unsubscribeBroadcast = subscribeBroadcast((payload) => {
-      const broadcast = payload as DaemonBroadcast;
-      if (broadcast.event === "env_progress") {
-        // The daemon broadcast has the same shape as EnvProgressEvent
-        // (env_type + flattened phase fields) plus the "event" tag
-        processEvent(broadcast as unknown as EnvProgressEvent);
+      if (isEnvProgressBroadcast(payload)) {
+        processEvent(payload);
       }
     });
 

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -104,68 +104,10 @@ export interface JupyterMessage {
   cell_id?: string;
 }
 
-// Environment preparation progress events
-export type EnvProgressPhase =
-  | { phase: "starting"; env_hash: string }
-  | { phase: "cache_hit"; env_path: string }
-  | { phase: "lock_file_hit" }
-  | { phase: "fetching_repodata"; channels: string[] }
-  | { phase: "repodata_complete"; record_count: number; elapsed_ms: number }
-  | { phase: "solving"; spec_count: number }
-  | { phase: "solve_complete"; package_count: number; elapsed_ms: number }
-  | { phase: "installing"; total: number }
-  | {
-      phase: "download_progress";
-      completed: number;
-      total: number;
-      current_package: string;
-      bytes_downloaded: number;
-      bytes_total: number | null;
-      bytes_per_second: number;
-    }
-  | {
-      phase: "link_progress";
-      completed: number;
-      total: number;
-      current_package: string;
-    }
-  | { phase: "install_complete"; elapsed_ms: number }
-  | { phase: "creating_venv" }
-  | { phase: "installing_packages"; packages: string[] }
-  | { phase: "ready"; env_path: string; python_path: string }
-  | { phase: "error"; message: string };
-
-export type EnvProgressEvent = EnvProgressPhase & {
-  env_type: "conda" | "uv";
-};
-
 // pixi.toml / environment.yml detection types now live in their
 // respective hooks (`hooks/usePixiDetection.ts`,
 // `hooks/useCondaDependencies.ts`). Both are derived from
 // `RuntimeState.project_context` rather than Tauri commands.
-
-// =============================================================================
-// Daemon Broadcast Types (Phase 8: Daemon-owned kernel execution)
-// =============================================================================
-
-/** Broadcast events from daemon.
- *
- * Ephemeral, room-wide events that don't fit the request/response or
- * CRDT-sync model. Kernel state, execution lifecycle, queue, outputs,
- * the notebook's `path`, and the `last_saved` timestamp all live in
- * `RuntimeStateDoc` (frame `0x05`) — read them via `useRuntimeState()`.
- */
-export type DaemonBroadcast =
-  | {
-      event: "comm";
-      msg_type: string; // "comm_open" | "comm_msg" | "comm_close"
-      content: Record<string, unknown>;
-      buffers: number[][]; // Binary buffers as byte arrays
-    }
-  | ({
-      event: "env_progress";
-      env_type: "conda" | "uv";
-    } & EnvProgressPhase);
 
 // Pool state types removed — pool state now syncs via PoolDoc (Automerge).
 // See apps/notebook/src/lib/pool-state.ts for the new types.

--- a/packages/runtimed/src/broadcast-types.ts
+++ b/packages/runtimed/src/broadcast-types.ts
@@ -20,14 +20,46 @@ export interface CommBroadcast {
   buffers: number[][];
 }
 
-export interface EnvProgressBroadcast {
+export type EnvProgressEnvType = "conda" | "uv" | "pixi" | (string & {});
+
+export type EnvProgressPhase =
+  | { phase: "starting"; env_hash: string }
+  | { phase: "cache_hit"; env_path: string }
+  | { phase: "lock_file_hit" }
+  | { phase: "offline_hit" }
+  | { phase: "fetching_repodata"; channels: string[] }
+  | { phase: "repodata_complete"; record_count: number; elapsed_ms: number }
+  | { phase: "solving"; spec_count: number }
+  | { phase: "solve_complete"; package_count: number; elapsed_ms: number }
+  | { phase: "installing"; total: number }
+  | {
+      phase: "download_progress";
+      completed: number;
+      total: number;
+      current_package: string;
+      bytes_downloaded: number;
+      bytes_total: number | null;
+      bytes_per_second: number;
+    }
+  | {
+      phase: "link_progress";
+      completed: number;
+      total: number;
+      current_package: string;
+    }
+  | { phase: "install_complete"; elapsed_ms: number }
+  | { phase: "creating_venv" }
+  | { phase: "installing_packages"; packages: string[] }
+  | { phase: "ready"; env_path: string; python_path: string }
+  | { phase: "error"; message: string };
+
+export type EnvProgressEvent = EnvProgressPhase & {
+  env_type: EnvProgressEnvType;
+};
+
+export type EnvProgressBroadcast = EnvProgressEvent & {
   event: "env_progress";
-  env_type: string;
-  // Phase-specific fields are flattened on the wire; carry them through
-  // as a permissive index so the daemon can extend the shape without
-  // breaking subscribers.
-  [key: string]: unknown;
-}
+};
 
 /** Union of all known broadcast types with an `event` field. */
 export type KnownBroadcast = CommBroadcast | EnvProgressBroadcast;

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -83,6 +83,9 @@ export { type PoolState, type RuntimePoolState, DEFAULT_POOL_STATE } from "./poo
 export {
   type CommBroadcast,
   type EnvProgressBroadcast,
+  type EnvProgressEnvType,
+  type EnvProgressEvent,
+  type EnvProgressPhase,
   isCommBroadcast,
   isEnvProgressBroadcast,
   type KnownBroadcast,

--- a/packages/runtimed/tests/broadcast-types.test.ts
+++ b/packages/runtimed/tests/broadcast-types.test.ts
@@ -10,7 +10,12 @@
  */
 
 import { describe, expect, it } from "vite-plus/test";
-import { isCommBroadcast, isEnvProgressBroadcast } from "../src/broadcast-types";
+import {
+  type EnvProgressBroadcast,
+  type EnvProgressEvent,
+  isCommBroadcast,
+  isEnvProgressBroadcast,
+} from "../src/broadcast-types";
 
 // All guards share `hasBroadcastEvent` — exercise the invalid-payload
 // matrix once so every guard inherits the coverage.
@@ -68,5 +73,18 @@ describe("broadcast type guards", () => {
       const hits = GUARDS.filter(([, guard]) => guard(payload));
       expect(hits.length).toBe(1);
     }
+  });
+
+  it("models flattened env progress broadcasts from Rust", () => {
+    const event: EnvProgressEvent = {
+      env_type: "pixi",
+      phase: "offline_hit",
+    };
+    const broadcast: EnvProgressBroadcast = {
+      event: "env_progress",
+      ...event,
+    };
+
+    expect(isEnvProgressBroadcast(broadcast)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- move env-progress phase/event broadcast types from `apps/notebook` into `packages/runtimed`
- include the Rust `offline_hit` phase and `pixi` env type in the shared TS broadcast surface
- make app hooks consume `isEnvProgressBroadcast` instead of casting an app-local daemon broadcast union

Refs #2340

## Test Plan
- `pnpm exec vp test run packages/runtimed/tests/broadcast-types.test.ts apps/notebook/src/hooks/__tests__/useEnvProgress.test.ts`
- `cargo xtask lint --fix`
- `pnpm test:run`