### PR TITLE
fix(runtimed): persist settings json startup reconciliation

### DIFF
--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -494,6 +494,11 @@ impl SettingsDoc {
                                 if let Ok(json) = serde_json::from_str(&contents) {
                                     if settings.apply_json_changes(&json) {
                                         info!("[settings] Reconciled Automerge doc with settings.json");
+                                        if let Err(e) = settings.save_to_file(automerge_path) {
+                                            log::warn!(
+                                                "[settings] Failed to persist reconciled Automerge doc: {e}"
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1464,6 +1469,37 @@ mod tests {
 
         assert_eq!(settings.uv.default_packages, vec!["numpy", "pandas"]);
         assert_eq!(settings.conda.default_packages, vec!["scipy"]);
+    }
+
+    #[test]
+    fn test_load_or_create_persists_json_reconcile_into_existing_automerge_doc() {
+        let tmp = TempDir::new().unwrap();
+        let automerge_path = tmp.path().join("settings.automerge");
+        let json_path = tmp.path().join("settings.json");
+
+        let mut stale_doc = SettingsDoc::new();
+        stale_doc.put("default_python_env", "uv");
+        stale_doc.save_to_file(&automerge_path).unwrap();
+
+        std::fs::write(
+            &json_path,
+            r#"{"default_python_env":"conda","uv":{"default_packages":["numpy"]}}"#,
+        )
+        .unwrap();
+
+        let reconciled = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        assert_eq!(
+            reconciled.get("default_python_env").as_deref(),
+            Some("conda")
+        );
+
+        let persisted = SettingsDoc::load_or_create(&automerge_path, None);
+        assert_eq!(
+            persisted.get("default_python_env").as_deref(),
+            Some("conda"),
+            "settings.json edits made while the daemon was stopped must persist into settings.automerge"
+        );
+        assert_eq!(persisted.get_list("uv.default_packages"), vec!["numpy"]);
     }
 
     #[test]

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -474,6 +474,68 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
 }
 
 #[tokio::test]
+async fn test_settings_json_mirror_write_does_not_feedback_loop() {
+    use runtimed::settings_doc::{SyncedSettings, ThemeMode};
+    use runtimed::sync_client::SyncClient;
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let settings_dir = temp_dir.path().canonicalize().unwrap();
+    let settings_doc_path = settings_dir.join("settings.automerge");
+    let settings_json_path = settings_dir.join("settings.json");
+    config.settings_doc_path = Some(settings_doc_path);
+    config.settings_json_path = Some(settings_json_path.clone());
+
+    let initial = serde_json::to_string_pretty(&SyncedSettings::default()).unwrap();
+    std::fs::write(&settings_json_path, initial).unwrap();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let mut writer = SyncClient::connect_with_timeout(socket_path.clone(), Duration::from_secs(2))
+        .await
+        .expect("writer SyncClient should connect");
+    let mut observer = SyncClient::connect_with_timeout(socket_path, Duration::from_secs(2))
+        .await
+        .expect("observer SyncClient should connect");
+
+    writer
+        .put_value("theme", &serde_json::Value::String("dark".into()))
+        .await
+        .expect("theme update should sync");
+
+    let observed = tokio::time::timeout(Duration::from_secs(5), observer.recv_changes())
+        .await
+        .expect("observer should receive the writer update")
+        .expect("observer sync should remain connected");
+    assert_eq!(observed.theme, ThemeMode::Dark);
+
+    // The daemon persists the JSON mirror for the writer's Automerge change.
+    // The settings.json watcher will see that filesystem event; it must
+    // recognize the mirror already matches the doc and avoid broadcasting
+    // another settings change back to peers.
+    sleep(Duration::from_secs(1)).await;
+    let extra = tokio::time::timeout(Duration::from_millis(300), observer.recv_changes()).await;
+    assert!(
+        extra.is_err(),
+        "daemon-generated settings.json mirror writes must not feedback-loop into another settings broadcast"
+    );
+
+    let saved_json = std::fs::read_to_string(&settings_json_path).unwrap();
+    let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
+    assert_eq!(saved.theme, ThemeMode::Dark);
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_blob_server_health() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);


### PR DESCRIPTION
## Summary

Keeps settings on the existing Automerge `SettingsSync` transport and tightens the daemon-owned `settings.json` mirror behavior instead of adding a new RPC channel.

This fixes the startup reconcile edge where an existing `settings.automerge` document was updated from `settings.json` in memory but the reconciled Automerge document was not immediately written back to disk. Manual edits made while the daemon was stopped now persist into `settings.automerge` as soon as the daemon loads them.

It also adds coverage for the mirror feedback-loop boundary: daemon-generated `settings.json` writes should be observed by the file watcher, recognized as already matching the Automerge doc, and not rebroadcast as another settings change.

## Design

- Keep `SettingsSync` / Automerge as the live frontend state transport.
- Treat `settings.json` as a daemon-managed mirror plus manual-edit import surface.
- Persist reconciled JSON imports into `settings.automerge` during `SettingsDoc::load_or_create`.
- Preserve existing watcher behavior: external JSON edits apply field deltas into the doc; daemon mirror writes should become no-ops.

## Test plan

- [x] `cargo test -p runtimed-client test_load_or_create_persists_json_reconcile_into_existing_automerge_doc`
- [x] `cargo test -p runtimed test_external_settings_json_edit_survives_settings_sync_ack --test integration`
- [x] `cargo test -p runtimed test_settings_json_mirror_write_does_not_feedback_loop --test integration`
- [x] `cargo clippy -p runtimed-client -p runtimed --test integration -- -D warnings`
- [x] `cargo xtask lint --fix`

Supersedes the closed RPC-channel exploration in #2390.
