### PR TITLE
refactor(runtimed): share frontend protocol boundary helpers

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,7 +1,13 @@
 import { useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
-import { DEFAULT_MIME_PRIORITY, SyncEngine } from "runtimed";
+import {
+  DEFAULT_MIME_PRIORITY,
+  SyncEngine,
+  isDisplayCapableJupyterOutput,
+  isInitialLoadFailed,
+  isInitialLoadStreaming,
+} from "runtimed";
 import { concatMap, from, Observable, switchMap } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
@@ -153,7 +159,7 @@ export function useAutomergeNotebook() {
     for (const c of newCells) {
       if (c.cell_type === "code") {
         for (const output of c.outputs) {
-          if (output.output_type === "execute_result" || output.output_type === "display_data") {
+          if (isDisplayCapableJupyterOutput(output)) {
             for (const mime of Object.keys(output.data)) {
               if (needsPlugin(mime)) pluginMimes.push(mime);
             }
@@ -272,7 +278,7 @@ export function useAutomergeNotebook() {
     const sessionStatusSub = engine.sessionStatus$.subscribe((status) => {
       latestSessionStatusRef.current = status;
 
-      if (status.initial_load.phase === "failed") {
+      if (isInitialLoadFailed(status.initial_load)) {
         logger.warn("[automerge-notebook] Initial load failed:", status.initial_load.reason);
         setLoadError(status.initial_load.reason);
         setIsLoading(false);
@@ -281,7 +287,7 @@ export function useAutomergeNotebook() {
 
       setLoadError(null);
       if (interactiveReadyRef.current) {
-        setIsLoading(status.initial_load.phase === "streaming");
+        setIsLoading(isInitialLoadStreaming(status.initial_load));
       }
     });
 
@@ -311,7 +317,7 @@ export function useAutomergeNotebook() {
             // runtimeState$ subscription will redo on the next tick.
             projectRuntimeStateToExecutions(getRuntimeState());
             const status = latestSessionStatusRef.current;
-            setIsLoading(status ? status.initial_load.phase === "streaming" : false);
+            setIsLoading(status ? isInitialLoadStreaming(status.initial_load) : false);
             notifyMetadataChanged();
             logger.info("[automerge-notebook] Interactive materialization done");
           })
@@ -647,7 +653,7 @@ export function useAutomergeNotebook() {
           let changed = false;
           const updatedOutputs = c.outputs.map((output) => {
             if (
-              (output.output_type === "display_data" || output.output_type === "execute_result") &&
+              isDisplayCapableJupyterOutput(output) &&
               output.display_id === displayId
             ) {
               changed = true;

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -652,10 +652,7 @@ export function useAutomergeNotebook() {
           if (c.cell_type !== "code") return c;
           let changed = false;
           const updatedOutputs = c.outputs.map((output) => {
-            if (
-              isDisplayCapableJupyterOutput(output) &&
-              output.display_id === displayId
-            ) {
+            if (isDisplayCapableJupyterOutput(output) && output.display_id === displayId) {
               changed = true;
               return { ...output, data: newData, metadata: newMetadata };
             }

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -17,6 +17,7 @@
 
 import type { Extension } from "@codemirror/state";
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useRef } from "react";
+import { isTextAttributionEvent } from "runtimed";
 import { type CrdtBridge, createCrdtBridge, type RemoteChange } from "../lib/crdt-editor-bridge";
 import { logger } from "../lib/logger";
 import { updateCellById } from "../lib/notebook-cells";
@@ -108,28 +109,13 @@ export function useCrdtBridge(cellId: string): {
   // Subscribe to the frame bus for inbound text attributions.
   useEffect(() => {
     const unsubscribe = subscribeBroadcast((payload: unknown) => {
-      if (
-        !payload ||
-        typeof payload !== "object" ||
-        (payload as { type?: string }).type !== "text_attribution"
-      ) {
+      if (!isTextAttributionEvent(payload)) {
         return;
       }
 
-      const event = payload as {
-        type: "text_attribution";
-        attributions: Array<{
-          cell_id: string;
-          index: number;
-          text: string;
-          deleted: number;
-          actors: string[];
-        }>;
-      };
-
       logger.debug(
-        `[crdt-bridge] text_attribution broadcast received: ${event.attributions.length} attrs, looking for cell ${cellId.slice(0, 8)}`,
-        event.attributions.map(
+        `[crdt-bridge] text_attribution broadcast received: ${payload.attributions.length} attrs, looking for cell ${cellId.slice(0, 8)}`,
+        payload.attributions.map(
           (a) =>
             `${a.cell_id.slice(0, 8)}: idx=${a.index} del=${a.deleted} text="${a.text.slice(0, 20)}"`,
         ),
@@ -142,7 +128,7 @@ export function useCrdtBridge(cellId: string): {
       // changes, so applying them again would corrupt the editor state.
       const localActor = ctxRef.current.localActor;
       const changes: RemoteChange[] = [];
-      for (const attr of event.attributions) {
+      for (const attr of payload.attributions) {
         if (attr.cell_id !== cellId) continue;
         if (attr.actors.length === 1 && attr.actors[0] === localActor) {
           continue;

--- a/apps/notebook/src/lib/attribution-registry.ts
+++ b/apps/notebook/src/lib/attribution-registry.ts
@@ -25,22 +25,10 @@ import {
   type AttributionMark,
   addTextAttributions,
 } from "@/components/editor/text-attribution";
+import { isTextAttributionEvent, type TextAttribution } from "runtimed";
 import { findPeerColorByActorLabel } from "./cursor-registry";
 import { getCellEditor } from "./editor-registry";
 import { subscribeBroadcast } from "./notebook-frame-bus";
-
-// ── Types (text_attribution event shape from WASM) ───────────────────
-
-interface TextAttributionEvent {
-  type: "text_attribution";
-  attributions: Array<{
-    cell_id: string;
-    index: number;
-    text: string;
-    deleted: number;
-    actors: string[];
-  }>;
-}
 
 // ── Color cache ──────────────────────────────────────────────────────
 
@@ -70,17 +58,11 @@ function colorForActors(actors: string[]): string {
 // ── Event handler ────────────────────────────────────────────────────
 
 function handleBroadcast(payload: unknown): void {
-  // Type-narrow: only handle text_attribution events
-  if (
-    !payload ||
-    typeof payload !== "object" ||
-    (payload as { type?: string }).type !== "text_attribution"
-  ) {
+  if (!isTextAttributionEvent(payload)) {
     return;
   }
 
-  const event = payload as TextAttributionEvent;
-  if (!event.attributions || event.attributions.length === 0) return;
+  if (payload.attributions.length === 0) return;
 
   // Defer mark creation by one microtask. The CRDT bridge also
   // subscribes to this broadcast and applies text changes to the CM
@@ -90,14 +72,12 @@ function handleBroadcast(payload: unknown): void {
   // insert-then-delete pairs to zero width. By deferring, we guarantee
   // the CM document already reflects the new content when we read
   // positions, so marks land on the correct text.
-  const attributions = event.attributions;
+  const attributions = payload.attributions;
   queueMicrotask(() => dispatchAttributionMarks(attributions));
 }
 
 /** Create and dispatch attribution marks after the CRDT bridge has applied text changes. */
-function dispatchAttributionMarks(
-  attributions: TextAttributionEvent["attributions"],
-): void {
+function dispatchAttributionMarks(attributions: TextAttribution[]): void {
   // Group attributions by cell_id for batch dispatch
   const byCellId = new Map<string, AttributionMark[]>();
 

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -10,7 +10,10 @@ import {
   needsPlugin,
   preWarmForMimes,
 } from "@/components/isolated/iframe-libraries";
-import { classifyCellChangesetMaterialization } from "runtimed";
+import {
+  classifyCellChangesetMaterialization,
+  isDisplayCapableJupyterOutputType,
+} from "runtimed";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort } from "./blob-port";
@@ -65,7 +68,7 @@ function preWarmPluginsForRawOutputs(rawOutputs: unknown[]): void {
   for (const raw of rawOutputs) {
     if (!raw || typeof raw !== "object") continue;
     const type = (raw as { output_type?: unknown }).output_type;
-    if (type !== "execute_result" && type !== "display_data") continue;
+    if (!isDisplayCapableJupyterOutputType(type)) continue;
     const data = (raw as { data?: unknown }).data;
     if (!data || typeof data !== "object") continue;
     for (const mime of Object.keys(data as Record<string, unknown>)) {

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -12,7 +12,12 @@
  * there is no synthetic `legacy:<eid>:<idx>` key in these stores.
  */
 
-import type { ExecutionState, RuntimeState } from "runtimed";
+import {
+  buildRuntimeExecutionSnapshot,
+  collectOutputIds,
+  executionFingerprint,
+  type RuntimeState,
+} from "runtimed";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
 import { logger } from "./logger";
@@ -23,7 +28,6 @@ import {
 } from "./manifest-resolution";
 import { isOutputManifest } from "./materialize-cells";
 import {
-  type ExecutionSnapshot,
   deleteExecutions,
   resetNotebookExecutions,
   setCellExecutionPointer,
@@ -55,42 +59,6 @@ let _knownExecutionIds: Set<string> = new Set();
  */
 const _prevExecutionFingerprint: Map<string, string> = new Map();
 
-function extractOutputId(output: unknown): string | null {
-  if (!output || typeof output !== "object") return null;
-  const oid = (output as { output_id?: unknown }).output_id;
-  return typeof oid === "string" && oid.length > 0 ? oid : null;
-}
-
-function collectExecutionOutputIds(raw: ExecutionState): string[] {
-  const ids: string[] = [];
-  if (!raw.outputs) return ids;
-  for (const output of raw.outputs) {
-    const oid = extractOutputId(output);
-    if (oid) ids.push(oid);
-  }
-  return ids;
-}
-
-function executionFingerprint(raw: ExecutionState): string {
-  // Include the ordered `output_id` list so same-length replacements
-  // (e.g. `clear_output(wait=True)` or a remove+add that keeps the list
-  // length constant) still invalidate the snapshot. Without this, the
-  // outputs store drifts past the execution's canonical pointer list and
-  // `useCellOutputs` resolves stale entries.
-  const ids = collectExecutionOutputIds(raw);
-  return `${raw.cell_id}|${raw.execution_count ?? ""}|${raw.status}|${raw.success ?? ""}|${ids.join(",")}`;
-}
-
-function buildExecutionSnapshot(raw: ExecutionState): ExecutionSnapshot {
-  return {
-    cell_id: raw.cell_id,
-    execution_count: raw.execution_count,
-    status: raw.status,
-    success: raw.success,
-    output_ids: collectExecutionOutputIds(raw),
-  };
-}
-
 /**
  * Project the current RuntimeState into the executions store.
  *
@@ -113,7 +81,7 @@ export function projectRuntimeStateToExecutions(state: RuntimeState): void {
     const fp = executionFingerprint(entry);
     if (_prevExecutionFingerprint.get(execution_id) === fp) continue;
     _prevExecutionFingerprint.set(execution_id, fp);
-    setExecution(execution_id, buildExecutionSnapshot(entry));
+    setExecution(execution_id, buildRuntimeExecutionSnapshot(entry));
   }
 
   // Evict executions the daemon dropped. Keeps the store from drifting
@@ -149,12 +117,7 @@ export function seedOutputStoresFromHandle(
     const rawOutputs = (handle.get_cell_outputs(cellId) as unknown[]) ?? [];
     if (rawOutputs.length === 0) continue;
 
-    const output_ids: string[] = [];
-    for (const output of rawOutputs) {
-      if (!output || typeof output !== "object") continue;
-      const oid = (output as { output_id?: unknown }).output_id;
-      if (typeof oid === "string" && oid.length > 0) output_ids.push(oid);
-    }
+    const output_ids = collectOutputIds(rawOutputs);
     if (output_ids.length === 0) continue;
 
     // Build a minimal execution snapshot. We don't have status / success

--- a/packages/runtimed/src/execution-projection.ts
+++ b/packages/runtimed/src/execution-projection.ts
@@ -14,9 +14,7 @@ export function extractOutputId(output: unknown): string | null {
   return typeof oid === "string" && oid.length > 0 ? oid : null;
 }
 
-export function collectOutputIds(
-  outputs: readonly unknown[] | undefined,
-): string[] {
+export function collectOutputIds(outputs: readonly unknown[] | undefined): string[] {
   const ids: string[] = [];
   if (!outputs) return ids;
   for (const output of outputs) {
@@ -37,9 +35,7 @@ export function executionFingerprint(raw: ExecutionState): string {
   return `${raw.cell_id}|${raw.execution_count ?? ""}|${raw.status}|${raw.success ?? ""}|${ids.join(",")}`;
 }
 
-export function buildRuntimeExecutionSnapshot(
-  raw: ExecutionState,
-): RuntimeExecutionSnapshot {
+export function buildRuntimeExecutionSnapshot(raw: ExecutionState): RuntimeExecutionSnapshot {
   return {
     cell_id: raw.cell_id,
     execution_count: raw.execution_count,

--- a/packages/runtimed/src/execution-projection.ts
+++ b/packages/runtimed/src/execution-projection.ts
@@ -1,0 +1,50 @@
+import type { ExecutionState } from "./runtime-state";
+
+export interface RuntimeExecutionSnapshot {
+  cell_id: string;
+  execution_count: number | null;
+  status: ExecutionState["status"];
+  success: boolean | null;
+  output_ids: string[];
+}
+
+export function extractOutputId(output: unknown): string | null {
+  if (!output || typeof output !== "object") return null;
+  const oid = (output as { output_id?: unknown }).output_id;
+  return typeof oid === "string" && oid.length > 0 ? oid : null;
+}
+
+export function collectOutputIds(
+  outputs: readonly unknown[] | undefined,
+): string[] {
+  const ids: string[] = [];
+  if (!outputs) return ids;
+  for (const output of outputs) {
+    const oid = extractOutputId(output);
+    if (oid) ids.push(oid);
+  }
+  return ids;
+}
+
+export function collectExecutionOutputIds(raw: ExecutionState): string[] {
+  return collectOutputIds(raw.outputs);
+}
+
+export function executionFingerprint(raw: ExecutionState): string {
+  // Include the ordered `output_id` list so same-length replacements
+  // (e.g. clear_output(wait=True)) still invalidate cached snapshots.
+  const ids = collectExecutionOutputIds(raw);
+  return `${raw.cell_id}|${raw.execution_count ?? ""}|${raw.status}|${raw.success ?? ""}|${ids.join(",")}`;
+}
+
+export function buildRuntimeExecutionSnapshot(
+  raw: ExecutionState,
+): RuntimeExecutionSnapshot {
+  return {
+    cell_id: raw.cell_id,
+    execution_count: raw.execution_count,
+    status: raw.status,
+    success: raw.success,
+    output_ids: collectExecutionOutputIds(raw),
+  };
+}

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -50,6 +50,16 @@ export {
   mergeChangesets,
 } from "./cell-changeset";
 
+// Execution projection
+export {
+  buildRuntimeExecutionSnapshot,
+  collectExecutionOutputIds,
+  collectOutputIds,
+  executionFingerprint,
+  extractOutputId,
+  type RuntimeExecutionSnapshot,
+} from "./execution-projection";
+
 // Runtime state
 export {
   type CommDocEntry,

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -40,6 +40,14 @@ export type {
   TextAttribution,
 } from "./handle";
 
+// Text attribution events
+export {
+  createTextAttributionEvent,
+  isTextAttributionEvent,
+  TEXT_ATTRIBUTION_EVENT_TYPE,
+  type TextAttributionEvent,
+} from "./text-attribution-event";
+
 // Cell changeset
 export {
   classifyCellChangesetMaterialization,

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -20,12 +20,19 @@ export {
 
 // Protocol contract
 export {
+  DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES,
   INITIAL_LOAD_PHASES,
   NOTEBOOK_DOC_PHASES,
   NOTEBOOK_REQUEST_TYPES,
   NOTEBOOK_RESPONSE_RESULTS,
   RUNTIME_STATE_PHASES,
   SESSION_CONTROL_TYPES,
+  isDisplayCapableJupyterOutput,
+  isDisplayCapableJupyterOutputType,
+  isInitialLoadFailed,
+  isInitialLoadStreaming,
+  type DisplayCapableJupyterOutput,
+  type DisplayCapableJupyterOutputType,
   type SessionControlMessage,
 } from "./protocol-contract";
 

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -112,3 +112,58 @@ export const INITIAL_LOAD_PHASES_EXHAUSTIVE: MissingUnionMember<
 > extends never
   ? true
   : never = true;
+
+export const DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES = [
+  "execute_result",
+  "display_data",
+] as const;
+
+export type DisplayCapableJupyterOutputType =
+  (typeof DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES)[number];
+
+export interface DisplayCapableJupyterOutput {
+  output_type: DisplayCapableJupyterOutputType;
+  data: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  execution_count?: number | null;
+  display_id?: string;
+}
+
+export function isDisplayCapableJupyterOutputType(
+  outputType: unknown,
+): outputType is DisplayCapableJupyterOutputType {
+  return (
+    outputType === "execute_result" ||
+    outputType === "display_data"
+  );
+}
+
+export function isDisplayCapableJupyterOutput<T extends { output_type: unknown }>(
+  output: T,
+): output is Extract<T, { output_type: DisplayCapableJupyterOutputType }>;
+export function isDisplayCapableJupyterOutput(
+  output: unknown,
+): output is DisplayCapableJupyterOutput;
+export function isDisplayCapableJupyterOutput(
+  output: unknown,
+): output is DisplayCapableJupyterOutput {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    isDisplayCapableJupyterOutputType(
+      (output as { output_type?: unknown }).output_type,
+    )
+  );
+}
+
+export function isInitialLoadFailed(
+  initialLoad: InitialLoadPhase,
+): initialLoad is Extract<InitialLoadPhase, { phase: "failed" }> {
+  return initialLoad.phase === "failed";
+}
+
+export function isInitialLoadStreaming(
+  initialLoad: InitialLoadPhase,
+): initialLoad is Extract<InitialLoadPhase, { phase: "streaming" }> {
+  return initialLoad.phase === "streaming";
+}

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -113,13 +113,9 @@ export const INITIAL_LOAD_PHASES_EXHAUSTIVE: MissingUnionMember<
   ? true
   : never = true;
 
-export const DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES = [
-  "execute_result",
-  "display_data",
-] as const;
+export const DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES = ["execute_result", "display_data"] as const;
 
-export type DisplayCapableJupyterOutputType =
-  (typeof DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES)[number];
+export type DisplayCapableJupyterOutputType = (typeof DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES)[number];
 
 export interface DisplayCapableJupyterOutput {
   output_type: DisplayCapableJupyterOutputType;
@@ -132,10 +128,7 @@ export interface DisplayCapableJupyterOutput {
 export function isDisplayCapableJupyterOutputType(
   outputType: unknown,
 ): outputType is DisplayCapableJupyterOutputType {
-  return (
-    outputType === "execute_result" ||
-    outputType === "display_data"
-  );
+  return outputType === "execute_result" || outputType === "display_data";
 }
 
 export function isDisplayCapableJupyterOutput<T extends { output_type: unknown }>(
@@ -150,9 +143,7 @@ export function isDisplayCapableJupyterOutput(
   return (
     typeof output === "object" &&
     output !== null &&
-    isDisplayCapableJupyterOutputType(
-      (output as { output_type?: unknown }).output_type,
-    )
+    isDisplayCapableJupyterOutputType((output as { output_type?: unknown }).output_type)
   );
 }
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -53,6 +53,7 @@ import {
   type ExecutionState,
   diffExecutions,
 } from "./runtime-state";
+import { createTextAttributionEvent } from "./text-attribution-event";
 import { FrameType } from "./transport";
 import type { NotebookTransport } from "./transport";
 
@@ -468,10 +469,7 @@ export class SyncEngine {
           concatMap((e) => {
             // Attributions → broadcast
             if (e.attributions && e.attributions.length > 0) {
-              this._broadcasts$.next({
-                type: "text_attribution",
-                attributions: e.attributions,
-              });
+              this._broadcasts$.next(createTextAttributionEvent(e.attributions));
             }
 
             // Send inline sync reply

--- a/packages/runtimed/src/text-attribution-event.ts
+++ b/packages/runtimed/src/text-attribution-event.ts
@@ -1,0 +1,48 @@
+import type { TextAttribution } from "./handle";
+
+export const TEXT_ATTRIBUTION_EVENT_TYPE = "text_attribution" as const;
+
+export interface TextAttributionEvent {
+  type: typeof TEXT_ATTRIBUTION_EVENT_TYPE;
+  attributions: TextAttribution[];
+}
+
+export function createTextAttributionEvent(
+  attributions: TextAttribution[],
+): TextAttributionEvent {
+  return {
+    type: TEXT_ATTRIBUTION_EVENT_TYPE,
+    attributions,
+  };
+}
+
+export function isTextAttributionEvent(payload: unknown): payload is TextAttributionEvent {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    (payload as { type?: unknown }).type !== TEXT_ATTRIBUTION_EVENT_TYPE
+  ) {
+    return false;
+  }
+
+  const attributions = (payload as { attributions?: unknown }).attributions;
+  return Array.isArray(attributions) && attributions.every(isTextAttribution);
+}
+
+function isTextAttribution(payload: unknown): payload is TextAttribution {
+  if (typeof payload !== "object" || payload === null) {
+    return false;
+  }
+
+  const attribution = payload as Partial<Record<keyof TextAttribution, unknown>>;
+  return (
+    typeof attribution.cell_id === "string" &&
+    typeof attribution.index === "number" &&
+    Number.isFinite(attribution.index) &&
+    typeof attribution.text === "string" &&
+    typeof attribution.deleted === "number" &&
+    Number.isFinite(attribution.deleted) &&
+    Array.isArray(attribution.actors) &&
+    attribution.actors.every((actor) => typeof actor === "string")
+  );
+}

--- a/packages/runtimed/src/text-attribution-event.ts
+++ b/packages/runtimed/src/text-attribution-event.ts
@@ -7,9 +7,7 @@ export interface TextAttributionEvent {
   attributions: TextAttribution[];
 }
 
-export function createTextAttributionEvent(
-  attributions: TextAttribution[],
-): TextAttributionEvent {
+export function createTextAttributionEvent(attributions: TextAttribution[]): TextAttributionEvent {
   return {
     type: TEXT_ATTRIBUTION_EVENT_TYPE,
     attributions,

--- a/packages/runtimed/tests/execution-projection.test.ts
+++ b/packages/runtimed/tests/execution-projection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildRuntimeExecutionSnapshot,
+  collectExecutionOutputIds,
+  collectOutputIds,
+  executionFingerprint,
+  extractOutputId,
+  type ExecutionState,
+} from "../src";
+
+describe("execution projection helpers", () => {
+  it("extracts only non-empty string output ids", () => {
+    expect(extractOutputId({ output_id: "out-1" })).toBe("out-1");
+    expect(extractOutputId({ output_id: "" })).toBeNull();
+    expect(extractOutputId({ output_id: 123 })).toBeNull();
+    expect(extractOutputId(null)).toBeNull();
+  });
+
+  it("collects ordered output ids and skips unstamped outputs", () => {
+    expect(
+      collectOutputIds([
+        { output_id: "first" },
+        { output_id: "" },
+        { output_type: "stream" },
+        { output_id: "second" },
+      ]),
+    ).toEqual(["first", "second"]);
+  });
+
+  it("collects execution output ids from RuntimeState entries", () => {
+    const entry: ExecutionState = {
+      cell_id: "cell-1",
+      execution_count: 1,
+      status: "running",
+      success: null,
+      outputs: [{ output_id: "out-1" }, { output_id: "out-2" }],
+    };
+
+    expect(collectExecutionOutputIds(entry)).toEqual(["out-1", "out-2"]);
+  });
+
+  it("fingerprints same-length output id replacements", () => {
+    const base: ExecutionState = {
+      cell_id: "cell-1",
+      execution_count: 1,
+      status: "running",
+      success: null,
+      outputs: [{ output_id: "old" }],
+    };
+    const replaced: ExecutionState = {
+      ...base,
+      outputs: [{ output_id: "new" }],
+    };
+
+    expect(executionFingerprint(replaced)).not.toBe(executionFingerprint(base));
+  });
+
+  it("derives execution snapshots without carrying raw outputs", () => {
+    const entry: ExecutionState = {
+      cell_id: "cell-1",
+      execution_count: 2,
+      status: "done",
+      success: true,
+      outputs: [{ output_id: "out-1", text: "hello" }],
+    };
+
+    expect(buildRuntimeExecutionSnapshot(entry)).toEqual({
+      cell_id: "cell-1",
+      execution_count: 2,
+      status: "done",
+      success: true,
+      output_ids: ["out-1"],
+    });
+  });
+});

--- a/packages/runtimed/tests/protocol-contract.test.ts
+++ b/packages/runtimed/tests/protocol-contract.test.ts
@@ -70,10 +70,7 @@ describe("protocol contract discriminants", () => {
   });
 
   it("identifies display-capable Jupyter output types", () => {
-    expect(DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES).toEqual([
-      "execute_result",
-      "display_data",
-    ]);
+    expect(DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES).toEqual(["execute_result", "display_data"]);
     expect(isDisplayCapableJupyterOutputType("execute_result")).toBe(true);
     expect(isDisplayCapableJupyterOutputType("display_data")).toBe(true);
     expect(isDisplayCapableJupyterOutputType("stream")).toBe(false);

--- a/packages/runtimed/tests/protocol-contract.test.ts
+++ b/packages/runtimed/tests/protocol-contract.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES,
   INITIAL_LOAD_PHASES,
   NOTEBOOK_DOC_PHASES,
   NOTEBOOK_REQUEST_TYPES,
   NOTEBOOK_RESPONSE_RESULTS,
   RUNTIME_STATE_PHASES,
   SESSION_CONTROL_TYPES,
+  isDisplayCapableJupyterOutput,
+  isDisplayCapableJupyterOutputType,
+  isInitialLoadFailed,
+  isInitialLoadStreaming,
+  type InitialLoadPhase,
 } from "../src";
 
 describe("protocol contract discriminants", () => {
@@ -61,5 +67,46 @@ describe("protocol contract discriminants", () => {
     expect(NOTEBOOK_DOC_PHASES).toEqual(["pending", "syncing", "interactive"]);
     expect(RUNTIME_STATE_PHASES).toEqual(["pending", "syncing", "ready"]);
     expect(INITIAL_LOAD_PHASES).toEqual(["not_needed", "streaming", "ready", "failed"]);
+  });
+
+  it("identifies display-capable Jupyter output types", () => {
+    expect(DISPLAY_CAPABLE_JUPYTER_OUTPUT_TYPES).toEqual([
+      "execute_result",
+      "display_data",
+    ]);
+    expect(isDisplayCapableJupyterOutputType("execute_result")).toBe(true);
+    expect(isDisplayCapableJupyterOutputType("display_data")).toBe(true);
+    expect(isDisplayCapableJupyterOutputType("stream")).toBe(false);
+    expect(isDisplayCapableJupyterOutputType("error")).toBe(false);
+    expect(isDisplayCapableJupyterOutputType(undefined)).toBe(false);
+  });
+
+  it("identifies display-capable Jupyter output objects", () => {
+    expect(
+      isDisplayCapableJupyterOutput({
+        output_type: "display_data",
+        data: { "text/plain": "ok" },
+      }),
+    ).toBe(true);
+    expect(
+      isDisplayCapableJupyterOutput({
+        output_type: "execute_result",
+        data: { "text/plain": "ok" },
+        execution_count: 1,
+      }),
+    ).toBe(true);
+    expect(isDisplayCapableJupyterOutput({ output_type: "stream" })).toBe(false);
+    expect(isDisplayCapableJupyterOutput(null)).toBe(false);
+  });
+
+  it("selects initial-load failed and streaming states", () => {
+    const failed: InitialLoadPhase = { phase: "failed", reason: "bad snapshot" };
+    const streaming: InitialLoadPhase = { phase: "streaming" };
+    const ready: InitialLoadPhase = { phase: "ready" };
+
+    expect(isInitialLoadFailed(failed)).toBe(true);
+    expect(isInitialLoadFailed(streaming)).toBe(false);
+    expect(isInitialLoadStreaming(streaming)).toBe(true);
+    expect(isInitialLoadStreaming(ready)).toBe(false);
   });
 });

--- a/packages/runtimed/tests/text-attribution-event.test.ts
+++ b/packages/runtimed/tests/text-attribution-event.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createTextAttributionEvent,
+  isTextAttributionEvent,
+  TEXT_ATTRIBUTION_EVENT_TYPE,
+} from "../src/text-attribution-event";
+
+const ATTRIBUTION = {
+  cell_id: "cell-1",
+  index: 3,
+  text: "abc",
+  deleted: 0,
+  actors: ["human:local"],
+};
+
+describe("text attribution event contract", () => {
+  it("creates the shared text attribution broadcast shape", () => {
+    expect(createTextAttributionEvent([ATTRIBUTION])).toEqual({
+      type: TEXT_ATTRIBUTION_EVENT_TYPE,
+      attributions: [ATTRIBUTION],
+    });
+  });
+
+  it("accepts valid text attribution events", () => {
+    expect(isTextAttributionEvent(createTextAttributionEvent([ATTRIBUTION]))).toBe(true);
+    expect(isTextAttributionEvent(createTextAttributionEvent([]))).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["wrong type", { type: "presence", attributions: [ATTRIBUTION] }],
+    ["missing attributions", { type: TEXT_ATTRIBUTION_EVENT_TYPE }],
+    ["non-array attributions", { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: ATTRIBUTION }],
+    [
+      "invalid cell_id",
+      { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: [{ ...ATTRIBUTION, cell_id: 1 }] },
+    ],
+    [
+      "invalid index",
+      { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: [{ ...ATTRIBUTION, index: "3" }] },
+    ],
+    [
+      "invalid text",
+      { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: [{ ...ATTRIBUTION, text: null }] },
+    ],
+    [
+      "invalid deleted",
+      { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: [{ ...ATTRIBUTION, deleted: NaN }] },
+    ],
+    [
+      "invalid actors",
+      { type: TEXT_ATTRIBUTION_EVENT_TYPE, attributions: [{ ...ATTRIBUTION, actors: [42] }] },
+    ],
+  ])("rejects %s", (_label, payload) => {
+    expect(isTextAttributionEvent(payload)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- move runtime execution/output projection helpers into `packages/runtimed`
- share the text attribution event contract from `packages/runtimed`
- add package-owned output/status protocol selectors and consume them in app code

## Context

This continues Phase 3 of #2340 by reducing app-local protocol/event vocabulary while keeping app code responsible for React stores and materialization.

## Verification

- `pnpm exec vp test run packages/runtimed/tests/execution-projection.test.ts packages/runtimed/tests/text-attribution-event.test.ts packages/runtimed/tests/protocol-contract.test.ts packages/runtimed/tests/sync-engine.test.ts apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts`
- `cargo xtask lint --fix`
