### PR TITLE
fix(runtimed): lease pool envs during launch

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -284,6 +284,9 @@ struct Pool {
     /// Paths of environments currently being warmed up (for GC protection).
     /// Populated when the env directory is created, removed on `add()` or failure.
     warming_paths: std::collections::HashSet<PathBuf>,
+    /// Paths of environments taken from the pool but not yet transferred to a
+    /// runtime, cache, or return/delete path.
+    leased_paths: std::collections::HashSet<PathBuf>,
     /// Target pool size.
     target: usize,
     /// Maximum age in seconds.
@@ -352,6 +355,7 @@ impl Pool {
             available: VecDeque::new(),
             warming: 0,
             warming_paths: std::collections::HashSet::new(),
+            leased_paths: std::collections::HashSet::new(),
             target,
             max_age_secs,
             failure_state: FailureState::default(),
@@ -445,6 +449,8 @@ impl Pool {
                 && entry.env.python_path.exists()
                 && entry.env.venv_path.join(".warmed").exists()
             {
+                self.leased_paths
+                    .insert(pool_env_root(&entry.env.venv_path));
                 let mut all_paths = stale_paths;
                 all_paths.extend(invalid_paths);
                 return (Some(entry.env), all_paths);
@@ -568,6 +574,20 @@ impl Pool {
     /// Register a warming path so GC won't delete it while it's being set up.
     fn register_warming_path(&mut self, path: PathBuf) {
         self.warming_paths.insert(path);
+    }
+
+    fn release_lease(&mut self, path: &Path) {
+        self.leased_paths.remove(&pool_env_root(path));
+    }
+
+    fn tracked_paths(&self) -> std::collections::HashSet<PathBuf> {
+        let mut tracked = std::collections::HashSet::new();
+        for entry in &self.available {
+            tracked.insert(pool_env_root(&entry.env.venv_path));
+        }
+        tracked.extend(self.warming_paths.iter().cloned());
+        tracked.extend(self.leased_paths.iter().cloned());
+        tracked
     }
 
     /// Get current stats.
@@ -749,6 +769,17 @@ impl Daemon {
     /// Snapshot the user's feature-flag settings.
     pub async fn feature_flags(&self) -> notebook_protocol::protocol::FeatureFlags {
         self.settings.read().await.get_all().feature_flags()
+    }
+
+    /// Release a pool lease after ownership has transferred to a runtime,
+    /// cache, return path, or explicit delete path.
+    pub(crate) async fn release_pool_lease(&self, env_type: EnvType, path: &Path) {
+        let pool = match env_type {
+            EnvType::Uv => &self.uv_pool,
+            EnvType::Conda => &self.conda_pool,
+            EnvType::Pixi => &self.pixi_pool,
+        };
+        pool.lock().await.release_lease(path);
     }
 
     /// Get the full list of Conda pool packages (base + user default_packages).
@@ -2671,6 +2702,7 @@ impl Daemon {
                 let should_delete = match env.env_type {
                     EnvType::Uv => {
                         let mut pool = self.uv_pool.lock().await;
+                        pool.release_lease(&env.venv_path);
                         if pool.available.len() < pool.target {
                             pool.available.push_back(PoolEntry {
                                 env: env.clone(),
@@ -2684,6 +2716,7 @@ impl Daemon {
                     }
                     EnvType::Conda => {
                         let mut pool = self.conda_pool.lock().await;
+                        pool.release_lease(&env.venv_path);
                         if pool.available.len() < pool.target {
                             pool.available.push_back(PoolEntry {
                                 env: env.clone(),
@@ -2697,6 +2730,7 @@ impl Daemon {
                     }
                     EnvType::Pixi => {
                         let mut pool = self.pixi_pool.lock().await;
+                        pool.release_lease(&env.venv_path);
                         if pool.available.len() < pool.target {
                             pool.available.push_back(PoolEntry {
                                 env: env.clone(),
@@ -3044,29 +3078,22 @@ impl Daemon {
                     // (runtimed-pixi-{uuid}/.pixi/envs/default) matches the
                     // top-level directory that the scan below sees.
                     // Also includes warming paths (mid-creation) to avoid
-                    // racing with in-progress warmup tasks.
+                    // racing with in-progress warmup tasks, and leased
+                    // paths that have been taken from the pool but not yet
+                    // transferred to a runtime/cache owner.
                     let mut tracked: std::collections::HashSet<PathBuf> =
                         std::collections::HashSet::new();
                     {
                         let pool = self.uv_pool.lock().await;
-                        for entry in &pool.available {
-                            tracked.insert(pool_env_root(&entry.env.venv_path));
-                        }
-                        tracked.extend(pool.warming_paths.iter().cloned());
+                        tracked.extend(pool.tracked_paths());
                     }
                     {
                         let pool = self.conda_pool.lock().await;
-                        for entry in &pool.available {
-                            tracked.insert(pool_env_root(&entry.env.venv_path));
-                        }
-                        tracked.extend(pool.warming_paths.iter().cloned());
+                        tracked.extend(pool.tracked_paths());
                     }
                     {
                         let pool = self.pixi_pool.lock().await;
-                        for entry in &pool.available {
-                            tracked.insert(pool_env_root(&entry.env.venv_path));
-                        }
-                        tracked.extend(pool.warming_paths.iter().cloned());
+                        tracked.extend(pool.tracked_paths());
                     }
 
                     let mut orphans_deleted = 0;
@@ -4939,6 +4966,7 @@ mod tests {
         assert_eq!(pool.max_age_secs, 3600);
         assert_eq!(pool.available.len(), 0);
         assert_eq!(pool.warming, 0);
+        assert!(pool.leased_paths.is_empty());
     }
 
     #[test]
@@ -4955,7 +4983,47 @@ mod tests {
         assert!(taken.is_some());
         assert_eq!(taken.unwrap().venv_path, env.venv_path);
         assert_eq!(pool.available.len(), 0);
+        assert!(pool.leased_paths.contains(&pool_env_root(&env.venv_path)));
         assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn test_pool_lease_released_on_commit() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut pool = Pool::new(3, 3600);
+        let env = create_test_env(&temp_dir, "runtimed-uv-leased");
+        let root = pool_env_root(&env.venv_path);
+        pool.add(env.clone());
+
+        let (taken, stale) = pool.take();
+        assert!(taken.is_some());
+        assert!(stale.is_empty());
+        assert!(pool.leased_paths.contains(&root));
+
+        pool.release_lease(&env.venv_path);
+        assert!(pool.leased_paths.is_empty());
+    }
+
+    #[test]
+    fn test_pool_tracked_paths_include_leases() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut pool = Pool::new(3, 3600);
+        let available_env = create_test_env(&temp_dir, "runtimed-uv-available");
+        let leased_env = create_test_env(&temp_dir, "runtimed-uv-leased");
+        let warming = temp_dir.path().join("runtimed-uv-warming");
+
+        pool.add(available_env.clone());
+        pool.add(leased_env.clone());
+        pool.register_warming_path(warming.clone());
+
+        let (taken, stale) = pool.take();
+        assert!(taken.is_some());
+        assert!(stale.is_empty());
+
+        let tracked = pool.tracked_paths();
+        assert!(tracked.contains(&pool_env_root(&available_env.venv_path)));
+        assert!(tracked.contains(&pool_env_root(&leased_env.venv_path)));
+        assert!(tracked.contains(&warming));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1910,14 +1910,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
     // claim to the unified-hash location, and capture into metadata.
     let pooled = acquire_pool_env_for_source(env_source, daemon, room).await?;
     let pooled = pooled?;
-    {
-        // Protect the taken pool env from orphan GC while we asynchronously
-        // claim/vendor it. The final launch path is written again below after
-        // claim resolves, but the raw pool path needs protection immediately
-        // after pool.take().
-        let mut ep = room.runtime_agent_env_path.write().await;
-        *ep = Some(pooled.venv_path.clone());
-    }
+    let leased_path = pooled.venv_path.clone();
 
     let env_id = metadata_snapshot
         .and_then(|s| s.runt.env_id.clone())
@@ -1954,6 +1947,9 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed UV env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
+                    daemon
+                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                        .await;
                     Some(Some(crate::PooledEnv {
                         env_type: crate::EnvType::Uv,
                         venv_path: claimed_path,
@@ -1966,6 +1962,13 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Failed to claim UV pool env ({}), using raw pool env",
                         e
                     );
+                    {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(pooled.venv_path.clone());
+                    }
+                    daemon
+                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                        .await;
                     Some(Some(pooled))
                 }
             }
@@ -2000,6 +2003,9 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed conda env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
+                    daemon
+                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
+                        .await;
                     Some(Some(crate::PooledEnv {
                         env_type: crate::EnvType::Conda,
                         venv_path: claimed_path,
@@ -2012,6 +2018,13 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Failed to claim conda pool env ({}), using raw pool env",
                         e
                     );
+                    {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(pooled.venv_path.clone());
+                    }
+                    daemon
+                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
+                        .await;
                     Some(Some(pooled))
                 }
             }
@@ -2244,6 +2257,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             return Err(());
         }
     };
+    let leased_path = env.venv_path.clone();
 
     let actual_packages = env.prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(&effective_deps, &actual_packages);
@@ -2261,6 +2275,9 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                 bootstrap_dx,
             )
             .await;
+            daemon
+                .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                .await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2291,6 +2308,9 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                         bootstrap_dx,
                     )
                     .await;
+                    daemon
+                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                        .await;
                     progress_handler.on_progress(
                         "uv",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2307,6 +2327,9 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     );
                     // Clean up the taken pool env — it's out of the pool's
                     // tracking and would otherwise leak on disk.
+                    daemon
+                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                        .await;
                     let root = crate::paths::pool_env_root(&env.venv_path);
                     let cache_dir = crate::paths::default_cache_dir();
                     if crate::is_within_cache_dir(&root, &cache_dir) {
@@ -2324,6 +2347,9 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
+            daemon
+                .release_pool_lease(crate::EnvType::Uv, &leased_path)
+                .await;
             let root = crate::paths::pool_env_root(&env.venv_path);
             let cache_dir = crate::paths::default_cache_dir();
             if crate::is_within_cache_dir(&root, &cache_dir) {
@@ -2379,6 +2405,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             return Err(());
         }
     };
+    let leased_path = env.venv_path.clone();
 
     let actual_packages = env.prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
@@ -2389,6 +2416,9 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             // Promote the pool env into the inline-env cache so the next
             // restart cache-hits. See #2089 / #2083.
             crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
+                .await;
+            daemon
+                .release_pool_lease(crate::EnvType::Conda, &leased_path)
                 .await;
             Ok((env, actual_packages))
         }
@@ -2428,6 +2458,9 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         &mut env, deps, channels,
                     )
                     .await;
+                    daemon
+                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
+                        .await;
                     progress_handler.on_progress(
                         "conda",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2442,6 +2475,9 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
+                    daemon
+                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
+                        .await;
                     let root = crate::paths::pool_env_root(&env.venv_path);
                     let cache_dir = crate::paths::default_cache_dir();
                     if crate::is_within_cache_dir(&root, &cache_dir) {
@@ -2458,6 +2494,9 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
+            daemon
+                .release_pool_lease(crate::EnvType::Conda, &leased_path)
+                .await;
             let root = crate::paths::pool_env_root(&env.venv_path);
             let cache_dir = crate::paths::default_cache_dir();
             if crate::is_within_cache_dir(&root, &cache_dir) {
@@ -3383,8 +3422,13 @@ pub(crate) async fn auto_launch_kernel(
     // Without this, there's a race window where GC sees the taken env as an
     // orphan and deletes it while we're still setting up the kernel.
     if let Some(ref env) = pooled_env {
-        let mut ep = room.runtime_agent_env_path.write().await;
-        *ep = Some(env.venv_path.clone());
+        {
+            let mut ep = room.runtime_agent_env_path.write().await;
+            *ep = Some(env.venv_path.clone());
+        }
+        daemon
+            .release_pool_lease(env.env_type, &env.venv_path)
+            .await;
     }
 
     // Build LaunchedEnvConfig to track what config the kernel was launched with

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1182,8 +1182,13 @@ pub(crate) async fn handle(
     // Register the env path for GC protection immediately after pool.take(),
     // BEFORE any async work (agent spawn, connect timeout, delta install).
     if let Some(ref env) = pooled_env {
-        let mut ep = room.runtime_agent_env_path.write().await;
-        *ep = Some(env.venv_path.clone());
+        {
+            let mut ep = room.runtime_agent_env_path.write().await;
+            *ep = Some(env.venv_path.clone());
+        }
+        daemon
+            .release_pool_lease(env.env_type, &env.venv_path)
+            .await;
     }
 
     // Build LaunchedEnvConfig to track what config the kernel was launched with.


### PR DESCRIPTION
## Summary
- add explicit leased pool paths so orphan GC protects envs after `pool.take()` and before runtime/cache ownership transfer
- release leases when envs move to runtime state, inline/captured caches, return paths, or explicit cleanup
- keep available, warming, and leased paths in the orphan-GC tracked set

## Validation
- cargo xtask lint --fix
- cargo check -p runtimed
- cargo test -p runtimed test_pool_tracked_paths_include_leases
- cargo test -p runtimed warming_paths
- cargo test -p runtimed --test tokio_mutex_lint

## Notes
- Follow-up to #2398 after CI exposed a real pool ownership race where orphan GC deleted a just-taken prewarmed env during launch.