### PR TITLE
fix(linux): document user-local daemon security model

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -763,7 +763,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev \
-            libssl-dev libayatana-appindicator3-dev librsvg2-dev rpm
+            libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -843,7 +843,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: crates/notebook
-          args: --bundles appimage,deb,rpm --config '{"build":{"beforeBuildCommand":""}}'
+          args: --bundles appimage --config '{"build":{"beforeBuildCommand":""}}'
           includeUpdaterJson: false
 
       - name: Collect artifacts
@@ -855,10 +855,6 @@ jobs:
           for f in target/release/bundle/appimage/*.AppImage.sig; do
             [ -f "$f" ] && cp "$f" "artifacts/nteract-${CHANNEL}-linux-x64.AppImage.sig"
           done
-          DEB_PATH=$(find target/release/bundle/deb -name "*.deb" | head -1)
-          cp "$DEB_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.deb"
-          RPM_PATH=$(find target/release/bundle/rpm -name "*.rpm" | head -1)
-          cp "$RPM_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.rpm"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -900,68 +896,6 @@ jobs:
               dnf install -y coreutils findutils fuse-libs grep procps-ng systemd
               bash scripts/ci/fedora-appimage-smoke.sh "$1"
             ' bash "$APPIMAGE"
-
-  smoke-ubuntu-deb:
-    name: Smoke Ubuntu DEB
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: [compute-version, build-notebook-linux-x64]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download Linux DEB
-        uses: actions/download-artifact@v4
-        with:
-          name: nteract-linux-x64
-          path: artifacts
-
-      - name: Smoke DEB in Ubuntu
-        run: |
-          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
-          if [ "$CHANNEL" = "nightly" ]; then
-            echo "::notice::Skipping nightly DEB smoke until Linux package-manager installs use channel-specific commands."
-            exit 0
-          fi
-          DEB="artifacts/nteract-${CHANNEL}-linux-x64.deb"
-          docker run --rm \
-            -v "${PWD}:/workspace" \
-            -w /workspace \
-            ubuntu:24.04 \
-            bash -lc '
-              set -euo pipefail
-              bash scripts/ci/ubuntu-deb-smoke.sh local "$1" "$2" "$3"
-            ' bash "$DEB" "$CHANNEL" "${{ needs.compute-version.outputs.version }}"
-
-  smoke-fedora-rpm:
-    name: Smoke Fedora RPM
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: [compute-version, build-notebook-linux-x64]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download Linux RPM
-        uses: actions/download-artifact@v4
-        with:
-          name: nteract-linux-x64
-          path: artifacts
-
-      - name: Smoke RPM in Fedora
-        run: |
-          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
-          if [ "$CHANNEL" = "nightly" ]; then
-            echo "::notice::Skipping nightly RPM smoke until Linux package-manager installs use channel-specific commands."
-            exit 0
-          fi
-          RPM="artifacts/nteract-${CHANNEL}-linux-x64.rpm"
-          docker run --rm \
-            -v "${PWD}:/workspace" \
-            -w /workspace \
-            fedora:latest \
-            bash -lc '
-              set -euo pipefail
-              bash scripts/ci/fedora-rpm-smoke.sh "$1" "$2" "$3"
-            ' bash "$RPM" "$CHANNEL" "${{ needs.compute-version.outputs.version }}"
 
   build-nteract-package:
     name: Build nteract Package
@@ -1285,8 +1219,6 @@ jobs:
         build-notebook-windows-x64,
         build-notebook-linux-x64,
         smoke-fedora-appimage,
-        smoke-ubuntu-deb,
-        smoke-fedora-rpm,
         build-python-wheels,
         build-nteract-package,
         build-dx-package,
@@ -1403,8 +1335,6 @@ jobs:
           cp "notebook-macos-x64/nteract-${CHANNEL}-darwin-x64.dmg" release-assets/
           cp "notebook-windows-x64/nteract-${CHANNEL}-windows-x64.exe" release-assets/
           cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.AppImage" release-assets/
-          cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.deb" release-assets/
-          cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.rpm" release-assets/
           # Updater bundles + signatures
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz" release-assets/
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig" release-assets/
@@ -1542,14 +1472,10 @@ jobs:
           CLI_NAME="runt"
           DAEMON_NAME="runtimed"
           MCP_NAME="nteract-mcp"
-          APT_PACKAGE="nteract"
-          APT_LIST_NAME="nteract"
           if [ "$VERSION_SUFFIX" = "nightly" ]; then
             CLI_NAME="runt-nightly"
             DAEMON_NAME="runtimed-nightly"
             MCP_NAME="nteract-mcp-nightly"
-            APT_PACKAGE="nteract-nightly"
-            APT_LIST_NAME="nteract-nightly"
           fi
           {
             echo "$RELEASE_INTRO"
@@ -1570,26 +1496,10 @@ jobs:
             echo "| macOS | x64 (Intel) | \`nteract-${VERSION_SUFFIX}-darwin-x64.dmg\` |"
             echo "| Windows | x64 | \`nteract-${VERSION_SUFFIX}-windows-x64.exe\` |"
             echo "| Linux | x64 | \`nteract-${VERSION_SUFFIX}-linux-x64.AppImage\` |"
-            echo "| Linux | x64 (deb) | \`nteract-${VERSION_SUFFIX}-linux-x64.deb\` |"
-            echo "| Linux | x64 (rpm) | \`nteract-${VERSION_SUFFIX}-linux-x64.rpm\` |"
             echo ''
-            echo "macOS builds are signed and notarized. Windows is not code signed — expect a SmartScreen prompt. Linux AppImage: \`chmod +x\` and run. Linux DEB: \`sudo apt install ./nteract-${VERSION_SUFFIX}-linux-x64.deb\`. Linux RPM: \`sudo dnf install ./nteract-${VERSION_SUFFIX}-linux-x64.rpm\`."
+            echo "macOS builds are signed and notarized. Windows is not code signed — expect a SmartScreen prompt. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
             echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
-            echo ''
-            echo '### Linux (APT repository)'
-            echo ''
-            echo '```bash'
-            echo '# Add the nteract signing key'
-            echo "curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \\"
-            echo '  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg'
-            echo ''
-            echo '# Add the repository'
-            echo "echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com ${VERSION_SUFFIX} main\" \\"
-            echo "  | sudo tee /etc/apt/sources.list.d/${APT_LIST_NAME}.list"
-            echo ''
-            echo "sudo apt update && sudo apt install ${APT_PACKAGE}"
-            echo '```'
             echo ''
             echo "## ${CLI_NAME} (CLI)"
             echo ''
@@ -1633,8 +1543,6 @@ jobs:
             ./release-assets/runt*-darwin-x64
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage.sig
-            ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.deb
-            ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.rpm
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.dmg
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.app.tar.gz
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.app.tar.gz.sig
@@ -1688,75 +1596,3 @@ jobs:
               \"color\": 3066993
             }]
           }" "$DISCORD_WEBHOOK"
-
-  publish-apt:
-    name: Publish to APT Repository
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: [build-notebook-linux-x64, smoke-ubuntu-deb]
-    if: github.event_name != 'pull_request' && inputs.version_suffix == 'stable'
-    concurrency:
-      group: apt-publish-${{ inputs.version_suffix }}
-      cancel-in-progress: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download Linux x64 notebook artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: nteract-linux-x64
-          path: ./linux-artifacts
-
-      - name: Install APT publishing dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends dpkg-dev awscli
-
-      - name: Install publish scripts
-        run: |
-          sudo cp scripts/apt/publish-apt.sh /usr/local/bin/publish-apt.sh
-          sudo cp scripts/apt/prune-packages.py /usr/local/bin/prune-packages.py
-          sudo chmod +x /usr/local/bin/publish-apt.sh /usr/local/bin/prune-packages.py
-
-      - name: Publish .deb to APT repository
-        env:
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
-          R2_PUBLIC_URL: https://apt.runtimed.com
-          GPG_KEY_ID: ${{ secrets.APT_GPG_KEY_ID }}
-          GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
-        run: |
-          CHANNEL="${{ inputs.version_suffix }}"
-          DEB_FILE="./linux-artifacts/nteract-${CHANNEL}-linux-x64.deb"
-
-          if [ ! -f "$DEB_FILE" ]; then
-            echo "ERROR: .deb not found at $DEB_FILE"
-            ls -la ./linux-artifacts/
-            exit 1
-          fi
-
-          publish-apt.sh --channel "$CHANNEL" "$DEB_FILE"
-
-  smoke-apt-repository:
-    name: Smoke APT Repository
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: [compute-version, publish-apt]
-    if: github.event_name != 'pull_request' && inputs.version_suffix == 'stable'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Smoke live APT install in Ubuntu
-        run: |
-          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
-          docker run --rm \
-            -v "${PWD}:/workspace" \
-            -w /workspace \
-            ubuntu:24.04 \
-            bash -lc '
-              set -euo pipefail
-              bash scripts/ci/ubuntu-deb-smoke.sh apt "$1" "$2"
-            ' bash "$CHANNEL" "${{ needs.compute-version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Built on [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol
 
 Download the latest release from [GitHub Releases](https://github.com/nteract/desktop/releases).
 
-Linux users on Debian or Ubuntu should prefer the APT repository at
-`https://apt.runtimed.com`; see [Linux install options](docs/linux.md).
+Linux desktop users should use the AppImage from GitHub Releases; see
+[Linux install options](docs/linux.md). DEB/RPM/APT installs are not currently
+supported because `runtimed` is a per-user daemon managed by the app and CLI,
+not by system package-manager scripts.
 
 The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,11 +25,12 @@ Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-rel
 | macOS ARM64 (Apple Silicon) | `nteract-{channel}-darwin-arm64.dmg` |
 | Windows x64 | `nteract-{channel}-windows-x64.exe` |
 | Linux x64 | `nteract-{channel}-linux-x64.AppImage` |
-| Linux x64 | `nteract-{channel}-linux-x64.deb` |
 | CLI (macOS ARM64) | `runt-darwin-arm64` |
 | CLI (Linux x64) | `runt-linux-x64` |
 
-macOS builds are signed and notarized. Windows builds are not code signed.
+macOS builds are signed and notarized. Windows builds are not code signed. Linux
+desktop releases publish AppImage only; DEB/RPM/APT installs are not currently
+supported because `runtimed` is a per-user daemon.
 
 ### Crate publishing
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -102,7 +102,26 @@ The first frame is a JSON `Handshake` message:
 
 The `Handshake` enum uses `#[serde(tag = "channel", rename_all = "snake_case")]`, so the wire format is flat with a `"channel"` discriminator field — not nested. Optional fields like `working_dir` and `initial_metadata` are omitted when `None` (via `skip_serializing_if`).
 
-Other handshake variants include `Pool`, `SettingsSync`, `Blob`, `OpenNotebook { path }`, and `CreateNotebook { runtime, ... }`. The `OpenNotebook` and `CreateNotebook` variants are the primary paths for opening/creating notebooks from the desktop app, while `NotebookSync` is used by programmatic clients (e.g., Python bindings).
+Other handshake variants include `Pool`, `SettingsSync`, `Blob`, `OpenNotebook { path }`, `CreateNotebook { runtime, ... }`, and `RuntimeAgent { ... }`. The `OpenNotebook` and `CreateNotebook` variants are the primary paths for opening/creating notebooks from the desktop app, while `NotebookSync` is used by programmatic clients (e.g., Python bindings).
+
+The runtimed socket is not an app-only IPC surface. It is a same-UID trusted API:
+the Unix socket permissions prevent cross-user access, but any process running as
+the same OS user and holding the socket path can intentionally use the daemon.
+`RUNTIMED_SOCKET_PATH` is therefore a capability-bearing pointer.
+
+| Handshake | Authority exposed |
+|-----------|-------------------|
+| `Pool` | Pool status, environment claims/returns, daemon status/admin requests including shutdown |
+| `SettingsSync` | Read/write access to the user's synced settings document |
+| `NotebookSync` | Peer access to a notebook room and its runtime-state sync |
+| `OpenNotebook` | Load or create a file-backed notebook from a path |
+| `CreateNotebook` | Create an untitled or ephemeral notebook room |
+| `Blob` | Store blobs and query the localhost blob HTTP port |
+| `RuntimeAgent` | Attach a runtime-agent peer to a notebook room |
+
+Do not add a new handshake variant under the assumption that only the desktop app
+can reach it. If a channel needs tighter authority than same-UID access, design
+an explicit capability or guard for that channel.
 
 The daemon responds with a `NotebookConnectionInfo`:
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -144,6 +144,18 @@ Python wheels are always built (macOS arm64, Linux x64, Windows x64) and always 
 
 Desktop version is computed as `{runt version}-{suffix}.{timestamp}` where suffix is `nightly` or `stable`. This is stamped into `tauri.conf.json` and `Cargo.toml` at build time — not committed.
 
+### Linux desktop artifacts
+
+Linux desktop releases publish the AppImage only. DEB/RPM/APT publication is
+disabled until there is a first-class distro-native lifecycle for `runtimed`.
+
+The reason is architectural: `runtimed` is a per-user daemon. It manages
+per-user notebooks, kernels, settings sync, environment pools, MCP/CLI access,
+and the user-owned Unix socket. Package-manager scripts should install files;
+they should not start, repair, or upgrade each logged-in user's daemon
+instance. AppImage keeps the Linux desktop update model aligned with Tauri's
+updater artifact and leaves daemon bootstrap to the app/CLI user-local paths.
+
 ### Trusted Publishing
 
 PyPI publishing uses OIDC trusted publishing (no API tokens). The GitHub Actions workflow identity is registered as a trusted publisher on PyPI for the `runtimed` package. Both `release-common.yml` and `python-package.yml` use this.

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -84,6 +84,36 @@ Execution is CRDT-driven — the coordinator writes execution entries (with sour
 
 **Daemon discovery is socket-first.** Clients connect to the socket and send a `GetDaemonInfo` request; the daemon answers from live state. The on-disk `daemon.json` exists only as a fallback for older daemons that don't recognise the request — it will be removed once every daemon in the wild speaks `GetDaemonInfo`. New code should not depend on `daemon.json`. See `crates/runtimed-client/src/singleton.rs::query_daemon_info`.
 
+## Security Model
+
+`runtimed` is a per-user daemon. The operating system account is the security
+boundary: cross-user access must be denied, and same-UID access is trusted by
+design.
+
+On Unix, the daemon listens on a Unix socket inside the channel cache namespace
+and sets the socket mode to `0600`. The channel-owned socket directory is kept
+owner-private (`0700`) where the daemon owns that namespace; custom
+`RUNTIMED_SOCKET_PATH` parents inherit the caller's filesystem policy. Any
+same-UID process that can connect to the socket can intentionally use the
+daemon's trusted APIs, including pool/admin requests, settings sync, notebook
+sync, open/create notebook, blob storage, runtime-agent attachment, MCP, and CLI
+workflows. `RUNTIMED_SOCKET_PATH` is therefore a capability-bearing pointer:
+only set or pass it to processes that should be allowed to control that user's
+daemon. On Windows, runtimed uses named pipes and relies on the platform's
+default pipe ACLs; the `0600` socket and `0700` directory guarantees are
+Unix-only.
+
+The blob HTTP server is part of the same local trust model. It binds to
+`127.0.0.1`, is read-only, and serves content-addressed blobs by unguessable
+hash plus embedded renderer plugin assets. Treat blob URLs as local same-user
+data exposure, not as a cross-user or remote network interface.
+
+Linux package managers do not own the daemon lifecycle. DEB/RPM/APT packages are
+not currently supported because maintainer scripts should not manage per-user
+daemon instances, sockets, notebooks, or kernel processes. Linux desktop releases
+use AppImage as the supported install/update artifact until a distro-native
+daemon lifecycle is designed separately.
+
 ## Development Workflow
 
 ### Default: Let the notebook start it

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -448,6 +448,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_blob_server_binds_loopback_only() {
+        let listener = bind_preferred_or_random().await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        assert_eq!(
+            addr.ip(),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+        );
+    }
+
+    #[tokio::test]
     async fn test_bind_bumps_on_collision() {
         // Hold the preferred port so the first attempt hits AddrInUse.
         let preferred = runt_workspace::preferred_blob_port();
@@ -474,16 +485,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_embedded_plugin_served() {
+        let response = serve_embedded_plugin("plotly.js");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_header(&response, "content-type"),
+            Some("application/javascript; charset=utf-8".into())
+        );
+        assert_eq!(
+            response_header(&response, "cache-control"),
+            Some("public, max-age=86400".into())
+        );
+        assert_eq!(
+            response_header(&response, "access-control-allow-origin"),
+            Some("*".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plugin_http_route_serves_known_asset() {
         let (_dir, _store, port) = setup().await;
         let (status, headers, _body) = get(port, "/plugins/plotly.js").await;
+
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
             header_value(&headers, "content-type"),
             Some("application/javascript; charset=utf-8".into())
-        );
-        assert_eq!(
-            header_value(&headers, "cache-control"),
-            Some("public, max-age=86400".into())
         );
         assert_eq!(
             header_value(&headers, "access-control-allow-origin"),
@@ -539,6 +565,13 @@ mod tests {
     async fn test_plugin_path_traversal_rejected() {
         let (_dir, _store, port) = setup().await;
         let (status, _, _) = get(port, "/plugins/../secret").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_blob_path_traversal_rejected() {
+        let (_dir, _store, port) = setup().await;
+        let (status, _, _) = get(port, "/blob/../secret").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -136,6 +136,94 @@ impl DaemonConfig {
     }
 }
 
+#[cfg(unix)]
+fn channel_socket_parent() -> Option<PathBuf> {
+    runt_workspace::socket_path_for_channel(runt_workspace::build_channel())
+        .parent()
+        .map(Path::to_path_buf)
+}
+
+#[cfg(unix)]
+fn should_force_owner_private_socket_dir(socket_path: &Path) -> bool {
+    let Some(parent) = socket_path.parent() else {
+        return false;
+    };
+    channel_socket_parent().is_some_and(|channel_parent| parent == channel_parent)
+}
+
+#[cfg(unix)]
+fn set_owner_private_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(unix)]
+fn set_owner_private_socket(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(unix)]
+async fn remove_stale_socket(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::FileTypeExt;
+
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("inspect socket path {}", path.display())),
+    };
+
+    if metadata.file_type().is_socket() {
+        tokio::fs::remove_file(path)
+            .await
+            .with_context(|| format!("remove stale socket {}", path.display()))?;
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "refusing to remove non-socket path at daemon socket location: {}",
+        path.display()
+    );
+}
+
+#[cfg(unix)]
+async fn prepare_unix_socket_path(socket_path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = socket_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create daemon socket directory {}", parent.display()))?;
+        if should_force_owner_private_socket_dir(socket_path) {
+            set_owner_private_dir(parent).with_context(|| {
+                format!(
+                    "set owner-only permissions on daemon socket directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    remove_stale_socket(socket_path).await?;
+
+    let sync_sock = socket_path.with_file_name("runtimed-sync.sock");
+    if sync_sock.exists() {
+        info!("[runtimed] Removing obsolete sync socket: {:?}", sync_sock);
+        tokio::fs::remove_file(&sync_sock).await.ok();
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn bind_private_unix_listener(socket_path: &Path) -> anyhow::Result<UnixListener> {
+    let listener = UnixListener::bind(socket_path)?;
+    // Restrict socket permissions to owner-only (0600) so other users cannot
+    // connect to the per-user daemon. Same-UID clients remain trusted.
+    set_owner_private_socket(socket_path)?;
+    Ok(listener)
+}
+
 /// A prewarmed environment in the pool.
 struct PoolEntry {
     env: PooledEnv,
@@ -921,32 +1009,7 @@ impl Daemon {
     pub async fn run(self: Arc<Self>) -> anyhow::Result<()> {
         // Platform-specific setup
         #[cfg(unix)]
-        {
-            // Ensure socket directory exists
-            if let Some(parent) = self.config.socket_path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
-
-            // Remove stale socket file — singleton lock guarantees exclusivity,
-            // so NotFound is fine; log other errors for diagnostics.
-            if self.config.socket_path.exists() {
-                if let Err(e) = tokio::fs::remove_file(&self.config.socket_path).await {
-                    if e.kind() != std::io::ErrorKind::NotFound {
-                        warn!(
-                            "[runtimed] Failed to remove stale socket {:?}: {}",
-                            self.config.socket_path, e
-                        );
-                    }
-                }
-            }
-
-            // Clean up obsolete sync socket from pre-unification daemons
-            let sync_sock = self.config.socket_path.with_file_name("runtimed-sync.sock");
-            if sync_sock.exists() {
-                info!("[runtimed] Removing obsolete sync socket: {:?}", sync_sock);
-                tokio::fs::remove_file(&sync_sock).await.ok();
-            }
-        }
+        prepare_unix_socket_path(&self.config.socket_path).await?;
 
         // Start the blob HTTP server (also serves renderer plugin assets)
         let blob_port = match blob_server::start_blob_server(
@@ -971,16 +1034,7 @@ impl Daemon {
         // the rest of initialisation finishes.  The accept loop runs later.
         #[cfg(unix)]
         let unix_listener = {
-            let listener = UnixListener::bind(&self.config.socket_path)?;
-            // Restrict socket permissions to owner-only (0600) so other users
-            // cannot connect to the daemon.
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(
-                    &self.config.socket_path,
-                    std::fs::Permissions::from_mode(0o600),
-                )?;
-            }
+            let listener = bind_private_unix_listener(&self.config.socket_path)?;
             info!("[runtimed] Listening on {:?}", self.config.socket_path);
             listener
         };
@@ -4905,6 +4959,71 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bind_private_unix_listener_sets_socket_mode_0600() {
+        let tmp = TempDir::new().unwrap();
+        let socket = tmp.path().join("runtimed.sock");
+
+        prepare_unix_socket_path(&socket).await.unwrap();
+        let listener = bind_private_unix_listener(&socket).unwrap();
+
+        let mode = std::fs::symlink_metadata(&socket)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_private_socket_dir_sets_mode_0700() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("daemon");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        set_owner_private_dir(&dir).unwrap();
+
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remove_stale_socket_removes_socket_files() {
+        let tmp = TempDir::new().unwrap();
+        let socket = tmp.path().join("runtimed.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        drop(listener);
+
+        remove_stale_socket(&socket).await.unwrap();
+
+        assert!(!socket.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remove_stale_socket_refuses_regular_files() {
+        let tmp = TempDir::new().unwrap();
+        let socket = tmp.path().join("runtimed.sock");
+        std::fs::write(&socket, b"not a socket").unwrap();
+
+        let err = remove_stale_socket(&socket).await.unwrap_err();
+
+        assert!(
+            err.to_string().contains("refusing to remove non-socket"),
+            "unexpected error: {err:#}"
+        );
+        assert!(socket.exists());
+    }
 
     fn create_test_env(temp_dir: &TempDir, name: &str) -> PooledEnv {
         let venv_path = temp_dir.path().join(name);

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,78 +1,43 @@
 # Linux Install Options
 
-nteract publishes Linux desktop builds through GitHub Releases and the APT
-repository at `https://apt.runtimed.com`.
+nteract currently supports the AppImage from GitHub Releases as the Linux
+desktop install and update artifact.
 
-## Debian and Ubuntu
+## Desktop Install
 
-Use APT for Debian and Ubuntu systems. Native packages are the recommended
-Linux install path because they integrate with the desktop and the per-user
-`runtimed` systemd service.
-
-### Stable
-
-```bash
-curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
-  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
-
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com stable main" \
-  | sudo tee /etc/apt/sources.list.d/nteract.list
-
-sudo apt update
-sudo apt install nteract
-```
-
-### Nightly
-
-Nightly builds install side-by-side with stable builds and use the
-`nteract-nightly`, `runt-nightly`, and `runtimed-nightly` names.
-
-```bash
-curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \
-  | sudo gpg --dearmor --yes -o /usr/share/keyrings/nteract-keyring.gpg
-
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com nightly main" \
-  | sudo tee /etc/apt/sources.list.d/nteract-nightly.list
-
-sudo apt update
-sudo apt install nteract-nightly
-```
-
-You can enable both channels by keeping both source-list files.
-
-## Direct Downloads
-
-GitHub Releases include:
-
-- `.deb` packages for direct Debian/Ubuntu installs when you do not want to add
-  the APT repository.
-- `.rpm` packages for direct Fedora/RHEL/openSUSE-family installs while we
-  evaluate whether to add a signed RPM repository.
-- AppImage builds for desktop Linux systems outside the Debian/Ubuntu family.
-
-For direct `.deb` installs:
-
-```bash
-sudo apt install ./nteract-stable-linux-x64.deb
-```
-
-For direct `.rpm` installs:
-
-```bash
-sudo dnf install ./nteract-stable-linux-x64.rpm
-```
-
-For AppImage:
+Download the AppImage from
+[GitHub Releases](https://github.com/nteract/desktop/releases), make it
+executable, and run it:
 
 ```bash
 chmod +x nteract-stable-linux-x64.AppImage
 ./nteract-stable-linux-x64.AppImage
 ```
 
-The AppImage is a portable fallback. It can run the app and bootstrap the
-daemon, but persistent CLI installation from the temporary AppImage mount is
-intentionally skipped. Use the APT or `.deb` package when you want the `runt`
-CLI and system service to stay integrated across upgrades.
+Nightly builds use the same shape:
+
+```bash
+chmod +x nteract-nightly-linux-x64.AppImage
+./nteract-nightly-linux-x64.AppImage
+```
+
+The AppImage is the Linux artifact used by the desktop updater. It bundles the
+desktop app, `runt`, `runtimed`, and `nteract-mcp` sidecars for that app
+instance.
+
+## Unsupported Package Formats
+
+DEB, RPM, and APT repository installs are not currently supported.
+
+`runtimed` is a user-local daemon. It owns per-user notebooks, kernels,
+environment pools, settings sync, socket state, and MCP/CLI access. System
+package managers are good at installing files under system-owned prefixes, but
+they should not manage every user's daemon instance or run per-user daemon
+repair from package maintainer scripts.
+
+Until we design a first-class distro-native lifecycle, Linux releases do not
+publish supported `.deb` or `.rpm` desktop packages and the release pipeline
+does not publish new APT repository packages.
 
 ## Headless Runtime Installs
 
@@ -92,6 +57,7 @@ For source-built nightly installs on Linux development machines:
 
 Both scripts install channel-specific `runt`, `runtimed`, and `nteract-mcp`
 binaries under `~/.local/share/` and configure a user-level systemd service.
+This is a user-local runtime install, not a distro package-manager install.
 
 ## Troubleshooting
 

--- a/scripts/apt/README.md
+++ b/scripts/apt/README.md
@@ -1,5 +1,10 @@
 # APT Repository Publisher
 
+> **Status:** disabled. Linux desktop releases currently publish AppImage only.
+> DEB/RPM/APT publication is intentionally unsupported until there is a
+> first-class distro-native lifecycle for the user-local `runtimed` daemon. See
+> `contributing/releasing.md`.
+
 Publishes nteract `.deb` packages to the Cloudflare R2-backed APT repository at
 `https://apt.runtimed.com`. Supports `nightly` and `stable` channels in the
 same bucket using standard Debian repository layout.

--- a/scripts/ci/fedora-rpm-smoke.sh
+++ b/scripts/ci/fedora-rpm-smoke.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Disabled from release gates while Linux desktop releases are AppImage-only.
+# See docs/linux.md and contributing/releasing.md before re-enabling RPM
+# package-manager smokes.
+
 usage() {
   echo "usage: fedora-rpm-smoke.sh <path-to-rpm> <stable|nightly> [expected-version]" >&2
 }

--- a/scripts/ci/ubuntu-deb-smoke.sh
+++ b/scripts/ci/ubuntu-deb-smoke.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Disabled from release gates while Linux desktop releases are AppImage-only.
+# See docs/linux.md and contributing/releasing.md before re-enabling DEB/APT
+# package-manager smokes.
+
 usage() {
   echo "usage: ubuntu-deb-smoke.sh local <path-to-deb> <stable|nightly> [expected-version]" >&2
   echo "       ubuntu-deb-smoke.sh apt <stable|nightly> [expected-version]" >&2


### PR DESCRIPTION
## Summary
- make Linux desktop releases AppImage-only for now and remove DEB/RPM/APT release gates
- document the same-UID runtimed socket trust boundary and unsupported package-manager installs
- harden/test Unix socket setup and blob-server local exposure assumptions

## Verification
- cargo xtask wasm
- cargo test -p runtimed socket
- cargo test -p runtimed blob_server
- actionlint .github/workflows/release-common.yml
- git diff --check