### PR TITLE
refactor(runtimed): share frame orchestration planning

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -355,9 +355,7 @@ export function useAutomergeNotebook() {
                 if (pointerRefresh.kind === "touched") {
                   updateCellExecutionPointersFromHandle(handle, pointerRefresh.cell_ids);
                 } else if (pointerRefresh.kind === "all") {
-                  updateCellExecutionPointersFromHandle(handle, [
-                    ...handle.get_cell_ids(),
-                  ]);
+                  updateCellExecutionPointersFromHandle(handle, [...handle.get_cell_ids()]);
                 }
               })
               .catch((err: unknown) =>

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -7,6 +7,7 @@ import {
   isDisplayCapableJupyterOutput,
   isInitialLoadFailed,
   isInitialLoadStreaming,
+  planCellPointerRefresh,
 } from "runtimed";
 import { concatMap, from, Observable, switchMap } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
@@ -350,14 +351,13 @@ export function useAutomergeNotebook() {
                 // RuntimeStateDoc entry happened to land last.
                 const handle = handleRef.current;
                 if (!handle) return;
-                if (changeset && changeset.added.length === 0) {
-                  const touched = new Set<string>(changeset.changed.map((c) => c.cell_id));
-                  if (touched.size > 0) {
-                    updateCellExecutionPointersFromHandle(handle, [...touched]);
-                  }
-                } else {
-                  // Full materialization or added cells — refresh all.
-                  updateCellExecutionPointersFromHandle(handle, [...handle.get_cell_ids()]);
+                const pointerRefresh = planCellPointerRefresh(changeset);
+                if (pointerRefresh.kind === "touched") {
+                  updateCellExecutionPointersFromHandle(handle, pointerRefresh.cell_ids);
+                } else if (pointerRefresh.kind === "all") {
+                  updateCellExecutionPointersFromHandle(handle, [
+                    ...handle.get_cell_ids(),
+                  ]);
                 }
               })
               .catch((err: unknown) =>

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -124,7 +124,7 @@ export async function materializeChangeset(
   let outputOnlySkipped = 0;
 
   for (const projection of projectionPlan.cells) {
-    const { cell_id: cellId, fields } = projection;
+    const cellId = projection.cell_id;
     // Phase C-lite: outputs live in the per-output / per-execution stores
     // (see notebook-outputs.ts, notebook-executions.ts). The cell store
     // still carries an `outputs: JupyterOutput[]` field for legacy readers

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -10,10 +10,7 @@ import {
   needsPlugin,
   preWarmForMimes,
 } from "@/components/isolated/iframe-libraries";
-import {
-  classifyCellChangesetMaterialization,
-  isDisplayCapableJupyterOutputType,
-} from "runtimed";
+import { isDisplayCapableJupyterOutputType, planCellChangesetProjection } from "runtimed";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort } from "./blob-port";
@@ -99,15 +96,15 @@ export async function materializeChangeset(
 
   // ── Full materialization fallback ──────────────────────────────────
 
-  const materialization = classifyCellChangesetMaterialization(changeset);
-  if (materialization.kind === "full") {
-    if (materialization.reason === "missing_changeset") {
+  const projectionPlan = planCellChangesetProjection(changeset);
+  if (projectionPlan.kind === "full") {
+    if (projectionPlan.reason === "missing_changeset") {
       logger.debug(
         "[frame-pipeline] full materialization: no changeset from WASM",
       );
     } else {
       logger.debug(
-        `[frame-pipeline] full materialization: +${changeset?.added.length ?? 0} -${changeset?.removed.length ?? 0} reorder=${changeset?.order_changed ?? false} reason=${materialization.reason}`,
+        `[frame-pipeline] full materialization: +${changeset?.added.length ?? 0} -${changeset?.removed.length ?? 0} reorder=${changeset?.order_changed ?? false} reason=${projectionPlan.reason}`,
       );
     }
     await deps.materializeCells(handle);
@@ -126,26 +123,20 @@ export async function materializeChangeset(
   let cellStoreTouched = 0;
   let outputOnlySkipped = 0;
 
-  for (const { cell_id: cellId, fields } of changeset.changed) {
+  for (const projection of projectionPlan.cells) {
+    const { cell_id: cellId, fields } = projection;
     // Phase C-lite: outputs live in the per-output / per-execution stores
     // (see notebook-outputs.ts, notebook-executions.ts). The cell store
     // still carries an `outputs: JupyterOutput[]` field for legacy readers
     // on full materialization, but the frame pipeline no longer touches
     // that field on incremental updates — the outputs store is the source
     // of truth for <OutputArea>.
-    const chromeChanged =
-      fields.source ||
-      fields.execution_count ||
-      fields.cell_type ||
-      fields.metadata ||
-      fields.position;
-
-    if (!chromeChanged) {
+    if (!projection.touches_chrome) {
       // Output-only change — the outputs store already has the new data
       // from `applyOutputChangeset`. Still warm the plugin cache for any
       // rich MIME types so <OutputArea> renders without waiting for async
       // loads, but don't touch the cell store.
-      if (fields.outputs) {
+      if (projection.touches_outputs) {
         outputOnlySkipped++;
         const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
         preWarmPluginsForRawOutputs(rawOutputs);
@@ -168,12 +159,12 @@ export async function materializeChangeset(
     );
     if (!cell) continue;
 
-    if (!fields.source) {
+    if (projection.preserve_source) {
       const existing = getCellById(cellId);
       if (existing) cell.source = existing.source;
     }
 
-    if (fields.outputs) {
+    if (projection.touches_outputs) {
       // Warm plugin cache so the <OutputArea> iframe has renderers ready.
       const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
       preWarmPluginsForRawOutputs(rawOutputs);
@@ -182,17 +173,8 @@ export async function materializeChangeset(
   }
 
   if (changeset.changed.length > 0) {
-    const fieldSummary = changeset.changed
-      .map((c) => {
-        const f = c.fields;
-        const flags = [
-          f.source && "src",
-          f.outputs && "out",
-          f.execution_count && "ec",
-          f.metadata && "meta",
-        ].filter(Boolean);
-        return `${c.cell_id.slice(0, 8)}(${flags.join(",")})`;
-      })
+    const fieldSummary = projectionPlan.cells
+      .map((c) => `${c.cell_id.slice(0, 8)}(${c.field_summary.join(",")})`)
       .join(" ");
     logger.debug(
       `[frame-pipeline] incremental: ${changeset.changed.length} cells [${fieldSummary}] cell-store=${cellStoreTouched} outputs-only-skipped=${outputOnlySkipped}`,

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -51,6 +51,11 @@ export type CellChangesetProjectionPlan =
   | { kind: "full"; reason: "missing_changeset" | "structural" | "resolved_assets" }
   | { kind: "incremental"; cells: IncrementalCellProjection[] };
 
+export type CellPointerRefreshPlan =
+  | { kind: "all" }
+  | { kind: "touched"; cell_ids: string[] }
+  | { kind: "none" };
+
 const CHROME_FIELD_KEYS = [
   "source",
   "execution_count",
@@ -141,6 +146,9 @@ export function planCellChangesetProjection(
   if (materialization.kind === "full") {
     return materialization;
   }
+  if (!changeset) {
+    return { kind: "full", reason: "missing_changeset" };
+  }
   return {
     kind: "incremental",
     cells: changeset.changed.map(({ cell_id, fields }) => ({
@@ -152,4 +160,29 @@ export function planCellChangesetProjection(
       field_summary: summarizeChangedFields(fields),
     })),
   };
+}
+
+/**
+ * Plan which notebook-doc cell execution_id pointers need refreshing after a
+ * materialization pass. Incremental non-structural changes only need touched
+ * cells; full/structural materialization refreshes the whole document.
+ */
+export function planCellPointerRefresh(
+  changeset: CellChangeset | null,
+): CellPointerRefreshPlan {
+  if (!changeset || changeset.added.length > 0) {
+    return { kind: "all" };
+  }
+  if (
+    changeset.removed.length > 0 ||
+    changeset.order_changed ||
+    changeset.changed.some((c) => c.fields.resolved_assets)
+  ) {
+    return { kind: "all" };
+  }
+  const cellIds = [...new Set(changeset.changed.map((c) => c.cell_id))];
+  if (cellIds.length === 0) {
+    return { kind: "none" };
+  }
+  return { kind: "touched", cell_ids: cellIds };
 }

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -64,6 +64,7 @@ const CHROME_FIELD_KEYS = [
   "position",
 ] as const satisfies readonly (keyof ChangedFields)[];
 
+// Debug summaries intentionally mirror the historic frame-pipeline log subset.
 const FIELD_SUMMARY_LABELS: ReadonlyArray<[keyof ChangedFields, string]> = [
   ["source", "src"],
   ["outputs", "out"],
@@ -167,13 +168,6 @@ export function planCellChangesetProjection(
  */
 export function planCellPointerRefresh(changeset: CellChangeset | null): CellPointerRefreshPlan {
   if (!changeset || changeset.added.length > 0) {
-    return { kind: "all" };
-  }
-  if (
-    changeset.removed.length > 0 ||
-    changeset.order_changed ||
-    changeset.changed.some((c) => c.fields.resolved_assets)
-  ) {
     return { kind: "all" };
   }
   const cellIds = [...new Set(changeset.changed.map((c) => c.cell_id))];

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -128,9 +128,7 @@ export function cellChangesetTouchesChrome(fields: ChangedFields): boolean {
 }
 
 export function summarizeChangedFields(fields: ChangedFields): string[] {
-  return FIELD_SUMMARY_LABELS.flatMap(([key, label]) =>
-    fields[key] === true ? [label] : [],
-  );
+  return FIELD_SUMMARY_LABELS.flatMap(([key, label]) => (fields[key] === true ? [label] : []));
 }
 
 /**
@@ -167,9 +165,7 @@ export function planCellChangesetProjection(
  * materialization pass. Incremental non-structural changes only need touched
  * cells; full/structural materialization refreshes the whole document.
  */
-export function planCellPointerRefresh(
-  changeset: CellChangeset | null,
-): CellPointerRefreshPlan {
+export function planCellPointerRefresh(changeset: CellChangeset | null): CellPointerRefreshPlan {
   if (!changeset || changeset.added.length > 0) {
     return { kind: "all" };
   }

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -38,6 +38,34 @@ export type CellChangesetMaterialization =
   | { kind: "full"; reason: "missing_changeset" | "structural" | "resolved_assets" }
   | { kind: "incremental" };
 
+export interface IncrementalCellProjection {
+  cell_id: string;
+  fields: ChangedFields;
+  touches_chrome: boolean;
+  touches_outputs: boolean;
+  preserve_source: boolean;
+  field_summary: string[];
+}
+
+export type CellChangesetProjectionPlan =
+  | { kind: "full"; reason: "missing_changeset" | "structural" | "resolved_assets" }
+  | { kind: "incremental"; cells: IncrementalCellProjection[] };
+
+const CHROME_FIELD_KEYS = [
+  "source",
+  "execution_count",
+  "cell_type",
+  "metadata",
+  "position",
+] as const satisfies readonly (keyof ChangedFields)[];
+
+const FIELD_SUMMARY_LABELS: ReadonlyArray<[keyof ChangedFields, string]> = [
+  ["source", "src"],
+  ["outputs", "out"],
+  ["execution_count", "ec"],
+  ["metadata", "meta"],
+];
+
 // ── Utilities ────────────────────────────────────────────────────────
 
 /**
@@ -88,4 +116,40 @@ export function classifyCellChangesetMaterialization(
     return { kind: "full", reason: "resolved_assets" };
   }
   return { kind: "incremental" };
+}
+
+export function cellChangesetTouchesChrome(fields: ChangedFields): boolean {
+  return CHROME_FIELD_KEYS.some((key) => fields[key] === true);
+}
+
+export function summarizeChangedFields(fields: ChangedFields): string[] {
+  return FIELD_SUMMARY_LABELS.flatMap(([key, label]) =>
+    fields[key] === true ? [label] : [],
+  );
+}
+
+/**
+ * Plan frontend projection work for a coalesced changeset.
+ *
+ * This keeps protocol-field interpretation in the runtimed package while
+ * allowing apps to supply their own store writes and renderer pre-warming.
+ */
+export function planCellChangesetProjection(
+  changeset: CellChangeset | null,
+): CellChangesetProjectionPlan {
+  const materialization = classifyCellChangesetMaterialization(changeset);
+  if (materialization.kind === "full") {
+    return materialization;
+  }
+  return {
+    kind: "incremental",
+    cells: changeset.changed.map(({ cell_id, fields }) => ({
+      cell_id,
+      fields,
+      touches_chrome: cellChangesetTouchesChrome(fields),
+      touches_outputs: fields.outputs === true,
+      preserve_source: fields.source !== true,
+      field_summary: summarizeChangedFields(fields),
+    })),
+  };
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -59,6 +59,7 @@ export {
 export {
   classifyCellChangesetMaterialization,
   cellChangesetTouchesChrome,
+  type CellPointerRefreshPlan,
   type CellChangeset,
   type CellChangesetMaterialization,
   type CellChangesetProjectionPlan,
@@ -66,6 +67,7 @@ export {
   type ChangedFields,
   type IncrementalCellProjection,
   mergeChangesets,
+  planCellPointerRefresh,
   planCellChangesetProjection,
   summarizeChangedFields,
 } from "./cell-changeset";

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -58,11 +58,16 @@ export {
 // Cell changeset
 export {
   classifyCellChangesetMaterialization,
+  cellChangesetTouchesChrome,
   type CellChangeset,
   type CellChangesetMaterialization,
+  type CellChangesetProjectionPlan,
   type ChangedCell,
   type ChangedFields,
+  type IncrementalCellProjection,
   mergeChangesets,
+  planCellChangesetProjection,
+  summarizeChangedFields,
 } from "./cell-changeset";
 
 // Execution projection

--- a/packages/runtimed/tests/cell-changeset.test.ts
+++ b/packages/runtimed/tests/cell-changeset.test.ts
@@ -86,6 +86,23 @@ describe("CellChangeset helpers", () => {
     });
   });
 
+  it("plans full projection for missing and structural changesets", () => {
+    expect(planCellChangesetProjection(null)).toEqual({
+      kind: "full",
+      reason: "missing_changeset",
+    });
+    expect(planCellChangesetProjection({ ...empty, added: ["cell-new"] })).toEqual({
+      kind: "full",
+      reason: "structural",
+    });
+    expect(
+      planCellChangesetProjection({
+        ...empty,
+        changed: [{ cell_id: "cell-1", fields: { resolved_assets: true } }],
+      }),
+    ).toEqual({ kind: "full", reason: "resolved_assets" });
+  });
+
   it("plans chrome updates and source preservation for app projections", () => {
     expect(
       planCellChangesetProjection({
@@ -151,23 +168,29 @@ describe("CellChangeset helpers", () => {
     ).toEqual({ kind: "touched", cell_ids: ["cell-1", "cell-2"] });
   });
 
-  it("plans full pointer refreshes for full materialization paths", () => {
+  it("preserves the historic full pointer refresh cases", () => {
     expect(planCellPointerRefresh(null)).toEqual({ kind: "all" });
     expect(planCellPointerRefresh({ ...empty, added: ["cell-new"] })).toEqual({
       kind: "all",
     });
+  });
+
+  it("preserves historic no-op pointer refreshes for structural changes without touched cells", () => {
     expect(planCellPointerRefresh({ ...empty, removed: ["cell-old"] })).toEqual({
-      kind: "all",
+      kind: "none",
     });
     expect(planCellPointerRefresh({ ...empty, order_changed: true })).toEqual({
-      kind: "all",
+      kind: "none",
     });
+  });
+
+  it("preserves historic touched pointer refreshes for resolved-assets changes", () => {
     expect(
       planCellPointerRefresh({
         ...empty,
         changed: [{ cell_id: "cell-1", fields: { resolved_assets: true } }],
       }),
-    ).toEqual({ kind: "all" });
+    ).toEqual({ kind: "touched", cell_ids: ["cell-1"] });
   });
 
   it("skips pointer refreshes when an incremental changeset touches no cells", () => {

--- a/packages/runtimed/tests/cell-changeset.test.ts
+++ b/packages/runtimed/tests/cell-changeset.test.ts
@@ -1,7 +1,10 @@
 import {
   classifyCellChangesetMaterialization,
+  cellChangesetTouchesChrome,
   type CellChangeset,
   mergeChangesets,
+  planCellChangesetProjection,
+  summarizeChangedFields,
 } from "runtimed";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -64,5 +67,73 @@ describe("CellChangeset helpers", () => {
     expect(classifyCellChangesetMaterialization(outputsOnly("cell-1"))).toEqual({
       kind: "incremental",
     });
+  });
+
+  it("plans output-only updates without cell chrome writes", () => {
+    expect(planCellChangesetProjection(outputsOnly("cell-1"))).toEqual({
+      kind: "incremental",
+      cells: [
+        {
+          cell_id: "cell-1",
+          fields: { outputs: true },
+          touches_chrome: false,
+          touches_outputs: true,
+          preserve_source: true,
+          field_summary: ["out"],
+        },
+      ],
+    });
+  });
+
+  it("plans chrome updates and source preservation for app projections", () => {
+    expect(
+      planCellChangesetProjection({
+        ...empty,
+        changed: [
+          {
+            cell_id: "cell-1",
+            fields: { outputs: true, execution_count: true },
+          },
+          {
+            cell_id: "cell-2",
+            fields: { source: true, metadata: true },
+          },
+        ],
+      }),
+    ).toEqual({
+      kind: "incremental",
+      cells: [
+        {
+          cell_id: "cell-1",
+          fields: { outputs: true, execution_count: true },
+          touches_chrome: true,
+          touches_outputs: true,
+          preserve_source: true,
+          field_summary: ["out", "ec"],
+        },
+        {
+          cell_id: "cell-2",
+          fields: { source: true, metadata: true },
+          touches_chrome: true,
+          touches_outputs: false,
+          preserve_source: false,
+          field_summary: ["src", "meta"],
+        },
+      ],
+    });
+  });
+
+  it("exposes field-level projection helpers", () => {
+    expect(cellChangesetTouchesChrome({ outputs: true })).toBe(false);
+    expect(cellChangesetTouchesChrome({ position: true })).toBe(true);
+    expect(
+      summarizeChangedFields({
+        source: true,
+        outputs: true,
+        execution_count: true,
+        metadata: true,
+        position: true,
+      }),
+    ).toEqual(["src", "out", "ec", "meta"]);
   });
 });

--- a/packages/runtimed/tests/cell-changeset.test.ts
+++ b/packages/runtimed/tests/cell-changeset.test.ts
@@ -3,6 +3,7 @@ import {
   cellChangesetTouchesChrome,
   type CellChangeset,
   mergeChangesets,
+  planCellPointerRefresh,
   planCellChangesetProjection,
   summarizeChangedFields,
 } from "runtimed";
@@ -135,5 +136,41 @@ describe("CellChangeset helpers", () => {
         position: true,
       }),
     ).toEqual(["src", "out", "ec", "meta"]);
+  });
+
+  it("plans pointer refreshes for touched cells only on incremental changes", () => {
+    expect(
+      planCellPointerRefresh({
+        ...empty,
+        changed: [
+          { cell_id: "cell-1", fields: { outputs: true } },
+          { cell_id: "cell-1", fields: { execution_count: true } },
+          { cell_id: "cell-2", fields: { source: true } },
+        ],
+      }),
+    ).toEqual({ kind: "touched", cell_ids: ["cell-1", "cell-2"] });
+  });
+
+  it("plans full pointer refreshes for full materialization paths", () => {
+    expect(planCellPointerRefresh(null)).toEqual({ kind: "all" });
+    expect(planCellPointerRefresh({ ...empty, added: ["cell-new"] })).toEqual({
+      kind: "all",
+    });
+    expect(planCellPointerRefresh({ ...empty, removed: ["cell-old"] })).toEqual({
+      kind: "all",
+    });
+    expect(planCellPointerRefresh({ ...empty, order_changed: true })).toEqual({
+      kind: "all",
+    });
+    expect(
+      planCellPointerRefresh({
+        ...empty,
+        changed: [{ cell_id: "cell-1", fields: { resolved_assets: true } }],
+      }),
+    ).toEqual({ kind: "all" });
+  });
+
+  it("skips pointer refreshes when an incremental changeset touches no cells", () => {
+    expect(planCellPointerRefresh(empty)).toEqual({ kind: "none" });
   });
 });


### PR DESCRIPTION
## Summary

- move cell changeset projection planning into `packages/runtimed`
- move execution pointer refresh planning out of `useAutomergeNotebook`
- keep browser-specific materialization, plugin prewarm, and React store writes in the app

## Verification

- `pnpm exec vp test run packages/runtimed/tests/cell-changeset.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts`
- `pnpm exec tsc -p packages/runtimed/tsconfig.json --noEmit`
- `pnpm --filter notebook-ui exec tsc --noEmit`
- `cargo xtask lint --fix`

## Notes

Part of #2340 Phase 3. This is intended as the final low-risk frontend boundary extraction before moving to Phase 4 legacy/schema cleanup.
