### PR TITLE
docs(notebook-doc): clarify legacy execution count boundary

### DIFF
--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -6,8 +6,10 @@ export interface CodeCell {
   id: string;
   source: string;
   /**
-   * Display count projected from RuntimeStateDoc when available, with the
-   * notebook-doc nbformat fallback used only when runtime state is absent.
+   * Display count for the code cell. Full materialization resolves this from
+   * RuntimeStateDoc first, then falls back to the notebook-doc nbformat value
+   * for runtime-free reload/export paths. Local in-flight updates may hold
+   * `null` until the daemon publishes runtime state.
    */
   execution_count: number | null;
   /**

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -5,6 +5,10 @@ export interface CodeCell {
   cell_type: "code";
   id: string;
   source: string;
+  /**
+   * Display count projected from RuntimeStateDoc when available, with the
+   * notebook-doc nbformat fallback used only when runtime state is absent.
+   */
   execution_count: number | null;
   /**
    * Legacy: after Phase C-lite, the frame pipeline no longer populates

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -25,7 +25,8 @@
 //!       cell_type: Str            ← "code" | "markdown" | "raw"
 //!       position: Str             ← Fractional index hex string for ordering
 //!       source: Text              ← Automerge Text CRDT (character-level merging)
-//!       execution_count: Str      ← JSON-encoded i32 or "null"
+//!       execution_count: Str      ← Legacy nbformat/import-export fallback;
+//!                                   live counts are in RuntimeStateDoc
 //!       metadata/                 ← Map (native Automerge types, legacy: JSON string fallback)
 //!       resolved_assets/          ← Map of markdown asset ref -> blob hash
 //!   metadata/                     ← Map
@@ -100,7 +101,11 @@ pub struct CellSnapshot {
     /// Cells are sorted lexicographically by this field.
     pub position: String,
     pub source: String,
-    /// JSON-encoded execution count: a number string like "5" or "null"
+    /// Legacy JSON-encoded execution count: a number string like "5" or "null".
+    ///
+    /// Live execution counts are daemon-authored in `RuntimeStateDoc`. This
+    /// field preserves nbformat/import-export history when runtime state is
+    /// unavailable.
     pub execution_count: String,
     /// Cell metadata (arbitrary JSON object, preserves unknown keys)
     #[serde(default = "default_empty_object")]
@@ -1112,7 +1117,12 @@ impl NotebookDoc {
         read_str(&self.doc, &cell_obj, "cell_type")
     }
 
-    /// Get a cell's execution count (O(1) lookup).
+    /// Get the persisted legacy execution count for a cell (O(1) lookup).
+    ///
+    /// This reads only the notebook document fallback used for nbformat
+    /// import/export and reloads without runtime state. Live execution counts
+    /// are RuntimeStateDoc-owned and should be read through higher-level
+    /// handles that can consult both documents.
     pub fn get_cell_execution_count(&self, cell_id: &str) -> Option<String> {
         let cell_obj = self.cell_obj_for(cell_id)?;
         read_str(&self.doc, &cell_obj, "execution_count")
@@ -1182,6 +1192,9 @@ impl NotebookDoc {
     }
 
     /// Insert a fully-populated cell with an explicit position string.
+    ///
+    /// `execution_count` is the persisted nbformat/import-export fallback. Live
+    /// execution counts are stored in RuntimeStateDoc.
     ///
     /// This is the preferred method for bulk loads (e.g., loading from .ipynb).
     /// The caller provides the position string directly, avoiding O(n²) overhead
@@ -2923,11 +2936,20 @@ mod tests {
         }
     }
 
-    /// Tests execution count sync propagates correctly.
+    /// Tests legacy execution count fallback sync propagates correctly.
     #[test]
-    fn test_execution_count_sync() {
+    fn test_legacy_execution_count_sync() {
         let mut daemon = NotebookDoc::new("exec-count-test");
-        daemon.add_cell(0, "cell-1", "code").unwrap();
+        daemon
+            .add_cell_full(
+                "cell-1",
+                "code",
+                "80",
+                "print('from file')",
+                "7",
+                &serde_json::json!({}),
+            )
+            .unwrap();
 
         let mut client = NotebookDoc {
             doc: AutoCommit::new(),
@@ -2943,8 +2965,23 @@ mod tests {
             10,
         );
 
-        // Live execution_count is covered by RuntimeStateDoc tests. NotebookDoc
-        // keeps only the persisted nbformat-history fallback.
+        // Live execution_count is covered by RuntimeStateDoc tests.
+        // NotebookDoc syncs only the persisted nbformat-history fallback.
+        assert_eq!(
+            client.get_cell_execution_count("cell-1").as_deref(),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn test_new_cells_default_to_null_legacy_execution_count() {
+        let mut doc = NotebookDoc::new("exec-count-default-test");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        assert_eq!(
+            doc.get_cell_execution_count("cell-1").as_deref(),
+            Some("null")
+        );
     }
 
     /// Tests three-peer sync: daemon + two clients.

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -25,8 +25,9 @@
 //!       cell_type: Str            ← "code" | "markdown" | "raw"
 //!       position: Str             ← Fractional index hex string for ordering
 //!       source: Text              ← Automerge Text CRDT (character-level merging)
-//!       execution_count: Str      ← Legacy nbformat/import-export fallback;
-//!                                   live counts are in RuntimeStateDoc
+//!       execution_count: Str      ← JSON-encoded i32 or "null"; legacy
+//!                                   nbformat/import-export fallback; live
+//!                                   counts are in RuntimeStateDoc
 //!       metadata/                 ← Map (native Automerge types, legacy: JSON string fallback)
 //!       resolved_assets/          ← Map of markdown asset ref -> blob hash
 //!   metadata/                     ← Map

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -292,6 +292,8 @@ pub struct JsCell {
     cell_type: String,
     position: String,
     source: String,
+    /// Legacy notebook-doc execution count fallback. RuntimeStateDoc is
+    /// authoritative when an execution exists for this cell.
     execution_count: String,
     outputs: Vec<serde_json::Value>,
     metadata: serde_json::Value,

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -16,7 +16,7 @@
 //!    (any pending doc bytes are flushed to disk via debounced persistence)
 //! 6. Documents persist to `~/.cache/runt/notebook-docs/{hash}.automerge`
 //!
-//! ## Phase 8: Daemon-owned kernel execution
+//! ## Daemon-owned kernel execution
 //!
 //! Each room can have an optional kernel. When a kernel is launched:
 //! - Execute requests flow through the daemon

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -122,9 +122,9 @@ where
 
     send_initial_pool_sync(&mut writer, &daemon, &mut pool_peer_state).await?;
 
-    // Phase 1.5 (removed): CommSync broadcast is no longer needed.
-    // Late joiners receive widget state via RuntimeStateDoc CRDT sync,
-    // and the frontend CRDT watcher synthesizes comm_open messages.
+    // CommSync broadcast is no longer needed. Late joiners receive widget
+    // state via RuntimeStateDoc CRDT sync, and the frontend CRDT watcher
+    // synthesizes comm_open messages.
 
     send_initial_presence_snapshot(&mut writer, room, peer_id).await?;
 
@@ -154,7 +154,7 @@ where
     // arm wins mid-payload (see issue + production diagnostics).
     let mut framed_reader = connection::FramedReader::spawn(reader, 16);
 
-    // Phase 2: Exchange messages until sync is complete, then watch for changes
+    // Steady state: exchange client frames and broadcast room changes.
     loop {
         tokio::select! {
             biased;

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -22,7 +22,7 @@ use super::*;
 /// Typed frames sync loop with first-byte type indicator.
 ///
 /// Handles both Automerge sync messages and NotebookRequest messages.
-/// This protocol supports daemon-owned kernel execution (Phase 8).
+/// This protocol supports daemon-owned kernel execution.
 ///
 /// Takes `reader` by value because the post-streaming-load main loop
 /// hands it to a `FramedReader` actor; from that point the read half

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -225,7 +225,9 @@ impl Default for RoomConnections {
 
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room, independent of the display
-    /// path or string lookup keys used by callers.
+    /// path or string lookup keys used by callers. Rooms are still looked up
+    /// by string key today; this identity is carried alongside that map for
+    /// stable cross-process references.
     pub id: uuid::Uuid,
     /// The canonical Automerge notebook document.
     pub doc: Arc<RwLock<NotebookDoc>>,

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -224,8 +224,8 @@ impl Default for RoomConnections {
 }
 
 pub struct NotebookRoom {
-    /// Permanent, immutable UUID for this room. Used as the map key once
-    /// Phase 5 lands; for now coexists with the string-keyed map.
+    /// Permanent, immutable UUID for this room, independent of the display
+    /// path or string lookup keys used by callers.
     pub id: uuid::Uuid,
     /// The canonical Automerge notebook document.
     pub doc: Arc<RwLock<NotebookDoc>>,

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -49,7 +49,7 @@ pub(crate) async fn send_runtime_agent_query(
     }
 }
 
-/// Send an RPC request to the runtime agent (legacy wrapper).
+/// Send an RPC request to the runtime agent.
 ///
 /// Routes commands as fire-and-forget, queries as sync RPCs.
 /// Callers that don't need a response should use `send_runtime_agent_command` directly.

--- a/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/runtime_bridge.rs
@@ -51,8 +51,9 @@ pub(crate) async fn send_runtime_agent_query(
 
 /// Send an RPC request to the runtime agent.
 ///
-/// Routes commands as fire-and-forget, queries as sync RPCs.
-/// Callers that don't need a response should use `send_runtime_agent_command` directly.
+/// Routes commands as fire-and-forget and queries as sync RPCs. Callers that
+/// already know they do not need a response should use
+/// `send_runtime_agent_command` directly.
 pub(crate) async fn send_runtime_agent_request(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2540,10 +2540,10 @@ fn test_create_empty_notebook_with_provided_env_id() {
 /// - add_cell_full per batch
 /// - generate_sync_message per batch
 ///
-/// Run with: cargo test -p runtimed -- bench_streaming_load_phases --nocapture --ignored
+/// Run with: cargo test -p runtimed -- bench_streaming_load_steps --nocapture --ignored
 #[tokio::test]
 #[ignore] // Only run manually — requires the fixture notebook
-async fn bench_streaming_load_phases() {
+async fn bench_streaming_load_steps() {
     let notebook_path = std::path::Path::new("/tmp/gelmanschools-bench.ipynb");
     if !notebook_path.exists() {
         eprintln!("Skipping: /tmp/gelmanschools-bench.ipynb not found");

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2385,7 +2385,7 @@ async fn test_format_notebook_cells_skips_unknown_runtime() {
 }
 
 // ========================================================================
-// Tests for daemon-owned notebook loading functions (Phase 2)
+// Tests for daemon-owned notebook loading functions
 // ========================================================================
 
 #[test]
@@ -2555,7 +2555,7 @@ async fn bench_streaming_load_phases() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
 
-    // Phase 0: Read + parse
+    // Step 1: Read + parse
     let t0 = std::time::Instant::now();
     let bytes = std::fs::read(notebook_path).unwrap();
     let read_elapsed = t0.elapsed();


### PR DESCRIPTION
## Summary

- document `notebook-doc` cell `execution_count` as a persisted nbformat/import-export fallback, with live counts coming from `RuntimeStateDoc`
- add focused notebook-doc coverage for legacy execution count sync and new-cell default values
- retire stale roadmap-style `Phase` / `legacy wrapper` comments in notebook sync internals

## Verification

- `cargo xtask lint --fix`
- `cargo test -p notebook-doc execution_count --lib`
- `cargo check -p runtimed --lib`
