### PR TITLE
refactor(runtimed): wrap pool leases in LeasedPoolEnv

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -813,20 +813,25 @@ impl PoolLeaseGuard {
     /// Release the lease — caller has transferred ownership of the env
     /// (typically by writing `runtime_agent_env_path` first). The env
     /// directory is left on disk; whoever now owns it is responsible.
+    ///
+    /// `released` is flipped only after the pool-set update completes so
+    /// a cancellation mid-await leaves Drop able to retry. Double-release
+    /// is harmless (`HashSet::remove` of an absent key is a no-op).
     pub async fn release(mut self) {
-        self.released = true;
         if let Some(daemon) = self.daemon.upgrade() {
             daemon
                 .release_pool_lease(self.env_type, &self.leased_path)
                 .await;
         }
+        self.released = true;
     }
 
     /// Delete the env directory and release the lease. Use on known
     /// failure paths (claim/vendor/spawn errors) where the env is in an
     /// inconsistent state and must not be reused.
+    ///
+    /// Same flag-after-await invariant as [`Self::release`].
     pub async fn release_and_delete(mut self) {
-        self.released = true;
         if let Some(daemon) = self.daemon.upgrade() {
             daemon
                 .release_pool_lease(self.env_type, &self.leased_path)
@@ -841,6 +846,7 @@ impl PoolLeaseGuard {
                 self.leased_path, e
             );
         }
+        self.released = true;
     }
 
     /// Path of the leased env directory (the top-level `pool_env_root`).
@@ -5472,6 +5478,53 @@ mod tests {
             "released env should be reclaimed by orphan sweep"
         );
         assert!(!venv_path.exists());
+    }
+
+    /// Regression test for the inline-cache claim-failure race that
+    /// codex flagged in review of #2408. The inline-deps helpers used
+    /// to release the lease right after `claim_pool_env_for_*_inline_cache`,
+    /// which is best-effort: if the rename collides or fails, the env
+    /// stays at its original `runtimed-{uv,conda,pixi}-*` path. With the
+    /// lease released and `runtime_agent_env_path` not yet written, the
+    /// orphan sweep would delete the env mid-launch.
+    ///
+    /// Models the unprotected window directly: take a env, release the
+    /// lease without writing `runtime_agent_env_path`, and assert the
+    /// sweep deletes it. Then repeat with the path in `in_use` and
+    /// assert it survives. This is the invariant the helpers must
+    /// uphold (write owner before release).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn released_env_unprotected_unless_runtime_owner_set() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-released-no-owner");
+
+        // Release the lease without recording any runtime owner, mirroring
+        // the bug shape: claim no-op'd, env stayed at the pool path.
+        let (_env, guard) = daemon.take_uv_env().await.expect("take");
+        guard.release().await;
+
+        // No room owns this path. Sweep finds it as an untracked pool
+        // dir and deletes it — exactly the race in PR #2408 review.
+        let deleted = daemon
+            .sweep_orphan_pool_envs(&std::collections::HashSet::new())
+            .await;
+        assert_eq!(
+            deleted, 1,
+            "released env without runtime owner is unprotected"
+        );
+        assert!(!venv_path.exists(), "sweep removes unprotected pool env");
+
+        // Same env restored. This time mark it as runtime-owned via the
+        // `in_use` set the way `env_gc_loop` would. Sweep must skip it.
+        let venv_path2 = plant_uv_pool_env(&daemon, "runtimed-uv-released-with-owner");
+        let (env2, guard2) = daemon.take_uv_env().await.expect("take");
+        let mut in_use = std::collections::HashSet::new();
+        in_use.insert(env2.venv_path.clone());
+        guard2.release().await;
+        let deleted = daemon.sweep_orphan_pool_envs(&in_use).await;
+        assert_eq!(deleted, 0, "in_use covers the released-but-owned window");
+        assert!(venv_path2.exists());
     }
 
     /// `release` clears the lease (caller now owns the env) but does

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Instant;
 
 use anyhow::Context;
@@ -769,6 +769,152 @@ impl Drop for WarmingGuard {
     }
 }
 
+/// Wraps a `PooledEnv` while it sits in the daemon's `leased_paths` set —
+/// after `Pool::take()` and before ownership transfers to a runtime
+/// (`runtime_agent_env_path`), an inline-cache claim, or an explicit delete.
+///
+/// The lease is what protects the env directory from orphan GC during the
+/// async work between take and ownership transfer. Forcing callers to
+/// consume this wrapper (instead of returning a raw `PooledEnv`) makes the
+/// release obligation a property of the type, so any `?` early return or
+/// branch that drops the wrapper releases the lease.
+///
+/// Lifecycle:
+/// - Success: [`LeasedPoolEnv::transfer_to_runtime`] drains the lease and
+///   returns the inner `PooledEnv`. The caller MUST set the new owner
+///   (typically `room.runtime_agent_env_path`) on the same await chain —
+///   once the lease is released, only that field protects the env from
+///   orphan GC.
+/// - Known failure: [`LeasedPoolEnv::release_and_delete`] removes the env
+///   directory and releases the lease. Use when claim/vendor/spawn errors
+///   leave the env in an inconsistent state.
+/// - Drop without commit (panic, early `?` return): the lease is released
+///   best-effort via `tokio::spawn`, the directory is **not** deleted.
+///   Forgetting to commit must not destroy a working env; orphan GC will
+///   collect the leaked directory once nothing protects it.
+pub struct LeasedPoolEnv {
+    inner: Option<PooledEnv>,
+    daemon: Weak<Daemon>,
+    env_type: EnvType,
+    leased_path: PathBuf,
+}
+
+impl LeasedPoolEnv {
+    fn new(daemon: &Arc<Daemon>, env: PooledEnv) -> Self {
+        let leased_path = pool_env_root(&env.venv_path);
+        let env_type = env.env_type;
+        Self {
+            inner: Some(env),
+            daemon: Arc::downgrade(daemon),
+            env_type,
+            leased_path,
+        }
+    }
+
+    /// Construct a wrapper for an env that was NOT taken from the pool
+    /// (e.g. a content-addressed cache hit or an inline-built env). The
+    /// transfer/release/Drop methods become no-ops on the lease set since
+    /// `daemon.upgrade()` returns `None`. Callers can use this to keep a
+    /// single `Option<LeasedPoolEnv>` type across mixed paths.
+    pub fn cached(env: PooledEnv) -> Self {
+        let env_type = env.env_type;
+        Self {
+            inner: Some(env),
+            daemon: Weak::new(),
+            env_type,
+            leased_path: PathBuf::new(),
+        }
+    }
+
+    /// Borrow the inner env (e.g. to read `venv_path`/`python_path` before
+    /// transferring ownership).
+    pub fn env(&self) -> &PooledEnv {
+        self.inner
+            .as_ref()
+            .expect("LeasedPoolEnv::env called after consumption")
+    }
+
+    /// Mutably borrow the inner env so callers can update `venv_path`
+    /// after a claim/rename promotes the env into a content-addressed
+    /// cache. The lease's `leased_path` is unchanged: it still tracks the
+    /// original `pool_env_root` so orphan GC / lease bookkeeping remains
+    /// consistent regardless of where the directory ends up.
+    pub fn env_mut(&mut self) -> &mut PooledEnv {
+        self.inner
+            .as_mut()
+            .expect("LeasedPoolEnv::env_mut called after consumption")
+    }
+
+    /// Drain the lease and return the inner `PooledEnv`. The caller MUST
+    /// set the new owner (typically `room.runtime_agent_env_path` or an
+    /// inline-cache record) on the same await chain — once the lease is
+    /// released, only that field protects the env from orphan GC.
+    pub async fn transfer_to_runtime(mut self) -> PooledEnv {
+        let env = self
+            .inner
+            .take()
+            .expect("LeasedPoolEnv::transfer_to_runtime called twice");
+        if let Some(daemon) = self.daemon.upgrade() {
+            daemon
+                .release_pool_lease(self.env_type, &self.leased_path)
+                .await;
+        }
+        env
+    }
+
+    /// Delete the env directory and release the lease. Use on known
+    /// failure paths (claim/vendor/spawn errors) where the env may be in
+    /// an inconsistent state and must not be reused.
+    pub async fn release_and_delete(mut self) {
+        let env = self.inner.take();
+        if let Some(daemon) = self.daemon.upgrade() {
+            daemon
+                .release_pool_lease(self.env_type, &self.leased_path)
+                .await;
+        }
+        if env.is_some() {
+            // Always delete the top-level pool dir, not the venv_path —
+            // pixi envs are nested under .pixi/envs/default and the
+            // orphan sweep operates on `runtimed-pixi-*` roots.
+            if let Err(e) = tokio::fs::remove_dir_all(&self.leased_path).await {
+                warn!(
+                    "[runtimed] release_and_delete: failed to remove {:?}: {}",
+                    self.leased_path, e
+                );
+            }
+        }
+    }
+}
+
+impl Drop for LeasedPoolEnv {
+    fn drop(&mut self) {
+        if self.inner.is_none() {
+            // transfer_to_runtime / release_and_delete already drained.
+            return;
+        }
+        let Some(daemon) = self.daemon.upgrade() else {
+            // No lease tracked — `cached(...)` wrapper or daemon already
+            // dropped. Silent no-op.
+            return;
+        };
+        // Caller forgot to call transfer_to_runtime or release_and_delete.
+        // Release the lease asynchronously so the env doesn't stay pinned
+        // forever. Do NOT delete the directory: if ownership had silently
+        // transferred elsewhere, deleting here would corrupt a live kernel.
+        // Orphan GC will collect the directory once nothing protects it.
+        warn!(
+            "[runtimed] LeasedPoolEnv dropped without commit/release: {:?} \
+             (releasing lease, env directory leaked until orphan GC)",
+            self.leased_path
+        );
+        let env_type = self.env_type;
+        let path = self.leased_path.clone();
+        tokio::spawn(async move {
+            daemon.release_pool_lease(env_type, &path).await;
+        });
+    }
+}
+
 /// The pool daemon state.
 pub struct Daemon {
     pub(crate) config: DaemonConfig,
@@ -868,6 +1014,74 @@ impl Daemon {
             EnvType::Pixi => &self.pixi_pool,
         };
         pool.lock().await.release_lease(path);
+    }
+
+    /// Delete `runtimed-{uv,conda,pixi}-*` directories under the cache that
+    /// no pool tracks (available, warming, or leased) and no running
+    /// kernel claims via `runtime_agent_env_path`. Returns the number of
+    /// directories removed.
+    ///
+    /// Extracted from `env_gc_loop` so the regression test can drive the
+    /// sweep without spinning the 30-min loop. The lease-set protection
+    /// (via `Pool::tracked_paths`) is the load-bearing invariant under
+    /// test: if leased paths ever fall out of `tracked_paths`, this sweep
+    /// will delete envs out from under in-flight launches.
+    pub(crate) async fn sweep_orphan_pool_envs(
+        &self,
+        in_use: &std::collections::HashSet<PathBuf>,
+    ) -> usize {
+        let cache_dir = &self.config.cache_dir;
+        if !cache_dir.exists() {
+            return 0;
+        }
+        // Collect pool-tracked paths, normalised to top-level pool dirs so
+        // pixi's nested venv_path (runtimed-pixi-{uuid}/.pixi/envs/default)
+        // matches the top-level directory that the scan below sees. Also
+        // includes warming paths (mid-creation) and leased paths
+        // (taken-but-not-yet-attached) to avoid racing with in-flight
+        // launches and warmup tasks.
+        let mut tracked: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        tracked.extend(self.uv_pool.lock().await.tracked_paths());
+        tracked.extend(self.conda_pool.lock().await.tracked_paths());
+        tracked.extend(self.pixi_pool.lock().await.tracked_paths());
+
+        let mut orphans_deleted = 0;
+        let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await else {
+            return 0;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !is_pool_env_dir(&name) {
+                continue;
+            }
+            let path = entry.path();
+            if tracked.contains(&path) || in_use.contains(&path) {
+                continue;
+            }
+            if !is_within_cache_dir(&path, cache_dir) {
+                warn!(
+                    "[runtimed] GC: refusing to delete {:?} (not within cache dir)",
+                    path
+                );
+                continue;
+            }
+            info!("[runtimed] GC: removing orphaned pool env {:?}", path);
+            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                warn!(
+                    "[runtimed] GC: failed to remove orphaned pool env {:?}: {}",
+                    path, e
+                );
+            } else {
+                orphans_deleted += 1;
+            }
+        }
+        if orphans_deleted > 0 {
+            info!(
+                "[runtimed] GC: cleaned up {} orphaned pool environments",
+                orphans_deleted
+            );
+        }
+        orphans_deleted
     }
 
     /// Get the full list of Conda pool packages (base + user default_packages).
@@ -2530,9 +2744,14 @@ impl Daemon {
 
     /// Take a UV environment from the pool for kernel launching.
     ///
-    /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
+    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
+    /// otherwise. The lease keeps the env in the daemon's per-pool
+    /// `leased_paths` set until the caller calls
+    /// [`LeasedPoolEnv::transfer_to_runtime`] (success) or
+    /// [`LeasedPoolEnv::release_and_delete`] (failure). Dropping the
+    /// wrapper without either releases the lease best-effort and warns.
     /// Automatically triggers replenishment when an environment is taken.
-    pub async fn take_uv_env(self: &Arc<Self>) -> Option<PooledEnv> {
+    pub async fn take_uv_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
@@ -2562,7 +2781,7 @@ impl Daemon {
                 spawn_best_effort("uv-replenish", async move {
                     daemon.create_uv_env().await;
                 });
-                return Some(e);
+                return Some(LeasedPoolEnv::new(self, e));
             }
 
             if self.uv_pool.lock().await.target() == 0 {
@@ -2619,9 +2838,10 @@ impl Daemon {
 
     /// Take a Conda environment from the pool for kernel launching.
     ///
-    /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
+    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
+    /// otherwise. See [`Daemon::take_uv_env`] for lease semantics.
     /// Automatically triggers replenishment when an environment is taken.
-    pub async fn take_conda_env(self: &Arc<Self>) -> Option<PooledEnv> {
+    pub async fn take_conda_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
@@ -2645,7 +2865,7 @@ impl Daemon {
                 spawn_best_effort("conda-replenish", async move {
                     daemon.replenish_conda_env().await;
                 });
-                return Some(e);
+                return Some(LeasedPoolEnv::new(self, e));
             }
 
             if self.conda_pool.lock().await.target() == 0 {
@@ -2702,43 +2922,49 @@ impl Daemon {
 
     /// Take a Pixi environment from the pool for kernel launching.
     ///
-    /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
-    pub async fn take_pixi_env(self: &Arc<Self>) -> Option<PooledEnv> {
+    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
+    /// otherwise. See [`Daemon::take_uv_env`] for lease semantics.
+    pub async fn take_pixi_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
         let (env, stale_paths) = self.pixi_pool.lock().await.take();
         spawn_env_deletions(stale_paths);
-        if let Some(ref e) = env {
-            info!(
-                "[runtimed] Took Pixi env for kernel launch: {:?}",
-                e.venv_path
+        let e = env?;
+        info!(
+            "[runtimed] Took Pixi env for kernel launch: {:?}",
+            e.venv_path
+        );
+        // Backstop: re-vendor the launcher into this env. See take_uv_env
+        // for rationale. Warn-and-continue on failure.
+        if let Err(err) = kernel_env::launcher::vendor_into_venv(&e.python_path).await {
+            warn!(
+                "[runtimed] Pool take (Pixi): failed to re-vendor launcher into {:?}: {}",
+                e.python_path, err
             );
-            // Backstop: re-vendor the launcher into this env. See take_uv_env
-            // for rationale. Warn-and-continue on failure.
-            if let Err(err) = kernel_env::launcher::vendor_into_venv(&e.python_path).await {
-                warn!(
-                    "[runtimed] Pool take (Pixi): failed to re-vendor launcher into {:?}: {}",
-                    e.python_path, err
-                );
-            }
-            let daemon = self.clone();
-            spawn_best_effort("pixi-replenish", async move {
-                daemon.replenish_pixi_env().await;
-            });
         }
-        env
+        let daemon = self.clone();
+        spawn_best_effort("pixi-replenish", async move {
+            daemon.replenish_pixi_env().await;
+        });
+        Some(LeasedPoolEnv::new(self, e))
     }
 
     /// Handle a single request.
     async fn handle_request(self: Arc<Self>, request: Request) -> Response {
         match request {
             Request::Take { env_type } => {
-                let env = match env_type {
+                let leased = match env_type {
                     EnvType::Uv => self.take_uv_env().await,
                     EnvType::Conda => self.take_conda_env().await,
                     EnvType::Pixi => self.take_pixi_env().await,
                 };
 
-                match env {
-                    Some(env) => {
+                match leased {
+                    Some(leased) => {
+                        // RPC clients own the env from this point — the
+                        // daemon has no handle to track their lifecycle, so
+                        // releasing the lease here matches today's behavior
+                        // (the orphan sweep collects it if the client never
+                        // calls Return).
+                        let env = leased.transfer_to_runtime().await;
                         self.update_pool_doc().await;
                         Response::Env { env }
                     }
@@ -3124,69 +3350,7 @@ impl Daemon {
             // runtimed-pixi-*) that are not tracked by the pool and not in use by
             // running kernels. These can leak when a notebook takes a pool env, mutates
             // it, and then the room is evicted without cleanup.
-            {
-                let cache_dir = &self.config.cache_dir;
-                if cache_dir.exists() {
-                    // Collect pool-tracked paths, normalised to top-level
-                    // pool dirs so pixi's nested venv_path
-                    // (runtimed-pixi-{uuid}/.pixi/envs/default) matches the
-                    // top-level directory that the scan below sees.
-                    // Also includes warming paths (mid-creation) to avoid
-                    // racing with in-progress warmup tasks, and leased
-                    // paths that have been taken from the pool but not yet
-                    // transferred to a runtime/cache owner.
-                    let mut tracked: std::collections::HashSet<PathBuf> =
-                        std::collections::HashSet::new();
-                    {
-                        let pool = self.uv_pool.lock().await;
-                        tracked.extend(pool.tracked_paths());
-                    }
-                    {
-                        let pool = self.conda_pool.lock().await;
-                        tracked.extend(pool.tracked_paths());
-                    }
-                    {
-                        let pool = self.pixi_pool.lock().await;
-                        tracked.extend(pool.tracked_paths());
-                    }
-
-                    let mut orphans_deleted = 0;
-                    if let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await {
-                        while let Ok(Some(entry)) = entries.next_entry().await {
-                            let name = entry.file_name().to_string_lossy().to_string();
-                            if !is_pool_env_dir(&name) {
-                                continue;
-                            }
-                            let path = entry.path();
-                            if tracked.contains(&path) || in_use.contains(&path) {
-                                continue;
-                            }
-                            if !is_within_cache_dir(&path, cache_dir) {
-                                warn!(
-                                    "[runtimed] GC: refusing to delete {:?} (not within cache dir)",
-                                    path
-                                );
-                                continue;
-                            }
-                            info!("[runtimed] GC: removing orphaned pool env {:?}", path);
-                            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
-                                warn!(
-                                    "[runtimed] GC: failed to remove orphaned pool env {:?}: {}",
-                                    path, e
-                                );
-                            } else {
-                                orphans_deleted += 1;
-                            }
-                        }
-                    }
-                    if orphans_deleted > 0 {
-                        info!(
-                            "[runtimed] GC: cleaned up {} orphaned pool environments",
-                            orphans_deleted
-                        );
-                    }
-                }
-            }
+            self.sweep_orphan_pool_envs(&in_use).await;
 
             // Clean up stale worktree state directories
             let worktrees_dir = dirs::cache_dir()
@@ -5143,6 +5307,299 @@ mod tests {
         assert!(tracked.contains(&pool_env_root(&available_env.venv_path)));
         assert!(tracked.contains(&pool_env_root(&leased_env.venv_path)));
         assert!(tracked.contains(&warming));
+    }
+
+    /// Build a minimal `DaemonConfig` for in-process tests. Pool sizes
+    /// are zero so the warming loop doesn't try to create real envs.
+    fn lease_test_config(temp_dir: &TempDir) -> DaemonConfig {
+        #[cfg(windows)]
+        let socket_path = {
+            let unique = temp_dir
+                .path()
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy();
+            std::path::PathBuf::from(format!(r"\\.\pipe\runtimed-lease-test-{}", unique))
+        };
+        #[cfg(not(windows))]
+        let socket_path = temp_dir.path().join("test-lease.sock");
+
+        DaemonConfig {
+            socket_path,
+            cache_dir: temp_dir.path().join("envs"),
+            blob_store_dir: temp_dir.path().join("blobs"),
+            execution_store_dir: temp_dir.path().join("executions"),
+            notebook_docs_dir: temp_dir.path().join("notebook-docs"),
+            uv_pool_size: 0,
+            conda_pool_size: 0,
+            pixi_pool_size: 0,
+            max_age_secs: 3600,
+            lock_dir: Some(temp_dir.path().to_path_buf()),
+            room_eviction_delay_ms: Some(50),
+            use_preferred_blob_port: false,
+            settings_doc_path: Some(temp_dir.path().join("settings.automerge")),
+            settings_json_path: Some(temp_dir.path().join("settings.json")),
+            ..Default::default()
+        }
+    }
+
+    /// Plant a fake pool env on disk under `cache_dir` and register it in
+    /// the UV pool's `available` queue so a subsequent `take_uv_env`
+    /// returns it.
+    fn plant_uv_pool_env(daemon: &Arc<Daemon>, name: &str) -> PathBuf {
+        let venv_path = daemon.config.cache_dir.join(name);
+        std::fs::create_dir_all(&venv_path).unwrap();
+        std::fs::write(venv_path.join(".warmed"), "").unwrap();
+        #[cfg(windows)]
+        let python_path = venv_path.join("Scripts").join("python.exe");
+        #[cfg(not(windows))]
+        let python_path = venv_path.join("bin").join("python");
+        std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
+        std::fs::write(&python_path, "").unwrap();
+        let env = PooledEnv {
+            env_type: EnvType::Uv,
+            venv_path: venv_path.clone(),
+            python_path,
+            prewarmed_packages: vec![],
+        };
+        // Use try_lock + plain blocking_write isn't available; we're
+        // already in a tokio test, but this helper is sync. Spin a
+        // futures::executor block to push the env in. Simpler: use the
+        // pool's std::sync::Mutex... but the Pool is wrapped in a
+        // tokio::sync::Mutex. Block on the lock via a current-thread
+        // runtime borrow.
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                daemon.uv_pool.lock().await.add(env);
+            });
+        });
+        venv_path
+    }
+
+    /// Bug-repro test for the orphan GC race that motivated the lease set.
+    ///
+    /// Without the lease tracking, an env taken via `take_uv_env` lives in
+    /// neither `available` nor `runtime_agent_env_path` until the launch
+    /// flow records it. A concurrent `sweep_orphan_pool_envs` pass during
+    /// that window deletes the env directory out from under the in-flight
+    /// launch. The lease set protects taken-but-not-yet-attached envs by
+    /// keeping them in `Pool::tracked_paths`.
+    ///
+    /// This test would FAIL on `main` prior to #2403 and on any future
+    /// refactor that drops `leased_paths` from `tracked_paths`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn leased_env_survives_orphan_sweep() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-leased-test");
+
+        // Take the env: it leaves `available` and enters `leased_paths`.
+        let leased = daemon
+            .take_uv_env()
+            .await
+            .expect("take_uv_env returned None");
+        assert_eq!(leased.env().venv_path, venv_path);
+        assert!(
+            !daemon
+                .uv_pool
+                .lock()
+                .await
+                .available
+                .iter()
+                .any(|e| e.env.venv_path == venv_path),
+            "env should have left available after take"
+        );
+
+        // Run the same sweep `env_gc_loop` would. No room records this
+        // env as runtime_agent_env_path, so only the lease protects it.
+        let in_use = std::collections::HashSet::new();
+        let deleted = daemon.sweep_orphan_pool_envs(&in_use).await;
+        assert_eq!(
+            deleted, 0,
+            "leased env must not be swept while the lease wrapper is alive"
+        );
+        assert!(
+            venv_path.exists(),
+            "leased env directory should still exist on disk"
+        );
+
+        // Release the lease via the explicit failure path. The directory
+        // is removed and the lease is no longer in `tracked_paths`.
+        leased.release_and_delete().await;
+        assert!(
+            !venv_path.exists(),
+            "release_and_delete should remove the env directory"
+        );
+        assert!(
+            !daemon
+                .uv_pool
+                .lock()
+                .await
+                .leased_paths
+                .contains(&venv_path),
+            "lease should be released from leased_paths"
+        );
+    }
+
+    /// Drop without `transfer_to_runtime` / `release_and_delete` releases
+    /// the lease (no longer protects the directory) but does NOT delete
+    /// the directory. Forgetting to commit must not destroy a working
+    /// env; orphan GC will collect it once nothing protects it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropped_lease_releases_but_does_not_delete() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-drop-test");
+
+        {
+            let _leased = daemon
+                .take_uv_env()
+                .await
+                .expect("take_uv_env returned None");
+            assert!(daemon
+                .uv_pool
+                .lock()
+                .await
+                .leased_paths
+                .contains(&venv_path));
+            // Wrapper drops at end of scope without commit/release.
+        }
+
+        // Drop spawns the release; give it a tick to run. Use tokio yield
+        // + a short loop so this stays robust without arbitrary sleeps.
+        for _ in 0..50 {
+            if !daemon
+                .uv_pool
+                .lock()
+                .await
+                .leased_paths
+                .contains(&venv_path)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            !daemon
+                .uv_pool
+                .lock()
+                .await
+                .leased_paths
+                .contains(&venv_path),
+            "Drop must release the lease (best-effort via tokio::spawn)"
+        );
+        assert!(
+            venv_path.exists(),
+            "Drop must NOT delete the env directory \
+             (forgetting to commit must not destroy a working env)"
+        );
+
+        // Now the env is unprotected (no lease, no runtime owner).
+        // Orphan sweep collects it.
+        let deleted = daemon
+            .sweep_orphan_pool_envs(&std::collections::HashSet::new())
+            .await;
+        assert_eq!(
+            deleted, 1,
+            "released env should be reclaimed by orphan sweep"
+        );
+        assert!(!venv_path.exists());
+    }
+
+    /// `transfer_to_runtime` releases the lease (caller now owns the env)
+    /// but does not delete. Caller is expected to set
+    /// `runtime_agent_env_path` so the env stays protected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transfer_to_runtime_releases_lease_keeps_env() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-transfer-test");
+
+        let leased = daemon
+            .take_uv_env()
+            .await
+            .expect("take_uv_env returned None");
+        let env = leased.transfer_to_runtime().await;
+
+        assert_eq!(env.venv_path, venv_path);
+        assert!(
+            !daemon
+                .uv_pool
+                .lock()
+                .await
+                .leased_paths
+                .contains(&venv_path),
+            "transfer_to_runtime must release the lease"
+        );
+        assert!(
+            venv_path.exists(),
+            "transfer_to_runtime must NOT delete the env directory"
+        );
+    }
+
+    /// Stress test: parallel `take_uv_env` + orphan sweeps must never
+    /// race in a way that deletes a leased env. This is the original CI
+    /// failure mode that motivated PR #2403.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_take_and_sweep_does_not_delete_leased() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+
+        // Plant several envs.
+        let envs: Vec<PathBuf> = (0..8)
+            .map(|i| plant_uv_pool_env(&daemon, &format!("runtimed-uv-stress-{i}")))
+            .collect();
+
+        // Spawn a sweeper that runs continuously.
+        let sweeper_daemon = daemon.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_sig = stop.clone();
+        let sweeper = tokio::spawn(async move {
+            let mut deleted_total = 0;
+            while !stop_sig.load(std::sync::atomic::Ordering::Relaxed) {
+                deleted_total += sweeper_daemon
+                    .sweep_orphan_pool_envs(&std::collections::HashSet::new())
+                    .await;
+                tokio::task::yield_now().await;
+            }
+            deleted_total
+        });
+
+        // Take each env, hold the lease for a few yields, then drop. Run
+        // them in parallel so the sweeper races against active leases.
+        let mut takers = Vec::new();
+        for _ in 0..envs.len() {
+            let d = daemon.clone();
+            takers.push(tokio::spawn(async move {
+                let leased = d.take_uv_env().await.expect("env should be takeable");
+                let venv_path = leased.env().venv_path.clone();
+                // Yield several times to give the sweeper a chance to fire.
+                for _ in 0..20 {
+                    tokio::task::yield_now().await;
+                }
+                // The lease is still alive — env must not be deleted.
+                assert!(
+                    venv_path.exists(),
+                    "env {:?} was deleted while leased",
+                    venv_path
+                );
+                let env = leased.transfer_to_runtime().await;
+                env.venv_path
+            }));
+        }
+
+        // Wait for all takers to finish. The in-loop assertion above
+        // (env still exists while the lease wrapper is alive) is the
+        // load-bearing check — once each taker calls
+        // `transfer_to_runtime`, the lease releases and the sweeper is
+        // free to reclaim the now-unprotected env. We only need to
+        // verify each taker survived its lease window without panicking.
+        for t in takers {
+            t.await.unwrap();
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _swept = sweeper.await.unwrap();
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -769,156 +769,103 @@ impl Drop for WarmingGuard {
     }
 }
 
-/// Wraps a `PooledEnv` while it sits in the daemon's `leased_paths` set —
-/// after `Pool::take()` and before ownership transfers to a runtime
-/// (`runtime_agent_env_path`), an inline-cache claim, or an explicit delete.
-///
-/// The lease is what protects the env directory from orphan GC during the
-/// async work between take and ownership transfer. Forcing callers to
-/// consume this wrapper (instead of returning a raw `PooledEnv`) makes the
-/// release obligation a property of the type, so any `?` early return or
-/// branch that drops the wrapper releases the lease.
+/// RAII guard for a pool lease. Held alongside the `PooledEnv` returned by
+/// `Daemon::take_*_env` to keep the daemon's `leased_paths` set populated
+/// during the async work between `Pool::take()` and ownership transfer
+/// (room's `runtime_agent_env_path`, an inline-cache claim, or an explicit
+/// delete). The lease is what protects the env directory from orphan GC
+/// during that window.
 ///
 /// Lifecycle:
-/// - Success: [`LeasedPoolEnv::transfer_to_runtime`] drains the lease and
-///   returns the inner `PooledEnv`. The caller MUST set the new owner
-///   (typically `room.runtime_agent_env_path`) on the same await chain —
-///   once the lease is released, only that field protects the env from
-///   orphan GC.
-/// - Known failure: [`LeasedPoolEnv::release_and_delete`] removes the env
-///   directory and releases the lease. Use when claim/vendor/spawn errors
-///   leave the env in an inconsistent state.
-/// - Drop without commit (panic, early `?` return): the lease is released
-///   best-effort via `tokio::spawn`, the directory is **not** deleted.
-///   Forgetting to commit must not destroy a working env; orphan GC will
-///   collect the leaked directory once nothing protects it.
-pub struct LeasedPoolEnv {
-    inner: Option<PooledEnv>,
+/// - Success: [`PoolLeaseGuard::release`] removes the entry from
+///   `leased_paths`. Caller MUST set the new owner (typically
+///   `runtime_agent_env_path`) on the same await chain — once the lease is
+///   released, only that field protects the env from orphan GC.
+/// - Known failure: [`PoolLeaseGuard::release_and_delete`] removes the
+///   env directory and releases the lease. Use when claim/vendor/spawn
+///   errors leave the env in an inconsistent state.
+/// - Drop without explicit release (panic, early `?` return): the lease
+///   is released best-effort via `tokio::spawn`, the directory is **not**
+///   deleted. Forgetting to release must not destroy a working env;
+///   orphan GC will collect the leaked directory once nothing protects
+///   it.
+///
+/// Separating the guard from the `PooledEnv` keeps both ownerships
+/// straightforward — env is moved/cloned freely, lease accounting lives
+/// in a small flag-only struct with no panicking accessors.
+pub struct PoolLeaseGuard {
     daemon: Weak<Daemon>,
     env_type: EnvType,
     leased_path: PathBuf,
+    released: bool,
 }
 
-impl LeasedPoolEnv {
-    fn new(daemon: &Arc<Daemon>, env: PooledEnv) -> Self {
-        let leased_path = pool_env_root(&env.venv_path);
-        let env_type = env.env_type;
+impl PoolLeaseGuard {
+    fn new(daemon: &Arc<Daemon>, env_type: EnvType, venv_path: &Path) -> Self {
         Self {
-            inner: Some(env),
             daemon: Arc::downgrade(daemon),
             env_type,
-            leased_path,
+            leased_path: pool_env_root(venv_path),
+            released: false,
         }
     }
 
-    /// Construct a wrapper for an env that was NOT taken from the pool
-    /// (e.g. a content-addressed cache hit or an inline-built env). The
-    /// transfer/release/Drop methods become no-ops on the lease set since
-    /// `daemon.upgrade()` returns `None`. Callers can use this to keep a
-    /// single `Option<LeasedPoolEnv>` type across mixed paths.
-    pub fn cached(env: PooledEnv) -> Self {
-        let env_type = env.env_type;
-        Self {
-            inner: Some(env),
-            daemon: Weak::new(),
-            env_type,
-            leased_path: PathBuf::new(),
-        }
-    }
-
-    /// Borrow the inner env (e.g. to read `venv_path`/`python_path` before
-    /// transferring ownership).
-    ///
-    /// `inner` is `Some` from `new`/`cached` until `transfer_to_runtime` or
-    /// `release_and_delete` consume `self`; once either runs, the wrapper
-    /// is gone, so this method can't observe the drained state. The
-    /// `expect` documents the ownership invariant rather than a runtime
-    /// failure mode.
-    #[allow(clippy::expect_used)]
-    pub fn env(&self) -> &PooledEnv {
-        self.inner
-            .as_ref()
-            .expect("LeasedPoolEnv::inner is Some until self is consumed")
-    }
-
-    /// Mutably borrow the inner env so callers can update `venv_path`
-    /// after a claim/rename promotes the env into a content-addressed
-    /// cache. The lease's `leased_path` is unchanged: it still tracks the
-    /// original `pool_env_root` so orphan GC / lease bookkeeping remains
-    /// consistent regardless of where the directory ends up.
-    ///
-    /// Same ownership invariant as [`Self::env`].
-    #[allow(clippy::expect_used)]
-    pub fn env_mut(&mut self) -> &mut PooledEnv {
-        self.inner
-            .as_mut()
-            .expect("LeasedPoolEnv::inner is Some until self is consumed")
-    }
-
-    /// Drain the lease and return the inner `PooledEnv`. The caller MUST
-    /// set the new owner (typically `room.runtime_agent_env_path` or an
-    /// inline-cache record) on the same await chain — once the lease is
-    /// released, only that field protects the env from orphan GC.
-    pub async fn transfer_to_runtime(mut self) -> PooledEnv {
-        // `self` is consumed by-value, so `inner` is guaranteed `Some`
-        // here: the only way it could be `None` is if some other method
-        // had already taken it, but those methods all consume `self`
-        // too, so this would be unreachable.
-        #[allow(clippy::expect_used)]
-        let env = self
-            .inner
-            .take()
-            .expect("LeasedPoolEnv::inner is Some on entry to transfer_to_runtime");
+    /// Release the lease — caller has transferred ownership of the env
+    /// (typically by writing `runtime_agent_env_path` first). The env
+    /// directory is left on disk; whoever now owns it is responsible.
+    pub async fn release(mut self) {
+        self.released = true;
         if let Some(daemon) = self.daemon.upgrade() {
             daemon
                 .release_pool_lease(self.env_type, &self.leased_path)
                 .await;
         }
-        env
     }
 
     /// Delete the env directory and release the lease. Use on known
-    /// failure paths (claim/vendor/spawn errors) where the env may be in
-    /// an inconsistent state and must not be reused.
+    /// failure paths (claim/vendor/spawn errors) where the env is in an
+    /// inconsistent state and must not be reused.
     pub async fn release_and_delete(mut self) {
-        let env = self.inner.take();
+        self.released = true;
         if let Some(daemon) = self.daemon.upgrade() {
             daemon
                 .release_pool_lease(self.env_type, &self.leased_path)
                 .await;
         }
-        if env.is_some() {
-            // Always delete the top-level pool dir, not the venv_path —
-            // pixi envs are nested under .pixi/envs/default and the
-            // orphan sweep operates on `runtimed-pixi-*` roots.
-            if let Err(e) = tokio::fs::remove_dir_all(&self.leased_path).await {
-                warn!(
-                    "[runtimed] release_and_delete: failed to remove {:?}: {}",
-                    self.leased_path, e
-                );
-            }
+        // Always delete the top-level pool dir, not a sub-path — pixi
+        // envs are nested under .pixi/envs/default and the orphan sweep
+        // operates on `runtimed-pixi-*` roots.
+        if let Err(e) = tokio::fs::remove_dir_all(&self.leased_path).await {
+            warn!(
+                "[runtimed] release_and_delete: failed to remove {:?}: {}",
+                self.leased_path, e
+            );
         }
+    }
+
+    /// Path of the leased env directory (the top-level `pool_env_root`).
+    pub fn leased_path(&self) -> &Path {
+        &self.leased_path
     }
 }
 
-impl Drop for LeasedPoolEnv {
+impl Drop for PoolLeaseGuard {
     fn drop(&mut self) {
-        if self.inner.is_none() {
-            // transfer_to_runtime / release_and_delete already drained.
+        if self.released {
             return;
         }
         let Some(daemon) = self.daemon.upgrade() else {
-            // No lease tracked — `cached(...)` wrapper or daemon already
-            // dropped. Silent no-op.
+            // Daemon already dropped; nothing to release.
             return;
         };
-        // Caller forgot to call transfer_to_runtime or release_and_delete.
-        // Release the lease asynchronously so the env doesn't stay pinned
+        // Caller forgot to call release / release_and_delete. Schedule
+        // a best-effort lease release so the env doesn't stay pinned
         // forever. Do NOT delete the directory: if ownership had silently
-        // transferred elsewhere, deleting here would corrupt a live kernel.
-        // Orphan GC will collect the directory once nothing protects it.
+        // transferred elsewhere, deleting here would corrupt a live
+        // kernel. Orphan GC will collect the directory once nothing
+        // protects it.
         warn!(
-            "[runtimed] LeasedPoolEnv dropped without commit/release: {:?} \
+            "[runtimed] PoolLeaseGuard dropped without explicit release: {:?} \
              (releasing lease, env directory leaked until orphan GC)",
             self.leased_path
         );
@@ -2759,14 +2706,14 @@ impl Daemon {
 
     /// Take a UV environment from the pool for kernel launching.
     ///
-    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
-    /// otherwise. The lease keeps the env in the daemon's per-pool
+    /// Returns `Some((env, guard))` if an environment is available, `None`
+    /// otherwise. The guard keeps the env in the daemon's per-pool
     /// `leased_paths` set until the caller calls
-    /// [`LeasedPoolEnv::transfer_to_runtime`] (success) or
-    /// [`LeasedPoolEnv::release_and_delete`] (failure). Dropping the
-    /// wrapper without either releases the lease best-effort and warns.
+    /// [`PoolLeaseGuard::release`] (success) or
+    /// [`PoolLeaseGuard::release_and_delete`] (failure). Dropping the
+    /// guard without either releases the lease best-effort and warns.
     /// Automatically triggers replenishment when an environment is taken.
-    pub async fn take_uv_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
+    pub async fn take_uv_env(self: &Arc<Self>) -> Option<(PooledEnv, PoolLeaseGuard)> {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
@@ -2796,7 +2743,8 @@ impl Daemon {
                 spawn_best_effort("uv-replenish", async move {
                     daemon.create_uv_env().await;
                 });
-                return Some(LeasedPoolEnv::new(self, e));
+                let guard = PoolLeaseGuard::new(self, EnvType::Uv, &e.venv_path);
+                return Some((e, guard));
             }
 
             if self.uv_pool.lock().await.target() == 0 {
@@ -2853,10 +2801,10 @@ impl Daemon {
 
     /// Take a Conda environment from the pool for kernel launching.
     ///
-    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
+    /// Returns `Some((env, guard))` if an environment is available, `None`
     /// otherwise. See [`Daemon::take_uv_env`] for lease semantics.
     /// Automatically triggers replenishment when an environment is taken.
-    pub async fn take_conda_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
+    pub async fn take_conda_env(self: &Arc<Self>) -> Option<(PooledEnv, PoolLeaseGuard)> {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
 
         loop {
@@ -2880,7 +2828,8 @@ impl Daemon {
                 spawn_best_effort("conda-replenish", async move {
                     daemon.replenish_conda_env().await;
                 });
-                return Some(LeasedPoolEnv::new(self, e));
+                let guard = PoolLeaseGuard::new(self, EnvType::Conda, &e.venv_path);
+                return Some((e, guard));
             }
 
             if self.conda_pool.lock().await.target() == 0 {
@@ -2937,9 +2886,9 @@ impl Daemon {
 
     /// Take a Pixi environment from the pool for kernel launching.
     ///
-    /// Returns `Some(LeasedPoolEnv)` if an environment is available, `None`
+    /// Returns `Some((env, guard))` if an environment is available, `None`
     /// otherwise. See [`Daemon::take_uv_env`] for lease semantics.
-    pub async fn take_pixi_env(self: &Arc<Self>) -> Option<LeasedPoolEnv> {
+    pub async fn take_pixi_env(self: &Arc<Self>) -> Option<(PooledEnv, PoolLeaseGuard)> {
         let (env, stale_paths) = self.pixi_pool.lock().await.take();
         spawn_env_deletions(stale_paths);
         let e = env?;
@@ -2959,27 +2908,28 @@ impl Daemon {
         spawn_best_effort("pixi-replenish", async move {
             daemon.replenish_pixi_env().await;
         });
-        Some(LeasedPoolEnv::new(self, e))
+        let guard = PoolLeaseGuard::new(self, EnvType::Pixi, &e.venv_path);
+        Some((e, guard))
     }
 
     /// Handle a single request.
     async fn handle_request(self: Arc<Self>, request: Request) -> Response {
         match request {
             Request::Take { env_type } => {
-                let leased = match env_type {
+                let taken = match env_type {
                     EnvType::Uv => self.take_uv_env().await,
                     EnvType::Conda => self.take_conda_env().await,
                     EnvType::Pixi => self.take_pixi_env().await,
                 };
 
-                match leased {
-                    Some(leased) => {
+                match taken {
+                    Some((env, guard)) => {
                         // RPC clients own the env from this point — the
                         // daemon has no handle to track their lifecycle, so
                         // releasing the lease here matches today's behavior
                         // (the orphan sweep collects it if the client never
                         // calls Return).
-                        let env = leased.transfer_to_runtime().await;
+                        guard.release().await;
                         self.update_pool_doc().await;
                         Response::Env { env }
                     }
@@ -5409,11 +5359,11 @@ mod tests {
         let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-leased-test");
 
         // Take the env: it leaves `available` and enters `leased_paths`.
-        let leased = daemon
+        let (env, guard) = daemon
             .take_uv_env()
             .await
             .expect("take_uv_env returned None");
-        assert_eq!(leased.env().venv_path, venv_path);
+        assert_eq!(env.venv_path, venv_path);
         assert!(
             !daemon
                 .uv_pool
@@ -5431,16 +5381,19 @@ mod tests {
         let deleted = daemon.sweep_orphan_pool_envs(&in_use).await;
         assert_eq!(
             deleted, 0,
-            "leased env must not be swept while the lease wrapper is alive"
+            "leased env must not be swept while the guard is alive"
         );
         assert!(
             venv_path.exists(),
             "leased env directory should still exist on disk"
         );
+        // Suppress unused warning — env value isn't read past the
+        // existence check above.
+        let _ = env;
 
         // Release the lease via the explicit failure path. The directory
         // is removed and the lease is no longer in `tracked_paths`.
-        leased.release_and_delete().await;
+        guard.release_and_delete().await;
         assert!(
             !venv_path.exists(),
             "release_and_delete should remove the env directory"
@@ -5467,7 +5420,7 @@ mod tests {
         let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-drop-test");
 
         {
-            let _leased = daemon
+            let (_env, _guard) = daemon
                 .take_uv_env()
                 .await
                 .expect("take_uv_env returned None");
@@ -5477,7 +5430,7 @@ mod tests {
                 .await
                 .leased_paths
                 .contains(&venv_path));
-            // Wrapper drops at end of scope without commit/release.
+            // Guard drops at end of scope without explicit release.
         }
 
         // Drop spawns the release; give it a tick to run. Use tokio yield
@@ -5521,20 +5474,20 @@ mod tests {
         assert!(!venv_path.exists());
     }
 
-    /// `transfer_to_runtime` releases the lease (caller now owns the env)
-    /// but does not delete. Caller is expected to set
+    /// `release` clears the lease (caller now owns the env) but does
+    /// not delete. Caller is expected to have set
     /// `runtime_agent_env_path` so the env stays protected.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn transfer_to_runtime_releases_lease_keeps_env() {
+    async fn release_clears_lease_keeps_env() {
         let temp_dir = TempDir::new().unwrap();
         let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
-        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-transfer-test");
+        let venv_path = plant_uv_pool_env(&daemon, "runtimed-uv-release-test");
 
-        let leased = daemon
+        let (env, guard) = daemon
             .take_uv_env()
             .await
             .expect("take_uv_env returned None");
-        let env = leased.transfer_to_runtime().await;
+        guard.release().await;
 
         assert_eq!(env.venv_path, venv_path);
         assert!(
@@ -5544,11 +5497,11 @@ mod tests {
                 .await
                 .leased_paths
                 .contains(&venv_path),
-            "transfer_to_runtime must release the lease"
+            "release must clear the lease"
         );
         assert!(
             venv_path.exists(),
-            "transfer_to_runtime must NOT delete the env directory"
+            "release must NOT delete the env directory"
         );
     }
 
@@ -5580,35 +5533,34 @@ mod tests {
             deleted_total
         });
 
-        // Take each env, hold the lease for a few yields, then drop. Run
-        // them in parallel so the sweeper races against active leases.
+        // Take each env, hold the lease for a few yields, then release.
+        // Run them in parallel so the sweeper races against active leases.
         let mut takers = Vec::new();
         for _ in 0..envs.len() {
             let d = daemon.clone();
             takers.push(tokio::spawn(async move {
-                let leased = d.take_uv_env().await.expect("env should be takeable");
-                let venv_path = leased.env().venv_path.clone();
+                let (env, guard) = d.take_uv_env().await.expect("env should be takeable");
+                let venv_path = env.venv_path.clone();
                 // Yield several times to give the sweeper a chance to fire.
                 for _ in 0..20 {
                     tokio::task::yield_now().await;
                 }
-                // The lease is still alive — env must not be deleted.
+                // The guard is still alive — env must not be deleted.
                 assert!(
                     venv_path.exists(),
                     "env {:?} was deleted while leased",
                     venv_path
                 );
-                let env = leased.transfer_to_runtime().await;
-                env.venv_path
+                guard.release().await;
+                venv_path
             }));
         }
 
-        // Wait for all takers to finish. The in-loop assertion above
-        // (env still exists while the lease wrapper is alive) is the
-        // load-bearing check — once each taker calls
-        // `transfer_to_runtime`, the lease releases and the sweeper is
-        // free to reclaim the now-unprotected env. We only need to
-        // verify each taker survived its lease window without panicking.
+        // Wait for all takers to finish. The in-loop assertion above (env
+        // still exists while the guard is alive) is the load-bearing
+        // check — once each taker calls `release`, the lease clears and
+        // the sweeper is free to reclaim the now-unprotected env. We
+        // only need to verify each taker survived its lease window.
         for t in takers {
             t.await.unwrap();
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -828,10 +828,17 @@ impl LeasedPoolEnv {
 
     /// Borrow the inner env (e.g. to read `venv_path`/`python_path` before
     /// transferring ownership).
+    ///
+    /// `inner` is `Some` from `new`/`cached` until `transfer_to_runtime` or
+    /// `release_and_delete` consume `self`; once either runs, the wrapper
+    /// is gone, so this method can't observe the drained state. The
+    /// `expect` documents the ownership invariant rather than a runtime
+    /// failure mode.
+    #[allow(clippy::expect_used)]
     pub fn env(&self) -> &PooledEnv {
         self.inner
             .as_ref()
-            .expect("LeasedPoolEnv::env called after consumption")
+            .expect("LeasedPoolEnv::inner is Some until self is consumed")
     }
 
     /// Mutably borrow the inner env so callers can update `venv_path`
@@ -839,10 +846,13 @@ impl LeasedPoolEnv {
     /// cache. The lease's `leased_path` is unchanged: it still tracks the
     /// original `pool_env_root` so orphan GC / lease bookkeeping remains
     /// consistent regardless of where the directory ends up.
+    ///
+    /// Same ownership invariant as [`Self::env`].
+    #[allow(clippy::expect_used)]
     pub fn env_mut(&mut self) -> &mut PooledEnv {
         self.inner
             .as_mut()
-            .expect("LeasedPoolEnv::env_mut called after consumption")
+            .expect("LeasedPoolEnv::inner is Some until self is consumed")
     }
 
     /// Drain the lease and return the inner `PooledEnv`. The caller MUST
@@ -850,10 +860,15 @@ impl LeasedPoolEnv {
     /// inline-cache record) on the same await chain — once the lease is
     /// released, only that field protects the env from orphan GC.
     pub async fn transfer_to_runtime(mut self) -> PooledEnv {
+        // `self` is consumed by-value, so `inner` is guaranteed `Some`
+        // here: the only way it could be `None` is if some other method
+        // had already taken it, but those methods all consume `self`
+        // too, so this would be unreachable.
+        #[allow(clippy::expect_used)]
         let env = self
             .inner
             .take()
-            .expect("LeasedPoolEnv::transfer_to_runtime called twice");
+            .expect("LeasedPoolEnv::inner is Some on entry to transfer_to_runtime");
         if let Some(daemon) = self.daemon.upgrade() {
             daemon
                 .release_pool_lease(self.env_type, &self.leased_path)

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1813,11 +1813,26 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     metadata_snapshot: Option<&NotebookMetadataSnapshot>,
-) -> Result<Option<crate::daemon::LeasedPoolEnv>, ()> {
+) -> Result<Option<crate::PooledEnv>, ()> {
     let runtime = match env_source {
         "uv:prewarmed" => CapturedEnvRuntime::Uv,
         "conda:prewarmed" => CapturedEnvRuntime::Conda,
-        _ => return acquire_pool_env_for_source(env_source, daemon, room).await,
+        _ => {
+            // Non-uv/conda prewarmed sources (e.g. pixi:prewarmed) skip
+            // the capture/claim step. Take the env, set the runtime
+            // owner before releasing the lease, and return the bare env.
+            return match acquire_pool_env_for_source(env_source, daemon, room).await? {
+                Some((env, guard)) => {
+                    {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(env.venv_path.clone());
+                    }
+                    guard.release().await;
+                    Ok(Some(env))
+                }
+                None => Ok(None),
+            };
+        }
     };
     let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
         std::sync::Arc::new(crate::inline_env::BroadcastProgressHandler::with_state(
@@ -1857,14 +1872,12 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                                 "[notebook-sync] Reopen cache-hit for env_id={} at {:?}",
                                 env_id, prepared.venv_path
                             );
-                            return Ok(Some(crate::daemon::LeasedPoolEnv::cached(
-                                crate::PooledEnv {
-                                    env_type: crate::EnvType::Uv,
-                                    venv_path: prepared.venv_path,
-                                    python_path: prepared.python_path,
-                                    prewarmed_packages: deps.dependencies.clone(),
-                                },
-                            )));
+                            return Ok(Some(crate::PooledEnv {
+                                env_type: crate::EnvType::Uv,
+                                venv_path: prepared.venv_path,
+                                python_path: prepared.python_path,
+                                prewarmed_packages: deps.dependencies.clone(),
+                            }));
                         }
                         Err(e) => {
                             warn!(
@@ -1889,14 +1902,12 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                                 "[notebook-sync] Reopen cache-hit for env_id={} at {:?}",
                                 env_id, prepared.env_path
                             );
-                            return Ok(Some(crate::daemon::LeasedPoolEnv::cached(
-                                crate::PooledEnv {
-                                    env_type: crate::EnvType::Conda,
-                                    venv_path: prepared.env_path,
-                                    python_path: prepared.python_path,
-                                    prewarmed_packages: deps.dependencies.clone(),
-                                },
-                            )));
+                            return Ok(Some(crate::PooledEnv {
+                                env_type: crate::EnvType::Conda,
+                                venv_path: prepared.env_path,
+                                python_path: prepared.python_path,
+                                prewarmed_packages: deps.dependencies.clone(),
+                            }));
                         }
                         Err(e) => {
                             warn!(
@@ -1912,7 +1923,8 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 
     // First-launch path: take from pool, strip base to derive user_defaults,
     // claim to the unified-hash location, and capture into metadata.
-    let Some(mut leased) = acquire_pool_env_for_source(env_source, daemon, room).await? else {
+    let Some((mut env, guard)) = acquire_pool_env_for_source(env_source, daemon, room).await?
+    else {
         // Pool returned `Ok(None)` (e.g. pixi → launch on demand). Pass
         // that through to the caller.
         return Ok(None);
@@ -1924,12 +1936,11 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 
     match runtime {
         CapturedEnvRuntime::Uv => {
-            let pooled = leased.env();
             let user_defaults =
-                kernel_env::strip_base(&pooled.prewarmed_packages, kernel_env::UV_BASE_PACKAGES);
+                kernel_env::strip_base(&env.prewarmed_packages, kernel_env::UV_BASE_PACKAGES);
             let prewarmed = kernel_env::uv::UvEnvironment {
-                venv_path: pooled.venv_path.clone(),
-                python_path: pooled.python_path.clone(),
+                venv_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
             };
             let cache_dir = kernel_env::uv::default_cache_dir_uv();
             match kernel_env::uv::claim_prewarmed_environment_in(
@@ -1941,17 +1952,14 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
             .await
             {
                 Ok(claimed) => {
-                    // Mutate the inner env to point at the claimed location.
-                    // The lease's `leased_path` is unchanged (still tracks
-                    // the original pool path, which `claim_prewarmed_*`
-                    // moved into the unified-hash cache). transfer_to_runtime
-                    // releases the lease for that original path.
+                    // claim_prewarmed_* moved the env from the original
+                    // pool path to the unified-hash cache. The lease still
+                    // tracks the original (now-empty) path; release it so
+                    // orphan GC can stop tracking it. Returned env points
+                    // to the claimed location.
                     let claimed_path = claimed.venv_path.clone();
-                    {
-                        let inner = leased.env_mut();
-                        inner.venv_path = claimed_path.clone();
-                        inner.python_path = claimed.python_path;
-                    }
+                    env.venv_path = claimed_path.clone();
+                    env.python_path = claimed.python_path;
                     let _wrote = capture_env_into_metadata(
                         room,
                         CapturedEnvRuntime::Uv,
@@ -1963,28 +1971,32 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed UV env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
-                    Ok(Some(leased))
+                    guard.release().await;
+                    Ok(Some(env))
                 }
                 Err(e) => {
                     warn!(
                         "[notebook-sync] Failed to claim UV pool env ({}), using raw pool env",
                         e
                     );
+                    // Set runtime_agent_env_path to the raw pool path
+                    // BEFORE releasing the lease so the env is never
+                    // momentarily unprotected.
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
-                        *ep = Some(leased.env().venv_path.clone());
+                        *ep = Some(env.venv_path.clone());
                     }
-                    Ok(Some(leased))
+                    guard.release().await;
+                    Ok(Some(env))
                 }
             }
         }
         CapturedEnvRuntime::Conda => {
-            let pooled = leased.env();
             let user_defaults =
-                kernel_env::strip_base(&pooled.prewarmed_packages, kernel_env::CONDA_BASE_PACKAGES);
+                kernel_env::strip_base(&env.prewarmed_packages, kernel_env::CONDA_BASE_PACKAGES);
             let prewarmed = kernel_env::conda::CondaEnvironment {
-                env_path: pooled.venv_path.clone(),
-                python_path: pooled.python_path.clone(),
+                env_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
             };
             let cache_dir = kernel_env::conda::default_cache_dir_conda();
             match kernel_env::conda::claim_prewarmed_environment_in(
@@ -1997,11 +2009,8 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
             {
                 Ok(claimed) => {
                     let claimed_path = claimed.env_path.clone();
-                    {
-                        let inner = leased.env_mut();
-                        inner.venv_path = claimed_path.clone();
-                        inner.python_path = claimed.python_path;
-                    }
+                    env.venv_path = claimed_path.clone();
+                    env.python_path = claimed.python_path;
                     let _wrote = capture_env_into_metadata(
                         room,
                         CapturedEnvRuntime::Conda,
@@ -2013,7 +2022,8 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed conda env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
-                    Ok(Some(leased))
+                    guard.release().await;
+                    Ok(Some(env))
                 }
                 Err(e) => {
                     warn!(
@@ -2022,9 +2032,10 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                     );
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
-                        *ep = Some(leased.env().venv_path.clone());
+                        *ep = Some(env.venv_path.clone());
                     }
-                    Ok(Some(leased))
+                    guard.release().await;
+                    Ok(Some(env))
                 }
             }
         }
@@ -2033,29 +2044,32 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 
 /// Acquire a pooled environment from the appropriate pool based on env_source.
 ///
-/// - `Ok(Some(leased))`: lease is still held; caller must call
-///   `transfer_to_runtime()` on success or `release_and_delete()` on failure.
-///   `Drop` releases the lease best-effort if the caller forgets either.
-/// - `Ok(None)`: env source doesn't need a pool entry (e.g. pixi pool empty
-///   → launch on demand via `pixi exec`).
+/// Returns the env paired with its `PoolLeaseGuard`. The caller is
+/// responsible for calling `release()` (success) or `release_and_delete()`
+/// (failure) on the guard; if dropped without either, the lease is
+/// released best-effort and the directory is left for orphan GC.
+///
+/// - `Ok(Some((env, guard)))`: env is leased.
+/// - `Ok(None)`: env source doesn't need a pool entry (e.g. pixi pool
+///   empty → launch on demand via `pixi exec`).
 /// - `Err(())`: pool empty for a source that requires one; caller should
 ///   bail with an error.
 async fn acquire_pool_env_for_source(
     env_source: &str,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     _room: &NotebookRoom,
-) -> Result<Option<crate::daemon::LeasedPoolEnv>, ()> {
+) -> Result<Option<(crate::PooledEnv, crate::daemon::PoolLeaseGuard)>, ()> {
     use notebook_protocol::connection::{EnvSource, PackageManager};
     let parsed = EnvSource::parse(env_source);
     // Route to appropriate pool based on the resolved manager family.
     if matches!(parsed, EnvSource::Prewarmed(PackageManager::Pixi)) {
         return match daemon.take_pixi_env().await {
-            Some(leased) => {
+            Some((env, guard)) => {
                 info!(
                     "[notebook-sync] Acquired Pixi env from pool: {:?}",
-                    leased.env().python_path
+                    env.python_path
                 );
-                Ok(Some(leased))
+                Ok(Some((env, guard)))
             }
             None => {
                 // Pixi pool empty — launch on demand via pixi exec (no pooled env needed)
@@ -2066,12 +2080,12 @@ async fn acquire_pool_env_for_source(
     }
     if parsed.package_manager() == Some(PackageManager::Conda) {
         match daemon.take_conda_env().await {
-            Some(leased) => {
+            Some((env, guard)) => {
                 info!(
                     "[notebook-sync] Acquired Conda env from pool: {:?}",
-                    leased.env().python_path
+                    env.python_path
                 );
-                Ok(Some(leased))
+                Ok(Some((env, guard)))
             }
             None => {
                 error!("[notebook-sync] Conda pool empty, cannot launch");
@@ -2081,12 +2095,12 @@ async fn acquire_pool_env_for_source(
     } else {
         // UV pool for uv:* sources and as default
         match daemon.take_uv_env().await {
-            Some(leased) => {
+            Some((env, guard)) => {
                 info!(
                     "[notebook-sync] Acquired UV env from pool: {:?}",
-                    leased.env().python_path
+                    env.python_path
                 );
-                Ok(Some(leased))
+                Ok(Some((env, guard)))
             }
             None => {
                 error!("[notebook-sync] UV pool empty, cannot launch");
@@ -2256,19 +2270,18 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     }
 
     // Take the env, then compare against what it *actually* has installed.
-    // The lease is held by `leased` until we either transfer ownership
-    // (success path: env promoted into the inline cache, lease released)
-    // or release_and_delete (failure path: env directory removed). Drop
-    // catches any forgotten branch.
-    let mut leased = match daemon.take_uv_env().await {
-        Some(leased) => leased,
+    // The guard holds the lease until we either release (success path:
+    // env promoted into the inline cache) or release_and_delete (failure
+    // path: env directory removed). Drop catches any forgotten branch.
+    let (mut env, guard) = match daemon.take_uv_env().await {
+        Some(taken) => taken,
         None => {
             info!("[notebook-sync] UV pool empty, falling back to full build");
             return Err(());
         }
     };
 
-    let actual_packages = leased.env().prewarmed_packages.clone();
+    let actual_packages = env.prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(&effective_deps, &actual_packages);
 
     match relation {
@@ -2278,13 +2291,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // restart with the same deps cache-hits instead of taking
             // another pool env. See #2089 / #2083.
             crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                leased.env_mut(),
+                &mut env,
                 deps,
                 None,
                 bootstrap_dx,
             )
             .await;
-            let env = leased.transfer_to_runtime().await;
+            guard.release().await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2293,8 +2306,8 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                 delta
             );
             let uv_env = kernel_env::UvEnvironment {
-                venv_path: leased.env().venv_path.clone(),
-                python_path: leased.env().python_path.clone(),
+                venv_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
             };
             progress_handler.on_progress(
                 "uv",
@@ -2309,13 +2322,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
                     crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                        leased.env_mut(),
+                        &mut env,
                         deps,
                         None,
                         bootstrap_dx,
                     )
                     .await;
-                    let env = leased.transfer_to_runtime().await;
+                    guard.release().await;
                     progress_handler.on_progress(
                         "uv",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2332,7 +2345,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     );
                     // Clean up the taken pool env — it's out of the pool's
                     // tracking and would otherwise leak on disk.
-                    leased.release_and_delete().await;
+                    guard.release_and_delete().await;
                     Err(())
                 }
             }
@@ -2340,7 +2353,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
-            leased.release_and_delete().await;
+            guard.release_and_delete().await;
             Err(())
         }
     }
@@ -2379,18 +2392,18 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     }
 
     // Take the env, then compare against what it *actually* has installed.
-    // Lease held by `leased`; consumed via transfer_to_runtime() (success)
-    // or release_and_delete() (failure). See try_uv_pool_for_inline_deps
-    // for the same pattern.
-    let mut leased = match daemon.take_conda_env().await {
-        Some(leased) => leased,
+    // Guard holds the lease; consumed via release() (success) or
+    // release_and_delete() (failure). See try_uv_pool_for_inline_deps for
+    // the same pattern.
+    let (mut env, guard) = match daemon.take_conda_env().await {
+        Some(taken) => taken,
         None => {
             info!("[notebook-sync] Conda pool empty, falling back to full build");
             return Err(());
         }
     };
 
-    let actual_packages = leased.env().prewarmed_packages.clone();
+    let actual_packages = env.prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
 
     match relation {
@@ -2398,13 +2411,9 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             info!("[notebook-sync] Inline Conda deps are subset of pool env, reusing directly");
             // Promote the pool env into the inline-env cache so the next
             // restart cache-hits. See #2089 / #2083.
-            crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                leased.env_mut(),
-                deps,
-                channels,
-            )
-            .await;
-            let env = leased.transfer_to_runtime().await;
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
+                .await;
+            guard.release().await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2413,8 +2422,8 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                 delta
             );
             let conda_env = kernel_env::CondaEnvironment {
-                env_path: leased.env().venv_path.clone(),
-                python_path: leased.env().python_path.clone(),
+                env_path: env.venv_path.clone(),
+                python_path: env.python_path.clone(),
             };
             // Pass ALL inline deps to sync_dependencies, not just the delta.
             // The conda solver treats the spec list as the complete desired
@@ -2440,12 +2449,10 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                        leased.env_mut(),
-                        deps,
-                        channels,
+                        &mut env, deps, channels,
                     )
                     .await;
-                    let env = leased.transfer_to_runtime().await;
+                    guard.release().await;
                     progress_handler.on_progress(
                         "conda",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2460,14 +2467,14 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
-                    leased.release_and_delete().await;
+                    guard.release_and_delete().await;
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
-            leased.release_and_delete().await;
+            guard.release_and_delete().await;
             Err(())
         }
     }
@@ -2723,15 +2730,16 @@ pub(crate) async fn auto_launch_kernel(
                     )
                     .await
                     {
-                        Ok(Some(leased)) => {
-                            // Set the runtime owner BEFORE releasing the
-                            // lease so the env is never momentarily
-                            // unprotected.
-                            {
-                                let mut ep = room.runtime_agent_env_path.write().await;
-                                *ep = Some(leased.env().venv_path.clone());
-                            }
-                            Some(leased.transfer_to_runtime().await)
+                        Ok(Some(env)) => {
+                            // Set the active runtime owner now so the env
+                            // is protected by `runtime_agent_env_path`
+                            // through the rest of the auto-launch flow.
+                            // (`acquire_prewarmed_env_with_capture` already
+                            // released the pool lease internally.)
+                            let mut ep = room.runtime_agent_env_path.write().await;
+                            *ep = Some(env.venv_path.clone());
+                            drop(ep);
+                            Some(env)
                         }
                         Ok(None) => None,
                         Err(()) => {
@@ -2792,12 +2800,11 @@ pub(crate) async fn auto_launch_kernel(
                         )
                         .await
                         {
-                            Ok(Some(leased)) => {
-                                {
-                                    let mut ep = room.runtime_agent_env_path.write().await;
-                                    *ep = Some(leased.env().venv_path.clone());
-                                }
-                                Some(leased.transfer_to_runtime().await)
+                            Ok(Some(env)) => {
+                                let mut ep = room.runtime_agent_env_path.write().await;
+                                *ep = Some(env.venv_path.clone());
+                                drop(ep);
+                                Some(env)
                             }
                             Ok(None) => None,
                             Err(()) => {
@@ -2825,12 +2832,11 @@ pub(crate) async fn auto_launch_kernel(
                 )
                 .await
                 {
-                    Ok(Some(leased)) => {
-                        {
-                            let mut ep = room.runtime_agent_env_path.write().await;
-                            *ep = Some(leased.env().venv_path.clone());
-                        }
-                        Some(leased.transfer_to_runtime().await)
+                    Ok(Some(env)) => {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(env.venv_path.clone());
+                        drop(ep);
+                        Some(env)
                     }
                     Ok(None) => None,
                     Err(()) => {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1813,7 +1813,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     metadata_snapshot: Option<&NotebookMetadataSnapshot>,
-) -> Option<Option<crate::PooledEnv>> {
+) -> Result<Option<crate::daemon::LeasedPoolEnv>, ()> {
     let runtime = match env_source {
         "uv:prewarmed" => CapturedEnvRuntime::Uv,
         "conda:prewarmed" => CapturedEnvRuntime::Conda,
@@ -1857,12 +1857,14 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                                 "[notebook-sync] Reopen cache-hit for env_id={} at {:?}",
                                 env_id, prepared.venv_path
                             );
-                            return Some(Some(crate::PooledEnv {
-                                env_type: crate::EnvType::Uv,
-                                venv_path: prepared.venv_path,
-                                python_path: prepared.python_path,
-                                prewarmed_packages: deps.dependencies.clone(),
-                            }));
+                            return Ok(Some(crate::daemon::LeasedPoolEnv::cached(
+                                crate::PooledEnv {
+                                    env_type: crate::EnvType::Uv,
+                                    venv_path: prepared.venv_path,
+                                    python_path: prepared.python_path,
+                                    prewarmed_packages: deps.dependencies.clone(),
+                                },
+                            )));
                         }
                         Err(e) => {
                             warn!(
@@ -1887,12 +1889,14 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                                 "[notebook-sync] Reopen cache-hit for env_id={} at {:?}",
                                 env_id, prepared.env_path
                             );
-                            return Some(Some(crate::PooledEnv {
-                                env_type: crate::EnvType::Conda,
-                                venv_path: prepared.env_path,
-                                python_path: prepared.python_path,
-                                prewarmed_packages: deps.dependencies.clone(),
-                            }));
+                            return Ok(Some(crate::daemon::LeasedPoolEnv::cached(
+                                crate::PooledEnv {
+                                    env_type: crate::EnvType::Conda,
+                                    venv_path: prepared.env_path,
+                                    python_path: prepared.python_path,
+                                    prewarmed_packages: deps.dependencies.clone(),
+                                },
+                            )));
                         }
                         Err(e) => {
                             warn!(
@@ -1908,9 +1912,11 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 
     // First-launch path: take from pool, strip base to derive user_defaults,
     // claim to the unified-hash location, and capture into metadata.
-    let pooled = acquire_pool_env_for_source(env_source, daemon, room).await?;
-    let pooled = pooled?;
-    let leased_path = pooled.venv_path.clone();
+    let Some(mut leased) = acquire_pool_env_for_source(env_source, daemon, room).await? else {
+        // Pool returned `Ok(None)` (e.g. pixi → launch on demand). Pass
+        // that through to the caller.
+        return Ok(None);
+    };
 
     let env_id = metadata_snapshot
         .and_then(|s| s.runt.env_id.clone())
@@ -1918,6 +1924,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 
     match runtime {
         CapturedEnvRuntime::Uv => {
+            let pooled = leased.env();
             let user_defaults =
                 kernel_env::strip_base(&pooled.prewarmed_packages, kernel_env::UV_BASE_PACKAGES);
             let prewarmed = kernel_env::uv::UvEnvironment {
@@ -1934,8 +1941,17 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
             .await
             {
                 Ok(claimed) => {
+                    // Mutate the inner env to point at the claimed location.
+                    // The lease's `leased_path` is unchanged (still tracks
+                    // the original pool path, which `claim_prewarmed_*`
+                    // moved into the unified-hash cache). transfer_to_runtime
+                    // releases the lease for that original path.
                     let claimed_path = claimed.venv_path.clone();
-                    let python_path = claimed.python_path.clone();
+                    {
+                        let inner = leased.env_mut();
+                        inner.venv_path = claimed_path.clone();
+                        inner.python_path = claimed.python_path;
+                    }
                     let _wrote = capture_env_into_metadata(
                         room,
                         CapturedEnvRuntime::Uv,
@@ -1947,15 +1963,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed UV env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
-                    daemon
-                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                        .await;
-                    Some(Some(crate::PooledEnv {
-                        env_type: crate::EnvType::Uv,
-                        venv_path: claimed_path,
-                        python_path,
-                        prewarmed_packages: pooled.prewarmed_packages,
-                    }))
+                    Ok(Some(leased))
                 }
                 Err(e) => {
                     warn!(
@@ -1964,16 +1972,14 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                     );
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
-                        *ep = Some(pooled.venv_path.clone());
+                        *ep = Some(leased.env().venv_path.clone());
                     }
-                    daemon
-                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                        .await;
-                    Some(Some(pooled))
+                    Ok(Some(leased))
                 }
             }
         }
         CapturedEnvRuntime::Conda => {
+            let pooled = leased.env();
             let user_defaults =
                 kernel_env::strip_base(&pooled.prewarmed_packages, kernel_env::CONDA_BASE_PACKAGES);
             let prewarmed = kernel_env::conda::CondaEnvironment {
@@ -1991,7 +1997,11 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
             {
                 Ok(claimed) => {
                     let claimed_path = claimed.env_path.clone();
-                    let python_path = claimed.python_path.clone();
+                    {
+                        let inner = leased.env_mut();
+                        inner.venv_path = claimed_path.clone();
+                        inner.python_path = claimed.python_path;
+                    }
                     let _wrote = capture_env_into_metadata(
                         room,
                         CapturedEnvRuntime::Conda,
@@ -2003,15 +2013,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                         "[notebook-sync] Captured prewarmed conda env into metadata for env_id={} at {:?}",
                         env_id, claimed_path
                     );
-                    daemon
-                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                        .await;
-                    Some(Some(crate::PooledEnv {
-                        env_type: crate::EnvType::Conda,
-                        venv_path: claimed_path,
-                        python_path,
-                        prewarmed_packages: pooled.prewarmed_packages,
-                    }))
+                    Ok(Some(leased))
                 }
                 Err(e) => {
                     warn!(
@@ -2020,12 +2022,9 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
                     );
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
-                        *ep = Some(pooled.venv_path.clone());
+                        *ep = Some(leased.env().venv_path.clone());
                     }
-                    daemon
-                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                        .await;
-                    Some(Some(pooled))
+                    Ok(Some(leased))
                 }
             }
         }
@@ -2033,58 +2032,65 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 }
 
 /// Acquire a pooled environment from the appropriate pool based on env_source.
-/// Returns None and broadcasts error if pool is empty.
+///
+/// - `Ok(Some(leased))`: lease is still held; caller must call
+///   `transfer_to_runtime()` on success or `release_and_delete()` on failure.
+///   `Drop` releases the lease best-effort if the caller forgets either.
+/// - `Ok(None)`: env source doesn't need a pool entry (e.g. pixi pool empty
+///   → launch on demand via `pixi exec`).
+/// - `Err(())`: pool empty for a source that requires one; caller should
+///   bail with an error.
 async fn acquire_pool_env_for_source(
     env_source: &str,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     _room: &NotebookRoom,
-) -> Option<Option<crate::PooledEnv>> {
+) -> Result<Option<crate::daemon::LeasedPoolEnv>, ()> {
     use notebook_protocol::connection::{EnvSource, PackageManager};
     let parsed = EnvSource::parse(env_source);
     // Route to appropriate pool based on the resolved manager family.
     if matches!(parsed, EnvSource::Prewarmed(PackageManager::Pixi)) {
-        match daemon.take_pixi_env().await {
-            Some(env) => {
+        return match daemon.take_pixi_env().await {
+            Some(leased) => {
                 info!(
                     "[notebook-sync] Acquired Pixi env from pool: {:?}",
-                    env.python_path
+                    leased.env().python_path
                 );
-                return Some(Some(env));
+                Ok(Some(leased))
             }
             None => {
                 // Pixi pool empty — launch on demand via pixi exec (no pooled env needed)
                 info!("[notebook-sync] Pixi pool empty, will launch on demand via pixi exec");
-                return Some(None);
+                Ok(None)
             }
-        }
+        };
     }
     if parsed.package_manager() == Some(PackageManager::Conda) {
         match daemon.take_conda_env().await {
-            Some(env) => {
+            Some(leased) => {
                 info!(
                     "[notebook-sync] Acquired Conda env from pool: {:?}",
-                    env.python_path
+                    leased.env().python_path
                 );
-                Some(Some(env))
+                Ok(Some(leased))
             }
             None => {
                 error!("[notebook-sync] Conda pool empty, cannot launch");
-                None // Signal caller to return early
+                Err(())
             }
         }
     } else {
         // UV pool for uv:* sources and as default
         match daemon.take_uv_env().await {
-            Some(env) => {
+            Some(leased) => {
                 info!(
                     "[notebook-sync] Acquired UV env from pool: {:?}",
-                    env.python_path
+                    leased.env().python_path
                 );
-                Some(Some(env))
+                Ok(Some(leased))
             }
             None => {
                 error!("[notebook-sync] UV pool empty, cannot launch");
-                None // Signal caller to return early
+                Err(())
             }
         }
     }
@@ -2249,17 +2255,20 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
         return Err(());
     }
 
-    // Take the env, then compare against what it *actually* has installed
-    let mut env = match daemon.take_uv_env().await {
-        Some(env) => env,
+    // Take the env, then compare against what it *actually* has installed.
+    // The lease is held by `leased` until we either transfer ownership
+    // (success path: env promoted into the inline cache, lease released)
+    // or release_and_delete (failure path: env directory removed). Drop
+    // catches any forgotten branch.
+    let mut leased = match daemon.take_uv_env().await {
+        Some(leased) => leased,
         None => {
             info!("[notebook-sync] UV pool empty, falling back to full build");
             return Err(());
         }
     };
-    let leased_path = env.venv_path.clone();
 
-    let actual_packages = env.prewarmed_packages.clone();
+    let actual_packages = leased.env().prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(&effective_deps, &actual_packages);
 
     match relation {
@@ -2269,15 +2278,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // restart with the same deps cache-hits instead of taking
             // another pool env. See #2089 / #2083.
             crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                &mut env,
+                leased.env_mut(),
                 deps,
                 None,
                 bootstrap_dx,
             )
             .await;
-            daemon
-                .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                .await;
+            let env = leased.transfer_to_runtime().await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2286,8 +2293,8 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                 delta
             );
             let uv_env = kernel_env::UvEnvironment {
-                venv_path: env.venv_path.clone(),
-                python_path: env.python_path.clone(),
+                venv_path: leased.env().venv_path.clone(),
+                python_path: leased.env().python_path.clone(),
             };
             progress_handler.on_progress(
                 "uv",
@@ -2302,15 +2309,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
                     crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                        &mut env,
+                        leased.env_mut(),
                         deps,
                         None,
                         bootstrap_dx,
                     )
                     .await;
-                    daemon
-                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                        .await;
+                    let env = leased.transfer_to_runtime().await;
                     progress_handler.on_progress(
                         "uv",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2327,19 +2332,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     );
                     // Clean up the taken pool env — it's out of the pool's
                     // tracking and would otherwise leak on disk.
-                    daemon
-                        .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                        .await;
-                    let root = crate::paths::pool_env_root(&env.venv_path);
-                    let cache_dir = crate::paths::default_cache_dir();
-                    if crate::is_within_cache_dir(&root, &cache_dir) {
-                        if let Err(e) = tokio::fs::remove_dir_all(&root).await {
-                            warn!(
-                                "[notebook-sync] Failed to clean up UV pool env {:?}: {}",
-                                root, e
-                            );
-                        }
-                    }
+                    leased.release_and_delete().await;
                     Err(())
                 }
             }
@@ -2347,19 +2340,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
-            daemon
-                .release_pool_lease(crate::EnvType::Uv, &leased_path)
-                .await;
-            let root = crate::paths::pool_env_root(&env.venv_path);
-            let cache_dir = crate::paths::default_cache_dir();
-            if crate::is_within_cache_dir(&root, &cache_dir) {
-                if let Err(e) = tokio::fs::remove_dir_all(&root).await {
-                    warn!(
-                        "[notebook-sync] Failed to clean up UV pool env {:?}: {}",
-                        root, e
-                    );
-                }
-            }
+            leased.release_and_delete().await;
             Err(())
         }
     }
@@ -2397,17 +2378,19 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
         return Err(());
     }
 
-    // Take the env, then compare against what it *actually* has installed
-    let mut env = match daemon.take_conda_env().await {
-        Some(env) => env,
+    // Take the env, then compare against what it *actually* has installed.
+    // Lease held by `leased`; consumed via transfer_to_runtime() (success)
+    // or release_and_delete() (failure). See try_uv_pool_for_inline_deps
+    // for the same pattern.
+    let mut leased = match daemon.take_conda_env().await {
+        Some(leased) => leased,
         None => {
             info!("[notebook-sync] Conda pool empty, falling back to full build");
             return Err(());
         }
     };
-    let leased_path = env.venv_path.clone();
 
-    let actual_packages = env.prewarmed_packages.clone();
+    let actual_packages = leased.env().prewarmed_packages.clone();
     let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
 
     match relation {
@@ -2415,11 +2398,13 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             info!("[notebook-sync] Inline Conda deps are subset of pool env, reusing directly");
             // Promote the pool env into the inline-env cache so the next
             // restart cache-hits. See #2089 / #2083.
-            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
-                .await;
-            daemon
-                .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                .await;
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(
+                leased.env_mut(),
+                deps,
+                channels,
+            )
+            .await;
+            let env = leased.transfer_to_runtime().await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2428,8 +2413,8 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                 delta
             );
             let conda_env = kernel_env::CondaEnvironment {
-                env_path: env.venv_path.clone(),
-                python_path: env.python_path.clone(),
+                env_path: leased.env().venv_path.clone(),
+                python_path: leased.env().python_path.clone(),
             };
             // Pass ALL inline deps to sync_dependencies, not just the delta.
             // The conda solver treats the spec list as the complete desired
@@ -2455,12 +2440,12 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                        &mut env, deps, channels,
+                        leased.env_mut(),
+                        deps,
+                        channels,
                     )
                     .await;
-                    daemon
-                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                        .await;
+                    let env = leased.transfer_to_runtime().await;
                     progress_handler.on_progress(
                         "conda",
                         kernel_env::EnvProgressPhase::Ready {
@@ -2475,38 +2460,14 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
-                    daemon
-                        .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                        .await;
-                    let root = crate::paths::pool_env_root(&env.venv_path);
-                    let cache_dir = crate::paths::default_cache_dir();
-                    if crate::is_within_cache_dir(&root, &cache_dir) {
-                        if let Err(e) = tokio::fs::remove_dir_all(&root).await {
-                            warn!(
-                                "[notebook-sync] Failed to clean up Conda pool env {:?}: {}",
-                                root, e
-                            );
-                        }
-                    }
+                    leased.release_and_delete().await;
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
-            daemon
-                .release_pool_lease(crate::EnvType::Conda, &leased_path)
-                .await;
-            let root = crate::paths::pool_env_root(&env.venv_path);
-            let cache_dir = crate::paths::default_cache_dir();
-            if crate::is_within_cache_dir(&root, &cache_dir) {
-                if let Err(e) = tokio::fs::remove_dir_all(&root).await {
-                    warn!(
-                        "[notebook-sync] Failed to clean up Conda pool env {:?}: {}",
-                        root, e
-                    );
-                }
-            }
+            leased.release_and_delete().await;
             Err(())
         }
     }
@@ -2762,8 +2723,18 @@ pub(crate) async fn auto_launch_kernel(
                     )
                     .await
                     {
-                        Some(env) => env,
-                        None => {
+                        Ok(Some(leased)) => {
+                            // Set the runtime owner BEFORE releasing the
+                            // lease so the env is never momentarily
+                            // unprotected.
+                            {
+                                let mut ep = room.runtime_agent_env_path.write().await;
+                                *ep = Some(leased.env().venv_path.clone());
+                            }
+                            Some(leased.transfer_to_runtime().await)
+                        }
+                        Ok(None) => None,
+                        Err(()) => {
                             reset_starting_state(room, None).await;
                             return;
                         }
@@ -2821,8 +2792,15 @@ pub(crate) async fn auto_launch_kernel(
                         )
                         .await
                         {
-                            Some(env) => env,
-                            None => {
+                            Ok(Some(leased)) => {
+                                {
+                                    let mut ep = room.runtime_agent_env_path.write().await;
+                                    *ep = Some(leased.env().venv_path.clone());
+                                }
+                                Some(leased.transfer_to_runtime().await)
+                            }
+                            Ok(None) => None,
+                            Err(()) => {
                                 reset_starting_state(room, None).await;
                                 return;
                             }
@@ -2847,8 +2825,15 @@ pub(crate) async fn auto_launch_kernel(
                 )
                 .await
                 {
-                    Some(env) => env,
-                    None => {
+                    Ok(Some(leased)) => {
+                        {
+                            let mut ep = room.runtime_agent_env_path.write().await;
+                            *ep = Some(leased.env().venv_path.clone());
+                        }
+                        Some(leased.transfer_to_runtime().await)
+                    }
+                    Ok(None) => None,
+                    Err(()) => {
                         reset_starting_state(room, None).await;
                         return;
                     }
@@ -3417,18 +3402,14 @@ pub(crate) async fn auto_launch_kernel(
         }
     }
 
-    // Register the env path for GC protection immediately after pool.take(),
-    // BEFORE any async work (agent spawn, connect timeout, delta install).
-    // Without this, there's a race window where GC sees the taken env as an
-    // orphan and deletes it while we're still setting up the kernel.
+    // Register the env path for GC protection. For prewarmed pool envs this
+    // is already set above (right after `transfer_to_runtime`); for inline /
+    // PEP 723 / env_yml flows that built their own env, set it here so the
+    // env directory is in `runtime_agent_env_path` before any async work
+    // (agent spawn, connect timeout) runs.
     if let Some(ref env) = pooled_env {
-        {
-            let mut ep = room.runtime_agent_env_path.write().await;
-            *ep = Some(env.venv_path.clone());
-        }
-        daemon
-            .release_pool_lease(env.env_type, &env.venv_path)
-            .await;
+        let mut ep = room.runtime_agent_env_path.write().await;
+        *ep = Some(env.venv_path.clone());
     }
 
     // Build LaunchedEnvConfig to track what config the kernel was launched with

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2251,6 +2251,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     deps: &[String],
     bootstrap_dx: bool,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
+    room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
     // `inline_deps_with_bootstrap` is a shim since 0.2.0 — launcher
@@ -2290,6 +2291,14 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // Promote the pool env into the inline-env cache so the next
             // restart with the same deps cache-hits instead of taking
             // another pool env. See #2089 / #2083.
+            //
+            // The claim is best-effort: if the rename target already
+            // exists or the move fails, `env.venv_path` stays at the
+            // raw pool path (`runtimed-uv-*`). That path is subject to
+            // the orphan sweep, so we MUST install runtime ownership
+            // before releasing the lease — otherwise the sweep races
+            // with the launch handler's later `runtime_agent_env_path`
+            // write and can delete the env mid-launch.
             crate::inline_env::claim_pool_env_for_uv_inline_cache(
                 &mut env,
                 deps,
@@ -2297,6 +2306,10 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                 bootstrap_dx,
             )
             .await;
+            {
+                let mut ep = room.runtime_agent_env_path.write().await;
+                *ep = Some(env.venv_path.clone());
+            }
             guard.release().await;
             Ok((env, actual_packages))
         }
@@ -2321,6 +2334,8 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     );
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
+                    // Same claim-best-effort caveat as the Subset arm —
+                    // install runtime ownership before releasing.
                     crate::inline_env::claim_pool_env_for_uv_inline_cache(
                         &mut env,
                         deps,
@@ -2328,6 +2343,10 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                         bootstrap_dx,
                     )
                     .await;
+                    {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(env.venv_path.clone());
+                    }
                     guard.release().await;
                     progress_handler.on_progress(
                         "uv",
@@ -2368,6 +2387,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     deps: &[String],
     channels: &[String],
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
+    room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
     // Only use pool for default conda-forge channel
@@ -2410,9 +2430,15 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Subset => {
             info!("[notebook-sync] Inline Conda deps are subset of pool env, reusing directly");
             // Promote the pool env into the inline-env cache so the next
-            // restart cache-hits. See #2089 / #2083.
+            // restart cache-hits. See #2089 / #2083. The claim is
+            // best-effort, so install runtime ownership before releasing
+            // the lease (see try_uv_pool_for_inline_deps for rationale).
             crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
                 .await;
+            {
+                let mut ep = room.runtime_agent_env_path.write().await;
+                *ep = Some(env.venv_path.clone());
+            }
             guard.release().await;
             Ok((env, actual_packages))
         }
@@ -2447,11 +2473,17 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         delta.len()
                     );
                     // Promote the pool env into the inline-env cache so
-                    // the next restart cache-hits. See #2089 / #2083.
+                    // the next restart cache-hits. Same claim-best-effort
+                    // caveat as the Subset arm — install runtime
+                    // ownership before releasing.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
                         &mut env, deps, channels,
                     )
                     .await;
+                    {
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(env.venv_path.clone());
+                    }
                     guard.release().await;
                     progress_handler.on_progress(
                         "conda",
@@ -2974,6 +3006,7 @@ pub(crate) async fn auto_launch_kernel(
                     &deps,
                     bootstrap_dx,
                     &daemon,
+                    room,
                     progress_handler.clone(),
                 )
                 .await
@@ -3081,6 +3114,7 @@ pub(crate) async fn auto_launch_kernel(
                     &deps,
                     &channels,
                     &daemon,
+                    room,
                     progress_handler.clone(),
                 )
                 .await

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -547,19 +547,21 @@ pub(crate) async fn handle(
                 )
                 .await
                 {
-                    Ok(Some(leased)) => {
+                    Ok(Some(env)) => {
                         info!(
                             "[notebook-sync] LaunchKernel: acquired {} env: {:?}",
                             resolved_env_source.as_str(),
-                            leased.env().python_path
+                            env.python_path
                         );
-                        // Set the runtime owner BEFORE releasing the lease
-                        // so the env is never momentarily unprotected.
-                        {
-                            let mut ep = room.runtime_agent_env_path.write().await;
-                            *ep = Some(leased.env().venv_path.clone());
-                        }
-                        Some(leased.transfer_to_runtime().await)
+                        // Set the active runtime owner now so the env is
+                        // protected by `runtime_agent_env_path` through
+                        // the rest of the launch flow. (The pool lease
+                        // was already released inside
+                        // `acquire_prewarmed_env_with_capture`.)
+                        let mut ep = room.runtime_agent_env_path.write().await;
+                        *ep = Some(env.venv_path.clone());
+                        drop(ep);
+                        Some(env)
                     }
                     Ok(None) => None,
                     Err(()) => {
@@ -592,12 +594,12 @@ pub(crate) async fn handle(
                 None
             }
             other => {
-                // For remaining conda sources, route to conda pool.
-                // Set runtime_agent_env_path BEFORE transfer_to_runtime so
-                // the env is never momentarily unprotected.
-                let leased = if other.starts_with("conda:") {
+                // For remaining conda sources, route to conda pool. Set
+                // runtime_agent_env_path BEFORE releasing the lease so the
+                // env is never momentarily unprotected.
+                let (env, guard) = if other.starts_with("conda:") {
                     match daemon.take_conda_env().await {
-                        Some(leased) => leased,
+                        Some(taken) => taken,
                         None => {
                             reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
@@ -608,7 +610,7 @@ pub(crate) async fn handle(
                 } else {
                     // Prewarmed UV
                     match daemon.take_uv_env().await {
-                        Some(leased) => leased,
+                        Some(taken) => taken,
                         None => {
                             reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
@@ -619,9 +621,10 @@ pub(crate) async fn handle(
                 };
                 {
                     let mut ep = room.runtime_agent_env_path.write().await;
-                    *ep = Some(leased.env().venv_path.clone());
+                    *ep = Some(env.venv_path.clone());
                 }
-                Some(leased.transfer_to_runtime().await)
+                guard.release().await;
+                Some(env)
             }
         }
     };

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -547,16 +547,22 @@ pub(crate) async fn handle(
                 )
                 .await
                 {
-                    Some(Some(env)) => {
+                    Ok(Some(leased)) => {
                         info!(
                             "[notebook-sync] LaunchKernel: acquired {} env: {:?}",
                             resolved_env_source.as_str(),
-                            env.python_path
+                            leased.env().python_path
                         );
-                        Some(env)
+                        // Set the runtime owner BEFORE releasing the lease
+                        // so the env is never momentarily unprotected.
+                        {
+                            let mut ep = room.runtime_agent_env_path.write().await;
+                            *ep = Some(leased.env().venv_path.clone());
+                        }
+                        Some(leased.transfer_to_runtime().await)
                     }
-                    Some(None) => None,
-                    None => {
+                    Ok(None) => None,
+                    Err(()) => {
                         // `acquire_prewarmed_env_with_capture`
                         // already broadcast the error; bail out.
                         reset_starting_state(room, None).await;
@@ -586,10 +592,12 @@ pub(crate) async fn handle(
                 None
             }
             other => {
-                // For remaining conda sources, route to conda pool
-                if other.starts_with("conda:") {
+                // For remaining conda sources, route to conda pool.
+                // Set runtime_agent_env_path BEFORE transfer_to_runtime so
+                // the env is never momentarily unprotected.
+                let leased = if other.starts_with("conda:") {
                     match daemon.take_conda_env().await {
-                        Some(env) => Some(env),
+                        Some(leased) => leased,
                         None => {
                             reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
@@ -600,7 +608,7 @@ pub(crate) async fn handle(
                 } else {
                     // Prewarmed UV
                     match daemon.take_uv_env().await {
-                        Some(env) => Some(env),
+                        Some(leased) => leased,
                         None => {
                             reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
@@ -608,7 +616,12 @@ pub(crate) async fn handle(
                             };
                         }
                     }
+                };
+                {
+                    let mut ep = room.runtime_agent_env_path.write().await;
+                    *ep = Some(leased.env().venv_path.clone());
                 }
+                Some(leased.transfer_to_runtime().await)
             }
         }
     };
@@ -1179,16 +1192,14 @@ pub(crate) async fn handle(
         }
     }
 
-    // Register the env path for GC protection immediately after pool.take(),
-    // BEFORE any async work (agent spawn, connect timeout, delta install).
+    // For prewarmed pool envs the active path was set above (right at
+    // `transfer_to_runtime`); for inline / PEP 723 / env_yml flows that
+    // built their own env, set it here so the env directory is in
+    // `runtime_agent_env_path` before any further async work (agent spawn,
+    // connect timeout).
     if let Some(ref env) = pooled_env {
-        {
-            let mut ep = room.runtime_agent_env_path.write().await;
-            *ep = Some(env.venv_path.clone());
-        }
-        daemon
-            .release_pool_lease(env.env_type, &env.venv_path)
-            .await;
+        let mut ep = room.runtime_agent_env_path.write().await;
+        *ep = Some(env.venv_path.clone());
     }
 
     // Build LaunchedEnvConfig to track what config the kernel was launched with.

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -734,6 +734,7 @@ pub(crate) async fn handle(
                     &deps,
                     bootstrap_dx,
                     daemon,
+                    room,
                     launch_progress_handler.clone(),
                 )
                 .await
@@ -835,6 +836,7 @@ pub(crate) async fn handle(
                     &deps,
                     &channels,
                     daemon,
+                    room,
                     launch_progress_handler.clone(),
                 )
                 .await


### PR DESCRIPTION
## Summary

Follow-up to #2403. The lease set fixes the orphan-GC race correctly, but `take_*_env` still returns a bare `PooledEnv`, so ~10 ownership-transfer sites have to remember to call `daemon.release_pool_lease`. Make the lease bookkeeping live in an RAII guard alongside the env. Drop catches forgotten branches; no panicking accessors anywhere (the daemon serves multiple sessions and crashing on an internal-invariant violation would take down everyone).

## Design

`take_uv_env` / `take_conda_env` / `take_pixi_env` now return `Option<(PooledEnv, PoolLeaseGuard)>`. The env is plain — pass it around freely — while the guard carries the lease bookkeeping (`Weak<Daemon>`, `env_type`, `leased_path`, a `released` flag). Three terminal operations:

| | When | Effect |
|---|---|---|
| `guard.release().await` | success | Removes the entry from `leased_paths`. Caller MUST have set the new owner (typically `runtime_agent_env_path`) on the same await chain. |
| `guard.release_and_delete().await` | known failure | Removes the env directory and releases the lease. Use when claim/vendor/spawn errors leave the env in an inconsistent state. |
| `Drop` | forgotten / panic / `?` early return | Releases the lease best-effort via `tokio::spawn`. **Does not delete.** Forgetting to release must not destroy a working env; orphan GC reclaims the leak once nothing protects it. |

Splitting the env from the guard means there's no `Option<PooledEnv>` tombstone to defend against, no `expect()` calls, and no `cached(env)` workaround for non-leased paths (cache hits just return the env without a guard).

## Other changes

- `acquire_pool_env_for_source` returns `Result<Option<(PooledEnv, PoolLeaseGuard)>, ()>`. The previous `Option<Option<T>>` (Some(Some) = got, Some(None) = no env needed, None = error) was redundant; Result spells the three states more directly.
- `acquire_prewarmed_env_with_capture` consumes the lease internally and returns plain `Result<Option<PooledEnv>, ()>` — callers don't see a guard. The fallback path sets `runtime_agent_env_path` before releasing, just like before. Pixi prewarmed flows through this same release-before-return path via the early-return at line 1820.
- `try_uv_pool_for_inline_deps` / `try_conda_pool_for_inline_deps` thread `(env, guard)` through their match arms — `release` on success, `release_and_delete` on failure.
- All transfer sites in `metadata.rs`, `requests/launch_kernel.rs`, and `auto_launch_kernel` set `runtime_agent_env_path` BEFORE releasing, eliminating the brief unprotected window between lease release and active-path registration.
- The orphan sweep was extracted into `Daemon::sweep_orphan_pool_envs` so the new regression tests can exercise it without spinning the 30-min `env_gc_loop`.

## Tests

Four new tests in `daemon::tests`:

- `leased_env_survives_orphan_sweep` - **bug repro**. Take env, run sweep, assert env survives. Would fail on `main` prior to #2403 and on any future refactor that drops `leased_paths` from `tracked_paths`.
- `dropped_lease_releases_but_does_not_delete` - Drop releases the lease but preserves the directory (the safer failure mode if a code path forgets to release).
- `release_clears_lease_keeps_env` - happy-path semantics.
- `concurrent_take_and_sweep_does_not_delete_leased` - **stress test**. Parallel takes against a continuously-running sweeper. The original CI failure mode that motivated #2403.

## Validation

- `cargo xtask lint --fix`
- `cargo xtask clippy` — no `expect_used` allows added
- `cargo test -p runtimed --lib` — 590 passed
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo test -p runtimed --test integration test_daemon_take_empty_pool` — regression check on the existing pool RPC path

## Out of scope

- `inline_env.rs::rename_env_to_target` silently continues at the original path on rename failure. Worth tightening, but it's a separate semantic bug.
