### PR TITLE
chore(codex): build wasm during environment setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -6,6 +6,7 @@ name = "desktop"
 script = '''
 direnv allow .
 pnpm install
+cargo xtask wasm
 export RUNTIMED_DEV=1
 '''
 


### PR DESCRIPTION
## Summary

- Add `cargo xtask wasm` to the Codex environment setup script after `pnpm install`.
- Keeps gitignored WASM and renderer-plugin artifacts warm for fresh Codex workspaces before daemon/dev commands run.

## Validation

- `cargo xtask lint --fix`