### PR TITLE
docs: refresh runtime architecture guidance

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -62,7 +62,7 @@ Each notebook room has a daemon-authoritative **RuntimeStateDoc** — a separate
 
 **The daemon is the sole writer.** Frontend reads via `useRuntimeState()`. Python reads via `notebook.runtime`.
 
-Key files: `crates/notebook-doc/src/runtime_state.rs`, `apps/notebook/src/lib/runtime-state.ts`.
+Key files: `crates/runtime-doc/src/doc.rs`, `crates/runtime-doc/src/handle.rs`, `apps/notebook/src/lib/runtime-state.ts`.
 
 ## Binary vs Text Content -- CRITICAL DISTINCTION
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -28,7 +28,7 @@ paths:
 
 | Crate | Owns | Consumers |
 |-------|------|-----------|
-| `notebook-doc` | Automerge schema, cell CRUD, output writes, per-cell accessors, `CellChangeset` diffing, fractional indexing, presence encoding, frame type constants | daemon, WASM, Python bindings |
+| `notebook-doc` | Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors, `CellChangeset` diffing, fractional indexing, presence encoding, frame type constants | daemon, WASM, Python bindings |
 | `notebook-protocol` | Wire types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`), connection handshake, frame parsing | daemon, `notebook-sync`, Python bindings |
 | `notebook-sync` | Sync infrastructure (`DocHandle`), snapshot watch channel, per-cell accessors for Python clients, sync task management | Python bindings (`runtimed-py`) |
 
@@ -159,12 +159,12 @@ Never pass code directly in execution requests. The correct flow: write to the C
 
 | File | Role |
 |------|------|
-| `crates/notebook-doc/src/lib.rs` | `NotebookDoc` -- Automerge schema, cell CRUD, output writes |
+| `crates/notebook-doc/src/lib.rs` | `NotebookDoc` -- Automerge schema, cell CRUD, nbformat fallback fields |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset` -- structural diff from Automerge patches |
 | `crates/notebook-doc/src/mime.rs` | Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`) |
 | `crates/notebook-protocol/src/protocol.rs` | Wire types: requests, responses, broadcasts |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync infrastructure, per-cell accessors |
-| `crates/runtimed/src/notebook_sync_server.rs` | `NotebookRoom`, room lifecycle, autosave, path_index |
+| `crates/runtimed/src/notebook_sync_server/` | `NotebookRoom`, room lifecycle, peer sync loops, persistence, metadata/trust/project context |
 | `crates/runtimed/src/output_prep.rs` | IOPub output-prep helpers (conversion, widget buffers, blob-store offload) |
 | `crates/runtimed/src/output_store.rs` | Manifest creation/resolution, `ContentRef` |
 | `crates/runtimed/src/blob_store.rs` | Content-addressed storage |

--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -109,7 +109,7 @@ The daemon maintains a pool of pre-created environments with `ipykernel` and `ip
 
 ## Project File Discovery
 
-Unified detection in `project_file.rs`, used by daemon's `auto_launch_kernel()`:
+Unified detection in `project_file.rs`, used by daemon auto-launch helpers:
 
 | Module | Purpose |
 |--------|---------|
@@ -156,7 +156,7 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 
 1. Create `crates/notebook/src/{format}.rs` with `find_{format}()` (directory walk) and `parse_{format}()` functions
 2. Add Tauri commands in `lib.rs`: `detect_{format}`, `get_{format}_dependencies`, `import_{format}_dependencies`
-3. Wire detection into daemon's `auto_launch_kernel()` in `notebook_sync_server.rs` at the correct priority position
+3. Wire detection into the daemon auto-launch helpers in `notebook_sync_server/metadata.rs` at the correct priority position
 4. Add frontend detection in `useDaemonKernel.ts` and the appropriate dependencies hook
 5. Add test fixture in `crates/notebook/fixtures/audit-test/`
 
@@ -183,7 +183,8 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 | File | Role |
 |------|------|
 | `crates/runtimed/src/daemon.rs` | Pool management |
-| `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` -- detection and resolution |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | auto-launch detection and resolution helpers |
+| `crates/runtimed/src/requests/launch_kernel.rs` | manual launch request handling |
 | `crates/runtimed/src/runtime_agent.rs` | Spawned as a subprocess by `RuntimeAgentHandle::spawn()`. `run_runtime_agent()` is the per-notebook event loop owning sockets, `QueueCommand` channels, and RuntimeStateDoc writes; `handle_runtime_agent_request()` dispatches each `LaunchKernel`/`RestartKernel`/etc. RPC |
 | `crates/runtimed/src/jupyter_kernel.rs` | `JupyterKernel::launch()` -- spawns the kernel process and wires ZMQ sockets |
 | `crates/runtimed/src/output_prep.rs` | Output-prep helpers — `QueueCommand`, `KernelStatus`, `QueuedCell`, iopub → nbformat conversion + display-update helpers, widget-buffer offload to the blob store. Imported by `runtime_agent.rs`, `jupyter_kernel.rs`, and `kernel_state.rs` |

--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -150,7 +150,7 @@ Dependencies are signed with HMAC-SHA256 to prevent untrusted code execution on 
 - **Machine-specific:** Every shared notebook is untrusted on the recipient's machine
 - **Verification:** `verify_signature()` returns `bool`. Higher-level `verify_notebook_trust()` returns `TrustInfo` with `TrustStatus`: Trusted, Untrusted, SignatureInvalid, or NoDependencies
 
-Changes to dependency metadata structure require updating `crates/runt-trust/src/lib.rs` (re-exported by `crates/notebook/src/trust.rs`).
+Changes to dependency metadata structure require updating `crates/notebook-doc/src/metadata.rs` and `crates/runt-trust/src/lib.rs`.
 
 ## Adding a New Project File Format
 
@@ -196,12 +196,9 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 | File | Role |
 |------|------|
 | `crates/notebook/src/lib.rs` | Tauri commands, `launch_kernel_via_daemon` |
-| `crates/notebook/src/uv_env.rs` | UV dependency metadata |
-| `crates/notebook/src/conda_env.rs` | Conda dependency metadata |
-| `crates/notebook/src/pyproject.rs` | pyproject.toml discovery and parsing |
-| `crates/notebook/src/pixi.rs` | pixi.toml discovery and parsing |
-| `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
-| `crates/notebook/src/trust.rs` | HMAC trust verification (re-exports from `runt-trust`) |
+| `crates/notebook-doc/src/metadata.rs` | Notebook dependency metadata schema and accessors |
+| `crates/runtimed/src/project_file.rs` | Unified closest-wins project file detection |
+| `crates/runt-trust/src/lib.rs` | HMAC trust verification |
 
 ### Frontend
 

--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -154,11 +154,11 @@ Changes to dependency metadata structure require updating `crates/notebook-doc/s
 
 ## Adding a New Project File Format
 
-1. Create `crates/notebook/src/{format}.rs` with `find_{format}()` (directory walk) and `parse_{format}()` functions
-2. Add Tauri commands in `lib.rs`: `detect_{format}`, `get_{format}_dependencies`, `import_{format}_dependencies`
-3. Wire detection into the daemon auto-launch helpers in `notebook_sync_server/metadata.rs` at the correct priority position
-4. Add frontend detection in `useDaemonKernel.ts` and the appropriate dependencies hook
-5. Add test fixture in `crates/notebook/fixtures/audit-test/`
+1. Extend `crates/runtimed/src/project_file.rs` so the unified closest-wins walk detects and parses the new format.
+2. Extend `crates/notebook-doc/src/metadata.rs` if the format adds notebook dependency metadata.
+3. Wire the parsed project context into daemon auto-launch helpers in `notebook_sync_server/metadata.rs` at the correct priority position.
+4. Add frontend projection in `packages/runtimed/src/derived-state.ts` and the appropriate dependencies hook/component.
+5. Add test fixture coverage in `crates/notebook/fixtures/audit-test/` and daemon project-file tests.
 
 ## Frontend Architecture
 
@@ -204,6 +204,6 @@ Changes to dependency metadata structure require updating `crates/notebook-doc/s
 
 | File | Role |
 |------|------|
-| `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, env sync |
+| `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution actions and ephemeral runtime event callbacks |
 | `apps/notebook/src/hooks/useDependencies.ts` | UV dep management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Conda dep management |

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -63,7 +63,7 @@ The frontend goes through `@nteract/notebook-host` for every host-platform
 side effect. **Do not import `@tauri-apps/*` directly** — that's what the
 host abstraction exists to prevent. The only places that may import
 `@tauri-apps/*` are `packages/notebook-host/src/tauri/` and the daemon
-relay glue in `apps/notebook/src/lib/` (frame-types.ts, tauri-transport).
+relay glue in `apps/notebook/src/lib/` (frame pipeline, Tauri transport).
 
 | Namespace | Role |
 |-----------|------|
@@ -157,7 +157,7 @@ The frontend has a single ingress point for daemon frames. All data flows throug
    - `updateCellById()` -- O(1) map update, notifies only that cell's subscribers
    - `replaceNotebookCells()` -- full replacement with `cellsEqual()` diffing
 
-4. **useDaemonKernel / useEnvProgress** -- Subscribe via `subscribeBroadcast()` from frame bus
+4. **Runtime state projection** -- `useDaemonKernel` consumes ephemeral broadcast events; persistent kernel/env/project state is projected from RuntimeStateDoc through runtime-state stores and hooks such as `useEnvProgress`
 
 5. **usePresence** -- Subscribes via `subscribePresence()` from frame bus. Maintains peer map.
 
@@ -185,7 +185,8 @@ Defined in `notebook-doc/src/diff.rs`, with TypeScript types in `packages/runtim
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM -> React conversion |
 | `apps/notebook/src/lib/notebook-cells.ts` | Split cell store, per-cell subscriptions |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcasts and presence |
-| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC |
+| `packages/runtimed/src/transport.ts` | Shared `FrameType` constants and transport interface |
+| `apps/notebook/src/lib/frame-pipeline.ts` | App-side frame event processing and materialization planning |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, broadcast handling |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
 | `src/components/outputs/media-router.tsx` | Output type dispatch |

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -5,6 +5,7 @@ paths:
   - packages/runtimed/src/transport.ts
   - packages/runtimed/src/protocol-contract.ts
   - packages/runtimed/src/request-types.ts
+  - apps/notebook/src/lib/frame-pipeline.ts
   - apps/notebook/src/lib/notebook-frame-bus*
 ---
 

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -142,7 +142,7 @@ Inline manifest system with blob offload for large payloads. When daemon receive
 
 State-carrying broadcasts (kernel status, queue, env sync, trust) have been replaced by a **daemon-authoritative, per-notebook Automerge document** synced via frame type `0x05`. Clients read via `useRuntimeState()`.
 
-Schema (in `crates/notebook-doc/src/runtime_state.rs`):
+Schema (in `crates/runtime-doc/src/doc.rs`):
 
 | Path | Type | Description |
 |------|------|-------------|
@@ -183,7 +183,7 @@ Each cell execution is assigned a unique `execution_id` (UUID). The `QueueEntry`
 | `crates/notebook-sync/src/connect.rs` | Connection setup |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync, per-cell accessors |
 | `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00-0x07) |
-| `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc` schema |
+| `crates/runtime-doc/src/doc.rs` | `RuntimeStateDoc` schema |
 | `packages/runtimed/src/transport.ts` | TypeScript `FrameType` constants and transport boundary |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub |
 | `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + hook |

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -2,7 +2,9 @@
 paths:
   - crates/notebook-protocol/**
   - crates/notebook-sync/**
-  - apps/notebook/src/lib/frame-types*
+  - packages/runtimed/src/transport.ts
+  - packages/runtimed/src/protocol-contract.ts
+  - packages/runtimed/src/request-types.ts
   - apps/notebook/src/lib/notebook-frame-bus*
 ---
 
@@ -12,7 +14,7 @@ paths:
 
 Two independent version numbers, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `4`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v4 removes legacy environment-sync request/response variants and requires current clients.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection/handshake.rs`, re-exported by `connection.rs`, currently `4`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v4 removes legacy environment-sync request/response variants and requires current clients.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) -- governs Automerge document compatibility. Bump when document structure changes.
 
 These are just incrementing integers that evolve independently from each other and from the artifact version.
@@ -123,7 +125,7 @@ After WASM `receive_frame()` demuxes frames, broadcasts and presence are dispatc
 | Function | Purpose |
 |----------|---------|
 | `emitBroadcast(payload)` | Called after WASM demux for type `0x03` frames |
-| `subscribeBroadcast(cb)` | Used by `useDaemonKernel`, `useEnvProgress` |
+| `subscribeBroadcast(cb)` | Used by `useDaemonKernel` for ephemeral runtime events; persistent env state is RuntimeStateDoc-backed |
 | `emitPresence(payload)` | Called after WASM CBOR decode for type `0x04` frames |
 | `subscribePresence(cb)` | Used by `usePresence`, `cursor-registry` |
 
@@ -173,13 +175,15 @@ Each cell execution is assigned a unique `execution_id` (UUID). The `QueueEntry`
 
 | File | Role |
 |------|------|
-| `crates/notebook-protocol/src/connection.rs` | Frame protocol, handshake, preamble |
+| `crates/notebook-protocol/src/connection.rs` | Public connection API facade and compatibility re-exports |
+| `crates/notebook-protocol/src/connection/framing.rs` | Frame protocol, preamble, typed frames, frame caps |
+| `crates/notebook-protocol/src/connection/handshake.rs` | Protocol version, handshake, capabilities, connection info |
 | `crates/notebook-protocol/src/protocol.rs` | Wire types: requests, responses, broadcasts |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync, per-cell accessors |
-| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00-0x06) |
+| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00-0x07) |
 | `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc` schema |
-| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` |
+| `packages/runtimed/src/transport.ts` | TypeScript `FrameType` constants and transport boundary |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub |
 | `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + hook |

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -6,7 +6,7 @@ paths:
   - packages/runtimed/src/protocol-contract.ts
   - packages/runtimed/src/request-types.ts
   - apps/notebook/src/lib/frame-pipeline.ts
-  - apps/notebook/src/lib/notebook-frame-bus*
+  - apps/notebook/src/lib/notebook-frame-bus.ts
 ---
 
 # Wire Protocol

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -49,25 +49,26 @@ Python packages. The major architectural seams are:
 - Unix socket, length-prefixed typed frames (7 frame types)
 - Preamble (magic + version) → JSON handshake → Automerge initial sync → steady state
 - Frame types: AutomergeSync (0x00), Request (0x01), Response (0x02),
-  Broadcast (0x03), Presence (0x04), RuntimeStateSync (0x05), PoolStateSync (0x06)
+  Broadcast (0x03), Presence (0x04), RuntimeStateSync (0x05),
+  PoolStateSync (0x06), SessionControl (0x07)
 - Requests are fire-and-forget style (ExecuteCell, LaunchKernel, etc.)
-- Broadcasts push state changes to all connected clients
+- Broadcasts carry ephemeral events; persistent runtime state syncs through RuntimeStateDoc
 
 ### Document Model
-- Automerge doc is the live notebook state; `.ipynb` on disk is a checkpoint
-- Two peers: frontend WASM peer (local-first edits) and daemon peer (execution, outputs)
-- Cell outputs stored as manifest hashes (content refs → blob store)
-- Separate RuntimeStateDoc (frame 0x05) for kernel status, queue, env sync, trust
+- NotebookDoc is the live notebook content/structure state; `.ipynb` on disk is a checkpoint
+- Two NotebookDoc peers: frontend WASM peer (local-first edits) and daemon peer (persistence/import/export)
+- Live cell outputs are RuntimeStateDoc execution manifests with content refs to the blob store
+- Separate RuntimeStateDoc (frame 0x05) for kernel status, queue, outputs, comms, env progress, trust, and project context
 - Per-cell O(1) accessors in WASM, Rust, and Python (three implementations)
 - CellChangeset for incremental field-level diffs (source, outputs, metadata, position...)
 
 ### CRDT Ownership Rules
 - Frontend WASM writes: cell source, position, type, metadata, notebook metadata
-- Daemon writes: cell outputs (manifest hashes), execution count, RuntimeStateDoc
+- Daemon writes: RuntimeStateDoc, including outputs, live execution counts, comms, trust, env progress, and project context
 - Rule: never write to CRDT in response to a daemon broadcast (daemon already wrote)
 
 ### Crate Boundaries
-- `notebook-doc`: Automerge schema, cell CRUD, output writes, per-cell accessors, diffing
+- `notebook-doc`: Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors, diffing
 - `notebook-protocol`: Wire types (Request, Response, Broadcast)
 - `notebook-sync`: DocHandle, sync infrastructure, Python-side per-cell accessors
 - `runtimed`: Central daemon (kernel lifecycle, pools, notebook rooms, blob store, autosave)
@@ -182,7 +183,7 @@ Start with these to understand the actual implementation:
 
 **Core daemon:**
 - `crates/runtimed/src/daemon.rs`
-- `crates/runtimed/src/notebook_sync_server.rs`
+- `crates/runtimed/src/notebook_sync_server/`
 - `crates/runtimed/src/output_prep.rs`
 - `crates/runtimed/src/output_store.rs`
 - `crates/runtimed/src/blob_store.rs`

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -231,7 +231,7 @@ ROOT/
 - **Frontend reads only** via `useRuntimeState()` hook in `apps/notebook/src/lib/runtime-state.ts`
 - **Python reads** via `notebook.runtime` property (`RuntimeState` class)
 
-Key files: `crates/notebook-doc/src/runtime_state.rs` (schema), `apps/notebook/src/lib/runtime-state.ts` (frontend).
+Key files: `crates/runtime-doc/src/doc.rs` (schema), `crates/runtime-doc/src/handle.rs` (handle), `apps/notebook/src/lib/runtime-state.ts` (frontend).
 
 ## Execution Lifecycle
 

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -81,7 +81,7 @@ Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server/room.
 
 ### Autosave
 
-Debounced: 2s quiet period, 10s max interval via `spawn_autosave_debouncer`. `NotebookAutosaved` broadcast clears frontend dirty flag. Explicit Cmd+S also runs cell formatting (ruff/deno fmt). Skips untitled notebooks and notebooks mid-load.
+Debounced: 2s quiet period, 10s max interval via `spawn_autosave_debouncer`. Frontend dirty state is cleared from save state/confirmations, not a room broadcast. Explicit Cmd+S also runs cell formatting (ruff/deno fmt). Skips untitled notebooks and notebooks mid-load.
 
 ### Saving an untitled notebook
 
@@ -91,7 +91,7 @@ Room keys are always UUIDs (never change). When an untitled notebook is first sa
 3. Inserts into `path_index: HashMap<PathBuf, Uuid>`
 4. Updates room's `path: RwLock<Option<PathBuf>>`
 5. Spawns file watcher for new path
-6. Broadcasts `PathChanged { path }` so peers update local path tracking
+6. Updates room path state so peers update local path tracking
 
 ### Crash Recovery
 

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -30,7 +30,7 @@ The daemon (`runtimed`) is a singleton process that communicates with notebook w
 
 - **Unix socket** — IPC endpoint for all notebook windows
 - **Lock file** — Singleton guarantee (only one daemon runs)
-- **Info file** (`daemon.json`) — Discovery: PID, endpoint, version
+- **Info file** (`daemon.json`) — Legacy discovery fallback; new code should query the live daemon over the socket
 - **UV Pool + Conda Pool** — Prewarmed Python environments (configurable pool size)
 - **Blob store** — Content-addressed output storage (`blobs/`)
 - **Notebook docs** — Persisted Automerge documents (`notebook-docs/`)
@@ -51,7 +51,7 @@ When you change daemon code and want the system service to pick it up on a cloud
 
 Builds runtimed + runt + nteract-mcp (release), installs them to `~/.local/share/runt-nightly/bin/` with channel-suffixed names, writes + starts the systemd user unit on first install, upgrades in place on subsequent runs. On macOS it refuses by default — use the nteract Nightly app (it auto-updates). Pass `--on-macos` to override, `--replace-installed-app` if an app bundle is already present.
 
-Verify: `runt-nightly daemon status` or `cat ~/.cache/runt-nightly/daemon.json`.
+Verify: `runt-nightly daemon status`.
 
 ### Fast iteration
 
@@ -77,7 +77,7 @@ Integration tests use temp directories for socket/lock files to avoid conflicts.
 
 ## Notebook Room Lifecycle
 
-Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server.rs`), always keyed by UUID. A secondary `path_index: HashMap<PathBuf, Uuid>` maps file paths to room UUIDs.
+Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server/room.rs`), keyed by UUID in `NotebookRooms`. A secondary `PathIndex` maps canonical `.ipynb` paths to room UUIDs.
 
 ### Autosave
 
@@ -162,7 +162,7 @@ crates/runtimed/src/
   lib.rs                   — Public types, path helpers
   main.rs                  — CLI entry point
   daemon.rs                — Daemon state, pool management, connection routing
-  notebook_sync_server.rs  — NotebookRoom, room lifecycle, autosave, path_index
+  notebook_sync_server/    — Room lifecycle, peer sync loops, persistence, metadata/trust/project context
   jupyter_kernel.rs        — JupyterKernel: process spawn, ZMQ socket wiring, IOPub output routing
   output_prep.rs           — Output-prep helpers: QueueCommand, KernelStatus, QueuedCell, iopub → nbformat conversion, widget buffers, blob-store offload
   runtime_agent.rs         — Process-isolated runtime agent: kernel lifecycle, IOPub, RuntimeStateDoc writes
@@ -173,7 +173,8 @@ crates/runtimed/src/
   inline_env.rs            — Inline dependency environment caching
   stream_terminal.rs       — Stream terminal output handling
   singleton.rs             — Daemon singleton management (lock file, PID tracking)
-  kernel_pids.rs           — Kernel process ID tracking and cleanup
+  kernel_ports.rs          — Daemon-owned five-port kernel reservations
+  process_groups.rs        — Cross-platform process-group cleanup helpers
   markdown_assets.rs       — Markdown output asset rendering and resolution
   terminal_size.rs         — Terminal size detection for kernel PTY
   project_file.rs          — Unified project file discovery (pyproject, pixi, env.yml)
@@ -253,7 +254,7 @@ Key files: `crates/runtimed-client/src/settings_doc.rs` (schema), `src/hooks/use
 ### Daemon won't start (lock held)
 
 ```bash
-cat ~/.cache/runt/daemon.json
+runt daemon status
 lsof ~/.cache/runt/daemon.lock
 
 # If stale (crashed daemon), remove manually
@@ -305,7 +306,7 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.nteract.runtimed.plis
 | Installed binary | `~/Library/Application Support/runt/bin/runtimed` |
 | Service config | `~/Library/LaunchAgents/io.nteract.runtimed.plist` |
 | Socket | `~/Library/Caches/runt/runtimed.sock` |
-| Daemon info | `~/Library/Caches/runt/daemon.json` |
+| Daemon info fallback | `~/Library/Caches/runt/daemon.json` |
 | Logs | `~/Library/Caches/runt/runtimed.log` |
 
 ## Dev Mode: Per-Worktree Isolation

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -22,7 +22,7 @@ All published artifacts share the same version (semver). Five sources must stay 
 
 Two independent version numbers (incrementing integers, not semver):
 
-- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`) — Wire compatibility. Validated by magic bytes preamble at connection time.
+- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`, re-exported by `connection.rs`) — Wire compatibility. Validated by magic bytes preamble at connection time.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — Automerge document compatibility. Stored in doc root.
 
 These evolve independently from each other and from the artifact version.
@@ -96,7 +96,7 @@ Builds macOS + Linux wheels and publishes to PyPI.
 
 ## Protocol Version Change Procedure
 
-1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`
+1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`
 2. Update the `PROTOCOL_V*` string constant if the version string changes
 3. Update `contributing/protocol.md`
 4. Decide version bump type based on user impact

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -32,8 +32,7 @@ pnpm test:run     # Run once
 - `src/components/outputs/__tests__/` — Output renderers
 - `src/components/widgets/__tests__/` — Widget store, registry
 - `src/lib/__tests__/` — ErrorBoundary
-- `apps/notebook/src/hooks/__tests__/` — useEnvProgress
-- `apps/notebook/src/lib/__tests__/` — Cursor registry, manifest resolution, materialize cells, kernel status, markdown assets
+- `apps/notebook/src/lib/__tests__/` — Cursor registry, manifest resolution, materialize cells, runtime/project stores, kernel status, markdown assets
 
 ## Rust Unit Tests
 

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -5,7 +5,7 @@
 When changing frame handling, keep the following aligned:
 
 - `crates/notebook-doc/src/frame_types.rs`
-- `apps/notebook/src/lib/frame-types.ts`
+- `packages/runtimed/src/transport.ts`
 - Any relay or sync code that assumes a specific frame layout
 
 When changing the wire handshake or typed frame semantics, also inspect:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ If `nteract-dev` is unavailable, fall back to `cargo xtask` (it derives the work
 | `runtimed-py` | Python bindings (PyO3/maturin) |
 | `runtimed-wasm` | WASM bindings for the notebook doc |
 | `notebook` | Tauri desktop app |
-| `notebook-doc` | Automerge schema, cell CRUD, output writes, MIME classification, `CellChangeset` |
+| `notebook-doc` | Automerge schema, cell CRUD, nbformat fallback fields, MIME classification, `CellChangeset` |
 | `notebook-protocol` | Wire types (requests, responses, broadcasts) |
 | `notebook-sync` | `DocHandle`, sync infrastructure, per-cell Python accessors |
 | `runt` | CLI - daemon mgmt, kernel control, `runt mcp` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ If `nteract-dev` is unavailable, fall back to `cargo xtask` (it derives the work
 | `runt-workspace` | Per-worktree daemon isolation |
 | `kernel-launch` | Kernel launching, tool bootstrapping |
 | `kernel-env` | UV + Conda env management |
+| `runtime-doc` | Daemon-authoritative runtime state CRDT schema and handle |
 | `repr-llm` | LLM-friendly text summaries (synthesizes `text/llm+plain`) |
 | `nteract-predicate` | Pure-Rust dataframe/Arrow compute kernels (backs Sift) |
 | `sift-wasm` | WASM bindings for `nteract-predicate` |

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -265,7 +265,7 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `RuntimeAgentRequest`, `RuntimeAgentResponse`
 - `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors
 - `crates/notebook-doc/src/diff.rs` — `CellChangeset`: structural diff from Automerge patches
-- `crates/notebook-doc/src/runtime_state.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
+- `crates/runtime-doc/src/doc.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
 - `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
 - `crates/runtimed/src/notebook_sync_server/` — room lifecycle, peer sync loops, session-control readiness, persistence, metadata/trust/project-file helpers
 - `crates/runtimed/src/requests/` — daemon-side notebook request routing handlers

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -64,13 +64,13 @@ Editing is local-first for responsiveness. Execution is always against synced st
 
 ### 5. Binary Separation via Manifests
 
-Cell outputs are stored as content-addressed blobs with manifest references. This keeps large binary data (images, plots) out of the sync protocol.
+Live cell outputs are stored as RuntimeStateDoc manifests with content-addressed blob references. This keeps large binary data (images, plots) out of NotebookDoc while still giving late joiners the daemon-authored output state.
 
 **Implications:**
-- Output broadcasts contain blob hashes, not inline data
+- Output rendering is driven by RuntimeStateDoc sync, not output broadcasts
 - Clients resolve blobs from the blob store (disk or HTTP)
 - Manifest format allows lazy loading and deduplication
-- Large outputs don't block document sync
+- Large outputs don't block NotebookDoc editing sync
 
 **On `.ipynb` save** the daemon still inlines most outputs as base64 — the same as vanilla Jupyter — so other tools can read the file. A small whitelist of nteract-specific MIMEs (currently just `application/vnd.apache.parquet`, the format the Sift dataframe viewer round-trips through) is externalized as a `BLOB_REF_MIME` entry pointing at the local blob store, keeping `.ipynb` size bounded for outputs that would otherwise serialize tens or hundreds of MiB. The Python `nteract/dx` package is the helper that produces those parquet payloads from a kernel. See `crates/runtimed/src/output_store.rs` (`should_externalize_mime_on_save`) and `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md`.
 
@@ -198,7 +198,7 @@ Three crates share "notebook" in the name but have distinct responsibilities:
 
 | Crate | Owns | Consumers |
 |-------|------|-----------|
-| `notebook-doc` | Automerge document schema, cell CRUD, output writes, per-cell accessors, `CellChangeset` diffing, fractional indexing, presence encoding, frame type constants | daemon, WASM, Python bindings |
+| `notebook-doc` | Automerge document schema, cell CRUD, nbformat fallback fields, per-cell accessors, `CellChangeset` diffing, fractional indexing, presence encoding, frame type constants | daemon, WASM, Python bindings |
 | `notebook-protocol` | Wire protocol types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`), connection handshake, frame parsing | daemon, `notebook-sync`, Python bindings |
 | `notebook-sync` | Sync infrastructure (`DocHandle`), snapshot watch channel, per-cell accessors for Python clients, sync task management | Python bindings (`runtimed-py`) |
 
@@ -263,11 +263,12 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 ## References
 
 - `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `RuntimeAgentRequest`, `RuntimeAgentResponse`
-- `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors
+- `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors
 - `crates/notebook-doc/src/diff.rs` — `CellChangeset`: structural diff from Automerge patches
 - `crates/notebook-doc/src/runtime_state.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
 - `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
-- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, runtime agent sync handler, CRDT execution queue
+- `crates/runtimed/src/notebook_sync_server/` — room lifecycle, peer sync loops, session-control readiness, persistence, metadata/trust/project-file helpers
+- `crates/runtimed/src/requests/` — daemon-side notebook request routing handlers
 - `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, comm state diffing, kernel ownership
 - `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
 - `crates/runtimed/src/jupyter_kernel.rs` — `JupyterKernel`: kernel process spawn, ZMQ socket wiring, IOPub output routing
@@ -278,8 +279,8 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
 - `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`
 - `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame` accepts raw binary via `tauri::ipc::Request`, `setup_sync_receivers`)
-- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x06)
-- `apps/notebook/src/lib/frame-types.ts` — Frame type constants + `sendFrame()` binary IPC helper
+- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x07)
+- `packages/runtimed/src/transport.ts` — TypeScript `FrameType` constants and transport boundary
 - `apps/notebook/src/hooks/useAutomergeNotebook.ts` — WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch
 - `apps/notebook/src/lib/materialize-cells.ts` — `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full)
 - `apps/notebook/src/lib/notebook-cells.ts` — Split cell store: `useCell(id)`, `useCellIds()`, per-cell subscriptions

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -32,14 +32,14 @@ The `.ipynb` file on disk is a checkpoint/snapshot. The Automerge document is th
 - Daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval) via `spawn_autosave_debouncer` — no user action required
 - Explicit save (Cmd+S) additionally runs cell formatting (ruff/deno fmt) before writing
 - Unknown metadata keys in `.ipynb` are preserved through round-trips
-- `NotebookAutosaved` broadcast clears the frontend dirty flag; `NotebookSaved` response confirms explicit saves
+- Autosave and explicit save completion are reflected through daemon save state/confirmations; `NotebookSaved` response confirms explicit saves
 
 **Crash recovery:**
 - Untitled notebooks (UUID-keyed rooms) persist their Automerge doc to `notebook-docs/{hash}.automerge` in the cache directory. On daemon restart, the room loads from this file.
 - Saved notebooks reload from `.ipynb` (which autosave keeps current). Before deleting a persisted Automerge doc on reopen, the daemon snapshots it to `notebook-docs/snapshots/` (max 5 per notebook).
 - Outputs are ephemeral. They live in the per-notebook RuntimeStateDoc and are not persisted.
 
-**UUID-stable rooms:** Room keys are always UUIDs. When an untitled notebook is first saved, the daemon updates a secondary `path_index` map and broadcasts `PathChanged { path }` so peers can update local path tracking. The UUID never changes.
+**UUID-stable rooms:** Room keys are always UUIDs. When an untitled notebook is first saved, the daemon updates a secondary `path_index` map and room path state so peers can update local path tracking. The UUID never changes.
 
 ### 4. Local-First Editing, Synced Execution
 
@@ -221,9 +221,7 @@ Client                              Daemon
   |-- ExecuteCell { cell_id } ------->|  // No code parameter
   |<-- CellQueued --------------------|
   |                                   |
-  |<-- ExecutionStarted --------------|  // broadcast via notebook:frame
-  |<-- Output -------------------------|  // broadcast via notebook:frame
-  |<-- ExecutionDone -----------------|
+  |<-- RuntimeStateDoc sync ----------|  // execution lifecycle + output manifests
 ```
 
 **Incorrect flow (anti-pattern):**

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -78,7 +78,7 @@ graph TB
     end
 
     subgraph Daemon ["runtimed Daemon (owns kernels)"]
-        NSS[notebook_sync_server.rs<br/>auto_launch_kernel]
+        NSS[notebook_sync_server/metadata.rs<br/>auto-launch helpers]
         RA[runtime_agent.rs<br/>(spawned as subprocess)<br/>run_runtime_agent]
         JK[jupyter_kernel.rs<br/>JupyterKernel::launch<br/>(in runtime-agent process)]
 
@@ -165,7 +165,7 @@ graph TB
 sequenceDiagram
     participant FE as Frontend<br/>useDaemonKernel.ts
     participant TC as Tauri Backend<br/>lib.rs
-    participant DM as runtimed Daemon<br/>notebook_sync_server.rs
+    participant DM as runtimed Daemon<br/>notebook_sync_server/
     participant PF as Project File<br/>Detection
     participant IE as inline_env.rs
     participant RA as runtime_agent.rs
@@ -176,7 +176,7 @@ sequenceDiagram
     FE->>TC: invoke("launch_kernel_via_daemon")
     TC->>DM: LaunchKernel request via IPC
 
-    DM->>DM: auto_launch_kernel()
+    DM->>DM: auto-launch helpers
 
     alt Has inline UV deps (metadata.uv.dependencies)
         DM->>IE: prepare_uv_inline_env(deps)
@@ -306,7 +306,7 @@ graph TB
 
 The diagrams show two main layers:
 
-1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `notebook:broadcast` events (kernel status, execution lifecycle) and `notebook:frame` events (document state including outputs via Automerge sync, demuxed by WASM). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. The daemon sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution), but the `onOutput` rendering callback is a no-op — output **rendering** is driven by Automerge sync (`materializeCells`).
+1. **Frontend** (blue) — React hooks that invoke Tauri commands, listen for typed notebook frames, and project daemon-authored runtime state from RuntimeStateDoc. `useDaemonKernel.ts` handles kernel actions and ephemeral runtime events. Output **rendering** is driven by RuntimeStateDoc manifests (`materialize-cells.ts`, `notebook-outputs.ts`, and `manifest-resolution.ts`), not output broadcasts.
 
 2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: metadata inline deps first, then PEP 723 cell metadata (`uv:pep723`), then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
 
@@ -419,7 +419,7 @@ A notebook is "captured" on first launch out of the pool. The daemon:
 
 After this, the notebook is indistinguishable from an inline-deps notebook — the pool is a bootstrap optimisation, not a runtime dependency.
 
-`capture_env_into_metadata` in `notebook_sync_server.rs` is idempotent and write-once: it only populates empty sections. User-edited deps are not clobbered.
+`capture_env_into_metadata` in `notebook_sync_server/metadata.rs` is idempotent and write-once: it only populates empty sections. User-edited deps are not clobbered.
 
 ### Reopen: cache-hit via `unified_env_on_disk`
 
@@ -447,7 +447,7 @@ Kernel is guaranteed dead at this point, so renaming is safe (no process holds t
 
 ## Project File Discovery
 
-The unified project file detection lives in `project_file.rs` and is used by the daemon's `auto_launch_kernel()` for kernel launch decisions:
+The unified project file detection lives in `project_file.rs` and is used by the daemon's auto-launch helpers for kernel launch decisions:
 
 | Module | Purpose |
 |--------|---------|
@@ -565,7 +565,8 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 | File | Role |
 |------|------|
 | `crates/runtimed/src/daemon.rs` | Background daemon pool management, passes settings to handlers |
-| `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | runtime detection and environment resolution helpers used by auto-launch |
+| `crates/runtimed/src/requests/launch_kernel.rs` | manual launch request handling |
 | `crates/runtimed/src/runtime_agent.rs` | Spawned as a subprocess by `RuntimeAgentHandle::spawn()`. `run_runtime_agent()` is the per-notebook event loop owning sockets, `QueueCommand` channels, and RuntimeStateDoc writes; `handle_runtime_agent_request()` dispatches each `LaunchKernel`/`RestartKernel`/etc. RPC |
 | `crates/runtimed/src/jupyter_kernel.rs` | `JupyterKernel::launch()` — spawns Python or Deno kernel processes, wires ZMQ sockets |
 | `crates/runtimed/src/output_prep.rs` | Output-prep helpers — `QueueCommand`, `KernelStatus`, `QueuedCell`, iopub → nbformat conversion + display-update helpers, widget-buffer offload. Imported by `runtime_agent.rs`, `jupyter_kernel.rs`, and `kernel_state.rs` |

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -131,9 +131,9 @@ graph TB
     UD -->|"invoke(detect_pyproject)"| DETP
     UCD -->|"invoke(detect_pixi_toml)"| DETP
 
-    %% Daemon → relay → frontend (notebook:frame, re-emitted as notebook:broadcast after WASM demux)
-    NSS -.->|"notebook:frame → notebook:broadcast {KernelLaunched, env_source}"| UDK
-    JK -.->|"notebook:frame → notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
+    %% Daemon → relay → frontend (typed notebook frames)
+    NSS -.->|"notebook:frame → RuntimeStateDoc {kernel, env_source}"| UDK
+    JK -.->|"notebook:frame → RuntimeStateDoc {lifecycle, queue, outputs}"| UDK
     VNT -.->|trust status| UD
 
     %% Environment creation → external tools

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -517,7 +517,7 @@ Dependencies are signed with HMAC-SHA256 to prevent untrusted code execution on 
 - **Machine-specific**: The key is per-machine, so every shared notebook is untrusted on the recipient's machine
 - **Verification**: `trust.rs:verify_signature()` returns `bool`. The higher-level `verify_notebook_trust()` returns `TrustInfo` (containing a `TrustStatus`: Trusted, Untrusted, SignatureInvalid, or NoDependencies)
 
-Changes to the dependency metadata structure require updating the signing logic in `crates/runt-trust/src/lib.rs` (re-exported by `crates/notebook/src/trust.rs`).
+Changes to the dependency metadata structure require updating `crates/notebook-doc/src/metadata.rs` and the signing logic in `crates/runt-trust/src/lib.rs`.
 
 ## Frontend Architecture
 
@@ -577,14 +577,10 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 | File | Role |
 |------|------|
 | `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), sync pipe setup, `launch_kernel_via_daemon` |
-| `crates/notebook/src/uv_env.rs` | UV dependency metadata (set/get deps in notebook JSON) |
-| `crates/notebook/src/conda_env.rs` | Conda dependency metadata (set/get deps in notebook JSON) |
-| `crates/notebook/src/pyproject.rs` | pyproject.toml discovery and parsing |
-| `crates/notebook/src/pixi.rs` | pixi.toml discovery and parsing |
-| `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
-| `crates/notebook/src/deno_env.rs` | Deno config detection |
+| `crates/notebook-doc/src/metadata.rs` | Notebook dependency metadata schema and accessors |
+| `crates/runtimed/src/project_file.rs` | Unified closest-wins project file detection |
 | `crates/notebook/src/settings.rs` | User preferences (default runtime, env type) |
-| `crates/notebook/src/trust.rs` | HMAC trust verification (re-exports from `runt-trust` crate) |
+| `crates/runt-trust/src/lib.rs` | HMAC trust verification |
 
 ### Frontend
 

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -530,11 +530,10 @@ Three UI components manage dependencies for different runtimes:
 | `DenoDependencyHeader.tsx` | `useDenoConfig.ts` | Deno configuration and deno.json detection |
 
 The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
-- Listens for `notebook:broadcast` events (re-emitted by `useAutomergeNotebook` after WASM frame demux)
-- Captures the `env_source` string (e.g. `"uv:pyproject"`, `"pixi:toml"`) from `KernelLaunched` responses
-- Tracks kernel status and execution queue
+- Derives kernel status, execution queue, and env sync state from RuntimeStateDoc
+- Listens for ephemeral runtime event callbacks from typed notebook frames
 - Provides `launchKernel()`, `executeCell()`, `syncEnvironment()` methods
-- Runs auto-launch detection on notebook open
+- Leaves project-file detection and auto-launch decisions to the daemon
 
 ## Testing
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -165,9 +165,9 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 | Hook | Role |
 |------|------|
 | `useAutomergeNotebook` | Owns WASM NotebookHandle, `scheduleMaterialize`, `CellChangeset` dispatch |
-| `useDaemonKernel` | Kernel execution, status broadcasts, widget comm routing |
+| `useDaemonKernel` | Kernel execution and ephemeral runtime event callbacks |
 | `usePresence` | Remote cursor/selection tracking via presence frames |
-| `useEnvProgress` | Environment setup progress tracking |
+| `useEnvProgress` | RuntimeStateDoc-backed environment progress projection |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
 | `useDenoConfig` | Deno config detection plus flexible-npm-imports toggle |
@@ -237,7 +237,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
    - `updateCellById()` — O(1) map update, notifies only that cell's subscribers
    - `replaceNotebookCells()` — full replacement with `cellsEqual()` diffing to preserve object identity for unchanged cells
 
-4. **useDaemonKernel / useEnvProgress** — Subscribe via `subscribeBroadcast()` from the frame bus for kernel status, execution events, and environment progress
+4. **Runtime state projection** — `useDaemonKernel` still consumes ephemeral broadcast events, while persistent kernel/env/project state is projected from RuntimeStateDoc through `runtime-state.ts`, `project-runtime-stores.ts`, and hooks such as `useEnvProgress`.
 
 5. **usePresence** — Subscribes via `subscribePresence()` from the frame bus. Maintains a React-accessible peer map with `cursorsForCell()`/`selectionsForCell()` queries.
 
@@ -269,6 +269,7 @@ and `apps/notebook/src/lib/frame-pipeline.ts`:
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcast and presence dispatch |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
-| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |
+| `packages/runtimed/src/transport.ts` | Shared `FrameType` constants and transport interface |
+| `apps/notebook/src/lib/frame-pipeline.ts` | App-side frame event processing and materialization planning |
 | `src/components/outputs/media-router.tsx` | Output type dispatch |
 | `src/components/editor/codemirror-editor.tsx` | Main editor |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -409,7 +409,9 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 | `crates/notebook-sync/src/connect.rs` | Connection setup (`connect_open_relay`, `connect_create_relay`) |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` — sync infrastructure, per-cell accessors for Python clients |
 | `crates/runtimed/src/notebook_sync_server/mod.rs` | Notebook sync server module facade |
+| `crates/runtimed/src/notebook_sync_server/catalog.rs` | Room lookup and creation |
 | `crates/runtimed/src/notebook_sync_server/room.rs` | `NotebookRoom` and room-owned state |
+| `crates/runtimed/src/notebook_sync_server/peer_connection.rs` | Notebook sync connection handler |
 | `crates/runtimed/src/notebook_sync_server/peer_loop.rs` | Main peer sync loop and frame dispatch |
 | `crates/runtimed/src/notebook_sync_server/peer_session.rs` | Initial readiness/session-control state |
 | `crates/runtimed/src/notebook_sync_server/peer_writer.rs` | Bounded peer writer |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -400,7 +400,7 @@ Several broadcast variants carry **state** (kernel status, env sync diff, queue)
 
 The daemon writes kernel status, execution queue, environment progress, project context, and trust state. Clients receive updates via normal Automerge sync — read-only enforced by stripping client changes. The frontend reads via `useRuntimeState()` and the project runtime stores.
 
-**Key files:** `crates/notebook-doc/src/runtime_state.rs` (schema + setters), `apps/notebook/src/lib/runtime-state.ts` (frontend store + hook).
+**Key files:** `crates/runtime-doc/src/doc.rs` (schema + setters), `crates/runtime-doc/src/handle.rs` (handle), `apps/notebook/src/lib/runtime-state.ts` (frontend store + hook).
 
 ### Comms in doc (#761) — Done
 
@@ -437,7 +437,7 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 | `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset`: structural diff from Automerge patches |
 | `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x07) |
-| `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc`: per-notebook daemon-authoritative state (kernel, queue, env sync) |
+| `crates/runtime-doc/src/doc.rs` | `RuntimeStateDoc`: per-notebook daemon-authoritative state (kernel, queue, env sync) |
 | `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + `useRuntimeState()` hook |
 | `packages/runtimed/src/transport.ts` | TypeScript `FrameType` constants and transport boundary |
 | `apps/notebook/src/lib/frame-pipeline.ts` | App-side frame event processing and materialization planning |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -56,7 +56,7 @@ The notebook app communicates with runtimed over a Unix socket (named pipe on Wi
 1. **Automerge sync** — binary CRDT sync messages that keep the notebook document consistent between the frontend WASM peer and the daemon peer
 2. **Request/response** — JSON messages where a client asks the daemon to do something (execute a cell, launch a kernel) and gets a reply
 3. **Runtime and pool state sync** — binary Automerge sync for daemon-authored state documents
-4. **Broadcasts** — JSON messages the daemon pushes to all connected clients for comm messages and environment progress
+4. **Broadcasts** — JSON messages the daemon pushes to all connected clients for ephemeral comm messages and environment progress
 5. **Presence and session control** — binary presence updates plus daemon-originated readiness/status frames
 
 ## Connection Topology
@@ -311,35 +311,22 @@ Broadcasts are daemon-initiated messages pushed to all connected clients for a n
 
 | Broadcast | Purpose |
 |-----------|---------|
-| `KernelStatus { status, cell_id }` | Kernel state changed: `"starting"`, `"idle"`, `"busy"`, `"error"`, `"shutdown"` |
-| `ExecutionStarted { cell_id, execution_count }` | A cell began executing |
-| `Output { cell_id, output_type, output_json, output_index }` | Cell produced output (stdout, display data, error) |
-| `DisplayUpdate { display_id, data, metadata }` | Update an existing output by display ID |
-| `ExecutionDone { cell_id }` | Cell execution completed |
-| `QueueChanged { executing, queued }` | Execution queue state changed |
-| `KernelError { error }` | Kernel crashed or failed to launch |
-| `OutputsCleared { cell_id }` | Cell outputs cleared |
-| `Comm { msg_type, content, buffers }` | Jupyter comm message (widget open/msg/close) |
+| `Comm { msg_type, content, buffers }` | Jupyter comm message (widget open/msg/close). Custom one-shot events; widget state syncs via RuntimeStateDoc. |
+| `EnvProgress { env_type, phase }` | Environment setup progress (`phase` is a flattened `EnvProgressPhase`). RuntimeStateDoc remains authoritative for durable env state. |
 | ~~`CommSync`~~ | Removed — widget state syncs via RuntimeStateDoc CRDT |
-| `EnvProgress { env_type, phase }` | Environment setup progress (`phase` is a flattened `EnvProgressPhase`) |
-| `EnvSyncState { in_sync, diff }` | Notebook dependencies drifted from launched kernel config |
-| `PathChanged { path }` | Room's `.ipynb` path changed (e.g. untitled notebook saved) — UUID is stable; peers update local path tracking |
-| `NotebookAutosaved { path }` | Daemon autosaved `.ipynb` to disk — frontend clears dirty flag |
 
-Several broadcast variants have been superseded by RuntimeStateDoc CRDT sync: `CommSync` (removed), `KernelStatus`, `ExecutionStarted`, `ExecutionDone`, `QueueChanged`, and `EnvSyncState` are filtered at the relay stage and never reach clients. The `Comm` variant is now limited to custom messages (`method != "update"`) — state updates flow through the CRDT instead.
+The old state-carrying broadcast variants were removed after RuntimeStateDoc became authoritative: kernel state, execution lifecycle, queue, outputs/display updates, path/autosave, and env sync state now flow through CRDT sync. The `Comm` variant is limited to custom messages (`method != "update"`) — state updates flow through RuntimeStateDoc instead.
 
-### Broadcast flow
+### Output sync flow
 
 ```
 Kernel produces output
   → Daemon intercepts Jupyter IOPub message
-  → Daemon writes output to Automerge doc (as blob manifest)
-  → Daemon sends NotebookBroadcast::Output on broadcast channel
-  → Frame type 0x03 sent to all connected clients
+  → Daemon writes output manifest to RuntimeStateDoc
+  → RuntimeStateDoc sync produces a frame type 0x05 message
   → Relay receives, emits "notebook:frame" Tauri event
-  → WASM handle.receive_frame() demuxes → Broadcast event
-  → useAutomergeNotebook dispatches via emitBroadcast() (in-memory frame bus)
-  → useDaemonKernel subscribeBroadcast() callback processes the broadcast
+  → WASM handle.receive_frame() demuxes → RuntimeStateDoc merge
+  → frame-pipeline.ts plans output materialization
   → UI updates
 ```
 
@@ -384,9 +371,9 @@ Stream outputs (stdout/stderr) are special: text is fed through a terminal emula
 
 ## Notebook Lifecycle
 
-**Autosave:** The daemon autosaves `.ipynb` on a debounce (2s quiet, 10s max). `NotebookAutosaved` broadcast clears the frontend dirty flag. Explicit save (Cmd+S) additionally formats cells.
+**Autosave:** The daemon autosaves `.ipynb` on a debounce (2s quiet, 10s max). Explicit save (Cmd+S) additionally formats cells; frontend dirty state is derived from sync/save confirmations rather than a room broadcast.
 
-**UUID-stable rooms:** Room keys are always UUIDs. Saving an untitled notebook updates a secondary `path_index` map and broadcasts `PathChanged { path }` so peers can update their local path tracking. The UUID never changes.
+**UUID-stable rooms:** Room keys are always UUIDs. Saving an untitled notebook updates a secondary `path_index` map and the daemon-authored room state so peers can update their local path tracking. The UUID never changes.
 
 **Crash recovery:** Untitled notebooks persist their Automerge doc to `notebook-docs/{hash}.automerge`. Before overwriting on reopen, the daemon snapshots to `notebook-docs/snapshots/`. Outputs are ephemeral (RuntimeStateDoc, not persisted), so snapshots hold source and metadata only.
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -362,7 +362,7 @@ After WASM `receive_frame()` demuxes typed frames, broadcast and presence payloa
 | Function | Purpose |
 |----------|---------|
 | `emitBroadcast(payload)` | Called by `useAutomergeNotebook` after WASM demux for type `0x03` frames |
-| `subscribeBroadcast(cb)` | Used by `useDaemonKernel`, `useEnvProgress` to receive kernel/env broadcasts |
+| `subscribeBroadcast(cb)` | Used by `useDaemonKernel` for ephemeral runtime events; persistent env state is RuntimeStateDoc-backed |
 | `emitPresence(payload)` | Called by `useAutomergeNotebook` after WASM CBOR decode for type `0x04` frames |
 | `subscribePresence(cb)` | Used by `usePresence`, `cursor-registry` to receive remote cursor updates |
 
@@ -398,7 +398,7 @@ Stream outputs (stdout/stderr) are special: text is fed through a terminal emula
 
 Several broadcast variants carry **state** (kernel status, env sync diff, queue) rather than **events**. State-carrying broadcasts suffer from silent drops, no initial state for late joiners, and ordering races between windows. The `RuntimeStateDoc` replaces these with a daemon-authoritative, per-notebook Automerge document synced via frame type `0x05` on the existing notebook connection.
 
-The daemon writes kernel status, execution queue, and environment sync drift. Clients receive updates via normal Automerge sync — read-only enforced by stripping client changes. The frontend reads via `useRuntimeState()`. See `.context/plans/daemon-state-doc.md` for the full phased plan.
+The daemon writes kernel status, execution queue, environment progress, project context, and trust state. Clients receive updates via normal Automerge sync — read-only enforced by stripping client changes. The frontend reads via `useRuntimeState()` and the project runtime stores.
 
 **Key files:** `crates/notebook-doc/src/runtime_state.rs` (schema + setters), `apps/notebook/src/lib/runtime-state.ts` (frontend store + hook).
 
@@ -421,19 +421,26 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup (`connect_open_relay`, `connect_create_relay`) |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` — sync infrastructure, per-cell accessors for Python clients |
-| `crates/runtimed/src/notebook_sync_server.rs` | `NotebookRoom`, room lifecycle, autosave debouncer, sync loop |
+| `crates/runtimed/src/notebook_sync_server/mod.rs` | Notebook sync server module facade |
+| `crates/runtimed/src/notebook_sync_server/room.rs` | `NotebookRoom` and room-owned state |
+| `crates/runtimed/src/notebook_sync_server/peer_loop.rs` | Main peer sync loop and frame dispatch |
+| `crates/runtimed/src/notebook_sync_server/peer_session.rs` | Initial readiness/session-control state |
+| `crates/runtimed/src/notebook_sync_server/peer_writer.rs` | Bounded peer writer |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | Metadata, trust, project-file, and environment detection helpers |
+| `crates/runtimed/src/requests/` | Notebook request routing handlers |
 | `crates/runtimed/src/output_prep.rs` | IOPub output-prep helpers: message-to-nbformat conversion, widget buffers, blob-store offload |
-| `crates/runtimed/src/comm_state.rs` | Widget comm state + Output widget capture routing |
+| `crates/runtimed/src/runtime_agent.rs` | Runtime-agent peer loop, kernel lifecycle, comm-state diff forwarding, RuntimeStateDoc writes |
 | `crates/runtimed/src/output_store.rs` | Output manifest creation, blob inlining threshold |
 | `crates/runtimed/src/blob_store.rs` | Content-addressed blob storage |
 | `crates/notebook/src/lib.rs` | Tauri commands and relay tasks (transparent byte pipe) |
 | `crates/runtimed-wasm/src/lib.rs` | WASM bindings: cell mutations, sync, per-cell accessors, `CellChangeset` |
-| `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors |
+| `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, nbformat fallback fields, per-cell accessors |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset`: structural diff from Automerge patches |
 | `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x07) |
 | `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc`: per-notebook daemon-authoritative state (kernel, queue, env sync) |
 | `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + `useRuntimeState()` hook |
-| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |
+| `packages/runtimed/src/transport.ts` | TypeScript `FrameType` constants and transport boundary |
+| `apps/notebook/src/lib/frame-pipeline.ts` | App-side frame event processing and materialization planning |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, widget comm routing, broadcast handling |
 | `apps/notebook/src/lib/materialize-cells.ts` | `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full) |

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -24,7 +24,7 @@ Standard semver rules apply:
 
 Two independent version numbers handle compatibility, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`) — governs wire compatibility. Validated by the magic bytes preamble at connection time. Bump when the framing, handshake shape, or message serialization format changes.
+- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`, re-exported by `connection.rs`) — governs wire compatibility. Validated by the magic bytes preamble at connection time. Bump when the framing, handshake shape, or message serialization format changes.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — governs Automerge document compatibility. Stored in the doc root. Bump when the document structure changes. Every bump MUST ship a matching `migrate_vN_to_v(N+1)` function that preserves user data. The pre-release v1–v3 schemas are discarded on load by v4; do not take that as a template for real migrations.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol bump doesn't force a major version bump — it depends on whether the change is user-facing.
@@ -114,7 +114,7 @@ This builds macOS and Linux Python artifacts for both `runtimed` and `nteract`, 
 
 When making a breaking wire protocol change:
 
-1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`
+1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`
 2. Update the `PROTOCOL_V*` string constant if the version string changes
 3. Update `contributing/protocol.md`
 4. Decide whether this warrants a major, minor, or patch version bump based on user impact

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -205,7 +205,7 @@ Integration tests use temp directories for socket and lock files to avoid confli
 
 ## Notebook Room Lifecycle
 
-Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server.rs`), always keyed by UUID. A secondary `path_index: HashMap<PathBuf, Uuid>` maps canonical file paths to room UUIDs for path-based lookups.
+Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server/room.rs`), keyed by UUID in `NotebookRooms`. A secondary `PathIndex` maps canonical `.ipynb` paths to room UUIDs for path-based lookups.
 
 ### Autosave
 
@@ -264,12 +264,13 @@ crates/runtimed/
 │   ├── lib.rs                   # Daemon crate + backward-compatible re-exports from runtimed-client
 │   ├── main.rs                  # Daemon CLI entry point
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
-│   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, path_index, sync loop
+│   ├── notebook_sync_server/    # Room lifecycle, peer sync loops, persistence, metadata/trust/project context
 │   ├── runtime_agent.rs         # Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
 │   ├── runtime_agent_handle.rs  # Coordinator-side runtime agent process management (spawn + monitor)
 │   ├── jupyter_kernel.rs        # JupyterKernel: process spawn, ZMQ socket wiring, IOPub output routing
 │   ├── output_prep.rs           # Output-prep helpers: QueueCommand, KernelStatus, QueuedCell, iopub → nbformat conversion, widget buffers, blob-store offload
-│   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
+│   ├── kernel_ports.rs          # Daemon-owned five-port kernel reservations
+│   ├── process_groups.rs        # Cross-platform process-group cleanup helpers
 │   ├── singleton.rs             # Daemon locking/singleton management
 │   ├── sync_server.rs           # Settings Automerge sync handler
 │   ├── output_store.rs          # Output manifest creation, blob inlining threshold

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -209,9 +209,9 @@ Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server/room.
 
 ### Autosave
 
-The daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval) via `spawn_autosave_debouncer`. No user action required. `NotebookAutosaved` broadcast clears the frontend dirty flag. Explicit Cmd+S additionally runs cell formatting (ruff/deno fmt).
+The daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval) via `spawn_autosave_debouncer`. No user action required. Frontend dirty state is cleared from save state/confirmations, not a room broadcast. Explicit Cmd+S additionally runs cell formatting (ruff/deno fmt).
 
-Autosave skips untitled notebooks (no file path) and notebooks mid-load (`is_loading` flag). After saving, the debouncer drains the change channel to detect mutations during the async write — the `NotebookAutosaved` broadcast only fires when the file is truly caught up.
+Autosave skips untitled notebooks (no file path) and notebooks mid-load (`is_loading` flag). After saving, the debouncer drains the change channel to detect mutations during the async write so clients only observe a caught-up save state.
 
 ### Saving an untitled notebook
 
@@ -222,7 +222,7 @@ Room keys are always UUIDs — they never change after a room is created. When a
 3. Inserts into `path_index: HashMap<PathBuf, Uuid>` (secondary map for path → UUID lookups)
 4. Updates the room's `path: RwLock<Option<PathBuf>>`
 5. Spawns a file watcher for the new path
-6. Broadcasts `PathChanged { path }` so peers can update local path tracking
+6. Updates room path state so peers can update local path tracking
 
 The `NotebookSaved` response returns the room's UUID (unchanged).
 

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -65,8 +65,7 @@ describe("AnsiOutput", () => {
 - `src/components/outputs/__tests__/` — Output renderers
 - `src/components/widgets/__tests__/` — Widget store, registry
 - `src/lib/__tests__/` — ErrorBoundary
-- `apps/notebook/src/hooks/__tests__/` — useEnvProgress
-- `apps/notebook/src/lib/__tests__/` — Cursor registry, manifest resolution, materialize cells, kernel status, markdown assets, and more
+- `apps/notebook/src/lib/__tests__/` — Cursor registry, manifest resolution, materialize cells, runtime/project stores, kernel status, markdown assets, and more
 
 ## Rust Unit Tests
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -6,9 +6,9 @@ runtimed is a long-lived daemon that owns the heavy, stateful parts of the noteb
 
 The architecture has two core ideas:
 
-1. **Outputs live outside the CRDT.** Kernel outputs (images, HTML, logs) are write-once blobs from a single actor. Storing them in an Automerge document wastes CRDT history tracking on data that will never be concurrently edited. Instead, outputs go into a content-addressed blob store. The CRDT stores lightweight hash references.
+1. **Live outputs live outside NotebookDoc.** Kernel outputs (images, HTML, logs) are write-once data from a single actor. NotebookDoc stores source and structure; RuntimeStateDoc stores live execution/output state. Large text and binary payloads spill to the content-addressed blob store.
 
-2. **Two levels of output abstraction.** An "output" (the Jupyter-level concept — a display_data, stream, error, etc.) is described by a manifest that references raw content blobs. Small data is inlined in the manifest; large data points to the blob store. `GET /output/{id}` returns the manifest. `GET /blob/{hash}` returns raw bytes. Most renders need only one request.
+2. **Two levels of output abstraction.** An "output" (the Jupyter-level concept — a display_data, stream, error, etc.) is described by a RuntimeStateDoc manifest that references raw content blobs. Small text is inlined in the manifest; large text and binary data point to the blob store. `GET /blob/{hash}` returns raw bytes.
 
 ---
 
@@ -76,7 +76,7 @@ The foundation. A singleton daemon that prewarms Python environments so notebook
 
 ### Singleton management
 
-Only one daemon per user. A file lock (`~/.cache/runt/daemon.lock`) provides mutual exclusion. A sidecar JSON file (`~/.cache/runt/daemon.json`) advertises the running daemon's state:
+Only one daemon per user. A file lock (`~/.cache/runt/daemon.lock`) provides mutual exclusion. Daemon discovery is socket-first: clients connect to the socket and ask the daemon for live info. The sidecar JSON file (`~/.cache/runt/daemon.json`) remains only as a fallback for older daemons and should not be used by new code.
 
 ```rust
 pub struct DaemonInfo {
@@ -242,20 +242,23 @@ Cell ordering uses fractional indexing via the `position` field. Cells are sorte
 
 ### Room architecture
 
-`NotebookRoom` (defined in `crates/runtimed/src/notebook_sync_server.rs`) has 20+ fields — key ones:
+`NotebookRoom` (defined in `crates/runtimed/src/notebook_sync_server/room.rs`) is keyed by UUID and groups the notebook doc, runtime state, persistence, and runtime-agent coordination. Key fields:
 
 | Field | Type | Role |
 |-------|------|------|
+| `id` | `uuid::Uuid` | Stable room identity and `NotebookRooms` key |
 | `doc` | `Arc<RwLock<NotebookDoc>>` | Canonical Automerge document |
-| `kernel` | `Arc<Mutex<Option<RoomKernel>>>` | Daemon-owned kernel process |
+| `broadcasts` | `RoomBroadcasts` | Fan-out channels for peer sync loops |
 | `blob_store` | `Arc<BlobStore>` | Content-addressed output storage |
 | `trust_state` | `Arc<RwLock<TrustState>>` | HMAC trust for auto-launch |
-| `notebook_path` | `PathBuf` | Notebook file path (= notebook_id) |
-| `comm_state` | `Arc<CommState>` | Active widget comm channels |
-| `presence` | `Arc<RwLock<PresenceState>>` | Cursor/selection peer state |
-| `persist_tx` | `watch::Sender<Option<Vec<u8>>>` | Debounced persistence channel |
+| `identity` | `RoomIdentity` | Persist path, `.ipynb` path, working directory, and ephemeral flag |
+| `connections` | `RoomConnections` | Active-peer and had-peer accounting |
+| `persistence` | `RoomPersistence` | Debounced persistence, autosave/file watcher shutdown, save baselines, attachments |
+| `state` | `RuntimeStateHandle` | Per-notebook daemon-authoritative runtime state |
+| `runtime_agent_handle` | `Arc<Mutex<Option<RuntimeAgentHandle>>>` | Runtime agent subprocess handle |
+| `runtime_agent_request_tx` | `Arc<Mutex<Option<RuntimeAgentRequestSender>>>` | RPC channel to the connected runtime agent |
 
-See source for full definition (includes `working_dir`, `nbformat_attachments`, `auto_launch_at`, `last_self_write`, file watcher shutdown, etc.).
+See source for the full definition and the split support structs (`RoomIdentity`, `RoomPersistence`, `RoomConnections`, `RoomBroadcasts`).
 
 **Room lifecycle**:
 1. First window opens notebook -> daemon acquires room via `get_or_create_room()`, loading persisted doc from disk (or creating fresh)
@@ -282,7 +285,7 @@ See source for full definition (includes `working_dir`, `nbformat_attachments`, 
 | `crates/runtimed/src/sync_server.rs` | Settings sync handler |
 | `crates/runtimed-client/src/sync_client.rs` | Settings sync client library |
 | `crates/notebook-doc/src/lib.rs` | Notebook Automerge document, cell CRUD, text editing, persistence |
-| `crates/runtimed/src/notebook_sync_server.rs` | Room-based notebook sync, peer management, eviction |
+| `crates/runtimed/src/notebook_sync_server/` | Room-based notebook sync, peer management, persistence, metadata/trust/project context |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 
 ---
@@ -350,7 +353,7 @@ Minimal hyper 1.x server on `127.0.0.1:0` (random port).
 
 **`GET /health`** — 200 OK
 
-Port advertised in `daemon.json` via `DaemonInfo.blob_port`.
+Blob server details are reported by the live daemon info response. `daemon.json` may contain the same data only as a legacy discovery fallback.
 
 ### Security model
 
@@ -455,7 +458,8 @@ pub enum BlobResponse {
 | `crates/runtimed-client/src/sync_client.rs` | Uses `Handshake::SettingsSync` |
 | `crates/runtimed/src/sync_server.rs` | Handler function (no longer owns accept loop) |
 | `crates/notebook-sync/src/connect.rs` | Uses `Handshake::NotebookSync` for relay connections |
-| `crates/runtimed/src/notebook_sync_server.rs` | Handler function, room lookup |
+| `crates/runtimed/src/notebook_sync_server/peer_connection.rs` | Notebook sync connection handler |
+| `crates/runtimed/src/notebook_sync_server/catalog.rs` | Room lookup and creation |
 | `crates/runtimed-client/src/protocol.rs` | `BlobRequest`/`BlobResponse` enums |
 
 ---
@@ -501,15 +505,16 @@ Character-level source edits use Automerge's `update_text` for CRDT-friendly mer
 
 ### How outputs arrive
 
-Outputs flow through the Automerge doc, not Tauri events:
+Outputs flow through RuntimeStateDoc sync, not Tauri events:
 
 1. Kernel emits iopub message → daemon's `output_prep` receives it
-2. Daemon writes output to the notebook's Automerge doc (cell outputs array)
-3. Daemon produces a sync message → Tauri relay forwards raw bytes to the frontend (pipe mode — no Automerge processing in the relay)
-4. Frontend receives `notebook:frame` → WASM `receive_frame()` demuxes and merges into local doc
-5. `materialize-cells.ts` converts the updated doc into React cell state
+2. Daemon creates an output manifest with `ContentRef` entries; small text is inlined, large text and binary data go to the blob store
+3. Daemon writes the structured manifest to RuntimeStateDoc under the execution record
+4. RuntimeStateDoc produces a sync message → Tauri relay forwards raw bytes to the frontend
+5. Frontend receives a typed frame → WASM `receive_frame()` demuxes and merges runtime state
+6. `materialize-cells.ts` and `notebook-outputs.ts` resolve manifests into React output state
 
-The `onOutput` callback is omitted entirely from the `useDaemonKernel` call — when undefined, the hook skips Output broadcast processing (including blob resolution). Outputs are rendered from Automerge sync, not broadcasts.
+Output broadcasts are not the rendering path. Outputs are rendered from RuntimeStateDoc manifests and resolved through WASM/frontend manifest-resolution helpers.
 
 ### Save and format-on-save
 
@@ -523,7 +528,7 @@ Save is delegated to the daemon via `NotebookRequest::SaveNotebook`. The daemon:
 
 - Two windows open the same notebook → both have local Automerge docs synced through the daemon
 - Edit source in window A → binary sync message → daemon → window B sees the change
-- Execute cell in window A → daemon writes outputs → both windows materialize them
+- Execute cell in window A → daemon writes RuntimeStateDoc execution/output state → both windows materialize it
 - Save from either window → daemon writes the same canonical `.ipynb`
 
 ### Key files
@@ -533,7 +538,7 @@ Save is delegated to the daemon via `NotebookRequest::SaveNotebook`. The daemon:
 | `crates/runtimed-wasm/` | WASM module exposing `NotebookHandle` to the frontend |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Frontend hook owning the local Automerge doc and sync lifecycle |
 | `apps/notebook/src/lib/materialize-cells.ts` | Converts Automerge doc state into React cell arrays |
-| `crates/runtimed/src/notebook_sync_server.rs` | Daemon-side notebook room management and sync |
+| `crates/runtimed/src/notebook_sync_server/` | Daemon-side notebook room management and sync |
 | `crates/runtimed/src/output_prep.rs` | Daemon-side iopub → Automerge output conversion and blob-store offload |
 | `crates/notebook/src/lib.rs` | Tauri commands and relay plumbing |
 
@@ -541,15 +546,15 @@ Save is delegated to the daemon via `NotebookRequest::SaveNotebook`. The daemon:
 
 ## Phase 6: Output store
 
-> **Foundation implemented** (PR #237 adds ContentRef, manifest types, inlining threshold)
+> **Implemented**
 
-Move outputs from inline JSON in the CRDT to the blob store. This solves the CRDT bloat problem from Phase 5 and introduces two-level serving.
+Outputs are structured manifests in RuntimeStateDoc. Manifest fields use `ContentRef` values: small text is inlined directly in the CRDT, while larger text and all binary data are stored in the blob store. NotebookDoc does not store live outputs.
 
 ### The two levels
 
 **Level 1 — Blob store** (`GET /blob/{hash}`): Pure content-addressed bytes. Returns raw PNG, text, JSON — whatever was stored. Used for `<img src>`, direct rendering, large data.
 
-**Level 2 — Output store** (`GET /output/{id}`): Jupyter-aware. Returns structured information about an output — what type it is, what representations are available, and the data itself (inlined for small content, blob-referenced for large content). Used by the frontend to understand what to render.
+**Level 2 — Output manifests** (RuntimeStateDoc): Jupyter-aware structured objects describing output type, available representations, metadata, execution count, and `ContentRef` payloads. Used by frontend, Python, and MCP consumers to understand what to render or summarize.
 
 ### ContentRef
 
@@ -623,7 +628,7 @@ Traceback is a ContentRef holding the JSON-serialized array of traceback lines. 
 
 ### Inlining threshold
 
-**Default: 8 KB.** Below -> inline in manifest. Above -> blob store.
+**Default: 1 KB.** Text below the threshold is inlined in the manifest. Text at or above the threshold goes to the blob store. Binary content always goes to the blob store.
 
 - Most `text/plain`: inline (one request)
 - Most images: blob (two requests)
@@ -633,50 +638,18 @@ Traceback is a ContentRef holding the JSON-serialized array of traceback lines. 
 
 Daemon-side decision at write time. The frontend just checks `inline` vs `blob`.
 
-### Manifest storage
+### RuntimeStateDoc integration
 
-Manifests are themselves blobs (media type `application/x-jupyter-output+json`), content-addressed. `GET /output/{id}` is a thin view over `GET /blob/{hash}` that validates the media type.
-
-### Automerge doc integration
-
-Outputs change from JSON strings to manifest hashes:
-
-```
-cells/{cell_id}/
-  outputs/           <- List of Str
-    [0]: Str         <- output manifest hash (e.g. "a1b2c3d4...")
-```
-
-The CRDT stores only hashes (~64 bytes each). All output structure and content lives in the blob store:
-- No CRDT bloat from images or large text
-- Clearing outputs removes hashes (no tombstone inflation from large data)
-- Output history doesn't accumulate in the Automerge change log
-
-### Tauri backend changes
-
-The iopub listener (from Phase 5) changes what it writes to automerge:
-
-**Before** (Phase 5): `sync_client.append_output(cell_id, json_string)` — full JSON output
-**After** (Phase 6):
-1. For each MIME type / stream text / traceback: size < 8KB -> inline, >= 8KB -> blob store via daemon
-2. Construct output manifest JSON
-3. Store manifest in blob store -> get manifest hash
-4. `sync_client.append_output(cell_id, manifest_hash)` — just the hash
+RuntimeStateDoc stores execution records keyed by `execution_id`. Each record points at output IDs, and each output is a structured manifest object with `ContentRef` fields. The cell's current execution pointer lives in RuntimeStateDoc as well, so live outputs and live execution counts disappear when runtime state is gone. NotebookDoc keeps only source, metadata, ordering, resolved assets, and nbformat/import-export fallback fields.
 
 ### Frontend changes
 
-**`OutputArea.tsx`** — the big change. Currently receives `JupyterOutput[]` (parsed JSON). Now receives `string[]` (manifest hashes).
+The frontend reads output manifests through WASM/runtime-state sync:
 
-New rendering flow:
-1. Cell outputs = `["hash1", "hash2", ...]`
-2. For each hash, fetch `GET /output/{hash}` -> manifest JSON
-3. Parse manifest, select MIME type by priority
-4. For `ContentRef::Inline` — use data directly
-5. For `ContentRef::Blob` — `<img src="http://localhost:{port}/blob/{blobHash}">` for images, `fetch()` for HTML/text
-
-This needs a loading state per output (while manifest is being fetched) and caching (manifests are immutable, cache aggressively).
-
-**Stream output handling during execution**: The iopub listener still emits `kernel:iopub` events for live display. The frontend renders stream text incrementally from events. When execution finishes, the finalized manifest hash appears in the automerge doc. The frontend transitions from live event-driven display to blob-backed display.
+1. RuntimeStateDoc sync updates execution/output records.
+2. `frame-pipeline.ts` plans which cells need output or chrome refreshes.
+3. `materialize-cells.ts` and `notebook-outputs.ts` resolve manifests with cache-aware helpers.
+4. `manifest-resolution.ts` fetches blobs through the daemon blob server when a `ContentRef::Blob` is encountered.
 
 ### Python bindings: MIME type contract
 
@@ -694,7 +667,7 @@ Key differences from the frontend path:
 - **JSON types return native dicts.** `application/json` and `*+json` ContentRefs are parsed into Python dicts/lists, not returned as JSON strings.
 - **`text/llm+plain` synthesis.** When an output contains binary image data but no `text/llm+plain` entry, the output resolver synthesizes one. The synthesized text includes the image MIME type, size in KB, and — when available — the blob URL (`http://localhost:{port}/blob/{hash}`). This gives LLM-based agents a text representation of image outputs without requiring them to consume raw bytes.
 
-The MIME classification logic is implemented in `mime_kind()` in `crates/runtimed-client/src/output_resolver.rs`, mirrored by `isBinaryMime()` in `apps/notebook/src/lib/manifest-resolution.ts`, and kept aligned with `is_binary_mime()` in `crates/runtimed/src/output_store.rs`.
+The MIME classification logic has one Rust source of truth in `crates/notebook-doc/src/mime.rs`. Rust consumers import `mime_kind()`, `MimeKind`, and `is_binary_mime()` from there. The frontend receives already-resolved `ContentRef` variants from WASM; `looksLikeBinaryMime()` in `manifest-resolution.ts` is only a safety net for unresolved blob refs.
 
 ### Key files
 
@@ -704,8 +677,8 @@ The MIME classification logic is implemented in `mime_kind()` in `crates/runtime
 | `crates/runtimed/src/blob_server.rs` | HTTP read server (`GET /blob/{hash}`, `GET /health`) |
 | `crates/runtimed/src/output_prep.rs` | iopub listener constructs manifests and stores blobs |
 | `crates/runtimed-client/src/output_resolver.rs` | Shared manifest resolution, MIME typing, `text/llm+plain` synthesis used by Python/MCP consumers |
-| `src/components/cell/OutputArea.tsx` | Fetch manifests, resolve blob URLs |
-| `apps/notebook/src/hooks/useManifestResolver.ts` | Hook for fetching/caching output manifests |
+| `apps/notebook/src/lib/manifest-resolution.ts` | Resolve `ContentRef` payloads and blob URLs |
+| `apps/notebook/src/lib/notebook-outputs.ts` | Output store projected from RuntimeStateDoc |
 
 ---
 
@@ -713,20 +686,20 @@ The MIME classification logic is implemented in `mime_kind()` in `crates/runtime
 
 The `.ipynb` file on disk is always a valid Jupyter notebook with fully inline outputs. The blob store is acceleration, not a dependency.
 
-### Load (.ipynb -> automerge + blobs)
+### Load (.ipynb -> NotebookDoc + RuntimeStateDoc + blobs)
 
 For each output in the notebook file:
 
 1. **display_data / execute_result**: For each MIME entry — decode base64 for binary types, apply inlining threshold, build manifest
 2. **stream**: Inline or blob based on size
 3. **error**: Inline traceback (usually small)
-4. Store manifest in blob store -> append manifest hash to automerge doc
+4. Store output manifests in RuntimeStateDoc and large payloads in the blob store
 
 Content addressing makes this idempotent.
 
-### Save (automerge + blobs -> .ipynb)
+### Save (NotebookDoc + RuntimeStateDoc + blobs -> .ipynb)
 
-For each manifest hash: fetch manifest, resolve ContentRefs (inline or blob), reconstruct standard Jupyter output dict (base64-encode binary), write valid nbformat JSON.
+For each cell's current execution output manifests, resolve ContentRefs (inline or blob), reconstruct standard Jupyter output dict (base64-encode binary), and write valid nbformat JSON.
 
 ### Metadata hints for fast re-load
 
@@ -768,15 +741,15 @@ The daemon owns kernel processes and the output pipeline. Notebook windows are v
 ```
 Notebook window (thin view)
   +-- sends LaunchKernel/ExecuteCell/RunAllCells to daemon
-  +-- receives broadcasts (KernelStatus, Output, ExecutionStarted)
+  +-- receives RuntimeStateDoc sync and ephemeral broadcasts
   +-- syncs cell source via Automerge
-  +-- renders outputs from Automerge doc
+  +-- renders outputs from RuntimeStateDoc manifests
 
 runtimed (daemon)
   +-- owns kernel process per notebook room
   +-- subscribes to ZMQ iopub
-  +-- writes outputs to Automerge doc (nbformat JSON)
-  +-- broadcasts real-time events to all windows
+  +-- writes execution, output, and comm state to RuntimeStateDoc
+  +-- broadcasts only ephemeral events
   +-- auto-detects project files for environment selection
 ```
 
@@ -784,26 +757,19 @@ runtimed (daemon)
 
 | Channel | Purpose | Persisted? |
 |---------|---------|------------|
-| **Automerge Sync** | Document state (cells, source, outputs) | Yes |
-| **Broadcasts** | Real-time events | No |
+| **NotebookDoc Sync** | Persisted notebook state: cells, source, metadata, resolved assets, nbformat fallback fields | Yes |
+| **RuntimeStateDoc Sync** | Daemon-authored runtime state: kernel lifecycle, queue, outputs, comms, env progress, trust/project context | No |
+| **Broadcasts** | Ephemeral events that are not durable state | No |
 
-**Why both?** Automerge provides persistence and late-joiner sync. Broadcasts provide sub-50ms UI updates for kernel status during execution.
+**Why all three?** NotebookDoc sync provides local-first editing and persistence. RuntimeStateDoc sync gives late joiners the current daemon-owned state without replaying historical broadcasts. Broadcasts remain only for event-like messages that should not become durable state.
 
 Broadcast types (see `NotebookBroadcast` in `crates/notebook-protocol/src/protocol.rs`):
-- `KernelStatus { status, cell_id }` — idle/busy/starting/error/shutdown, with optional triggering cell
-- `ExecutionStarted { cell_id, execution_count }` — clear outputs, show spinner
-- `Output { cell_id, output_type, output_json, output_index }` — streamed output; `output_index` distinguishes append vs update-in-place
-- `DisplayUpdate { display_id, data, metadata }` — update_display_data (widget progress bars); keyed by `display_id`, no `cell_id`
-- `ExecutionDone { cell_id }` — execution completed
 - `OutputsCleared { cell_id }` — outputs cleared for a cell
-- `QueueChanged { executing, queued }` — execution queue state
 - `KernelError { error }` — launch failure or crash
-- `Comm { msg_type, content, buffers }` — ipywidgets protocol (comm_open/msg/close)
+- `Comm { msg_type, content, buffers }` — ephemeral custom comm messages; widget state updates flow through RuntimeStateDoc
 - ~~`CommSync`~~ — removed; widget state syncs via RuntimeStateDoc CRDT
-- `EnvProgress { env_type, phase }` — rich environment setup progress (repodata, solve, download, link)
-- `EnvSyncState { in_sync, diff }` — notebook metadata vs launched config drift
 
-> **Note:** `Output` broadcasts are still sent by the daemon, but `onOutput` is omitted from the `useDaemonKernel` call so the hook skips broadcast processing entirely. All output **rendering** is driven by the Automerge sync channel (`notebook:frame` → WASM `receive_frame()` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
+Several formerly state-carrying broadcasts are filtered at the relay stage and never reach clients: `KernelStatus`, `ExecutionStarted`, `ExecutionDone`, `QueueChanged`, and `EnvSyncState`. Outputs are rendered from RuntimeStateDoc manifests and resolved through the blob/content-ref layer.
 
 ### Project file auto-detection
 
@@ -827,9 +793,9 @@ Walk-up stops at `.git` boundary or home directory.
 
 > **Note:** The daemon also checks the legacy paths `metadata.uv.dependencies` and `metadata.conda.dependencies` as fallbacks for notebooks that haven't been migrated to the `metadata.runt.*` namespace.
 
-### Widget support (partial)
+### Widget support
 
-> **Implemented** (PR #275) — single-window widgets work, multi-window sync is a known limitation
+> **Implemented** — widget state syncs through RuntimeStateDoc so late-joining windows can reconstruct widget models.
 
 Widgets require bidirectional comm message routing through the daemon:
 
@@ -838,12 +804,10 @@ Frontend ←──comm_msg──→ Daemon ←──ZMQ──→ Kernel
 ```
 
 The implementation:
-1. **Kernel → Frontend**: Daemon broadcasts `comm_open`, `comm_msg`, `comm_close` from iopub to all connected windows
-2. **Frontend → Kernel**: Frontend sends full Jupyter message envelope via `SendComm` request, daemon preserves original headers and forwards to kernel shell channel
-
-**Known limitation**: Widgets only render in the window that was active when the widget was created. Secondary windows show "Loading widget" because they miss the initial `comm_open` message. See issue #276.
-
-**Future work**: Sync widget/comm state via Automerge so late-joining windows can reconstruct widget models.
+1. **Kernel → Daemon**: runtime agent records `comm_open`, `comm_msg(update)`, and `comm_close` state in RuntimeStateDoc.
+2. **Daemon → Frontend**: clients receive widget state through RuntimeStateDoc sync; late joiners do not need historical `comm_open` broadcasts.
+3. **Frontend → Kernel**: frontend-originated widget updates write to RuntimeStateDoc, and the runtime agent diffs comm state on each sync to forward deltas to the kernel.
+4. **Ephemeral events**: custom comm messages that are not model state still travel as `NotebookBroadcast::Comm`.
 
 ### Benefits
 
@@ -857,7 +821,8 @@ The implementation:
 | File | Role |
 |------|------|
 | `crates/runtimed/src/output_prep.rs` | Output-prep helpers: iopub → nbformat conversion, widget buffer handling, blob-store offload |
-| `crates/runtimed/src/notebook_sync_server.rs` | Room management, request handling, broadcasts |
+| `crates/runtimed/src/notebook_sync_server/` | Room management, peer sync, persistence, metadata/trust/project context |
+| `crates/runtimed/src/requests/` | Notebook request handling |
 | `crates/runtimed/src/project_file.rs` | Project file detection for auto-env |
 | `crates/notebook-doc/src/lib.rs` | Automerge doc operations, output persistence |
 | `crates/notebook/src/lib.rs` | Tauri commands (`launch_kernel_via_daemon`, etc.) |
@@ -875,9 +840,9 @@ Cross-cutting decisions that affect multiple phases. These are living answers �
 
 **Phase 6**: Outputs render from manifests + blob store. Images no longer bloat the CRDT. Re-opening a notebook with existing outputs renders them correctly from blobs, and new execution outputs use the manifest path.
 
-### Output format backward compatibility (Phase 5 -> 6)
+### Output format compatibility
 
-The outputs list is `List of Str`. A string that starts with `{` and parses as a Jupyter output object is Phase 5 inline JSON. A string that's 64 hex characters is a Phase 6 manifest hash. The reader can detect which format it's looking at trivially. Phase 6 rolls out incrementally — old outputs keep working, new outputs use manifests. No migration step needed.
+NotebookDoc may still contain legacy nbformat output data from older documents or import/export fallback paths. Current live output rendering reads RuntimeStateDoc execution records and structured output manifests. Save/export resolves those manifests back to nbformat-compatible JSON when writing `.ipynb`.
 
 ### ipynb metadata hints are advisory only
 
@@ -911,22 +876,13 @@ For output manifests, the `output_type` field provides structural versioning. Ne
 
 ### Output Flow
 
-Output **rendering** is driven exclusively by Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them. The `onOutput` callback is omitted from the `useDaemonKernel` call, so the hook skips Output broadcast processing entirely (including blob resolution).
+Output **rendering** is driven by RuntimeStateDoc sync: the daemon writes execution/output manifests into runtime state, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` and `notebook-outputs.ts` render them.
 
-Output latency is bounded by the Automerge sync round-trip rather than direct broadcast delivery. Providing an `onOutput` callback would re-enable broadcast processing for lower-latency streaming, but would require dedup IDs to prevent duplicates with sync-delivered outputs. Issue #557 was resolved by making sync the sole output rendering path.
+Output latency is bounded by the RuntimeStateDoc sync round-trip rather than direct broadcast delivery. That is intentional: it gives every window the same daemon-authored state and avoids duplicate output paths.
 
-### Multi-Window Widget Sync (#276)
+### Multi-Window Widget Sync
 
-Widgets only render in the window that was active when the widget was created. Secondary windows show "Loading widget" because they miss the initial `comm_open` message that established the widget model.
-
-**Root cause**: The Jupyter comm protocol establishes widget models via messages. When a second window connects to the same notebook via the daemon, it doesn't receive the historical `comm_open` messages.
-
-**Workaround**: Single-window mode works correctly, which covers the majority of use cases.
-
-**Proposed fix**: Sync widget/comm state via Automerge:
-1. Store comm channel state (target_name, comm_id, initial data) in Automerge document
-2. When a new client connects, reconstruct widget models from Automerge state
-3. Keep widget model updates in sync across clients
+Widget model state lives in RuntimeStateDoc. New windows receive the current comm map through normal CRDT sync, and the frontend synthesizes the widget model openings needed by the renderer. Custom comm messages remain ephemeral broadcasts because they represent events, not durable widget state.
 
 ---
 
@@ -941,4 +897,4 @@ Widgets only render in the window that was active when the widget was created. S
 | **5** | Local-first Automerge notebook sync | Implemented — frontend owns local Automerge doc via `runtimed-wasm` WASM, cell mutations happen in WASM, sync to daemon via binary messages |
 | **6** | Output store (manifests, ContentRef, inlining) | Implemented (PR #237) |
 | **7** | ipynb round-tripping | Future (outputs already persist in nbformat) |
-| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #265, #267, #271) — widgets work single-window |
+| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #265, #267, #271) |

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -171,7 +171,9 @@ Auto-upgrade: the client detects version mismatches and replaces the binary.
 |------|------|
 | `daemon.rs` | Daemon state, pool management, warming loops, connection routing |
 | `crates/notebook-protocol/src/protocol.rs` | Notebook request/response/broadcast wire types |
-| `crates/notebook-protocol/src/connection.rs` | Unified framing, handshake enum, send/recv helpers |
+| `crates/notebook-protocol/src/connection/handshake.rs` | Handshake enum, protocol version, channel compatibility |
+| `crates/notebook-protocol/src/connection/framing.rs` | Length-prefixed frame send/recv helpers |
+| `crates/notebook-protocol/src/connection.rs` | Compatibility re-exports for connection helpers |
 | `crates/runtimed-client/src/client.rs` | Client library (`PoolClient`, notebook clients) |
 | `crates/runtimed-client/src/singleton.rs` | File locking, `DaemonInfo` discovery |
 | `crates/runtimed-client/src/service.rs` | Platform-specific install/start/stop helpers |
@@ -452,7 +454,9 @@ pub enum BlobResponse {
 
 | File | Role |
 |------|------|
-| `crates/notebook-protocol/src/connection.rs` | Unified framing, handshake enum, send/recv helpers |
+| `crates/notebook-protocol/src/connection/handshake.rs` | Handshake enum, protocol version, channel compatibility |
+| `crates/notebook-protocol/src/connection/framing.rs` | Length-prefixed frame send/recv helpers |
+| `crates/notebook-protocol/src/connection.rs` | Compatibility re-exports for connection helpers |
 | `daemon.rs` | Single accept loop, `route_connection()` dispatcher |
 | `crates/runtimed-client/src/client.rs` | Uses `Handshake::Pool` |
 | `crates/runtimed-client/src/sync_client.rs` | Uses `Handshake::SettingsSync` |

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -556,6 +556,8 @@ Outputs are structured manifests in RuntimeStateDoc. Manifest fields use `Conten
 
 **Level 2 — Output manifests** (RuntimeStateDoc): Jupyter-aware structured objects describing output type, available representations, metadata, execution count, and `ContentRef` payloads. Used by frontend, Python, and MCP consumers to understand what to render or summarize.
 
+There is no separate `GET /output/{id}` rendering endpoint in the current design; output identity and structure live in RuntimeStateDoc manifests, and any large payloads are fetched by blob hash.
+
 ### ContentRef
 
 The fundamental type for "content that might be inlined or might be in the blob store":
@@ -764,12 +766,11 @@ runtimed (daemon)
 **Why all three?** NotebookDoc sync provides local-first editing and persistence. RuntimeStateDoc sync gives late joiners the current daemon-owned state without replaying historical broadcasts. Broadcasts remain only for event-like messages that should not become durable state.
 
 Broadcast types (see `NotebookBroadcast` in `crates/notebook-protocol/src/protocol.rs`):
-- `OutputsCleared { cell_id }` — outputs cleared for a cell
-- `KernelError { error }` — launch failure or crash
 - `Comm { msg_type, content, buffers }` — ephemeral custom comm messages; widget state updates flow through RuntimeStateDoc
+- `EnvProgress { env_type, phase }` — environment setup progress; RuntimeStateDoc remains authoritative for durable env state
 - ~~`CommSync`~~ — removed; widget state syncs via RuntimeStateDoc CRDT
 
-Several formerly state-carrying broadcasts are filtered at the relay stage and never reach clients: `KernelStatus`, `ExecutionStarted`, `ExecutionDone`, `QueueChanged`, and `EnvSyncState`. Outputs are rendered from RuntimeStateDoc manifests and resolved through the blob/content-ref layer.
+The old state-carrying broadcast variants were removed after RuntimeStateDoc became authoritative: kernel state, execution lifecycle, queue, outputs/display updates, path/autosave, and env sync state now flow through CRDT sync. Outputs are rendered from RuntimeStateDoc manifests and resolved through the blob/content-ref layer.
 
 ### Project file auto-detection
 
@@ -858,9 +859,9 @@ Localhost-only binding, content-addressed with 256-bit hashes (unguessable), non
 
 ### Multi-window sync latency targets
 
-Source edits: sub-200ms perceived. The `sync_to_daemon` round-trip is ~1-5ms locally (Unix socket). The daemon broadcasts immediately. The bottleneck is React re-render, not sync.
+Source edits: sub-200ms perceived. The `sync_to_daemon` round-trip is ~1-5ms locally (Unix socket). The daemon relays sync frames immediately. The bottleneck is React re-render, not sync.
 
-Outputs during execution: the dual delivery path (iopub events for speed, automerge for durability) means the executing window sees outputs instantly. Other windows see them after the automerge round-trip (<50ms). Acceptable for outputs which are inherently asynchronous.
+Outputs during execution: the daemon writes RuntimeStateDoc output manifests as iopub messages arrive, then relays the resulting sync frames to every peer. Latency is the RuntimeStateDoc sync round-trip plus frontend materialization, which is acceptable for outputs that are inherently asynchronous.
 
 If latency becomes an issue during rapid output bursts (e.g., training loops), the first optimization is batching sync messages rather than syncing per-output.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,7 +109,7 @@ If `doctor --fix` doesn't resolve your issue, try these manual steps.
 | Daemon binary | `~/Library/Application Support/runt/bin/runtimed` |
 | Service config | `~/Library/LaunchAgents/io.nteract.runtimed.plist` |
 | Socket | `~/Library/Caches/runt/runtimed.sock` |
-| State file | `~/Library/Caches/runt/daemon.json` |
+| Legacy info fallback | `~/Library/Caches/runt/daemon.json` |
 | Logs | `~/Library/Caches/runt/runtimed.log` |
 
 **Full reset:**
@@ -136,7 +136,7 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.nteract.runtimed.plis
 | Daemon binary | `~/.local/share/runt/bin/runtimed` |
 | Service config | `~/.config/systemd/user/runtimed.service` |
 | Socket | `~/.cache/runt/runtimed.sock` |
-| State file | `~/.cache/runt/daemon.json` |
+| Legacy info fallback | `~/.cache/runt/daemon.json` |
 | Logs | `~/.cache/runt/runtimed.log` |
 
 **Full reset:**


### PR DESCRIPTION
## Summary
- refresh runtime/output/widget docs around RuntimeStateDoc, ContentRef manifests, and nbformat fallback fields
- update protocol/frontend docs and Claude/Codex guidance for package-owned frame constants and split notebook sync server modules
- correct stale protocol-version, RuntimeStateDoc, env metadata, and trust path references across docs/settings

## Verification
- cargo xtask lint --fix
- jq empty .claude/settings.json
- rg "crates/notebook-doc/src/runtime_state|crates/notebook/src/(uv_env|conda_env|pyproject|pixi|environment_yml|deno_env|trust)\.rs|apps/notebook/src/hooks/useSyncedSettings|apps/notebook/src/lib/frame-types\.ts|notebook_sync_server\.rs|kernel_pids|comm_state\.rs|GET /output|manifest hash|output writes|auto_launch_kernel\(\)" docs/*.md contributing/*.md .claude/rules .claude/skills .codex/skills AGENTS.md -n
