### PR TITLE
refactor(runtimed): introduce notebook file binding owner

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2414,7 +2414,7 @@ impl Daemon {
         let (reader, mut writer) = tokio::io::split(stream);
         let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let notebook_path = room
-            .identity
+            .file_binding
             .path
             .read()
             .await
@@ -2963,7 +2963,7 @@ impl Daemon {
                         .unwrap_or((None, None, None));
 
                     let notebook_path = room
-                        .identity
+                        .file_binding
                         .path
                         .read()
                         .await
@@ -2985,7 +2985,7 @@ impl Daemon {
                         env_source,
                         kernel_status,
                         ephemeral: room
-                            .identity
+                            .file_binding
                             .is_ephemeral
                             .load(std::sync::atomic::Ordering::Relaxed),
                         notebook_path,
@@ -3011,7 +3011,7 @@ impl Daemon {
                 };
                 // Clean up path_index if the room had a path.
                 if let Some(ref room) = maybe_room {
-                    let path = room.identity.path.read().await.clone();
+                    let path = room.file_binding.path.read().await.clone();
                     if let Some(p) = path {
                         self.path_index.lock().await.remove(&p);
                     }

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -90,20 +90,8 @@ pub async fn get_or_create_room(
         }
     }
 
-    // Spawn file watcher for .ipynb files (not for untitled notebooks).
     if let Some(ref notebook_path) = options.path {
-        if notebook_path.extension().is_some_and(|ext| ext == "ipynb") {
-            let shutdown_tx = spawn_notebook_file_watcher(notebook_path.clone(), room.clone());
-            // Blocking lock is OK here — room is brand new, no contention.
-            if let Ok(mut guard) = room.persistence.watcher_shutdown_tx.try_lock() {
-                *guard = Some(shutdown_tx);
-            }
-        }
-
-        // Spawn autosave debouncer to keep .ipynb on disk current.
-        let path_str = notebook_path.to_string_lossy().to_string();
-        let shutdown_tx = spawn_autosave_debouncer(path_str, room.clone());
-        install_autosave_shutdown_tx(&room, shutdown_tx).await;
+        NotebookFileBinding::bind_existing(&room, notebook_path).await;
     }
 
     room

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -460,7 +460,7 @@ where
         start.elapsed()
     );
     let notebook_path = room
-        .identity
+        .file_binding
         .path
         .read()
         .await
@@ -1099,7 +1099,7 @@ pub(crate) async fn apply_ipynb_changes(
         }
         map
     };
-    let notebook_path_for_assets = room.identity.path.read().await.clone();
+    let notebook_path_for_assets = room.file_binding.path.read().await.clone();
     let converted_assets: HashMap<String, ResolvedAssets> = {
         let mut map = HashMap::new();
         for cell in external_cells {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -618,7 +618,7 @@ pub(crate) fn compute_env_sync_diff(
 /// isolated markdown rendering can rewrite those refs to blob URLs.
 pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
     let notebook_path = room
-        .identity
+        .file_binding
         .path
         .read()
         .await

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -81,7 +81,6 @@ pub(crate) use peer_presence::sanitize_peer_label;
 pub(crate) use peer_runtime_agent::handle_runtime_agent_sync_connection;
 pub(crate) use peer_runtime_sync::notebook_execution_context_id;
 pub(crate) use persist::*;
-pub(crate) use project_context::refresh_project_context_on_save_as;
 pub(crate) use room::*;
 pub(crate) use runtime_bridge::*;
 

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -108,7 +108,7 @@ where
     // Auto-launch kernel if this is the first peer and notebook is trusted
     if peers == 1 {
         // Check if notebook_id is a UUID (new unsaved notebook) vs a file path
-        let path_snapshot = room.identity.path.read().await.clone();
+        let path_snapshot = room.file_binding.path.read().await.clone();
         let is_new_notebook = path_snapshot.as_ref().is_none_or(|p| !p.exists())
             && uuid::Uuid::parse_str(&notebook_id).is_ok();
 

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -179,8 +179,8 @@ pub(super) async fn handle_peer_disconnect(
             }; // rooms lock dropped here
 
             // Clean up path_index entry (separate lock, after rooms lock is dropped).
-            // Use remove_by_uuid rather than reading room.identity.path — a concurrent writer
-            // A concurrent save-path-update could hold room.identity.path.write() and a
+            // Use remove_by_uuid rather than reading room.file_binding.path — a concurrent writer
+            // A concurrent save-path-update could hold room.file_binding.path.write() and a
             // try_read() would silently return None, leaking the path_index entry.
             if should_teardown {
                 if let Some(uuid) = evicted_uuid {
@@ -239,7 +239,7 @@ pub(super) async fn handle_peer_disconnect(
                 // always present on `RoomPersistence`, but the Option inside
                 // is None until a watcher is actually spawned.
                 if let Some(shutdown_tx) = room_for_eviction
-                    .persistence
+                    .file_binding
                     .watcher_shutdown_tx
                     .lock()
                     .await
@@ -257,7 +257,7 @@ pub(super) async fn handle_peer_disconnect(
                 // file to watch; untitled / bare-dir notebooks leave it
                 // unset.
                 if let Some(shutdown_tx) = room_for_eviction
-                    .persistence
+                    .file_binding
                     .project_file_watcher_shutdown_tx
                     .lock()
                     .await
@@ -286,7 +286,7 @@ pub(super) async fn handle_peer_disconnect(
                 let mut flushed_runtime: Option<CapturedEnvRuntime> = None;
                 let mut save_succeeded = false;
                 if let Some(ref launched) = launched_snapshot {
-                    let has_saved_path = room_for_eviction.identity.path.read().await.is_some();
+                    let has_saved_path = room_for_eviction.file_binding.path.read().await.is_some();
                     let env_source = room_for_eviction
                         .state
                         .read(|sd| sd.read_state().kernel.env_source.clone())
@@ -406,7 +406,8 @@ pub(super) async fn handle_peer_disconnect(
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        let has_saved_path = room_for_eviction.identity.path.read().await.is_some();
+                        let has_saved_path =
+                            room_for_eviction.file_binding.path.read().await.is_some();
                         let metadata = {
                             let doc = room_for_eviction.doc.read().await;
                             doc.get_metadata_snapshot()

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -211,7 +211,7 @@ pub(super) async fn persist_terminal_execution_records(
     persisted_records: &mut PersistedExecutionRecords,
 ) {
     let notebook_path = room
-        .identity
+        .file_binding
         .path
         .read()
         .await

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -25,10 +25,10 @@ pub(crate) async fn save_notebook_to_disk(
     // room currently has as its path. Triangulates stray-file bugs by letting
     // us correlate saves against whoever fired them.
     debug!(
-        "[save] save_notebook_to_disk entered: target_path={:?}, room.id={}, room.identity.path={:?}",
+        "[save] save_notebook_to_disk entered: target_path={:?}, room.id={}, room.file_binding.path={:?}",
         target_path,
         room.id,
-        room.identity.path.read().await.as_deref()
+        room.file_binding.path.read().await.as_deref()
     );
     // Determine the actual save path
     let notebook_path = match target_path {
@@ -51,7 +51,7 @@ pub(crate) async fn save_notebook_to_disk(
                 PathBuf::from(format!("{}.ipynb", p))
             }
         }
-        None => match room.identity.path.read().await.clone() {
+        None => match room.file_binding.path.read().await.clone() {
             Some(p) => p,
             None => {
                 return Err(SaveError::Unrecoverable(
@@ -209,7 +209,7 @@ pub(crate) async fn save_notebook_to_disk(
             );
             // Still update save baselines so the file watcher stays consistent.
             let is_primary_path = target_path.is_none()
-                || room.identity.path.read().await.as_deref() == Some(notebook_path.as_path());
+                || room.file_binding.path.read().await.as_deref() == Some(notebook_path.as_path());
             if is_primary_path {
                 let mut saved = HashMap::with_capacity(cells.len());
                 for cell in &cells {
@@ -261,7 +261,7 @@ pub(crate) async fn save_notebook_to_disk(
     // to the primary path - saving to an alternate path (Save As) must not
     // corrupt the baseline for the file watcher.
     let is_primary_path = target_path.is_none()
-        || room.identity.path.read().await.as_deref() == Some(notebook_path.as_path());
+        || room.file_binding.path.read().await.as_deref() == Some(notebook_path.as_path());
     if is_primary_path {
         let mut saved = HashMap::with_capacity(cells.len());
         for cell in &cells {
@@ -279,7 +279,7 @@ pub(crate) async fn save_notebook_to_disk(
 }
 
 /// Transitions an untitled room to file-backed: claims path in path_index,
-/// updates room.identity.path, cleans up the stale `.automerge` persist file, spawns
+/// updates room.file_binding.path, cleans up the stale `.automerge` persist file, spawns
 /// the `.ipynb` file watcher and autosave debouncer, clears ephemeral markers,
 /// and stamps the new path on the runtime-state doc (peers see it via sync).
 ///
@@ -323,14 +323,11 @@ pub(crate) async fn try_claim_path(
 }
 
 /// Finalize the untitled-to-file-backed transition AFTER the .ipynb has been
-/// written and path_index already holds the claim. This is the non-claim half
-/// of the promotion: path field update, persist file cleanup, file watcher +
-/// autosave debouncer spawn, ephemeral marker clear, and runtime-state doc
-/// `path` write.
+/// written and path_index already holds the claim. `NotebookFileBinding` owns
+/// the path, watcher/autosave lifecycle, runtime-state path write, and project
+/// context refresh; this helper only handles the stale untitled Automerge file
+/// and notebook metadata transition around that binding update.
 pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canonical: PathBuf) {
-    // Update room's path now that path_index owns it.
-    *room.identity.path.write().await = Some(canonical.clone());
-
     // NOTE: We don't actually stop the .automerge persist debouncer here —
     // stopping it would require taking ownership of room.persist_tx, which
     // the current struct definition doesn't support (it's a plain
@@ -352,36 +349,13 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
         }
     }
 
-    // Spawn .ipynb file watcher. RoomPersistence is always present, so the
-    // shutdown sender finds a home whether the room was born file-backed or
-    // promoted from ephemeral.
-    if canonical.extension().is_some_and(|ext| ext == "ipynb") {
-        let shutdown_tx = spawn_notebook_file_watcher(canonical.clone(), Arc::clone(room));
-        *room.persistence.watcher_shutdown_tx.lock().await = Some(shutdown_tx);
-    }
+    NotebookFileBinding::promote_after_save(room, canonical.clone()).await;
 
-    // Spawn autosave debouncer so subsequent edits persist to .ipynb.
-    let shutdown_tx =
-        spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
-    install_autosave_shutdown_tx(room, shutdown_tx).await;
-
-    // Clear ephemeral markers.
-    room.identity.is_ephemeral.store(false, Ordering::Relaxed);
+    // Clear the document-level ephemeral marker after the binding is file-backed.
     {
         let mut doc = room.doc.write().await;
         let _ = doc.delete_metadata("ephemeral");
     }
-
-    // Stamp the new path on the runtime-state doc; peers see it via sync.
-    let path_str = canonical.to_string_lossy().into_owned();
-    if let Err(e) = room.state.with_doc(|sd| sd.set_path(Some(&path_str))) {
-        warn!("[notebook-sync] set_path on promote failed: {}", e);
-    }
-
-    // Project context was `Pending` for untitled; now that we have a
-    // real path, walk up from it. Same call shape catalog uses on room
-    // creation.
-    super::project_context::refresh_project_context_async(room, Some(canonical.as_path())).await;
 
     info!(
         "[notebook-sync] Promoted untitled room {} to file-backed path {:?}",
@@ -674,37 +648,6 @@ pub(crate) fn spawn_autosave_debouncer(
     spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default())
 }
 
-pub(crate) async fn install_autosave_shutdown_tx(
-    room: &NotebookRoom,
-    shutdown_tx: mpsc::UnboundedSender<AutosaveShutdownRequest>,
-) {
-    let previous_tx = room
-        .persistence
-        .autosave_shutdown_tx
-        .lock()
-        .await
-        .replace(shutdown_tx);
-
-    if let Some(previous_tx) = previous_tx {
-        let (ack_tx, ack_rx) = oneshot::channel::<bool>();
-        if previous_tx.send(ack_tx).is_err() {
-            return;
-        }
-        match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
-            Ok(Ok(true)) => {}
-            Ok(Ok(false)) => {
-                warn!("[autosave] Replaced autosave task reported failed shutdown");
-            }
-            Ok(Err(_)) => {
-                warn!("[autosave] Replaced autosave task dropped shutdown ack");
-            }
-            Err(_) => {
-                warn!("[autosave] Timed out waiting for replaced autosave task shutdown");
-            }
-        }
-    }
-}
-
 /// Request one final autosave and stop the `.ipynb` autosave task.
 ///
 /// The task owns a room `Arc`, so room eviction cannot rely on broadcast
@@ -715,38 +658,9 @@ pub(crate) async fn shutdown_autosave_debouncer(
     notebook_id: &str,
     timeout: std::time::Duration,
 ) -> bool {
-    let shutdown_tx = room.persistence.autosave_shutdown_tx.lock().await.take();
-    let Some(shutdown_tx) = shutdown_tx else {
-        return true;
-    };
-
-    let (ack_tx, ack_rx) = oneshot::channel::<bool>();
-    if shutdown_tx.send(ack_tx).is_err() {
-        debug!(
-            "[autosave] Shutdown skipped for {} (autosave task already exited)",
-            notebook_id
-        );
-        return true;
-    }
-
-    match tokio::time::timeout(timeout, ack_rx).await {
-        Ok(Ok(true)) => true,
-        Ok(Ok(false)) => false,
-        Ok(Err(_)) => {
-            warn!(
-                "[autosave] Shutdown ack dropped for {} before final save completed",
-                notebook_id
-            );
-            false
-        }
-        Err(_) => {
-            warn!(
-                "[autosave] Shutdown timed out for {} after {:?}",
-                notebook_id, timeout
-            );
-            false
-        }
-    }
+    room.file_binding
+        .shutdown_autosave(notebook_id, timeout)
+        .await
 }
 
 /// Spawn autosave debouncer with custom timing configuration (for testing).

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -40,13 +40,6 @@ use crate::project_file::{self as daemon_project_file, DetectedProjectFile};
 use super::room::NotebookRoom;
 use crate::task_supervisor::spawn_best_effort;
 
-/// Cross-module entrypoint for the save-as handler. Save-as hands us a
-/// concrete path (no `Option`), and lives in `crate::requests`, outside
-/// `notebook_sync_server`'s `pub(super)` visibility.
-pub(crate) async fn refresh_project_context_on_save_as(room: &Arc<NotebookRoom>, canonical: &Path) {
-    refresh_project_context_async(room, Some(canonical)).await;
-}
-
 /// Walk up from the notebook path, parse what the daemon can, write the
 /// result into `RuntimeStateDoc.project_context`, and arm (or rearm) a
 /// filesystem watcher on the detected project file. External edits to
@@ -89,7 +82,7 @@ pub(super) async fn refresh_project_context_async(room: &Arc<NotebookRoom>, path
 /// empty; the next refresh trigger will re-evaluate.
 async fn rearm_project_file_watcher(room: &Arc<NotebookRoom>, detected_path: Option<PathBuf>) {
     if let Some(tx) = room
-        .persistence
+        .file_binding
         .project_file_watcher_shutdown_tx
         .lock()
         .await
@@ -104,7 +97,7 @@ async fn rearm_project_file_watcher(room: &Arc<NotebookRoom>, detected_path: Opt
 
     let (shutdown_tx, ready_rx) = spawn_project_file_watcher(watch_path, room.clone());
     *room
-        .persistence
+        .file_binding
         .project_file_watcher_shutdown_tx
         .lock()
         .await = Some(shutdown_tx);
@@ -222,7 +215,7 @@ fn spawn_project_file_watcher(
                             // path: the notebook may have been moved such
                             // that a closer project file now wins, or the
                             // detected file may have been deleted.
-                            let notebook_path = room.identity.path.read().await.clone();
+                            let notebook_path = room.file_binding.path.read().await.clone();
                             refresh_project_context_async(&room, notebook_path.as_deref()).await;
                         }
                         Err(e) => {

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1,20 +1,12 @@
 use super::*;
 
-/// Per-room identity and filesystem bindings.
+/// Per-room identity.
 ///
-/// Groups the four fields that describe *which* notebook this room represents,
-/// separate from its document state, broadcasts, or kernel lifecycle. These
-/// fields are read from most code paths but mutated rarely (path changes when
-/// an untitled notebook is saved; working_dir is set once at create time).
+/// Holds immutable identity and untitled working-directory context. The
+/// mutable file-backed binding lives in `NotebookFileBinding`.
 pub struct RoomIdentity {
     /// Persistence path for this room's Automerge document (not the .ipynb).
     pub persist_path: PathBuf,
-    /// Whether this notebook is ephemeral (in-memory only, no .ipynb on disk).
-    pub is_ephemeral: AtomicBool,
-    /// The `.ipynb` path, when this room is file-backed. `None` for untitled
-    /// and ephemeral rooms. Mutated when an untitled room is saved to disk
-    /// (see `handle_save_notebook`).
-    pub path: RwLock<Option<PathBuf>>,
     /// Working directory for untitled notebooks (used for project file detection).
     /// When the notebook_id is a UUID (untitled), this provides the directory
     /// context for finding pyproject.toml, pixi.toml, or environment.yaml.
@@ -22,12 +14,185 @@ pub struct RoomIdentity {
 }
 
 impl RoomIdentity {
-    pub fn new(persist_path: PathBuf, path: Option<PathBuf>, ephemeral: bool) -> Self {
+    pub fn new(persist_path: PathBuf) -> Self {
         Self {
             persist_path,
-            is_ephemeral: AtomicBool::new(ephemeral),
-            path: RwLock::new(path),
             working_dir: RwLock::new(None),
+        }
+    }
+}
+
+/// Owns the mutable relationship between a room and its `.ipynb` file.
+///
+/// This is the single daemon-side owner for canonical path state, file-backed
+/// lifecycle handles, and the runtime-state `path` projection. Callers should
+/// go through this type when a notebook is opened, promoted from untitled, or
+/// saved-as to a new path.
+pub struct NotebookFileBinding {
+    /// The canonical `.ipynb` path, when this room is file-backed.
+    pub path: RwLock<Option<PathBuf>>,
+    /// Whether this notebook is ephemeral (in-memory only, no .ipynb on disk).
+    pub is_ephemeral: AtomicBool,
+    /// Shutdown signal for the `.ipynb` file watcher task.
+    pub watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Shutdown signal for the project-file watcher task.
+    ///
+    /// This watcher is derived from the bound notebook path and is rearmed when
+    /// the binding moves to a new path.
+    pub project_file_watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Shutdown/flush request channel for the `.ipynb` autosave task.
+    pub autosave_shutdown_tx: Mutex<Option<mpsc::UnboundedSender<AutosaveShutdownRequest>>>,
+}
+
+impl NotebookFileBinding {
+    pub fn new(path: Option<PathBuf>, ephemeral: bool) -> Self {
+        Self {
+            path: RwLock::new(path),
+            is_ephemeral: AtomicBool::new(ephemeral),
+            watcher_shutdown_tx: Mutex::new(None),
+            project_file_watcher_shutdown_tx: Mutex::new(None),
+            autosave_shutdown_tx: Mutex::new(None),
+        }
+    }
+
+    pub async fn claim_path(
+        path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
+        canonical: &Path,
+        uuid: uuid::Uuid,
+    ) -> Result<(), notebook_protocol::protocol::SaveErrorKind> {
+        try_claim_path(path_index, canonical, uuid).await
+    }
+
+    pub async fn release_path(path_index: &Arc<tokio::sync::Mutex<PathIndex>>, canonical: &Path) {
+        path_index.lock().await.remove(canonical);
+    }
+
+    pub async fn replace_claim(
+        path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
+        old: &Path,
+        new: PathBuf,
+        uuid: uuid::Uuid,
+    ) {
+        let mut idx = path_index.lock().await;
+        idx.remove(old);
+        if let Err(e) = idx.insert(new.clone(), uuid) {
+            warn!(
+                "[notebook-sync] post-write path_index reinsert failed for {:?}: {} \
+                 — room {} may be orphaned from path lookup",
+                new, e, uuid
+            );
+        }
+    }
+
+    pub async fn set_runtime_path(room: &NotebookRoom, canonical: &Path) {
+        let path_str = canonical.to_string_lossy().into_owned();
+        if let Err(e) = room.state.with_doc(|sd| sd.set_path(Some(&path_str))) {
+            warn!("[notebook-sync] set_path failed for {:?}: {}", canonical, e);
+        }
+    }
+
+    pub async fn bind_existing(room: &Arc<NotebookRoom>, canonical: &Path) {
+        Self::set_runtime_path(room, canonical).await;
+        room.file_binding
+            .start_file_lifecycle(room, canonical)
+            .await;
+    }
+
+    pub async fn promote_after_save(room: &Arc<NotebookRoom>, canonical: PathBuf) {
+        *room.file_binding.path.write().await = Some(canonical.clone());
+        room.file_binding
+            .is_ephemeral
+            .store(false, Ordering::Relaxed);
+        Self::set_runtime_path(room, &canonical).await;
+        room.file_binding
+            .start_file_lifecycle(room, &canonical)
+            .await;
+        super::project_context::refresh_project_context_async(room, Some(canonical.as_path()))
+            .await;
+    }
+
+    pub async fn rebind_after_save_as(room: &Arc<NotebookRoom>, canonical: PathBuf) {
+        *room.file_binding.path.write().await = Some(canonical.clone());
+        Self::set_runtime_path(room, &canonical).await;
+        room.file_binding
+            .start_file_lifecycle(room, &canonical)
+            .await;
+        super::project_context::refresh_project_context_async(room, Some(canonical.as_path()))
+            .await;
+    }
+
+    async fn start_file_lifecycle(&self, room: &Arc<NotebookRoom>, canonical: &Path) {
+        if canonical.extension().is_some_and(|ext| ext == "ipynb") {
+            let shutdown_tx =
+                spawn_notebook_file_watcher(canonical.to_path_buf(), Arc::clone(room));
+            if let Some(previous_tx) = self.watcher_shutdown_tx.lock().await.replace(shutdown_tx) {
+                let _ = previous_tx.send(());
+            }
+        }
+
+        let shutdown_tx =
+            spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
+        self.install_autosave_shutdown_tx(shutdown_tx).await;
+    }
+
+    pub async fn install_autosave_shutdown_tx(
+        &self,
+        shutdown_tx: mpsc::UnboundedSender<AutosaveShutdownRequest>,
+    ) {
+        let previous_tx = self.autosave_shutdown_tx.lock().await.replace(shutdown_tx);
+
+        if let Some(previous_tx) = previous_tx {
+            let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+            if previous_tx.send(ack_tx).is_err() {
+                return;
+            }
+            match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
+                Ok(Ok(true)) => {}
+                Ok(Ok(false)) => {
+                    warn!("[autosave] Replaced autosave task reported failed shutdown");
+                }
+                Ok(Err(_)) => {
+                    warn!("[autosave] Replaced autosave task dropped shutdown ack");
+                }
+                Err(_) => {
+                    warn!("[autosave] Timed out waiting for replaced autosave task shutdown");
+                }
+            }
+        }
+    }
+
+    pub async fn shutdown_autosave(&self, notebook_id: &str, timeout: std::time::Duration) -> bool {
+        let shutdown_tx = self.autosave_shutdown_tx.lock().await.take();
+        let Some(shutdown_tx) = shutdown_tx else {
+            return true;
+        };
+
+        let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+        if shutdown_tx.send(ack_tx).is_err() {
+            debug!(
+                "[autosave] Shutdown skipped for {} (autosave task already exited)",
+                notebook_id
+            );
+            return true;
+        }
+
+        match tokio::time::timeout(timeout, ack_rx).await {
+            Ok(Ok(true)) => true,
+            Ok(Ok(false)) => false,
+            Ok(Err(_)) => {
+                warn!(
+                    "[autosave] Shutdown ack dropped for {} before final save completed",
+                    notebook_id
+                );
+                false
+            }
+            Err(_) => {
+                warn!(
+                    "[autosave] Timed out waiting for final save during shutdown of {}",
+                    notebook_id
+                );
+                false
+            }
         }
     }
 }
@@ -76,15 +241,9 @@ impl Default for RoomBroadcasts {
 ///
 /// Always present on every room. The optional `debouncer` field nests the
 /// two debouncer channels that only exist for non-ephemeral rooms
-/// (untitled-saved or file-backed); everything else (save-baseline
-/// snapshots, file-watcher shutdown, streaming-load gate, attachment
-/// cache) is needed whether the room is ephemeral today or will be
-/// promoted to file-backed later.
-///
-/// When an ephemeral room is saved via `finalize_untitled_promotion`, the
-/// watcher shutdown sender and save baselines start getting populated
-/// without any struct-level resurrection — the fields were waiting for
-/// the file-backed state to arrive.
+/// (untitled-saved or file-backed); save-baseline snapshots, streaming-load
+/// gate, and attachment cache are needed whether the room is ephemeral today
+/// or will be promoted to file-backed later.
 pub struct RoomPersistence {
     /// Debouncer channels — present only when the room writes to a
     /// persisted Automerge doc (`notebook-docs/*.automerge`). Ephemeral
@@ -101,23 +260,6 @@ pub struct RoomPersistence {
     /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
     /// Used to skip file watcher events triggered by our own saves.
     pub last_self_write: AtomicU64,
-    /// Shutdown signal for the file watcher task.
-    /// Sent when the room is evicted to stop the watcher.
-    pub watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
-    /// Shutdown/flush request channel for the `.ipynb` autosave task.
-    ///
-    /// The autosave task owns an `Arc<NotebookRoom>`, so broadcast-channel
-    /// closure is not a reliable room-lifecycle signal. Eviction uses this
-    /// channel to request one acknowledged final save before the task exits.
-    pub autosave_shutdown_tx: Mutex<Option<mpsc::UnboundedSender<AutosaveShutdownRequest>>>,
-    /// Shutdown signal for the project-file watcher task.
-    ///
-    /// Separate from `watcher_shutdown_tx` (which watches the `.ipynb`)
-    /// because the project-file watcher is pinned to a different path
-    /// and can be swapped on save-as without bouncing the notebook
-    /// watcher. `None` until `refresh_project_context` finds a project
-    /// file and the watcher gets armed.
-    pub project_file_watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     /// Raw nbformat attachments preserved from disk, keyed by cell ID.
     ///
     /// Populated only by `.ipynb` load paths. Resolved image data already
@@ -155,9 +297,6 @@ impl RoomPersistence {
             debouncer: None,
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
-            watcher_shutdown_tx: Mutex::new(None),
-            autosave_shutdown_tx: Mutex::new(None),
-            project_file_watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
         }
@@ -175,9 +314,6 @@ impl RoomPersistence {
             }),
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
-            watcher_shutdown_tx: Mutex::new(None),
-            autosave_shutdown_tx: Mutex::new(None),
-            project_file_watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
         }
@@ -233,11 +369,11 @@ pub struct NotebookRoom {
     pub doc: Arc<RwLock<NotebookDoc>>,
     /// Broadcast channels + presence state for fan-out to peer sync loops.
     pub broadcasts: RoomBroadcasts,
-    /// Disk persistence state. Always present; ephemeral rooms carry an
-    /// `ephemeral()` instance with no active debouncer, and gain the
-    /// file watcher + save-baseline tracking when promoted via Save.
+    /// Disk persistence state for Automerge/doc save bookkeeping.
     pub persistence: RoomPersistence,
-    /// Notebook identity: persist_path, is_ephemeral, .ipynb path, working_dir.
+    /// File binding owner: canonical .ipynb path, file watcher, autosave.
+    pub file_binding: NotebookFileBinding,
+    /// Notebook identity: persist_path and working_dir.
     pub identity: RoomIdentity,
     /// Per-connection accounting: active_peers + had_peers.
     pub connections: RoomConnections,
@@ -441,7 +577,8 @@ impl NotebookRoom {
             doc: Arc::new(RwLock::new(doc)),
             broadcasts: RoomBroadcasts::default(),
             persistence,
-            identity: RoomIdentity::new(persist_path, path, ephemeral),
+            file_binding: NotebookFileBinding::new(path, ephemeral),
+            identity: RoomIdentity::new(persist_path),
             connections: RoomConnections::default(),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
@@ -522,7 +659,8 @@ impl NotebookRoom {
             doc: Arc::new(RwLock::new(doc)),
             broadcasts: RoomBroadcasts::default(),
             persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
-            identity: RoomIdentity::new(persist_path, path, false),
+            file_binding: NotebookFileBinding::new(path, false),
+            identity: RoomIdentity::new(persist_path),
             connections: RoomConnections::default(),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -137,7 +137,7 @@ async fn untitled_room_has_path_none() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
     let room = NotebookRoom::new_fresh(Uuid::new_v4(), None, tmp.path(), blob_store, false);
-    assert!(room.identity.path.read().await.is_none());
+    assert!(room.file_binding.path.read().await.is_none());
 }
 
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn file_backed_room_has_path_some() {
         blob_store,
         false,
     );
-    let guard = room.identity.path.read().await;
+    let guard = room.file_binding.path.read().await;
     assert_eq!(guard.as_deref(), Some(fake_path.as_path()));
 }
 
@@ -452,7 +452,7 @@ async fn test_ephemeral_room_skips_persistence() {
 
     assert!(room.persistence.debouncer.is_none());
     assert!(room
-        .identity
+        .file_binding
         .is_ephemeral
         .load(std::sync::atomic::Ordering::Relaxed));
 
@@ -470,7 +470,7 @@ async fn test_session_room_persists() {
 
     assert!(room.persistence.debouncer.is_some());
     assert!(!room
-        .identity
+        .file_binding
         .is_ephemeral
         .load(std::sync::atomic::Ordering::Relaxed));
 }
@@ -713,7 +713,8 @@ fn test_room_with_path_and_store(
         doc: Arc::new(RwLock::new(doc)),
         broadcasts: RoomBroadcasts::default(),
         persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
-        identity: RoomIdentity::new(persist_path, Some(notebook_path.clone()), false),
+        file_binding: NotebookFileBinding::new(Some(notebook_path.clone()), false),
+        identity: RoomIdentity::new(persist_path),
         connections: RoomConnections::default(),
         blob_store,
         trust_state: Arc::new(RwLock::new(TrustState {
@@ -2712,7 +2713,7 @@ async fn test_update_kernel_presence_publishes_state_and_relays() {
 // ── Regression test: autosave after save_notebook path update ──────
 
 /// Verify that saving an untitled (UUID-keyed) room updates path_index and
-/// room.identity.path, while keeping the UUID stable in the rooms map.
+/// room.file_binding.path, while keeping the UUID stable in the rooms map.
 #[tokio::test]
 async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2747,13 +2748,13 @@ async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
         .await
         .insert(canonical.clone(), room.id)
         .unwrap();
-    *room.identity.path.write().await = Some(canonical.clone());
+    *room.file_binding.path.write().await = Some(canonical.clone());
 
-    // UUID key unchanged, path_index populated, room.identity.path set.
+    // UUID key unchanged, path_index populated, room.file_binding.path set.
     assert!(rooms.lock().await.contains_key(&uuid));
     assert_eq!(path_index.lock().await.lookup(&canonical), Some(uuid));
     assert_eq!(
-        room.identity.path.read().await.as_deref(),
+        room.file_binding.path.read().await.as_deref(),
         Some(canonical.as_path())
     );
 }
@@ -2797,10 +2798,10 @@ async fn saving_to_already_open_path_returns_path_already_open_error() {
         other => panic!("expected PathAlreadyOpen, got {:?}", other),
     }
 
-    // room.identity.path must NOT have been mutated on error.
+    // room.file_binding.path must NOT have been mutated on error.
     assert!(
-        room.identity.path.read().await.is_none(),
-        "room.identity.path should still be None after a failed claim"
+        room.file_binding.path.read().await.is_none(),
+        "room.file_binding.path should still be None after a failed claim"
     );
 }
 
@@ -2909,9 +2910,9 @@ async fn test_promote_untitled_starts_autosave() {
         "UUID key should still be present after promotion"
     );
     assert_eq!(
-        room.identity.path.read().await.as_deref(),
+        room.file_binding.path.read().await.as_deref(),
         Some(canonical.as_path()),
-        "room.identity.path should be set after promotion"
+        "room.file_binding.path should be set after promotion"
     );
     assert_eq!(
         path_index.lock().await.lookup(&canonical),
@@ -2919,7 +2920,7 @@ async fn test_promote_untitled_starts_autosave() {
         "path_index should contain the room's UUID"
     );
     assert!(
-        !room.identity.is_ephemeral.load(Ordering::Relaxed),
+        !room.file_binding.is_ephemeral.load(Ordering::Relaxed),
         "is_ephemeral should be cleared after promotion"
     );
 
@@ -6476,7 +6477,7 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
 
     // Ephemeral.
     assert!(clone_room
-        .identity
+        .file_binding
         .is_ephemeral
         .load(std::sync::atomic::Ordering::Acquire));
 
@@ -6888,7 +6889,7 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
 
     // Sanity: watcher state is armed.
     assert!(room
-        .persistence
+        .file_binding
         .project_file_watcher_shutdown_tx
         .lock()
         .await
@@ -6929,7 +6930,7 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
 
     // Tear down the watcher so the temp dir can drop cleanly.
     let shutdown = room
-        .persistence
+        .file_binding
         .project_file_watcher_shutdown_tx
         .lock()
         .await
@@ -7278,7 +7279,11 @@ async fn test_autosave_shutdown_flushes_pending_doc_change() {
         "shutdown final save should include the edit made inside the debounce window; got: {sources:?}"
     );
     assert!(
-        room.persistence.autosave_shutdown_tx.lock().await.is_none(),
+        room.file_binding
+            .autosave_shutdown_tx
+            .lock()
+            .await
+            .is_none(),
         "shutdown should consume the autosave lifecycle handle"
     );
 }
@@ -7295,7 +7300,7 @@ async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
     let room = NotebookRoom::new_fresh(Uuid::new_v4(), None, &docs_dir, blob_store, false);
 
     let (old_tx, mut old_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
-    install_autosave_shutdown_tx(&room, old_tx).await;
+    room.file_binding.install_autosave_shutdown_tx(old_tx).await;
 
     let (new_tx, mut new_rx) = mpsc::unbounded_channel::<AutosaveShutdownRequest>();
     let replaced_ack_task = tokio::spawn(async move {
@@ -7305,7 +7310,7 @@ async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
             .expect("replacing the handle should signal the old task");
         let _ = ack_tx.send(true);
     });
-    install_autosave_shutdown_tx(&room, new_tx).await;
+    room.file_binding.install_autosave_shutdown_tx(new_tx).await;
     replaced_ack_task.await.unwrap();
     assert!(
         new_rx.try_recv().is_err(),
@@ -7324,6 +7329,65 @@ async fn test_install_autosave_shutdown_tx_signals_replaced_handle() {
         "explicit shutdown should receive ack from the new handle"
     );
     ack_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_save_as_rebind_replaces_file_lifecycle_and_runtime_path() {
+    use std::time::Duration;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, old_path) = test_room_with_path(&tmp, "old.ipynb");
+    let room = Arc::new(room);
+    let new_path = tmp.path().join("new.ipynb");
+    std::fs::write(&old_path, "{}").unwrap();
+    std::fs::write(&new_path, "{}").unwrap();
+
+    let (old_watcher_tx, old_watcher_rx) = oneshot::channel::<()>();
+    *room.file_binding.watcher_shutdown_tx.lock().await = Some(old_watcher_tx);
+
+    let (old_autosave_tx, mut old_autosave_rx) =
+        mpsc::unbounded_channel::<AutosaveShutdownRequest>();
+    room.file_binding
+        .install_autosave_shutdown_tx(old_autosave_tx)
+        .await;
+    let autosave_ack_task = tokio::spawn(async move {
+        let ack_tx = old_autosave_rx
+            .recv()
+            .await
+            .expect("rebind should signal the old autosave task");
+        let _ = ack_tx.send(true);
+    });
+
+    NotebookFileBinding::rebind_after_save_as(&room, new_path.clone()).await;
+
+    tokio::time::timeout(Duration::from_secs(1), old_watcher_rx)
+        .await
+        .expect("rebind should signal old notebook watcher")
+        .expect("old notebook watcher sender should not be dropped");
+    autosave_ack_task.await.unwrap();
+
+    assert_eq!(
+        room.file_binding.path.read().await.as_deref(),
+        Some(new_path.as_path())
+    );
+    let runtime_path = room
+        .state
+        .read(|sd| sd.read_state().path)
+        .expect("runtime state should be readable");
+    let expected_runtime_path = new_path.to_string_lossy().into_owned();
+    assert_eq!(
+        runtime_path.as_deref(),
+        Some(expected_runtime_path.as_str())
+    );
+
+    if let Some(shutdown_tx) = room.file_binding.watcher_shutdown_tx.lock().await.take() {
+        let _ = shutdown_tx.send(());
+    }
+    assert!(
+        shutdown_autosave_debouncer(&room, &new_path.to_string_lossy(), Duration::from_secs(1))
+            .await,
+        "new autosave task should shut down cleanly"
+    );
 }
 
 #[tokio::test]
@@ -7356,10 +7420,12 @@ async fn test_autosave_shutdown_during_loading_returns_false_without_write() {
     let canonical = tokio::fs::canonicalize(&written)
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
-    *room.identity.path.write().await = Some(canonical.clone());
+    *room.file_binding.path.write().await = Some(canonical.clone());
     let shutdown_tx =
         spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(&room));
-    install_autosave_shutdown_tx(&room, shutdown_tx).await;
+    room.file_binding
+        .install_autosave_shutdown_tx(shutdown_tx)
+        .await;
 
     {
         let mut doc = room.doc.write().await;

--- a/crates/runtimed/src/requests/approve_project_environment.rs
+++ b/crates/runtimed/src/requests/approve_project_environment.rs
@@ -75,7 +75,7 @@ async fn resolve_project_file(
         return Ok(crate::project_file::DetectedProjectFile { path, kind });
     }
 
-    let notebook_path = room.identity.path.read().await.clone();
+    let notebook_path = room.file_binding.path.read().await.clone();
     let working_dir = room.identity.working_dir.read().await.clone();
     let detection_path = notebook_path.as_ref().or(working_dir.as_ref());
     let Some(path) = detection_path else {

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -108,7 +108,7 @@ pub(crate) async fn handle_inner(
 /// if file-backed, or the explicit working_dir stored on the room for
 /// untitled rooms. None only if both are absent.
 async fn derive_working_dir(room: &NotebookRoom) -> Option<PathBuf> {
-    if let Some(path) = room.identity.path.read().await.as_ref() {
+    if let Some(path) = room.file_binding.path.read().await.as_ref() {
         if let Some(parent) = path.parent() {
             return Some(parent.to_path_buf());
         }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -50,7 +50,7 @@ pub(crate) async fn handle(
     let notebook_path = match notebook_path {
         Some(p) => Some(p),
         None => room
-            .identity
+            .file_binding
             .path
             .read()
             .await

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
     canonical_target_path, finalize_untitled_promotion, format_notebook_cells,
-    persist_notebook_bytes, save_notebook_to_disk, try_claim_path, NotebookRoom, SaveError,
+    persist_notebook_bytes, save_notebook_to_disk, NotebookFileBinding, NotebookRoom, SaveError,
 };
 use crate::protocol::NotebookResponse;
 
@@ -29,7 +29,7 @@ pub(crate) async fn handle(
     // Capture was_untitled and old_path in a single critical section to
     // avoid a TOCTOU race between the two reads.
     let (was_untitled, old_path) = {
-        let p = room.identity.path.read().await;
+        let p = room.file_binding.path.read().await;
         (p.is_none(), p.clone())
     };
 
@@ -41,7 +41,7 @@ pub(crate) async fn handle(
     //
     // Compute the pre-write canonical target. For untitled rooms a path
     // is required; for file-backed rooms we only need a pre-write claim
-    // if the caller specified a path different from room.identity.path.
+    // if the caller specified a path different from room.file_binding.path.
     let target_for_claim: Option<PathBuf> = match (&path, was_untitled) {
         (Some(p), _) => match crate::paths::normalize_save_target(p) {
             Ok(normalized) => Some(canonical_target_path(&normalized).await),
@@ -70,7 +70,9 @@ pub(crate) async fn handle(
     };
 
     if let Some(ref canonical_pre) = pre_claim {
-        if let Err(kind) = try_claim_path(&daemon.path_index, canonical_pre, room.id).await {
+        if let Err(kind) =
+            NotebookFileBinding::claim_path(&daemon.path_index, canonical_pre, room.id).await
+        {
             return NotebookResponse::SaveError { error: kind };
         }
     }
@@ -81,11 +83,11 @@ pub(crate) async fn handle(
             // Rollback the path_index claim we just made so the room
             // stays untitled / its old path stays claimed.
             if let Some(ref canonical_pre) = pre_claim {
-                daemon.path_index.lock().await.remove(canonical_pre);
+                NotebookFileBinding::release_path(&daemon.path_index, canonical_pre).await;
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
-            if room.identity.is_ephemeral.load(Ordering::Relaxed)
+            if room.file_binding.is_ephemeral.load(Ordering::Relaxed)
                 && room.persistence.debouncer.is_none()
             {
                 let bytes = room.doc.write().await.save();
@@ -121,16 +123,13 @@ pub(crate) async fn handle(
 
     if let Some(ref canonical_pre) = pre_claim {
         if canonical_pre != &canonical {
-            let mut idx = daemon.path_index.lock().await;
-            idx.remove(canonical_pre);
-            // Best-effort reinsert under the post-write canonical.
-            if let Err(e) = idx.insert(canonical.clone(), room.id) {
-                warn!(
-                    "[notebook-sync] post-write path_index reinsert failed for {:?}: {} \
-                     — room {} may be orphaned from path lookup",
-                    canonical, e, room.id
-                );
-            }
+            NotebookFileBinding::replace_claim(
+                &daemon.path_index,
+                canonical_pre,
+                canonical.clone(),
+                room.id,
+            )
+            .await;
         }
     }
 
@@ -140,23 +139,9 @@ pub(crate) async fn handle(
         let path_changed = old != &canonical;
         if path_changed {
             // Save-as rename: new path already claimed above; remove
-            // the old path_index entry and update room.identity.path.
-            {
-                let mut idx = daemon.path_index.lock().await;
-                idx.remove(old);
-            }
-            *room.identity.path.write().await = Some(canonical.clone());
-            let path_str = canonical.to_string_lossy().into_owned();
-            if let Err(e) = room.state.with_doc(|sd| sd.set_path(Some(&path_str))) {
-                tracing::warn!("[save_notebook] set_path failed: {}", e);
-            }
-            // Walk up from the new location; the previous project_context
-            // reflected the old parent directory and is now stale.
-            crate::notebook_sync_server::refresh_project_context_on_save_as(
-                room,
-                canonical.as_path(),
-            )
-            .await;
+            // the old path_index entry and update room.file_binding.path.
+            NotebookFileBinding::release_path(&daemon.path_index, old).await;
+            NotebookFileBinding::rebind_after_save_as(room, canonical.clone()).await;
         }
         // If path didn't change, this is save-in-place: nothing else.
     }


### PR DESCRIPTION
## Summary
- add `NotebookFileBinding` as the room-level owner for canonical notebook path, file watcher, project-file watcher, autosave lifecycle, and runtime-state path writes
- route open, untitled promotion, Save As rebinding, eviction, and path consumers through the new binding
- add coverage for Save As rebinding replacing watcher/autosave lifecycle and updating RuntimeStateDoc path

## Verification
- `cargo check -p runtimed`
- `cargo test -p runtimed test_save_as_rebind_replaces_file_lifecycle_and_runtime_path --lib`
- `cargo test -p runtimed autosave --lib`
- `git diff --check`

## External review
- Claude Bedrock Opus 4.6 reviewed the branch for API shape and architecture. Initial review requested Save As lifecycle coverage; follow-up after adding the test reported no actionable findings and said the branch is ready.