### PR TITLE
feat(notebook-doc): promote attachments to crdt schema

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -30,6 +30,7 @@
 //!                                   counts are in RuntimeStateDoc
 //!       metadata/                 ← Map (native Automerge types, legacy: JSON string fallback)
 //!       resolved_assets/          ← Map of markdown asset ref -> blob hash
+//!       attachments/              ← Map of attachment name -> media type -> {blob_hash, encoding}
 //!   metadata/                     ← Map
 //!     runtime: Str
 //!     kernelspec/                 ← Map (native Automerge, per-field CRDT merge)
@@ -114,6 +115,17 @@ pub struct CellSnapshot {
     /// Resolved markdown asset refs (e.g. `attachment:image.png`, `images/foo.png`) → blob hash
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub resolved_assets: HashMap<String, String>,
+    /// nbformat attachments stored as blob refs.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub attachments: HashMap<String, HashMap<String, AttachmentRef>>,
+}
+
+/// A single nbformat attachment payload stored by blob reference.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AttachmentRef {
+    pub blob_hash: String,
+    /// How to reconstruct the nbformat payload (`base64`, `text`, or `json`).
+    pub encoding: String,
 }
 
 fn default_empty_object() -> serde_json::Value {
@@ -1188,6 +1200,8 @@ impl NotebookDoc {
         self.doc.put_object(&cell_map, "metadata", ObjType::Map)?;
         self.doc
             .put_object(&cell_map, "resolved_assets", ObjType::Map)?;
+        self.doc
+            .put_object(&cell_map, "attachments", ObjType::Map)?;
 
         Ok(position_str)
     }
@@ -1257,6 +1271,8 @@ impl NotebookDoc {
 
         self.doc
             .put_object(&cell_map, "resolved_assets", ObjType::Map)?;
+        self.doc
+            .put_object(&cell_map, "attachments", ObjType::Map)?;
 
         Ok(())
     }
@@ -1692,6 +1708,82 @@ impl NotebookDoc {
         Ok(true)
     }
 
+    /// Get all nbformat attachments for a cell as blob refs
+    /// (`attachment name` -> `media type` -> `blob hash`).
+    pub fn get_cell_attachments(
+        &self,
+        cell_id: &str,
+    ) -> Option<HashMap<String, HashMap<String, AttachmentRef>>> {
+        let cells_id = self.cells_map_id()?;
+        let cell_obj = self.cell_obj_id(&cells_id, cell_id)?;
+        let attachments_id = self.map_id(&cell_obj, "attachments")?;
+        Some(read_attachment_refs(&self.doc, &attachments_id))
+    }
+
+    /// Replace all nbformat attachment blob refs for a cell.
+    ///
+    /// Callers must store attachment bytes in the blob store before writing
+    /// these refs. The daemon load/watch paths are the current writers.
+    ///
+    /// Returns `true` if the map changed.
+    pub fn set_cell_attachments(
+        &mut self,
+        cell_id: &str,
+        attachments: &HashMap<String, HashMap<String, AttachmentRef>>,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_obj_id(&cells_id, cell_id) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+
+        let existing = self.get_cell_attachments(cell_id).unwrap_or_default();
+        if existing == *attachments {
+            return Ok(false);
+        }
+
+        let attachments_id = match self.map_id(&cell_obj, "attachments") {
+            Some(id) => id,
+            None => self
+                .doc
+                .put_object(&cell_obj, "attachments", ObjType::Map)?,
+        };
+
+        for key in existing.keys() {
+            if !attachments.contains_key(key) {
+                self.doc.delete(&attachments_id, key)?;
+            }
+        }
+
+        for (name, bundle) in attachments {
+            let bundle_id = match self.map_id(&attachments_id, name) {
+                Some(id) => id,
+                None => self.doc.put_object(&attachments_id, name, ObjType::Map)?,
+            };
+
+            let existing_bundle = existing.get(name).cloned().unwrap_or_default();
+            for media_type in existing_bundle.keys() {
+                if !bundle.contains_key(media_type) {
+                    self.doc.delete(&bundle_id, media_type)?;
+                }
+            }
+            for (media_type, attachment_ref) in bundle {
+                if existing_bundle.get(media_type) != Some(attachment_ref) {
+                    let ref_id = self.doc.put_object(&bundle_id, media_type, ObjType::Map)?;
+                    self.doc
+                        .put(&ref_id, "blob_hash", attachment_ref.blob_hash.as_str())?;
+                    self.doc
+                        .put(&ref_id, "encoding", attachment_ref.encoding.as_str())?;
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     // ── Notebook metadata ──────────────────────────────────────────
 
     /// Read a metadata value.
@@ -1989,6 +2081,10 @@ impl NotebookDoc {
                 .collect(),
             None => HashMap::new(),
         };
+        let attachments = match self.map_id(cell_obj, "attachments") {
+            Some(map_id) => read_attachment_refs(&self.doc, &map_id),
+            None => HashMap::new(),
+        };
 
         Some(CellSnapshot {
             id,
@@ -1998,6 +2094,7 @@ impl NotebookDoc {
             execution_count,
             metadata,
             resolved_assets,
+            attachments,
         })
     }
 
@@ -2026,6 +2123,7 @@ impl NotebookDoc {
             execution_count,
             metadata: serde_json::json!({}),
             resolved_assets: HashMap::new(),
+            attachments: HashMap::new(),
         })
     }
 }
@@ -2048,6 +2146,38 @@ fn read_str<O: AsRef<automerge::ObjId>, P: Into<automerge::Prop>>(
             },
             _ => None,
         })
+}
+
+fn read_attachment_refs(
+    doc: &AutoCommit,
+    attachments_id: &ObjId,
+) -> HashMap<String, HashMap<String, AttachmentRef>> {
+    doc.map_range(attachments_id, ..)
+        .filter_map(|item| {
+            if !matches!(item.value, automerge::ValueRef::Object(ObjType::Map)) {
+                return None;
+            }
+            let bundle: HashMap<String, AttachmentRef> = doc
+                .map_range(&item.id(), ..)
+                .filter_map(|media_item| {
+                    if matches!(media_item.value, automerge::ValueRef::Object(ObjType::Map)) {
+                        let blob_hash = read_str(doc, media_item.id(), "blob_hash")?;
+                        let encoding = read_str(doc, media_item.id(), "encoding")
+                            .unwrap_or_else(|| "base64".to_string());
+                        return Some((
+                            media_item.key.to_string(),
+                            AttachmentRef {
+                                blob_hash,
+                                encoding,
+                            },
+                        ));
+                    }
+                    None
+                })
+                .collect();
+            (!bundle.is_empty()).then(|| (item.key.to_string(), bundle))
+        })
+        .collect()
 }
 
 fn read_str_at<O: AsRef<automerge::ObjId>, P: Into<automerge::Prop>>(
@@ -2315,6 +2445,12 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                     .collect(),
                 _ => HashMap::new(),
             };
+            let attachments = match doc.get(&cell_obj, "attachments").ok().flatten() {
+                Some((automerge::Value::Object(ObjType::Map), map_id)) => {
+                    read_attachment_refs(doc, &map_id)
+                }
+                _ => HashMap::new(),
+            };
 
             Some(CellSnapshot {
                 id,
@@ -2324,6 +2460,7 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 execution_count,
                 metadata,
                 resolved_assets,
+                attachments,
             })
         })
         .collect();
@@ -2693,6 +2830,17 @@ mod tests {
         doc.update_source("cell-1", "x = 42").unwrap();
         doc.add_cell(1, "cell-2", "markdown").unwrap();
         doc.update_source("cell-2", "# Hello").unwrap();
+        let attachments = HashMap::from([(
+            "image.png".to_string(),
+            HashMap::from([(
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: "attachment-hash".to_string(),
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        )]);
+        doc.set_cell_attachments("cell-2", &attachments).unwrap();
 
         let bytes = doc.save();
         let loaded = NotebookDoc::load(&bytes).unwrap();
@@ -2704,6 +2852,7 @@ mod tests {
         assert_eq!(cells[0].source, "x = 42");
         assert_eq!(cells[1].id, "cell-2");
         assert_eq!(cells[1].source, "# Hello");
+        assert_eq!(cells[1].attachments, attachments);
     }
 
     #[test]

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -134,31 +134,55 @@ pub struct AttachmentRef {
 }
 
 /// How to reconstruct a blob-backed nbformat attachment payload.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+///
+/// This is a CRDT schema tag. The daemon's nbformat conversion helpers define
+/// how each known variant maps to on-disk `.ipynb` JSON.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttachmentEncoding {
     Base64,
     Text,
     Json,
+    /// Preserve forward-compatible schema values even when this client cannot
+    /// reconstruct the nbformat payload.
+    Unknown(String),
 }
 
 impl AttachmentEncoding {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Base64 => "base64",
             Self::Text => "text",
             Self::Json => "json",
+            Self::Unknown(value) => value.as_str(),
         }
     }
 
-    fn from_schema_str(value: Option<&str>) -> Option<Self> {
+    pub fn from_schema_str(value: &str) -> Self {
         match value {
-            None => Some(Self::Base64),
-            Some("base64") => Some(Self::Base64),
-            Some("text") => Some(Self::Text),
-            Some("json") => Some(Self::Json),
-            Some(_) => None,
+            "base64" => Self::Base64,
+            "text" => Self::Text,
+            "json" => Self::Json,
+            other => Self::Unknown(other.to_string()),
         }
+    }
+}
+
+impl Serialize for AttachmentEncoding {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for AttachmentEncoding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_schema_str(&value))
     }
 }
 
@@ -2190,9 +2214,9 @@ fn read_attachment_refs(doc: &AutoCommit, attachments_id: &ObjId) -> CellAttachm
                 .filter_map(|media_item| {
                     if matches!(media_item.value, automerge::ValueRef::Object(ObjType::Map)) {
                         let blob_hash = read_str(doc, media_item.id(), "blob_hash")?;
-                        let encoding = AttachmentEncoding::from_schema_str(
-                            read_str(doc, media_item.id(), "encoding").as_deref(),
-                        )?;
+                        let encoding = read_str(doc, media_item.id(), "encoding")
+                            .map(|value| AttachmentEncoding::from_schema_str(&value))
+                            .unwrap_or(AttachmentEncoding::Base64);
                         return Some((
                             media_item.key.to_string(),
                             AttachmentRef {
@@ -2882,6 +2906,55 @@ mod tests {
         assert_eq!(cells[1].id, "cell-2");
         assert_eq!(cells[1].source, "# Hello");
         assert_eq!(cells[1].attachments, attachments);
+    }
+
+    #[test]
+    fn test_cell_attachments_update_delete_noop_and_raw_roundtrip() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "raw-1", "raw").unwrap();
+
+        let initial = HashMap::from([(
+            "bundle".to_string(),
+            HashMap::from([
+                (
+                    "image/png".to_string(),
+                    AttachmentRef {
+                        blob_hash: "png-hash".to_string(),
+                        encoding: AttachmentEncoding::Base64,
+                    },
+                ),
+                (
+                    "text/plain".to_string(),
+                    AttachmentRef {
+                        blob_hash: "text-hash".to_string(),
+                        encoding: AttachmentEncoding::Text,
+                    },
+                ),
+            ]),
+        )]);
+        assert!(doc.set_cell_attachments("raw-1", &initial).unwrap());
+        assert!(!doc.set_cell_attachments("raw-1", &initial).unwrap());
+
+        let updated = HashMap::from([(
+            "bundle".to_string(),
+            HashMap::from([(
+                "application/custom".to_string(),
+                AttachmentRef {
+                    blob_hash: "custom-hash".to_string(),
+                    encoding: AttachmentEncoding::Unknown("custom".to_string()),
+                },
+            )]),
+        )]);
+        assert!(doc.set_cell_attachments("raw-1", &updated).unwrap());
+        assert_eq!(doc.get_cell_attachments("raw-1").unwrap(), updated);
+
+        let bytes = doc.save();
+        let loaded = NotebookDoc::load(&bytes).unwrap();
+        assert_eq!(loaded.get_cell("raw-1").unwrap().attachments, updated);
+
+        let empty = HashMap::new();
+        assert!(doc.set_cell_attachments("raw-1", &empty).unwrap());
+        assert!(doc.get_cell_attachments("raw-1").unwrap().is_empty());
     }
 
     #[test]

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -117,15 +117,49 @@ pub struct CellSnapshot {
     pub resolved_assets: HashMap<String, String>,
     /// nbformat attachments stored as blob refs.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub attachments: HashMap<String, HashMap<String, AttachmentRef>>,
+    pub attachments: CellAttachments,
 }
+
+/// nbformat attachments for one cell: attachment name -> MIME bundle.
+pub type CellAttachments = HashMap<String, AttachmentMediaBundle>;
+
+/// One nbformat attachment MIME bundle: media type -> blob ref.
+pub type AttachmentMediaBundle = HashMap<String, AttachmentRef>;
 
 /// A single nbformat attachment payload stored by blob reference.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AttachmentRef {
     pub blob_hash: String,
-    /// How to reconstruct the nbformat payload (`base64`, `text`, or `json`).
-    pub encoding: String,
+    pub encoding: AttachmentEncoding,
+}
+
+/// How to reconstruct a blob-backed nbformat attachment payload.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AttachmentEncoding {
+    Base64,
+    Text,
+    Json,
+}
+
+impl AttachmentEncoding {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Base64 => "base64",
+            Self::Text => "text",
+            Self::Json => "json",
+        }
+    }
+
+    fn from_schema_str(value: Option<&str>) -> Option<Self> {
+        match value {
+            None => Some(Self::Base64),
+            Some("base64") => Some(Self::Base64),
+            Some("text") => Some(Self::Text),
+            Some("json") => Some(Self::Json),
+            Some(_) => None,
+        }
+    }
 }
 
 fn default_empty_object() -> serde_json::Value {
@@ -1710,10 +1744,7 @@ impl NotebookDoc {
 
     /// Get all nbformat attachments for a cell as blob refs
     /// (`attachment name` -> `media type` -> `blob hash`).
-    pub fn get_cell_attachments(
-        &self,
-        cell_id: &str,
-    ) -> Option<HashMap<String, HashMap<String, AttachmentRef>>> {
+    pub fn get_cell_attachments(&self, cell_id: &str) -> Option<CellAttachments> {
         let cells_id = self.cells_map_id()?;
         let cell_obj = self.cell_obj_id(&cells_id, cell_id)?;
         let attachments_id = self.map_id(&cell_obj, "attachments")?;
@@ -1729,7 +1760,7 @@ impl NotebookDoc {
     pub fn set_cell_attachments(
         &mut self,
         cell_id: &str,
-        attachments: &HashMap<String, HashMap<String, AttachmentRef>>,
+        attachments: &CellAttachments,
     ) -> Result<bool, AutomergeError> {
         let cells_id = match self.cells_map_id() {
             Some(id) => id,
@@ -2148,22 +2179,20 @@ fn read_str<O: AsRef<automerge::ObjId>, P: Into<automerge::Prop>>(
         })
 }
 
-fn read_attachment_refs(
-    doc: &AutoCommit,
-    attachments_id: &ObjId,
-) -> HashMap<String, HashMap<String, AttachmentRef>> {
+fn read_attachment_refs(doc: &AutoCommit, attachments_id: &ObjId) -> CellAttachments {
     doc.map_range(attachments_id, ..)
         .filter_map(|item| {
             if !matches!(item.value, automerge::ValueRef::Object(ObjType::Map)) {
                 return None;
             }
-            let bundle: HashMap<String, AttachmentRef> = doc
+            let bundle: AttachmentMediaBundle = doc
                 .map_range(&item.id(), ..)
                 .filter_map(|media_item| {
                     if matches!(media_item.value, automerge::ValueRef::Object(ObjType::Map)) {
                         let blob_hash = read_str(doc, media_item.id(), "blob_hash")?;
-                        let encoding = read_str(doc, media_item.id(), "encoding")
-                            .unwrap_or_else(|| "base64".to_string());
+                        let encoding = AttachmentEncoding::from_schema_str(
+                            read_str(doc, media_item.id(), "encoding").as_deref(),
+                        )?;
                         return Some((
                             media_item.key.to_string(),
                             AttachmentRef {
@@ -2836,7 +2865,7 @@ mod tests {
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: "attachment-hash".to_string(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             )]),
         )]);

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2210,7 +2210,7 @@ fn read_attachment_refs(doc: &AutoCommit, attachments_id: &ObjId) -> CellAttachm
                 return None;
             }
             let bundle: AttachmentMediaBundle = doc
-                .map_range(&item.id(), ..)
+                .map_range(item.id(), ..)
                 .filter_map(|media_item| {
                     if matches!(media_item.value, automerge::ValueRef::Object(ObjType::Map)) {
                         let blob_hash = read_str(doc, media_item.id(), "blob_hash")?;

--- a/crates/notebook-doc/src/pep723.rs
+++ b/crates/notebook-doc/src/pep723.rs
@@ -320,6 +320,7 @@ print(os.getcwd())"#;
             execution_count: "null".to_string(),
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
+            attachments: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -437,6 +437,7 @@ async fn render_execution_result(
             .unwrap_or_else(|| "null".to_string()),
         metadata: serde_json::json!({}),
         resolved_assets: std::collections::HashMap::new(),
+        attachments: std::collections::HashMap::new(),
     };
     let snap = cell.unwrap_or(fallback_cell);
     let mut structured_content = if exec.outputs.is_empty() {

--- a/crates/runtimed-client/src/resolved_output.rs
+++ b/crates/runtimed-client/src/resolved_output.rs
@@ -239,6 +239,7 @@ mod tests {
             execution_count: "null".into(),
             metadata,
             resolved_assets: HashMap::new(),
+            attachments: HashMap::new(),
         }
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3408,8 +3408,9 @@ pub(crate) fn blob_gc_grace() -> std::time::Duration {
 /// Walk a persisted notebook-doc `.automerge` file and collect blob refs.
 ///
 /// Loads the saved document and pulls blob refs from `cell.resolved_assets`
-/// (markdown image refs). Returns `false` if the file cannot be read or
-/// decoded — the caller logs and moves on.
+/// (markdown image refs) and `cell.attachments` (nbformat attachment payloads).
+/// Returns `false` if the file cannot be read or decoded — the caller logs and
+/// moves on.
 ///
 /// Note: `RuntimeStateDoc` is not persisted to disk separately. Current
 /// schema-v3+ notebook docs store outputs in RuntimeStateDoc while the
@@ -3442,6 +3443,11 @@ pub(crate) async fn collect_hashes_from_persisted_doc(
     for cell in doc.get_cells() {
         for hash in cell.resolved_assets.values() {
             hashes.insert(hash.clone());
+        }
+        for bundle in cell.attachments.values() {
+            for attachment_ref in bundle.values() {
+                hashes.insert(attachment_ref.blob_hash.clone());
+            }
         }
     }
     true
@@ -3515,6 +3521,11 @@ impl Daemon {
                     for cell in doc.get_cells() {
                         for hash in cell.resolved_assets.values() {
                             referenced_hashes.insert(hash.clone());
+                        }
+                        for bundle in cell.attachments.values() {
+                            for attachment_ref in bundle.values() {
+                                referenced_hashes.insert(attachment_ref.blob_hash.clone());
+                            }
                         }
                     }
                 }
@@ -6015,12 +6026,14 @@ mod tests {
     }
 
     /// Build a persisted notebook-doc `.automerge` file with one markdown
-    /// cell that references `blob_hash` via `resolved_assets`. Mirrors the
-    /// real shape of a persisted untitled-notebook doc for GC purposes.
+    /// cell that references `blob_hash` via `resolved_assets` and
+    /// `attachment_hash` via `attachments`. Mirrors the real shape of a
+    /// persisted untitled-notebook doc for GC purposes.
     fn write_persisted_doc_with_blob(
         docs_dir: &Path,
         notebook_id: &str,
         blob_hash: &str,
+        attachment_hash: &str,
     ) -> PathBuf {
         use notebook_doc::NotebookDoc;
         let mut doc = NotebookDoc::new_with_actor(notebook_id, "test");
@@ -6030,6 +6043,17 @@ mod tests {
         let mut assets = std::collections::HashMap::new();
         assets.insert("image.png".to_string(), blob_hash.to_string());
         doc.set_cell_resolved_assets(cell_id, &assets).unwrap();
+        let attachments = std::collections::HashMap::from([(
+            "image.png".to_string(),
+            std::collections::HashMap::from([(
+                "image/png".to_string(),
+                notebook_doc::AttachmentRef {
+                    blob_hash: attachment_hash.to_string(),
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        )]);
+        doc.set_cell_attachments(cell_id, &attachments).unwrap();
 
         let filename = crate::paths::notebook_doc_filename(notebook_id);
         let path = docs_dir.join(filename);
@@ -6069,7 +6093,7 @@ mod tests {
     async fn collect_hashes_walks_persisted_doc_resolved_assets() {
         let tmp = tempfile::TempDir::new().unwrap();
         let docs_dir = tmp.path().to_path_buf();
-        let path = write_persisted_doc_with_blob(&docs_dir, "untitled-abc", "deadbeef");
+        let path = write_persisted_doc_with_blob(&docs_dir, "untitled-abc", "deadbeef", "feedface");
 
         let mut hashes = std::collections::HashSet::new();
         let ok = collect_hashes_from_persisted_doc(&path, &mut hashes).await;
@@ -6077,6 +6101,11 @@ mod tests {
         assert!(
             hashes.contains("deadbeef"),
             "resolved_assets blob hash should be collected, got {:?}",
+            hashes
+        );
+        assert!(
+            hashes.contains("feedface"),
+            "attachment blob hash should be collected, got {:?}",
             hashes
         );
     }
@@ -6099,13 +6128,18 @@ mod tests {
         // The mark phase must still surface it.
         let tmp = tempfile::TempDir::new().unwrap();
         let docs_dir = tmp.path().join("notebook-docs");
-        write_persisted_doc_with_blob(&docs_dir, "untitled-xyz", "cafebabe");
+        write_persisted_doc_with_blob(&docs_dir, "untitled-xyz", "cafebabe", "facefeed");
 
         let rooms: Vec<(String, Arc<crate::notebook_sync_server::NotebookRoom>)> = vec![];
         let refs = Daemon::collect_blob_refs_for_gc(&rooms, &docs_dir).await;
         assert!(
             refs.contains("cafebabe"),
             "persisted-doc blob ref should be collected, got {:?}",
+            refs
+        );
+        assert!(
+            refs.contains("facefeed"),
+            "persisted-doc attachment ref should be collected, got {:?}",
             refs
         );
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -6049,7 +6049,7 @@ mod tests {
                 "image/png".to_string(),
                 notebook_doc::AttachmentRef {
                     blob_hash: attachment_hash.to_string(),
-                    encoding: "base64".to_string(),
+                    encoding: notebook_doc::AttachmentEncoding::Base64,
                 },
             )]),
         )]);

--- a/crates/runtimed/src/notebook_sync_server/attachments.rs
+++ b/crates/runtimed/src/notebook_sync_server/attachments.rs
@@ -1,0 +1,232 @@
+use super::*;
+use base64::Engine;
+use std::fmt;
+
+pub(crate) type AttachmentRefs = HashMap<String, HashMap<String, AttachmentRef>>;
+
+#[derive(Debug)]
+pub(crate) enum AttachmentIngestError {
+    InvalidPayload(String),
+    StoreFailed(String),
+}
+
+impl fmt::Display for AttachmentIngestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AttachmentIngestError::InvalidPayload(msg)
+            | AttachmentIngestError::StoreFailed(msg) => f.write_str(msg),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum AttachmentResolveError {
+    MissingBlob(String),
+    BlobReadFailed(String),
+    InvalidPayload(String),
+}
+
+impl fmt::Display for AttachmentResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AttachmentResolveError::MissingBlob(msg)
+            | AttachmentResolveError::BlobReadFailed(msg)
+            | AttachmentResolveError::InvalidPayload(msg) => f.write_str(msg),
+        }
+    }
+}
+
+pub(crate) async fn nbformat_attachments_to_blob_refs(
+    attachments: Option<&serde_json::Value>,
+    blob_store: &BlobStore,
+) -> Result<AttachmentRefs, AttachmentIngestError> {
+    let Some(attachments) = attachments.and_then(|v| v.as_object()) else {
+        return Ok(HashMap::new());
+    };
+
+    let mut refs = HashMap::new();
+    for (name, bundle_value) in attachments {
+        let bundle = bundle_value.as_object().ok_or_else(|| {
+            AttachmentIngestError::InvalidPayload(format!(
+                "attachment {name} must be a MIME bundle object"
+            ))
+        })?;
+        let mut media_refs = HashMap::new();
+        for (media_type, payload) in bundle {
+            let (data, encoding) = decode_attachment_payload(media_type, payload)?;
+            let hash = blob_store.put(&data, media_type).await.map_err(|e| {
+                AttachmentIngestError::StoreFailed(format!(
+                    "failed to store attachment {name} ({media_type}): {e}"
+                ))
+            })?;
+            media_refs.insert(
+                media_type.clone(),
+                AttachmentRef {
+                    blob_hash: hash,
+                    encoding,
+                },
+            );
+        }
+        if !media_refs.is_empty() {
+            refs.insert(name.clone(), media_refs);
+        }
+    }
+    Ok(refs)
+}
+
+pub(crate) async fn attachment_refs_to_nbformat_value(
+    refs: &AttachmentRefs,
+    blob_store: &BlobStore,
+) -> Result<serde_json::Value, AttachmentResolveError> {
+    let mut attachments = serde_json::Map::new();
+    for (name, bundle) in refs {
+        let mut media_bundle = serde_json::Map::new();
+        for (media_type, attachment_ref) in bundle {
+            let data = blob_store
+                .get(&attachment_ref.blob_hash)
+                .await
+                .map_err(|e| {
+                    AttachmentResolveError::BlobReadFailed(format!(
+                        "failed to read attachment blob {} for {name} ({media_type}): {e}",
+                        attachment_ref.blob_hash
+                    ))
+                })?
+                .ok_or_else(|| {
+                    AttachmentResolveError::MissingBlob(format!(
+                        "missing attachment blob {} for {name} ({media_type})",
+                        attachment_ref.blob_hash
+                    ))
+                })?;
+            media_bundle.insert(
+                media_type.clone(),
+                encode_attachment_payload(media_type, attachment_ref.encoding.as_str(), &data)?,
+            );
+        }
+        if !media_bundle.is_empty() {
+            attachments.insert(name.clone(), serde_json::Value::Object(media_bundle));
+        }
+    }
+    Ok(serde_json::Value::Object(attachments))
+}
+
+pub(crate) fn image_attachment_hash(refs: &AttachmentRefs, name: &str) -> Option<String> {
+    let attachment = refs.get(strip_query_and_fragment(name))?;
+    const PREFERRED_IMAGE_MEDIA_TYPES: &[&str] = &[
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/svg+xml",
+        "image/avif",
+        "image/bmp",
+        "image/x-icon",
+        "image/tiff",
+    ];
+
+    for media_type in PREFERRED_IMAGE_MEDIA_TYPES {
+        if let Some(attachment_ref) = attachment.get(*media_type) {
+            return Some(attachment_ref.blob_hash.clone());
+        }
+    }
+
+    let mut image_refs: Vec<_> = attachment
+        .iter()
+        .filter(|(media_type, _)| media_type.starts_with("image/"))
+        .collect();
+    image_refs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    image_refs
+        .into_iter()
+        .next()
+        .map(|(_, attachment_ref)| attachment_ref.blob_hash.clone())
+}
+
+pub(crate) fn resolved_attachment_assets(
+    source: &str,
+    refs: &AttachmentRefs,
+) -> HashMap<String, String> {
+    let mut resolved = HashMap::new();
+    for asset_ref in extract_markdown_asset_refs(source) {
+        let Some(name) = asset_ref.strip_prefix("attachment:") else {
+            continue;
+        };
+        if let Some(hash) = image_attachment_hash(refs, name) {
+            resolved.insert(asset_ref, hash);
+        }
+    }
+    resolved
+}
+
+fn decode_attachment_payload(
+    media_type: &str,
+    payload: &serde_json::Value,
+) -> Result<(Vec<u8>, String), AttachmentIngestError> {
+    if attachment_payload_is_json(media_type) {
+        return serde_json::to_vec(payload)
+            .map(|data| (data, "json".to_string()))
+            .map_err(|e| {
+                AttachmentIngestError::InvalidPayload(format!(
+                    "attachment {media_type} JSON payload is invalid: {e}"
+                ))
+            });
+    }
+
+    if let Some(payload) = payload.as_str() {
+        if attachment_payload_is_text(media_type) {
+            return Ok((payload.as_bytes().to_vec(), "text".to_string()));
+        }
+        return base64::engine::general_purpose::STANDARD
+            .decode(payload)
+            .map(|data| (data, "base64".to_string()))
+            .map_err(|e| {
+                AttachmentIngestError::InvalidPayload(format!(
+                    "attachment {media_type} base64 payload is invalid: {e}"
+                ))
+            });
+    }
+
+    serde_json::to_vec(payload)
+        .map(|data| (data, "json".to_string()))
+        .map_err(|e| {
+            AttachmentIngestError::InvalidPayload(format!(
+                "attachment {media_type} JSON payload is invalid: {e}"
+            ))
+        })
+}
+
+fn encode_attachment_payload(
+    media_type: &str,
+    encoding: &str,
+    data: &[u8],
+) -> Result<serde_json::Value, AttachmentResolveError> {
+    if encoding == "json" {
+        return serde_json::from_slice(data).map_err(|e| {
+            AttachmentResolveError::InvalidPayload(format!(
+                "attachment {media_type} JSON payload is invalid: {e}"
+            ))
+        });
+    }
+
+    if encoding == "text" || attachment_payload_is_text(media_type) {
+        let text = std::str::from_utf8(data).map_err(|e| {
+            AttachmentResolveError::InvalidPayload(format!(
+                "attachment {media_type} is not valid UTF-8: {e}"
+            ))
+        })?;
+        return Ok(serde_json::Value::String(text.to_string()));
+    }
+    Ok(serde_json::Value::String(
+        base64::engine::general_purpose::STANDARD.encode(data),
+    ))
+}
+
+fn attachment_payload_is_json(media_type: &str) -> bool {
+    media_type == "application/json" || media_type.ends_with("+json")
+}
+
+fn attachment_payload_is_text(media_type: &str) -> bool {
+    media_type.starts_with("text/") || media_type == "image/svg+xml"
+}
+
+fn strip_query_and_fragment(path: &str) -> &str {
+    path.split(['?', '#']).next().unwrap_or(path)
+}

--- a/crates/runtimed/src/notebook_sync_server/attachments.rs
+++ b/crates/runtimed/src/notebook_sync_server/attachments.rs
@@ -99,7 +99,7 @@ pub(crate) async fn attachment_refs_to_nbformat_value(
                 })?;
             media_bundle.insert(
                 media_type.clone(),
-                encode_attachment_payload(media_type, attachment_ref.encoding.as_str(), &data)?,
+                encode_attachment_payload(media_type, attachment_ref.encoding, &data)?,
             );
         }
         if !media_bundle.is_empty() {
@@ -159,10 +159,10 @@ pub(crate) fn resolved_attachment_assets(
 fn decode_attachment_payload(
     media_type: &str,
     payload: &serde_json::Value,
-) -> Result<(Vec<u8>, String), AttachmentIngestError> {
+) -> Result<(Vec<u8>, AttachmentEncoding), AttachmentIngestError> {
     if attachment_payload_is_json(media_type) {
         return serde_json::to_vec(payload)
-            .map(|data| (data, "json".to_string()))
+            .map(|data| (data, AttachmentEncoding::Json))
             .map_err(|e| {
                 AttachmentIngestError::InvalidPayload(format!(
                     "attachment {media_type} JSON payload is invalid: {e}"
@@ -172,11 +172,11 @@ fn decode_attachment_payload(
 
     if let Some(payload) = payload.as_str() {
         if attachment_payload_is_text(media_type) {
-            return Ok((payload.as_bytes().to_vec(), "text".to_string()));
+            return Ok((payload.as_bytes().to_vec(), AttachmentEncoding::Text));
         }
         return base64::engine::general_purpose::STANDARD
             .decode(payload)
-            .map(|data| (data, "base64".to_string()))
+            .map(|data| (data, AttachmentEncoding::Base64))
             .map_err(|e| {
                 AttachmentIngestError::InvalidPayload(format!(
                     "attachment {media_type} base64 payload is invalid: {e}"
@@ -185,7 +185,7 @@ fn decode_attachment_payload(
     }
 
     serde_json::to_vec(payload)
-        .map(|data| (data, "json".to_string()))
+        .map(|data| (data, AttachmentEncoding::Json))
         .map_err(|e| {
             AttachmentIngestError::InvalidPayload(format!(
                 "attachment {media_type} JSON payload is invalid: {e}"
@@ -195,28 +195,35 @@ fn decode_attachment_payload(
 
 fn encode_attachment_payload(
     media_type: &str,
-    encoding: &str,
+    encoding: AttachmentEncoding,
     data: &[u8],
 ) -> Result<serde_json::Value, AttachmentResolveError> {
-    if encoding == "json" {
-        return serde_json::from_slice(data).map_err(|e| {
+    match encoding {
+        AttachmentEncoding::Json => serde_json::from_slice(data).map_err(|e| {
             AttachmentResolveError::InvalidPayload(format!(
                 "attachment {media_type} JSON payload is invalid: {e}"
             ))
-        });
+        }),
+        AttachmentEncoding::Text => encode_text_attachment(media_type, data),
+        AttachmentEncoding::Base64 if attachment_payload_is_text(media_type) => {
+            encode_text_attachment(media_type, data)
+        }
+        AttachmentEncoding::Base64 => Ok(serde_json::Value::String(
+            base64::engine::general_purpose::STANDARD.encode(data),
+        )),
     }
+}
 
-    if encoding == "text" || attachment_payload_is_text(media_type) {
-        let text = std::str::from_utf8(data).map_err(|e| {
-            AttachmentResolveError::InvalidPayload(format!(
-                "attachment {media_type} is not valid UTF-8: {e}"
-            ))
-        })?;
-        return Ok(serde_json::Value::String(text.to_string()));
-    }
-    Ok(serde_json::Value::String(
-        base64::engine::general_purpose::STANDARD.encode(data),
-    ))
+fn encode_text_attachment(
+    media_type: &str,
+    data: &[u8],
+) -> Result<serde_json::Value, AttachmentResolveError> {
+    let text = std::str::from_utf8(data).map_err(|e| {
+        AttachmentResolveError::InvalidPayload(format!(
+            "attachment {media_type} is not valid UTF-8: {e}"
+        ))
+    })?;
+    Ok(serde_json::Value::String(text.to_string()))
 }
 
 fn attachment_payload_is_json(media_type: &str) -> bool {

--- a/crates/runtimed/src/notebook_sync_server/attachments.rs
+++ b/crates/runtimed/src/notebook_sync_server/attachments.rs
@@ -99,7 +99,7 @@ pub(crate) async fn attachment_refs_to_nbformat_value(
                 })?;
             media_bundle.insert(
                 media_type.clone(),
-                encode_attachment_payload(media_type, attachment_ref.encoding, &data)?,
+                encode_attachment_payload(media_type, &attachment_ref.encoding, &data)?,
             );
         }
         if !media_bundle.is_empty() {
@@ -110,7 +110,9 @@ pub(crate) async fn attachment_refs_to_nbformat_value(
 }
 
 pub(crate) fn image_attachment_hash(refs: &AttachmentRefs, name: &str) -> Option<String> {
-    let attachment = refs.get(strip_query_and_fragment(name))?;
+    let attachment = refs
+        .get(name)
+        .or_else(|| refs.get(strip_query_and_fragment(name)))?;
     const PREFERRED_IMAGE_MEDIA_TYPES: &[&str] = &[
         "image/png",
         "image/jpeg",
@@ -195,7 +197,7 @@ fn decode_attachment_payload(
 
 fn encode_attachment_payload(
     media_type: &str,
-    encoding: AttachmentEncoding,
+    encoding: &AttachmentEncoding,
     data: &[u8],
 ) -> Result<serde_json::Value, AttachmentResolveError> {
     match encoding {
@@ -211,6 +213,9 @@ fn encode_attachment_payload(
         AttachmentEncoding::Base64 => Ok(serde_json::Value::String(
             base64::engine::general_purpose::STANDARD.encode(data),
         )),
+        AttachmentEncoding::Unknown(value) => Err(AttachmentResolveError::InvalidPayload(format!(
+            "attachment {media_type} has unknown encoding {value}"
+        ))),
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -95,6 +95,7 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
                 execution_count,
                 metadata,
                 resolved_assets: std::collections::HashMap::new(),
+                attachments: std::collections::HashMap::new(),
             }
         })
         .collect();
@@ -161,7 +162,13 @@ pub(crate) struct ParsedStreamingNotebook {
     pub metadata: Option<NotebookMetadataSnapshot>,
     pub attachments: NbformatAttachmentMap,
 }
-type StreamingLoadBatchEntry = (usize, StreamingCell, Vec<serde_json::Value>, ResolvedAssets);
+type StreamingLoadBatchEntry = (
+    usize,
+    StreamingCell,
+    Vec<serde_json::Value>,
+    ResolvedAssets,
+    AttachmentRefs,
+);
 
 fn should_resolve_markdown_assets(cell_type: &str) -> bool {
     cell_type == "markdown"
@@ -447,10 +454,6 @@ where
     let cells = parsed.cells;
     let metadata = parsed.metadata;
     let nbformat_attachments = parsed.attachments;
-    {
-        let mut cache = room.persistence.nbformat_attachments.write().await;
-        *cache = nbformat_attachments.clone();
-    }
 
     let total_cells = cells.len();
     info!(
@@ -486,25 +489,28 @@ where
             for output in &cell.outputs {
                 output_refs.push(output_value_to_manifest_ref(output, &room.blob_store).await);
             }
-            let resolved_assets = if should_resolve_markdown_assets(&cell.cell_type) {
-                resolve_markdown_assets(
-                    &cell.source,
-                    Some(path),
-                    nbformat_attachments.get(&cell.id),
-                    &room.blob_store,
-                )
-                .await
+            let attachment_refs = nbformat_attachments_to_blob_refs(
+                nbformat_attachments.get(&cell.id),
+                &room.blob_store,
+            )
+            .await
+            .map_err(|e| format!("Failed to ingest attachments for {}: {e}", cell.id))?;
+            let mut resolved_assets = if should_resolve_markdown_assets(&cell.cell_type) {
+                resolve_markdown_assets(&cell.source, Some(path), None, &room.blob_store).await
             } else {
                 ResolvedAssets::new()
             };
-            batch.push((idx, cell, output_refs, resolved_assets));
+            if should_resolve_markdown_assets(&cell.cell_type) {
+                resolved_assets.extend(resolved_attachment_assets(&cell.source, &attachment_refs));
+            }
+            batch.push((idx, cell, output_refs, resolved_assets, attachment_refs));
         }
 
         // Store outputs in RuntimeStateDoc with durable execution state when a
         // matching terminal record exists, otherwise mint synthetic IDs.
         // Collect (cell_id, execution) pairs for linking below.
         let mut cell_executions: HashMap<String, LoadedExecution> = HashMap::new();
-        for (_idx, cell, output_refs, _resolved_assets) in &batch {
+        for (_idx, cell, output_refs, _resolved_assets, _attachment_refs) in &batch {
             if output_refs.is_empty() {
                 continue;
             }
@@ -521,7 +527,7 @@ where
             cell_executions.insert(cell.id.clone(), execution);
         }
         let _ = room.state.with_doc(|sd| {
-            for (_idx, cell, output_refs, _resolved_assets) in &batch {
+            for (_idx, cell, output_refs, _resolved_assets, _attachment_refs) in &batch {
                 if let Some(execution) = cell_executions.get(&cell.id) {
                     let _ = sd.create_execution(&execution.execution_id, &cell.id);
                     let _ = sd.set_outputs(&execution.execution_id, output_refs);
@@ -537,7 +543,7 @@ where
         // Add batch to Automerge doc and generate sync message (inside lock)
         let encoded = {
             let mut doc = room.doc.write().await;
-            for (_idx, cell, _output_refs, resolved_assets) in &batch {
+            for (_idx, cell, _output_refs, resolved_assets, attachment_refs) in &batch {
                 doc.add_cell_full(
                     &cell.id,
                     &cell.cell_type,
@@ -553,6 +559,8 @@ where
                 }
                 doc.set_cell_resolved_assets(&cell.id, resolved_assets)
                     .map_err(|e| format!("Failed to set resolved assets for {}: {}", cell.id, e))?;
+                doc.set_cell_attachments(&cell.id, attachment_refs)
+                    .map_err(|e| format!("Failed to set attachments for {}: {}", cell.id, e))?;
             }
             match catch_automerge_panic("streaming-load-cells", || {
                 doc.generate_sync_message(peer_state).map(|m| m.encode())
@@ -764,6 +772,12 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
             .map_err(|e| format!("Failed to add cell: {}", e))?;
         doc.update_source(&cell.id, &cell.source)
             .map_err(|e| format!("Failed to update source: {}", e))?;
+        let attachment_refs =
+            nbformat_attachments_to_blob_refs(nbformat_attachments.get(&cell.id), blob_store)
+                .await
+                .map_err(|e| format!("Failed to ingest attachments for {}: {e}", cell.id))?;
+        doc.set_cell_attachments(&cell.id, &attachment_refs)
+            .map_err(|e| format!("Failed to set attachments: {}", e))?;
         // Parse execution_count from the .ipynb cell snapshot
         let parsed_ec: Option<i64> = cell.execution_count.parse::<i64>().ok();
         let cell_outputs = outputs_by_cell.get(&cell.id);
@@ -803,13 +817,9 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
                 .map_err(|e| format!("Failed to set execution_id: {}", e))?;
         }
         if should_resolve_markdown_assets(&cell.cell_type) {
-            let resolved_assets = resolve_markdown_assets(
-                &cell.source,
-                Some(path),
-                nbformat_attachments.get(&cell.id),
-                blob_store,
-            )
-            .await;
+            let mut resolved_assets =
+                resolve_markdown_assets(&cell.source, Some(path), None, blob_store).await;
+            resolved_assets.extend(resolved_attachment_assets(&cell.source, &attachment_refs));
             doc.set_cell_resolved_assets(&cell.id, &resolved_assets)
                 .map_err(|e| format!("Failed to set resolved assets: {}", e))?;
         }
@@ -1100,29 +1110,54 @@ pub(crate) async fn apply_ipynb_changes(
         map
     };
     let notebook_path_for_assets = room.file_binding.path.read().await.clone();
+    let converted_attachments: HashMap<String, AttachmentRefs> = {
+        let mut map = HashMap::new();
+        for cell in external_cells {
+            let refs = match nbformat_attachments_to_blob_refs(
+                external_attachments.get(&cell.id),
+                &room.blob_store,
+            )
+            .await
+            {
+                Ok(refs) => refs,
+                Err(e) => {
+                    warn!(
+                        "[notebook-watch] Failed to ingest attachments for {}: {}",
+                        cell.id, e
+                    );
+                    return false;
+                }
+            };
+            if !refs.is_empty() {
+                map.insert(cell.id.clone(), refs);
+            }
+        }
+        map
+    };
+    let empty_assets = HashMap::new();
+    let empty_attachments = HashMap::new();
     let converted_assets: HashMap<String, ResolvedAssets> = {
         let mut map = HashMap::new();
         for cell in external_cells {
             if should_resolve_markdown_assets(&cell.cell_type) {
-                let resolved_assets = resolve_markdown_assets(
+                let mut resolved_assets = resolve_markdown_assets(
                     &cell.source,
                     notebook_path_for_assets.as_deref(),
-                    external_attachments.get(&cell.id),
+                    None,
                     &room.blob_store,
                 )
                 .await;
+                resolved_assets.extend(resolved_attachment_assets(
+                    &cell.source,
+                    converted_attachments
+                        .get(cell.id.as_str())
+                        .unwrap_or(&empty_attachments),
+                ));
                 map.insert(cell.id.clone(), resolved_assets);
             }
         }
         map
     };
-
-    {
-        let mut cache = room.persistence.nbformat_attachments.write().await;
-        *cache = external_attachments.clone();
-    }
-
-    let empty_assets = HashMap::new();
 
     // Build maps for comparison
     let current_map: HashMap<&str, &CellSnapshot> =
@@ -1257,6 +1292,10 @@ pub(crate) async fn apply_ipynb_changes(
                         .get(ext_cell.id.as_str())
                         .unwrap_or(&empty_assets);
                     let _ = fork.set_cell_resolved_assets(&ext_cell.id, ext_assets);
+                    let ext_attachments = converted_attachments
+                        .get(ext_cell.id.as_str())
+                        .unwrap_or(&empty_attachments);
+                    let _ = fork.set_cell_attachments(&ext_cell.id, ext_attachments);
                 }
             }
 
@@ -1485,6 +1524,14 @@ pub(crate) async fn apply_ipynb_changes(
                         changed = true;
                     }
                 }
+                let ext_attachments = converted_attachments
+                    .get(ext_cell.id.as_str())
+                    .unwrap_or(&empty_attachments);
+                if current_cell.attachments != *ext_attachments {
+                    if let Ok(true) = doc.set_cell_attachments(&ext_cell.id, ext_attachments) {
+                        changed = true;
+                    }
+                }
             } else {
                 // New cell - add it
                 // New cells don't have any in-progress state, so always use external values
@@ -1517,6 +1564,10 @@ pub(crate) async fn apply_ipynb_changes(
                         .get(ext_cell.id.as_str())
                         .unwrap_or(&empty_assets);
                     let _ = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets);
+                    let ext_attachments = converted_attachments
+                        .get(ext_cell.id.as_str())
+                        .unwrap_or(&empty_attachments);
+                    let _ = doc.set_cell_attachments(&ext_cell.id, ext_attachments);
                 }
             }
         }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -624,32 +624,30 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
         .await
         .clone()
         .filter(|p| p.exists());
-    let nbformat_attachments = room.nbformat_attachments_snapshot().await;
-
     // Fork BEFORE async resolution so the fork's baseline predates
     // any concurrent edits. Asset updates on the fork are treated as
     // concurrent with user edits via Automerge's CRDT merge.
     let (markdown_cells, mut fork) = {
         let mut doc = room.doc.write().await;
-        let cells: Vec<(String, String, HashMap<String, String>)> = doc
+        let cells: Vec<(String, String, HashMap<String, String>, AttachmentRefs)> = doc
             .get_cells()
             .into_iter()
             .filter(|cell| cell.cell_type == "markdown")
-            .map(|cell| (cell.id, cell.source, cell.resolved_assets))
+            .map(|cell| (cell.id, cell.source, cell.resolved_assets, cell.attachments))
             .collect();
         let fork = doc.fork_with_actor(format!("runtimed:assets:{}", uuid::Uuid::new_v4()));
         (cells, fork)
     };
 
     let mut any_changed = false;
-    for (cell_id, source, existing_assets) in markdown_cells {
-        let desired_assets = resolve_markdown_assets(
-            &source,
-            notebook_path.as_deref(),
-            nbformat_attachments.get(&cell_id),
-            &room.blob_store,
-        )
-        .await;
+    for (cell_id, source, existing_assets, attachments) in markdown_cells {
+        let mut desired_assets =
+            resolve_markdown_assets(&source, notebook_path.as_deref(), None, &room.blob_store)
+                .await;
+        // Attachments are already durable blob refs in the cell schema, so
+        // this pass resolves `attachment:` URLs from those refs instead of
+        // from raw nbformat JSON.
+        desired_assets.extend(resolved_attachment_assets(&source, &attachments));
 
         if desired_assets != existing_assets {
             if let Err(e) = fork.set_cell_resolved_assets(&cell_id, &desired_assets) {

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -39,7 +39,7 @@ use tracing::{debug, error, info, warn};
 use crate::blob_store::BlobStore;
 use crate::connection::{self, NotebookFrameType};
 use crate::markdown_assets::{extract_markdown_asset_refs, resolve_markdown_assets};
-use crate::notebook_doc::{AttachmentRef, CellSnapshot, NotebookDoc};
+use crate::notebook_doc::{AttachmentEncoding, AttachmentRef, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
 use crate::paths::notebook_doc_filename;

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -38,8 +38,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::blob_store::BlobStore;
 use crate::connection::{self, NotebookFrameType};
-use crate::markdown_assets::resolve_markdown_assets;
-use crate::notebook_doc::{CellSnapshot, NotebookDoc};
+use crate::markdown_assets::{extract_markdown_asset_refs, resolve_markdown_assets};
+use crate::notebook_doc::{AttachmentRef, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
 use crate::paths::notebook_doc_filename;
@@ -48,6 +48,7 @@ use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use notebook_doc::presence::{self, PresenceState};
 use runtime_doc::RuntimeStateDoc;
 
+mod attachments;
 mod catalog;
 mod load;
 mod metadata;
@@ -70,6 +71,7 @@ mod runtime_bridge;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use attachments::*;
 pub(crate) use catalog::*;
 pub(crate) use load::*;
 pub(crate) use metadata::*;

--- a/crates/runtimed/src/notebook_sync_server/nbformat_convert.rs
+++ b/crates/runtimed/src/notebook_sync_server/nbformat_convert.rs
@@ -370,6 +370,7 @@ mod tests {
             execution_count: "null".to_string(),
             metadata: json!({}),
             resolved_assets: Default::default(),
+            attachments: std::collections::HashMap::new(),
         }
     }
 
@@ -503,6 +504,7 @@ mod tests {
             execution_count: "2".to_string(),
             metadata: json!({}),
             resolved_assets: Default::default(),
+            attachments: std::collections::HashMap::new(),
         };
         let outputs = vec![json!({
             "output_type": "stream",
@@ -582,6 +584,7 @@ mod tests {
                 execution_count: "1".to_string(),
                 metadata: json!({"tags": ["demo"]}),
                 resolved_assets: Default::default(),
+                attachments: std::collections::HashMap::new(),
             },
             cell_snapshot("cell-2", "markdown", "# heading"),
         ];

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -128,7 +128,23 @@ pub(crate) async fn save_notebook_to_disk(
         })
         .unwrap_or_default();
 
-    let nbformat_attachments = room.nbformat_attachments_snapshot().await;
+    let mut nbformat_attachments = HashMap::new();
+    for cell in &cells {
+        if cell.attachments.is_empty() {
+            continue;
+        }
+        let attachments = attachment_refs_to_nbformat_value(&cell.attachments, &room.blob_store)
+            .await
+            .map_err(|e| match e {
+                AttachmentResolveError::MissingBlob(_)
+                | AttachmentResolveError::BlobReadFailed(_)
+                | AttachmentResolveError::InvalidPayload(_) => SaveError::Unrecoverable(format!(
+                    "Failed to resolve attachments for cell {}: {e}",
+                    cell.id
+                )),
+            })?;
+        nbformat_attachments.insert(cell.id.clone(), attachments);
+    }
 
     // Resolve outputs from the blob store. `resolve_cell_output` returns
     // Jupyter-shape JSON (daemon-runtime shape: includes `output_id`, etc.).

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -241,9 +241,9 @@ impl Default for RoomBroadcasts {
 ///
 /// Always present on every room. The optional `debouncer` field nests the
 /// two debouncer channels that only exist for non-ephemeral rooms
-/// (untitled-saved or file-backed); save-baseline snapshots, streaming-load
-/// gate, and attachment cache are needed whether the room is ephemeral today
-/// or will be promoted to file-backed later.
+/// (untitled-saved or file-backed); save-baseline snapshots and the
+/// streaming-load gate are needed whether the room is ephemeral today or
+/// will be promoted to file-backed later.
 pub struct RoomPersistence {
     /// Debouncer channels — present only when the room writes to a
     /// persisted Automerge doc (`notebook-docs/*.automerge`). Ephemeral
@@ -260,18 +260,6 @@ pub struct RoomPersistence {
     /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
     /// Used to skip file watcher events triggered by our own saves.
     pub last_self_write: AtomicU64,
-    /// Raw nbformat attachments preserved from disk, keyed by cell ID.
-    ///
-    /// Populated only by `.ipynb` load paths. Resolved image data already
-    /// lives in the Automerge doc as blob URLs per cell; this map is the
-    /// raw base64 payload kept in memory so save can round-trip back to
-    /// `.ipynb` byte-identically without re-encoding the blob bytes.
-    ///
-    /// Transitional: this should eventually live in the doc alongside
-    /// cells (as blob references with a stable schema) so user-authored
-    /// attachments become first-class CRDT data. When that lands, this
-    /// field is deleted outright rather than relocated.
-    pub nbformat_attachments: RwLock<HashMap<String, serde_json::Value>>,
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
@@ -297,7 +285,6 @@ impl RoomPersistence {
             debouncer: None,
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
-            nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
         }
     }
@@ -314,7 +301,6 @@ impl RoomPersistence {
             }),
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
-            nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
         }
     }
@@ -684,12 +670,6 @@ impl NotebookRoom {
         // Check runtime agent handle
         let ra = self.runtime_agent_handle.lock().await;
         ra.as_ref().is_some_and(|a| a.is_alive())
-    }
-
-    /// Snapshot of nbformat attachments. Empty before the first `.ipynb`
-    /// load populates the cache.
-    pub async fn nbformat_attachments_snapshot(&self) -> HashMap<String, serde_json::Value> {
-        self.persistence.nbformat_attachments.read().await.clone()
     }
 
     /// Snapshot of cell sources as they were at last save. Empty before

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -84,6 +84,34 @@ fn test_sanitize_peer_label_strips_zero_width() {
 }
 
 #[test]
+fn test_image_attachment_hash_uses_stable_image_preference() {
+    let refs = HashMap::from([(
+        "plot".to_string(),
+        HashMap::from([
+            (
+                "image/jpeg".to_string(),
+                AttachmentRef {
+                    blob_hash: "jpeg-hash".to_string(),
+                    encoding: "base64".to_string(),
+                },
+            ),
+            (
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: "png-hash".to_string(),
+                    encoding: "base64".to_string(),
+                },
+            ),
+        ]),
+    )]);
+
+    assert_eq!(
+        image_attachment_hash(&refs, "plot#fragment").as_deref(),
+        Some("png-hash")
+    );
+}
+
+#[test]
 fn test_sanitize_peer_label_strips_control_chars() {
     assert_eq!(sanitize_peer_label(Some("Claude\x00\x1F"), "fb"), "Claude");
     assert_eq!(sanitize_peer_label(Some("\x07"), "fb"), "fb");
@@ -1381,6 +1409,7 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
         execution_count: "42".to_string(),
         metadata: serde_json::json!({}),
         resolved_assets: std::collections::HashMap::new(),
+        attachments: std::collections::HashMap::new(),
     }];
 
     let changed = apply_ipynb_changes(
@@ -1439,6 +1468,7 @@ async fn test_apply_ipynb_changes_preserves_execution_count_when_kernel_running(
         execution_count: "5".to_string(),
         metadata: serde_json::json!({}),
         resolved_assets: std::collections::HashMap::new(),
+        attachments: std::collections::HashMap::new(),
     }];
 
     let changed = apply_ipynb_changes(
@@ -1485,6 +1515,7 @@ async fn test_apply_ipynb_changes_new_cell_with_outputs_while_kernel_running() {
             execution_count: "null".to_string(),
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
+            attachments: std::collections::HashMap::new(),
         },
         CellSnapshot {
             id: "new-cell".to_string(),
@@ -1494,6 +1525,7 @@ async fn test_apply_ipynb_changes_new_cell_with_outputs_while_kernel_running() {
             execution_count: "42".to_string(),
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
+            attachments: std::collections::HashMap::new(),
         },
     ];
     let mut external_outputs: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
@@ -1575,6 +1607,7 @@ async fn test_apply_ipynb_changes_wholesale_replacement() {
             execution_count: "1".to_string(),
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
+            attachments: std::collections::HashMap::new(),
         },
         CellSnapshot {
             id: "new-2".to_string(),
@@ -1584,6 +1617,7 @@ async fn test_apply_ipynb_changes_wholesale_replacement() {
             execution_count: "2".to_string(),
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
+            attachments: std::collections::HashMap::new(),
         },
     ];
 
@@ -1648,6 +1682,7 @@ async fn test_apply_ipynb_changes_partial_overlap_preserves_unsaved() {
         execution_count: "null".to_string(),
         metadata: serde_json::json!({}),
         resolved_assets: std::collections::HashMap::new(),
+        attachments: std::collections::HashMap::new(),
     }];
 
     let changed = apply_ipynb_changes(
@@ -2118,6 +2153,105 @@ async fn test_load_notebook_from_disk_resolves_nbformat_attachments() {
 
     let bytes = blob_store.get(hash).await.unwrap().unwrap();
     assert_eq!(bytes, b"hello");
+
+    let attachment_ref = cells[0]
+        .attachments
+        .get("image.png")
+        .and_then(|bundle| bundle.get("image/png"))
+        .expect("attachment should be stored in the cell schema");
+    assert_eq!(attachment_ref.blob_hash, *hash);
+    assert_eq!(attachment_ref.encoding, "base64");
+}
+
+#[tokio::test]
+async fn test_load_notebook_from_disk_preserves_json_attachment_payloads() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+
+    let expected_attachments = serde_json::json!({
+        "payload.json": {
+            "application/json": {"kind": "loaded"}
+        },
+        "label.json": {
+            "application/json": "loaded-string"
+        }
+    });
+    let notebook_json = serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "id": "raw-1",
+                "cell_type": "raw",
+                "source": ["attachment ref"],
+                "metadata": {},
+                "attachments": expected_attachments
+            }
+        ]
+    });
+
+    let ipynb_path = tmp.path().join("json-attachments.ipynb");
+    std::fs::write(
+        &ipynb_path,
+        serde_json::to_string_pretty(&notebook_json).unwrap(),
+    )
+    .unwrap();
+
+    let notebook_id = ipynb_path.to_string_lossy().to_string();
+    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
+        .await
+        .unwrap();
+
+    let cells = doc.get_cells();
+    assert_eq!(cells.len(), 1);
+    let reconstructed = attachment_refs_to_nbformat_value(&cells[0].attachments, &blob_store)
+        .await
+        .unwrap();
+    assert_eq!(reconstructed, expected_attachments);
+}
+
+#[tokio::test]
+async fn test_load_notebook_from_disk_rejects_invalid_attachment_payloads() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+
+    let notebook_json = serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "id": "markdown-1",
+                "cell_type": "markdown",
+                "source": ["![inline](attachment:image.png)"],
+                "metadata": {},
+                "attachments": {
+                    "image.png": {
+                        "image/png": "not valid base64"
+                    }
+                }
+            }
+        ]
+    });
+
+    let ipynb_path = tmp.path().join("invalid-attachments.ipynb");
+    std::fs::write(
+        &ipynb_path,
+        serde_json::to_string_pretty(&notebook_json).unwrap(),
+    )
+    .unwrap();
+
+    let notebook_id = ipynb_path.to_string_lossy().to_string();
+    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let error = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
+        .await
+        .expect_err("invalid attachment payload should fail load");
+    assert!(
+        error.contains("base64 payload is invalid"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]
@@ -2200,6 +2334,44 @@ async fn test_process_markdown_assets_rebuilds_stale_refs() {
 }
 
 #[tokio::test]
+async fn test_process_markdown_assets_resolves_existing_attachment_refs() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "attachment-assets.ipynb");
+    std::fs::write(&notebook_path, "{}").unwrap();
+
+    let hash = room.blob_store.put(b"hello", "image/png").await.unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "markdown-1", "markdown").unwrap();
+        doc.update_source("markdown-1", "![inline](attachment:image.png)")
+            .unwrap();
+        let attachments = HashMap::from([(
+            "image.png".to_string(),
+            HashMap::from([(
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: hash.clone(),
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        )]);
+        doc.set_cell_attachments("markdown-1", &attachments)
+            .unwrap();
+    }
+
+    process_markdown_assets(&room).await;
+
+    let cells = room.doc.read().await.get_cells();
+    assert_eq!(
+        cells[0]
+            .resolved_assets
+            .get("attachment:image.png")
+            .map(String::as_str),
+        Some(hash.as_str())
+    );
+}
+
+#[tokio::test]
 async fn test_save_notebook_to_disk_with_target_path() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, _original_path) = test_room_with_path(&tmp, "original.ipynb");
@@ -2227,26 +2399,29 @@ async fn test_save_notebook_to_disk_with_target_path() {
 }
 
 #[tokio::test]
-async fn test_save_notebook_to_disk_preserves_nbformat_attachments_from_cache() {
+async fn test_save_notebook_to_disk_preserves_nbformat_attachments_from_doc() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, original_path) = test_room_with_path(&tmp, "original.ipynb");
 
     {
+        let hash = room.blob_store.put(b"hello", "image/png").await.unwrap();
+        let mut attachment_refs = HashMap::new();
+        attachment_refs.insert(
+            "image.png".to_string(),
+            HashMap::from([(
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: hash,
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        );
         let mut doc = room.doc.write().await;
         doc.add_cell(0, "markdown-1", "markdown").unwrap();
         doc.update_source("markdown-1", "![inline](attachment:image.png)")
             .unwrap();
-    }
-    {
-        let mut attachments = room.persistence.nbformat_attachments.write().await;
-        attachments.insert(
-            "markdown-1".to_string(),
-            serde_json::json!({
-                "image.png": {
-                    "image/png": "aGVsbG8="
-                }
-            }),
-        );
+        doc.set_cell_attachments("markdown-1", &attachment_refs)
+            .unwrap();
     }
 
     save_notebook_to_disk(&room, None).await.unwrap();
@@ -2264,7 +2439,7 @@ async fn test_save_notebook_to_disk_preserves_nbformat_attachments_from_cache() 
 }
 
 #[tokio::test]
-async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_cache() {
+async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_doc() {
     // The Jupyter v4.5 schema permits `attachments` on raw cells. nbformat
     // 2.2.0's `v4::Cell::Raw` has no slot for them, so the typed pipeline
     // drops them during conversion and `serialize_v4_notebook` re-injects
@@ -2273,20 +2448,40 @@ async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_cache() 
     let (room, original_path) = test_room_with_path(&tmp, "raw.ipynb");
 
     {
+        let hash = room.blob_store.put(b"hello", "text/plain").await.unwrap();
+        let json_payload = serde_json::json!({"kind": "raw-attachment"});
+        let json_hash = room
+            .blob_store
+            .put(
+                &serde_json::to_vec(&json_payload).unwrap(),
+                "application/json",
+            )
+            .await
+            .unwrap();
+        let mut attachment_refs = HashMap::new();
+        attachment_refs.insert(
+            "snippet.txt".to_string(),
+            HashMap::from([
+                (
+                    "text/plain".to_string(),
+                    AttachmentRef {
+                        blob_hash: hash,
+                        encoding: "text".to_string(),
+                    },
+                ),
+                (
+                    "application/json".to_string(),
+                    AttachmentRef {
+                        blob_hash: json_hash,
+                        encoding: "json".to_string(),
+                    },
+                ),
+            ]),
+        );
         let mut doc = room.doc.write().await;
         doc.add_cell(0, "raw-1", "raw").unwrap();
         doc.update_source("raw-1", "attachment ref").unwrap();
-    }
-    {
-        let mut attachments = room.persistence.nbformat_attachments.write().await;
-        attachments.insert(
-            "raw-1".to_string(),
-            serde_json::json!({
-                "snippet.txt": {
-                    "text/plain": "hello"
-                }
-            }),
-        );
+        doc.set_cell_attachments("raw-1", &attachment_refs).unwrap();
     }
 
     save_notebook_to_disk(&room, None).await.unwrap();
@@ -2297,9 +2492,47 @@ async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_cache() 
         notebook["cells"][0]["attachments"],
         serde_json::json!({
             "snippet.txt": {
+                "application/json": {"kind": "raw-attachment"},
                 "text/plain": "hello"
             }
         })
+    );
+}
+
+#[tokio::test]
+async fn test_save_notebook_to_disk_treats_missing_attachment_blob_as_unrecoverable() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _original_path) = test_room_with_path(&tmp, "missing-attachment.ipynb");
+
+    {
+        let attachment_refs = HashMap::from([(
+            "missing.png".to_string(),
+            HashMap::from([(
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: "missing-blob".to_string(),
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        )]);
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "markdown-1", "markdown").unwrap();
+        doc.update_source("markdown-1", "![inline](attachment:missing.png)")
+            .unwrap();
+        doc.set_cell_attachments("markdown-1", &attachment_refs)
+            .unwrap();
+    }
+
+    let error = save_notebook_to_disk(&room, None)
+        .await
+        .expect_err("missing attachment blob should fail save");
+    assert!(
+        matches!(error, SaveError::Unrecoverable(_)),
+        "missing blob should not be retried forever: {error}"
+    );
+    assert!(
+        error.to_string().contains("missing attachment blob"),
+        "unexpected error: {error}"
     );
 }
 
@@ -6389,7 +6622,7 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
 
-    // Build a file-backed source room with two cells + markdown attachments
+    // Build a file-backed source room with cells + markdown/raw attachments
     // + stamped trust, registered in the rooms map.
     let source_path = tmp.path().join("source.ipynb");
     let source_uuid = Uuid::new_v4();
@@ -6407,12 +6640,22 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
     )
     .await;
 
+    let attachment_hash = blob_store.put(b"hello", "image/png").await.unwrap();
+    let raw_attachment_hash = blob_store
+        .put(
+            &serde_json::to_vec(&serde_json::json!({"kind": "clone"})).unwrap(),
+            "application/json",
+        )
+        .await
+        .unwrap();
     {
         let mut doc = source_room.doc.write().await;
         doc.add_cell(0, "code-1", "code").unwrap();
         doc.update_source("code-1", "x = 1").unwrap();
         doc.add_cell(1, "md-1", "markdown").unwrap();
         doc.update_source("md-1", "# hello").unwrap();
+        doc.add_cell(2, "raw-1", "raw").unwrap();
+        doc.update_source("raw-1", "attachment ref").unwrap();
         // Seed resolved_assets on the markdown cell so we can verify the
         // clone carries them through (markdown cells render via
         // `cell.resolvedAssets` — asset ref -> blob hash — and an empty
@@ -6423,6 +6666,28 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
         );
         doc.set_cell_resolved_assets("md-1", &assets).unwrap();
+        let attachments = HashMap::from([(
+            "image.png".to_string(),
+            HashMap::from([(
+                "image/png".to_string(),
+                AttachmentRef {
+                    blob_hash: attachment_hash.clone(),
+                    encoding: "base64".to_string(),
+                },
+            )]),
+        )]);
+        doc.set_cell_attachments("md-1", &attachments).unwrap();
+        let raw_attachments = HashMap::from([(
+            "payload.json".to_string(),
+            HashMap::from([(
+                "application/json".to_string(),
+                AttachmentRef {
+                    blob_hash: raw_attachment_hash.clone(),
+                    encoding: "json".to_string(),
+                },
+            )]),
+        )]);
+        doc.set_cell_attachments("raw-1", &raw_attachments).unwrap();
         // Stamp source metadata: env_id + trust signature + timestamp.
         let mut snap = snapshot_empty();
         snap.runt.env_id = Some("source-env-id".to_string());
@@ -6430,14 +6695,6 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
         snap.runt.trust_timestamp = Some("2026-04-25T00:00:00Z".to_string());
         doc.set_metadata_snapshot(&snap).unwrap();
     }
-    {
-        let mut cache = source_room.persistence.nbformat_attachments.write().await;
-        cache.insert(
-            "md-1".to_string(),
-            serde_json::json!({"image.png": {"image/png": "base64data"}}),
-        );
-    }
-
     // Dispatch clone handler.
     let response = crate::requests::clone_notebook::handle_inner(
         &rooms,
@@ -6489,10 +6746,11 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
 
     // Doc content: same cells, execution_count cleared on code cells.
     let clone_cells = clone_room.doc.read().await.get_cells();
-    assert_eq!(clone_cells.len(), 2);
+    assert_eq!(clone_cells.len(), 3);
     let cell_ids: Vec<&str> = clone_cells.iter().map(|c| c.id.as_str()).collect();
     assert!(cell_ids.contains(&"code-1"));
     assert!(cell_ids.contains(&"md-1"));
+    assert!(cell_ids.contains(&"raw-1"));
     let code_cell = clone_cells.iter().find(|c| c.id == "code-1").unwrap();
     assert_eq!(code_cell.execution_count, "null");
 
@@ -6518,11 +6776,32 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
         Some("2026-04-25T00:00:00Z")
     );
 
-    // Attachments copied (nbformat cache, used by save path).
-    let clone_attachments = clone_room.nbformat_attachments_snapshot().await;
+    // Attachments copied at the CRDT level for save/export.
+    let clone_attachments = clone_room
+        .doc
+        .read()
+        .await
+        .get_cell_attachments("md-1")
+        .expect("markdown cell should carry attachment refs");
     assert_eq!(
-        clone_attachments.get("md-1"),
-        Some(&serde_json::json!({"image.png": {"image/png": "base64data"}}))
+        clone_attachments
+            .get("image.png")
+            .and_then(|bundle| bundle.get("image/png"))
+            .map(|attachment_ref| attachment_ref.blob_hash.as_str()),
+        Some(attachment_hash.as_str())
+    );
+    let clone_raw_attachments = clone_room
+        .doc
+        .read()
+        .await
+        .get_cell_attachments("raw-1")
+        .expect("raw cell should carry attachment refs");
+    assert_eq!(
+        clone_raw_attachments
+            .get("payload.json")
+            .and_then(|bundle| bundle.get("application/json"))
+            .map(|attachment_ref| attachment_ref.blob_hash.as_str()),
+        Some(raw_attachment_hash.as_str())
     );
 
     // resolved_assets copied on the markdown cell (CRDT-level asset map,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1454,6 +1454,59 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
 }
 
 #[tokio::test]
+async fn test_apply_ipynb_changes_updates_existing_cell_attachments() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "raw").unwrap();
+        doc.update_source("cell-1", "attachment ref").unwrap();
+    }
+
+    let external_cells = vec![CellSnapshot {
+        id: "cell-1".to_string(),
+        cell_type: "raw".to_string(),
+        position: "80".to_string(),
+        source: "attachment ref".to_string(),
+        execution_count: "null".to_string(),
+        metadata: serde_json::json!({}),
+        resolved_assets: HashMap::new(),
+        attachments: HashMap::new(),
+    }];
+    let external_attachments = HashMap::from([(
+        "cell-1".to_string(),
+        serde_json::json!({
+            "payload.json": {
+                "application/json": {"kind": "watch-update"}
+            }
+        }),
+    )]);
+
+    let changed = apply_ipynb_changes(
+        &room,
+        &external_cells,
+        &HashMap::new(),
+        &external_attachments,
+        false,
+    )
+    .await;
+    assert!(changed, "Should detect attachment changes");
+
+    let cells = room.doc.read().await.get_cells();
+    let attachment_ref = cells[0]
+        .attachments
+        .get("payload.json")
+        .and_then(|bundle| bundle.get("application/json"))
+        .expect("watch path should store attachment refs on the existing cell");
+    let reconstructed = attachment_refs_to_nbformat_value(&cells[0].attachments, &room.blob_store)
+        .await
+        .unwrap();
+    assert_eq!(attachment_ref.encoding, AttachmentEncoding::Json);
+    assert_eq!(reconstructed, external_attachments["cell-1"]);
+}
+
+#[tokio::test]
 async fn test_apply_ipynb_changes_preserves_execution_count_when_kernel_running() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, _) = test_room_with_path(&tmp, "test.ipynb");

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -92,14 +92,14 @@ fn test_image_attachment_hash_uses_stable_image_preference() {
                 "image/jpeg".to_string(),
                 AttachmentRef {
                     blob_hash: "jpeg-hash".to_string(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             ),
             (
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: "png-hash".to_string(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             ),
         ]),
@@ -2160,7 +2160,7 @@ async fn test_load_notebook_from_disk_resolves_nbformat_attachments() {
         .and_then(|bundle| bundle.get("image/png"))
         .expect("attachment should be stored in the cell schema");
     assert_eq!(attachment_ref.blob_hash, *hash);
-    assert_eq!(attachment_ref.encoding, "base64");
+    assert_eq!(attachment_ref.encoding, AttachmentEncoding::Base64);
 }
 
 #[tokio::test]
@@ -2351,7 +2351,7 @@ async fn test_process_markdown_assets_resolves_existing_attachment_refs() {
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: hash.clone(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             )]),
         )]);
@@ -2412,7 +2412,7 @@ async fn test_save_notebook_to_disk_preserves_nbformat_attachments_from_doc() {
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: hash,
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             )]),
         );
@@ -2466,14 +2466,14 @@ async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_doc() {
                     "text/plain".to_string(),
                     AttachmentRef {
                         blob_hash: hash,
-                        encoding: "text".to_string(),
+                        encoding: AttachmentEncoding::Text,
                     },
                 ),
                 (
                     "application/json".to_string(),
                     AttachmentRef {
                         blob_hash: json_hash,
-                        encoding: "json".to_string(),
+                        encoding: AttachmentEncoding::Json,
                     },
                 ),
             ]),
@@ -2511,7 +2511,7 @@ async fn test_save_notebook_to_disk_treats_missing_attachment_blob_as_unrecovera
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: "missing-blob".to_string(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             )]),
         )]);
@@ -6672,7 +6672,7 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
                 "image/png".to_string(),
                 AttachmentRef {
                     blob_hash: attachment_hash.clone(),
-                    encoding: "base64".to_string(),
+                    encoding: AttachmentEncoding::Base64,
                 },
             )]),
         )]);
@@ -6683,7 +6683,7 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
                 "application/json".to_string(),
                 AttachmentRef {
                     blob_hash: raw_attachment_hash.clone(),
-                    encoding: "json".to_string(),
+                    encoding: AttachmentEncoding::Json,
                 },
             )]),
         )]);

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -109,6 +109,21 @@ fn test_image_attachment_hash_uses_stable_image_preference() {
         image_attachment_hash(&refs, "plot#fragment").as_deref(),
         Some("png-hash")
     );
+
+    let refs_with_query_name = HashMap::from([(
+        "plot?actual".to_string(),
+        HashMap::from([(
+            "image/png".to_string(),
+            AttachmentRef {
+                blob_hash: "query-name-hash".to_string(),
+                encoding: AttachmentEncoding::Base64,
+            },
+        )]),
+    )]);
+    assert_eq!(
+        image_attachment_hash(&refs_with_query_name, "plot?actual").as_deref(),
+        Some("query-name-hash")
+    );
 }
 
 #[test]

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -116,9 +116,9 @@ async fn derive_working_dir(room: &NotebookRoom) -> Option<PathBuf> {
     room.identity.working_dir.read().await.clone()
 }
 
-/// Seed the clone room's Automerge doc from the source, then copy markdown
-/// attachments. Called once, immediately after room creation; no other peer
-/// can observe the room between `get_or_create_room` and this call.
+/// Seed the clone room's Automerge doc from the source. Called once,
+/// immediately after room creation; no other peer can observe the room between
+/// `get_or_create_room` and this call.
 async fn seed_clone_from_source(
     source: &NotebookRoom,
     clone: &Arc<NotebookRoom>,
@@ -128,7 +128,6 @@ async fn seed_clone_from_source(
         let doc = source.doc.read().await;
         (doc.get_cells(), doc.get_metadata_snapshot())
     };
-    let attachments = source.nbformat_attachments_snapshot().await;
 
     // Seed the clone's doc.
     {
@@ -158,12 +157,16 @@ async fn seed_clone_from_source(
             // `add_cell_full` seeds an empty `resolved_assets` map. Markdown
             // cells render via `cell.resolvedAssets` (attachment ref -> blob
             // hash), so without this copy, inline images in cloned markdown
-            // cells would break until a save+reload rebuilt the map from
-            // the attachment cache.
+            // cells would break until the next asset-processing pass.
             if !cell.resolved_assets.is_empty() {
                 clone_doc
                     .set_cell_resolved_assets(&cell.id, &cell.resolved_assets)
                     .map_err(|e| format!("set_cell_resolved_assets({}): {e}", cell.id))?;
+            }
+            if !cell.attachments.is_empty() {
+                clone_doc
+                    .set_cell_attachments(&cell.id, &cell.attachments)
+                    .map_err(|e| format!("set_cell_attachments({}): {e}", cell.id))?;
             }
         }
 
@@ -183,15 +186,6 @@ async fn seed_clone_from_source(
 
         // Ephemeral marker lives in raw metadata (set by new_fresh already),
         // no action here.
-    }
-
-    // Copy the markdown-attachment cache. Raw-cell attachments are included
-    // too since nbformat_attachments doesn't discriminate by cell_type; the
-    // save path re-injects them for raw cells via the existing
-    // nbformat_convert wrapper.
-    if !attachments.is_empty() {
-        let mut cache = clone.persistence.nbformat_attachments.write().await;
-        *cache = attachments;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Promote nbformat cell attachments into the notebook-doc CRDT schema as blob refs.
- Reconstruct nbformat attachments from CRDT refs on save, including raw-cell reinjection.
- Remove the daemon-local attachment side cache and update load/watch/clone/markdown-asset/GC paths to use document-owned refs.
- Add typed `AttachmentEncoding` plus regression coverage for JSON/text/base64 payloads, raw cells, clone, GC, markdown asset rebuild, and watched attachment updates.

## Review
- Ran Claude Bedrock review in focused slices for API shape/architecture and daemon load/save/watch/clone/GC paths.
- Addressed confirmed feedback: typed attachment encoding, unknown encoding preservation, exact attachment-name lookup before query/fragment fallback, and watched existing-cell attachment update coverage.
- Intentionally keep save failure unrecoverable when attachment blobs are missing/unreadable to avoid silently writing a lossy `.ipynb`.

## Verification
- `cargo test -p notebook-doc --lib`
- `cargo test -p notebook-doc -p runtimed-client -p runt-mcp --lib --no-run`
- `cargo test -p runtimed --lib --no-run`
- `cargo test -p runtimed attachment -- --nocapture`
- `cargo test -p runtimed test_apply_ipynb_changes_updates_existing_cell_attachments -- --nocapture`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `git diff --check`
