### PR TITLE
refactor(runtimed): own execution projection planning

### DIFF
--- a/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
+++ b/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
@@ -3,18 +3,16 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 import {
   getCellExecutionId,
   getExecutionById,
-  resetNotebookExecutions,
   setCellExecutionPointer,
 } from "../notebook-executions";
+import { getOutputById } from "../notebook-outputs";
 import {
-  getOutputById,
-  resetNotebookOutputs,
-} from "../notebook-outputs";
-import { projectRuntimeStateToExecutions } from "../project-runtime-stores";
+  projectRuntimeStateToExecutions,
+  resetRuntimeStoresProjection,
+} from "../project-runtime-stores";
 
 afterEach(() => {
-  resetNotebookExecutions();
-  resetNotebookOutputs();
+  resetRuntimeStoresProjection();
 });
 
 function stateWith(

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -70,10 +70,6 @@ export function projectRuntimeStateToExecutions(state: RuntimeState): void {
   }
 }
 
-export function resetRuntimeExecutionProjection(): void {
-  executionProjector.reset();
-}
-
 /**
  * Seed the outputs / executions stores directly from the WASM handle.
  *
@@ -221,7 +217,7 @@ function tryResolveSync(
 }
 
 export function resetRuntimeStoresProjection(): void {
-  resetRuntimeExecutionProjection();
+  executionProjector.reset();
   resetNotebookExecutions();
   resetNotebookOutputs();
 }

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -13,9 +13,8 @@
  */
 
 import {
-  buildRuntimeExecutionSnapshot,
   collectOutputIds,
-  executionFingerprint,
+  RuntimeExecutionProjector,
   type RuntimeState,
 } from "runtimed";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
@@ -43,21 +42,7 @@ import type { JupyterOutput } from "../types";
 
 // ── Executions store projection ──────────────────────────────────────
 
-/**
- * Module-local record of the previous sync's execution_id set. Used to
- * evict entries the daemon has trimmed out of `RuntimeStateDoc`. Without
- * this, old executions accumulate forever in the store.
- */
-let _knownExecutionIds: Set<string> = new Set();
-
-/**
- * Previously-seen scalar fingerprint per execution (`status`, count, success,
- * and output_id list). Lets the projection short-circuit on untouched
- * executions instead of rebuilding `output_ids` for every execution on
- * every tick — critical because `runtimeState$` emits once per stream
- * append.
- */
-const _prevExecutionFingerprint: Map<string, string> = new Map();
+const executionProjector = new RuntimeExecutionProjector();
 
 /**
  * Project the current RuntimeState into the executions store.
@@ -75,26 +60,18 @@ const _prevExecutionFingerprint: Map<string, string> = new Map();
  * `updateCellExecutionPointersFromHandle`).
  */
 export function projectRuntimeStateToExecutions(state: RuntimeState): void {
-  const nextIds = new Set<string>();
-  for (const [execution_id, entry] of Object.entries(state.executions)) {
-    nextIds.add(execution_id);
-    const fp = executionFingerprint(entry);
-    if (_prevExecutionFingerprint.get(execution_id) === fp) continue;
-    _prevExecutionFingerprint.set(execution_id, fp);
-    setExecution(execution_id, buildRuntimeExecutionSnapshot(entry));
+  const projection = executionProjector.project(state);
+  for (const [execution_id, snapshot] of projection.upserts) {
+    setExecution(execution_id, snapshot);
   }
 
-  // Evict executions the daemon dropped. Keeps the store from drifting
-  // monotonically larger across long sessions with restart cycles.
-  const removed: string[] = [];
-  for (const prev of _knownExecutionIds) {
-    if (!nextIds.has(prev)) removed.push(prev);
+  if (projection.removed_execution_ids.length > 0) {
+    deleteExecutions(projection.removed_execution_ids);
   }
-  if (removed.length > 0) {
-    deleteExecutions(removed);
-    for (const eid of removed) _prevExecutionFingerprint.delete(eid);
-  }
-  _knownExecutionIds = nextIds;
+}
+
+export function resetRuntimeExecutionProjection(): void {
+  executionProjector.reset();
 }
 
 /**
@@ -244,8 +221,7 @@ function tryResolveSync(
 }
 
 export function resetRuntimeStoresProjection(): void {
-  _knownExecutionIds = new Set();
-  _prevExecutionFingerprint.clear();
+  resetRuntimeExecutionProjection();
   resetNotebookExecutions();
   resetNotebookOutputs();
 }

--- a/packages/runtimed/src/execution-projection.ts
+++ b/packages/runtimed/src/execution-projection.ts
@@ -1,4 +1,4 @@
-import type { ExecutionState } from "./runtime-state";
+import type { ExecutionState, RuntimeState } from "./runtime-state";
 
 export interface RuntimeExecutionSnapshot {
   cell_id: string;
@@ -43,4 +43,54 @@ export function buildRuntimeExecutionSnapshot(raw: ExecutionState): RuntimeExecu
     success: raw.success,
     output_ids: collectExecutionOutputIds(raw),
   };
+}
+
+export interface RuntimeExecutionProjection {
+  upserts: Array<[execution_id: string, snapshot: RuntimeExecutionSnapshot]>;
+  removed_execution_ids: string[];
+}
+
+/**
+ * Stateful planner for projecting daemon-authored RuntimeState executions
+ * into an execution store.
+ *
+ * The package owns the RuntimeState diff/cache semantics; consumers provide
+ * the concrete store writes. This keeps React stores, Tauri apps, and tests
+ * from each carrying their own interpretation of execution eviction and
+ * output-id fingerprinting.
+ */
+export class RuntimeExecutionProjector {
+  private knownExecutionIds = new Set<string>();
+  private prevExecutionFingerprint = new Map<string, string>();
+
+  project(state: RuntimeState): RuntimeExecutionProjection {
+    const nextIds = new Set<string>();
+    const upserts: RuntimeExecutionProjection["upserts"] = [];
+
+    for (const [execution_id, entry] of Object.entries(state.executions)) {
+      nextIds.add(execution_id);
+      const fp = executionFingerprint(entry);
+      if (this.prevExecutionFingerprint.get(execution_id) === fp) continue;
+      this.prevExecutionFingerprint.set(execution_id, fp);
+      upserts.push([execution_id, buildRuntimeExecutionSnapshot(entry)]);
+    }
+
+    const removed_execution_ids: string[] = [];
+    for (const prev of this.knownExecutionIds) {
+      if (!nextIds.has(prev)) removed_execution_ids.push(prev);
+    }
+    if (removed_execution_ids.length > 0) {
+      for (const eid of removed_execution_ids) {
+        this.prevExecutionFingerprint.delete(eid);
+      }
+    }
+    this.knownExecutionIds = nextIds;
+
+    return { upserts, removed_execution_ids };
+  }
+
+  reset(): void {
+    this.knownExecutionIds.clear();
+    this.prevExecutionFingerprint.clear();
+  }
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -79,6 +79,8 @@ export {
   collectOutputIds,
   executionFingerprint,
   extractOutputId,
+  RuntimeExecutionProjector,
+  type RuntimeExecutionProjection,
   type RuntimeExecutionSnapshot,
 } from "./execution-projection";
 

--- a/packages/runtimed/tests/execution-projection.test.ts
+++ b/packages/runtimed/tests/execution-projection.test.ts
@@ -169,6 +169,71 @@ describe("RuntimeExecutionProjector", () => {
     });
   });
 
+  it("projects added, changed, and removed executions in the same tick", () => {
+    const projector = new RuntimeExecutionProjector();
+    projector.project(
+      stateWith({
+        "exec-stays": {
+          cell_id: "cell-1",
+          execution_count: 1,
+          status: "running",
+          success: null,
+          outputs: [{ output_id: "old" }],
+        },
+        "exec-removed": {
+          cell_id: "cell-2",
+          execution_count: 2,
+          status: "done",
+          success: true,
+          outputs: [],
+        },
+      }),
+    );
+
+    const projection = projector.project(
+      stateWith({
+        "exec-stays": {
+          cell_id: "cell-1",
+          execution_count: 1,
+          status: "running",
+          success: null,
+          outputs: [{ output_id: "new" }],
+        },
+        "exec-added": {
+          cell_id: "cell-3",
+          execution_count: 3,
+          status: "queued",
+          success: null,
+          outputs: [],
+        },
+      }),
+    );
+
+    expect(projection.removed_execution_ids).toEqual(["exec-removed"]);
+    expect(projection.upserts).toEqual([
+      [
+        "exec-stays",
+        {
+          cell_id: "cell-1",
+          execution_count: 1,
+          status: "running",
+          success: null,
+          output_ids: ["new"],
+        },
+      ],
+      [
+        "exec-added",
+        {
+          cell_id: "cell-3",
+          execution_count: 3,
+          status: "queued",
+          success: null,
+          output_ids: [],
+        },
+      ],
+    ]);
+  });
+
   it("reset clears projection cache", () => {
     const projector = new RuntimeExecutionProjector();
     const state = stateWith({

--- a/packages/runtimed/tests/execution-projection.test.ts
+++ b/packages/runtimed/tests/execution-projection.test.ts
@@ -4,10 +4,17 @@ import {
   buildRuntimeExecutionSnapshot,
   collectExecutionOutputIds,
   collectOutputIds,
+  DEFAULT_RUNTIME_STATE,
   executionFingerprint,
   extractOutputId,
   type ExecutionState,
+  RuntimeExecutionProjector,
+  type RuntimeState,
 } from "../src";
+
+function stateWith(executions: RuntimeState["executions"]): RuntimeState {
+  return { ...DEFAULT_RUNTIME_STATE, executions };
+}
 
 describe("execution projection helpers", () => {
   it("extracts only non-empty string output ids", () => {
@@ -72,5 +79,111 @@ describe("execution projection helpers", () => {
       success: true,
       output_ids: ["out-1"],
     });
+  });
+});
+
+describe("RuntimeExecutionProjector", () => {
+  it("emits upserts for changed executions and skips unchanged ticks", () => {
+    const projector = new RuntimeExecutionProjector();
+    const state = stateWith({
+      "exec-1": {
+        cell_id: "cell-1",
+        execution_count: 1,
+        status: "running",
+        success: null,
+        outputs: [{ output_id: "out-1" }],
+      },
+    });
+
+    expect(projector.project(state)).toEqual({
+      upserts: [
+        [
+          "exec-1",
+          {
+            cell_id: "cell-1",
+            execution_count: 1,
+            status: "running",
+            success: null,
+            output_ids: ["out-1"],
+          },
+        ],
+      ],
+      removed_execution_ids: [],
+    });
+    expect(projector.project(state)).toEqual({
+      upserts: [],
+      removed_execution_ids: [],
+    });
+  });
+
+  it("captures same-length output_id replacements", () => {
+    const projector = new RuntimeExecutionProjector();
+    projector.project(
+      stateWith({
+        "exec-1": {
+          cell_id: "cell-1",
+          execution_count: 1,
+          status: "running",
+          success: null,
+          outputs: [{ output_id: "old", output_type: "stream", text: "a" }],
+        },
+      }),
+    );
+
+    expect(
+      projector.project(
+        stateWith({
+          "exec-1": {
+            cell_id: "cell-1",
+            execution_count: 1,
+            status: "running",
+            success: null,
+            outputs: [{ output_id: "new", output_type: "stream", text: "b" }],
+          },
+        }),
+      ).upserts[0]?.[1].output_ids,
+    ).toEqual(["new"]);
+  });
+
+  it("emits removed execution ids for daemon-trimmed entries", () => {
+    const projector = new RuntimeExecutionProjector();
+    projector.project(
+      stateWith({
+        "exec-1": {
+          cell_id: "cell-1",
+          execution_count: 1,
+          status: "done",
+          success: true,
+          outputs: [],
+        },
+      }),
+    );
+
+    expect(projector.project(stateWith({}))).toEqual({
+      upserts: [],
+      removed_execution_ids: ["exec-1"],
+    });
+    expect(projector.project(stateWith({}))).toEqual({
+      upserts: [],
+      removed_execution_ids: [],
+    });
+  });
+
+  it("reset clears projection cache", () => {
+    const projector = new RuntimeExecutionProjector();
+    const state = stateWith({
+      "exec-1": {
+        cell_id: "cell-1",
+        execution_count: 1,
+        status: "done",
+        success: true,
+        outputs: [],
+      },
+    });
+    projector.project(state);
+
+    projector.reset();
+
+    expect(projector.project(state).upserts).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- move RuntimeState execution projection cache/eviction planning into packages/runtimed
- keep notebook app code as store adapters for execution/output writes
- add package coverage for unchanged ticks, output-id replacement, daemon-trimmed execution eviction, and projector reset

## Verification
- pnpm exec vp test run packages/runtimed/tests/execution-projection.test.ts apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
- pnpm exec tsc -p packages/runtimed/tsconfig.json --noEmit
- pnpm --filter notebook-ui exec tsc --noEmit
- cargo xtask lint --fix