### PR TITLE
docs(protocol): refresh runtime protocol docs

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -58,7 +58,7 @@ After handshake, frames are typed by first byte:
 | `0x06` | PoolStateSync | Binary (raw Automerge sync for PoolDoc — global daemon pool state) |
 | `0x07` | SessionControl | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
 
-Only `0x00` (AutomergeSync), `0x01` (NotebookRequest), `0x04` (Presence), and `0x06` (PoolStateSync) are valid outgoing frame types from the frontend/relay. `0x07` is daemon-originated.
+Frontend/relay outbound frames are `0x00` (AutomergeSync), `0x01` (NotebookRequest), `0x04` (Presence), `0x05` (RuntimeStateSync), and `0x06` (PoolStateSync). `0x02` responses, `0x03` broadcasts, and `0x07` session-control frames are daemon-originated.
 
 Notebook request and response frames use `NotebookRequestEnvelope` and `NotebookResponseEnvelope`. Every overlapping request must carry an `id`, and responses must route by id rather than by receive order.
 
@@ -74,6 +74,9 @@ Notebook request and response frames use `NotebookRequestEnvelope` and `Notebook
 | `RunAllCells` | Execute all code cells in order |
 | `SaveNotebook` | Persist Automerge doc to `.ipynb` |
 | `SyncEnvironment` | Hot-install packages into running kernel |
+| `ApproveTrust` / `ApproveProjectEnvironment` | Record user approval for dependency or project-file environments |
+| `CloneAsEphemeral` | Fork the current notebook into a new in-memory room |
+| `GetDocBytes` | Fetch canonical Automerge bytes to bootstrap a WASM peer |
 | `SendComm { message }` | Send comm message to kernel (widget interactions) |
 | `Complete { code, cursor_pos }` | Code completions from kernel |
 | `GetHistory { pattern, n, unique }` | Search kernel input history |
@@ -147,19 +150,25 @@ Schema (in `crates/runtime-doc/src/doc.rs`):
 
 | Path | Type | Description |
 |------|------|-------------|
-| `kernel.status` | Str | `"idle"`, `"busy"`, `"starting"`, `"error"`, `"shutdown"`, `"not_started"` |
-| `kernel.starting_phase` | Str | `""`, `"resolving"`, `"preparing_env"`, `"launching"`, `"connecting"` |
+| `kernel.lifecycle` | Str | Typed lifecycle: `"NotStarted"`, `"AwaitingTrust"`, `"AwaitingEnvBuild"`, `"Resolving"`, `"PreparingEnv"`, `"Launching"`, `"Connecting"`, `"Running"`, `"Error"`, `"Shutdown"` |
+| `kernel.activity` | Str | `""`, `"Unknown"`, `"Idle"`, `"Busy"`; meaningful when lifecycle is `Running` |
+| `kernel.error_reason`, `kernel.error_details` | Str | Typed and free-form error context when lifecycle is `Error` |
+| `kernel.runtime_agent_id` | Str | Runtime agent subprocess currently owning the kernel |
 | `kernel.name`, `kernel.language`, `kernel.env_source` | Str | Kernel metadata |
 | `queue.executing` | Str\|null | Cell ID currently executing |
 | `queue.executing_execution_id` | Str\|null | Execution ID for the executing cell |
 | `queue.queued` | List[Str] | Queued cell IDs |
 | `queue.queued_execution_ids` | List[Str] | Parallel execution IDs for queued entries |
 | `executions.{execution_id}` | Map | `{ cell_id, status, execution_count, success }` |
-| `env.in_sync`, `env.added`, `env.removed` | bool/List | Environment drift state |
+| `env.in_sync`, `env.added`, `env.removed`, `env.channels_changed`, `env.deno_changed` | bool/List | Environment drift state |
+| `env.prewarmed_packages`, `env.progress` | List/Map | Current prewarmed package snapshot and latest env progress |
 | `trust.status`, `trust.needs_approval` | Str/bool | Trust state |
+| `project_context` | Map | Daemon-observed project-file detection and parsed dependency context |
+| `display_index` | Map | `display_id` -> ordered `"execution_id\0output_id"` entries |
+| `comms` | Map | Widget state keyed by `comm_id` |
 | `last_saved` | Str\|null | ISO timestamp of last save |
 
-The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
+`kernel.status` and `kernel.starting_phase` remain source-compatible projection fields on `KernelState`, but new code should read `kernel.lifecycle` and `kernel.activity`. The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
 
 ### Execution ID Tracking
 

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -72,10 +72,10 @@ Notebook request and response frames use `NotebookRequestEnvelope` and `Notebook
 | `InterruptExecution` | Send SIGINT to running kernel |
 | `ShutdownKernel` | Stop the kernel process |
 | `RunAllCells` | Execute all code cells in order |
-| `SaveNotebook` | Persist Automerge doc to `.ipynb` |
+| `SaveNotebook { format_cells, path? }` | Persist Automerge doc to `.ipynb`, optionally save-as to `path` |
 | `SyncEnvironment` | Hot-install packages into running kernel |
 | `ApproveTrust` / `ApproveProjectEnvironment` | Record user approval for dependency or project-file environments |
-| `CloneAsEphemeral` | Fork the current notebook into a new in-memory room |
+| `CloneAsEphemeral { source_notebook_id }` | Fork an existing loaded notebook into a new in-memory room |
 | `GetDocBytes` | Fetch canonical Automerge bytes to bootstrap a WASM peer |
 | `SendComm { message }` | Send comm message to kernel (widget interactions) |
 | `Complete { code, cursor_pos }` | Code completions from kernel |
@@ -87,7 +87,8 @@ Notebook request and response frames use `NotebookRequestEnvelope` and `Notebook
 |----------|---------|
 | `KernelLaunched { env_source }` | Kernel started, includes environment origin label |
 | `CellQueued` | Cell added to execution queue |
-| `NotebookSaved` | File written to disk |
+| `NotebookSaved { path }` | File written to disk |
+| `HistoryResult { entries }` | Kernel input history search results |
 | `CompletionResult { items, cursor_start, cursor_end }` | Code completion results |
 | `Error { error }` | Something went wrong |
 
@@ -159,7 +160,7 @@ Schema (in `crates/runtime-doc/src/doc.rs`):
 | `queue.executing_execution_id` | Str\|null | Execution ID for the executing cell |
 | `queue.queued` | List[Str] | Queued cell IDs |
 | `queue.queued_execution_ids` | List[Str] | Parallel execution IDs for queued entries |
-| `executions.{execution_id}` | Map | `{ cell_id, status, execution_count, success }` |
+| `executions.{execution_id}` | Map | `{ cell_id, status, execution_count, success, outputs[], source?, seq }`; `outputs[]` are inline output manifests with blob refs |
 | `env.in_sync`, `env.added`, `env.removed`, `env.channels_changed`, `env.deno_changed` | bool/List | Environment drift state |
 | `env.prewarmed_packages`, `env.progress` | List/Map | Current prewarmed package snapshot and latest env progress |
 | `trust.status`, `trust.needs_approval` | Str/bool | Trust state |
@@ -168,7 +169,7 @@ Schema (in `crates/runtime-doc/src/doc.rs`):
 | `comms` | Map | Widget state keyed by `comm_id` |
 | `last_saved` | Str\|null | ISO timestamp of last save |
 
-`kernel.status` and `kernel.starting_phase` remain source-compatible projection fields on `KernelState`, but new code should read `kernel.lifecycle` and `kernel.activity`. The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
+`kernel.status` and `kernel.starting_phase` remain source-compatible Rust `KernelState` projection fields computed at read time from `kernel.lifecycle`. They are not separate persisted CRDT fields in the typed schema, and new code should read `kernel.lifecycle` and `kernel.activity`. The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
 
 ### Execution ID Tracking
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -277,11 +277,11 @@ Requests are one-shot JSON messages sent from the client to the daemon. Each req
 | `ShutdownKernel` | Stop the kernel process |
 | `RunAllCells` | Execute all code cells in order |
 | `RunAllCellsGuarded { observed_heads }` | Run all code cells only if the approved notebook heads still match |
-| `SaveNotebook` | Persist the Automerge doc to `.ipynb` on disk |
+| `SaveNotebook { format_cells, path? }` | Persist the Automerge doc to `.ipynb` on disk, optionally save-as to `path` |
 | `SyncEnvironment` | Hot-install packages into the running kernel's environment |
 | `ApproveTrust` | Sign current dependency metadata after user approval |
 | `ApproveProjectEnvironment` | Record local approval for a project-file environment |
-| `CloneAsEphemeral` | Fork the current notebook into a new in-memory room |
+| `CloneAsEphemeral { source_notebook_id }` | Fork an existing loaded notebook into a new in-memory room |
 | `SendComm { message }` | Send a comm message to the kernel (widget interactions) |
 | `Complete { code, cursor_pos }` | Get code completions from the kernel |
 | `GetHistory { pattern, n, unique }` | Search kernel input history |
@@ -300,13 +300,14 @@ launch and downstream protocol responses carry a concrete `EnvSource`.
 | `KernelAlreadyRunning { env_source, ... }` | Existing kernel reused |
 | `CellQueued` | Cell added to execution queue |
 | `AllCellsQueued { queued }` | All runnable code cells queued with execution IDs |
-| `NotebookSaved` | File written to disk |
+| `NotebookSaved { path }` | File written to disk |
 | `SaveError { error }` | Save failed with structured error details |
 | `GuardRejected { reason }` | Guarded action rejected because observed notebook state changed |
 | `NotebookCloned { notebook_id, working_dir }` | Ephemeral fork created |
 | `SyncEnvironmentComplete` / `SyncEnvironmentFailed` | Hot-sync result |
 | `DocBytes { bytes }` | Canonical Automerge doc bytes |
 | `CompletionResult { items, cursor_start, cursor_end }` | Code completion results (`items: Vec<CompletionItem>`) |
+| `HistoryResult { entries }` | Kernel input history search results |
 | `Error { error }` | Something went wrong |
 
 ### Request flow through the stack

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -80,7 +80,7 @@ The notebook app communicates with runtimed over a Unix socket (named pipe on Wi
                                    └─────────────────┘
 ```
 
-The **Tauri relay** is a transparent byte pipe for Automerge sync frames — it does not maintain its own document replica. It forwards raw bytes between the WASM peer and the daemon peer. For requests and broadcasts, it bridges Tauri IPC commands to the daemon's socket protocol.
+The **Tauri relay** is a transparent byte pipe for Automerge sync, request, runtime-state, pool-state, and presence frames — it does not maintain its own document replica. It forwards raw typed frames between the WASM/TypeScript peer and the daemon peer. Broadcast, response, presence, and session-control frames arrive through the unified `notebook:frame` event.
 
 ## Connection Lifecycle
 
@@ -187,6 +187,14 @@ After the handshake, frames are typed by their first byte:
 | `0x06`    | PoolStateSync      | Binary (raw Automerge sync for the per-daemon `PoolDoc`) |
 | `0x07`    | SessionControl     | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
 
+Frame direction is peer-specific:
+
+| Sender | Valid frame types |
+|--------|-------------------|
+| Frontend / Tauri relay | `0x00` AutomergeSync, `0x01` NotebookRequest, `0x04` Presence, `0x05` RuntimeStateSync, `0x06` PoolStateSync |
+| Daemon notebook peer | `0x00` AutomergeSync, `0x02` NotebookResponse, `0x03` NotebookBroadcast, `0x04` Presence, `0x05` RuntimeStateSync, `0x06` PoolStateSync, `0x07` SessionControl |
+| Runtime agent peer | `0x00` AutomergeSync, `0x01` RuntimeAgentRequest/Envelope, `0x02` RuntimeAgentResponse/Envelope, `0x05` RuntimeStateSync |
+
 `NotebookRequest` and `NotebookResponse` payloads are carried in flattened
 `NotebookRequestEnvelope` and `NotebookResponseEnvelope` values. Concurrent
 requests must include an `id`, and clients must route responses by id because
@@ -263,17 +271,21 @@ Requests are one-shot JSON messages sent from the client to the daemon. Each req
 |---------|---------|
 | `LaunchKernel` | Start a kernel with environment config |
 | `ExecuteCell { cell_id }` | Queue a cell for execution (daemon reads source from synced doc) |
+| `ExecuteCellGuarded { cell_id, observed_heads }` | Queue a cell only if the approved notebook heads still match |
 | `ClearOutputs { cell_id }` | Clear a cell's outputs |
 | `InterruptExecution` | Send SIGINT to the running kernel |
 | `ShutdownKernel` | Stop the kernel process |
 | `RunAllCells` | Execute all code cells in order |
+| `RunAllCellsGuarded { observed_heads }` | Run all code cells only if the approved notebook heads still match |
 | `SaveNotebook` | Persist the Automerge doc to `.ipynb` on disk |
 | `SyncEnvironment` | Hot-install packages into the running kernel's environment |
+| `ApproveTrust` | Sign current dependency metadata after user approval |
+| `ApproveProjectEnvironment` | Record local approval for a project-file environment |
+| `CloneAsEphemeral` | Fork the current notebook into a new in-memory room |
 | `SendComm { message }` | Send a comm message to the kernel (widget interactions) |
 | `Complete { code, cursor_pos }` | Get code completions from the kernel |
 | `GetHistory { pattern, n, unique }` | Search kernel input history |
-| `GetKernelInfo` | Query current kernel status |
-| `GetQueueState` | Query the execution queue |
+| `GetDocBytes` | Fetch canonical Automerge bytes to bootstrap a WASM peer |
 
 `LaunchKernel.env_source` is a request-time `LaunchSpec` string on the wire:
 `"auto"`, `"auto:uv"`, `"auto:conda"`, `"auto:pixi"`, or a concrete
@@ -285,22 +297,30 @@ launch and downstream protocol responses carry a concrete `EnvSource`.
 | Response | Meaning |
 |----------|---------|
 | `KernelLaunched { env_source, ... }` | Kernel started, includes resolved concrete environment origin label |
+| `KernelAlreadyRunning { env_source, ... }` | Existing kernel reused |
 | `CellQueued` | Cell added to execution queue |
+| `AllCellsQueued { queued }` | All runnable code cells queued with execution IDs |
 | `NotebookSaved` | File written to disk |
+| `SaveError { error }` | Save failed with structured error details |
+| `GuardRejected { reason }` | Guarded action rejected because observed notebook state changed |
+| `NotebookCloned { notebook_id, working_dir }` | Ephemeral fork created |
+| `SyncEnvironmentComplete` / `SyncEnvironmentFailed` | Hot-sync result |
+| `DocBytes { bytes }` | Canonical Automerge doc bytes |
 | `CompletionResult { items, cursor_start, cursor_end }` | Code completion results (`items: Vec<CompletionItem>`) |
 | `Error { error }` | Something went wrong |
 
 ### Request flow through the stack
 
 ```
-Frontend: invoke("execute_cell_via_daemon", { cellId })
-  → Tauri command handler
-  → Relay: handle.send_request(NotebookRequest::ExecuteCell { cell_id })
+Frontend: host.transport.sendRequest({ type: "execute_cell", cell_id })
+  → TauriTransport encodes NotebookRequestEnvelope with a correlation id
+  → send_frame(0x01 + JSON envelope)
+  → Relay: handle.forward_frame(NotebookRequest)
   → Frame type 0x01 sent on socket
   → Daemon processes request
-  → Frame type 0x02 returned
-  → Relay receives response via oneshot channel
-  → Returns to frontend
+  → Frame type 0x02 returned with matching id
+  → Relay emits "notebook:frame"
+  → TauriTransport response tap resolves the pending request by id
 ```
 
 ## Broadcasts
@@ -340,7 +360,7 @@ The relay and frontend use these Tauri events for cross-process communication:
 | `daemon:ready` | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
 | `daemon:disconnected` | Relay → Frontend | — | Connection to daemon lost |
 
-Outgoing frames from the frontend use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` passed as raw binary via `tauri::ipc::Request`. Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types.
+Outgoing frames from the frontend use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` passed as raw binary via `tauri::ipc::Request`. The relay accepts frontend-originated `0x00` (AutomergeSync), `0x01` (NotebookRequest), `0x04` (Presence), `0x05` (RuntimeStateSync), and `0x06` (PoolStateSync). `0x02` responses, `0x03` broadcasts, and `0x07` session-control frames are daemon-originated.
 
 ### In-memory frame bus
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -400,16 +400,24 @@ pub enum Handshake {
     SettingsSync,
     NotebookSync {
         notebook_id: String,
-        protocol: Option<String>,        // version negotiation (v2 = typed frames)
+        protocol: Option<String>,        // version negotiation (currently "v4")
         working_dir: Option<String>,      // for untitled notebook project detection
         initial_metadata: Option<String>, // kernelspec JSON for auto-launch
     },
     Blob,
     OpenNotebook { path: String },        // daemon loads from disk, returns NotebookConnectionInfo
+    RuntimeAgent {                        // runtime-agent subprocess attaches to a room
+        notebook_id: String,
+        runtime_agent_id: String,
+        blob_root: String,
+    },
     CreateNotebook {                      // daemon creates empty room
         runtime: String,                  // "python" or "deno"
         working_dir: Option<String>,
         notebook_id: Option<String>,      // restore hint for previous session
+        ephemeral: Option<bool>,
+        package_manager: Option<PackageManager>,
+        dependencies: Vec<String>,
     },
 }
 ```
@@ -424,6 +432,7 @@ The daemon's `route_connection()` validates the preamble first via `recv_preambl
 | `Blob` | Binary blob writes | Short-lived |
 | `OpenNotebook` | Returns `NotebookConnectionInfo`, then notebook sync | Long-lived |
 | `CreateNotebook` | Returns `NotebookConnectionInfo`, then notebook sync | Long-lived |
+| `RuntimeAgent` | RuntimeStateDoc sync plus runtime-agent RPC | Long-lived |
 
 ### Blob channel protocol
 


### PR DESCRIPTION
## Summary
- refresh protocol docs for current request/response and frame directionality
- update RuntimeStateDoc schema notes to typed lifecycle and current runtime fields
- align runtimed handshake docs with current handshake variants and CreateNotebook fields

## Verification
- cargo xtask lint --fix