### PR TITLE
refactor(runtimed): encapsulate notebook file binding

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2597,10 +2597,8 @@ impl Daemon {
         let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let notebook_path = room
             .file_binding
-            .path
-            .read()
+            .path()
             .await
-            .as_ref()
             .map(|p| p.to_string_lossy().to_string());
         let response = NotebookConnectionInfo {
             protocol: proto_str.to_string(),
@@ -3161,10 +3159,8 @@ impl Daemon {
 
                     let notebook_path = room
                         .file_binding
-                        .path
-                        .read()
+                        .path()
                         .await
-                        .as_ref()
                         .map(|p| p.to_string_lossy().to_string());
 
                     room_infos.push(crate::protocol::RoomInfo {
@@ -3181,10 +3177,7 @@ impl Daemon {
                         kernel_type,
                         env_source,
                         kernel_status,
-                        ephemeral: room
-                            .file_binding
-                            .is_ephemeral
-                            .load(std::sync::atomic::Ordering::Relaxed),
+                        ephemeral: room.file_binding.is_ephemeral(),
                         notebook_path,
                     });
                 }
@@ -3208,7 +3201,7 @@ impl Daemon {
                 };
                 // Clean up path_index if the room had a path.
                 if let Some(ref room) = maybe_room {
-                    let path = room.file_binding.path.read().await.clone();
+                    let path = room.file_binding.path().await;
                     if let Some(p) = path {
                         self.path_index.lock().await.remove(&p);
                     }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -464,10 +464,8 @@ where
     );
     let notebook_path = room
         .file_binding
-        .path
-        .read()
+        .path()
         .await
-        .as_ref()
         .map(|p| p.to_string_lossy().to_string());
     let context_id = super::notebook_execution_context_id(room, notebook_path.as_deref());
     let durable_records = durable_execution_records(execution_store, &context_id).await;
@@ -1109,7 +1107,7 @@ pub(crate) async fn apply_ipynb_changes(
         }
         map
     };
-    let notebook_path_for_assets = room.file_binding.path.read().await.clone();
+    let notebook_path_for_assets = room.file_binding.path().await;
     let converted_attachments: HashMap<String, AttachmentRefs> = {
         let mut map = HashMap::new();
         for cell in external_cells {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -617,13 +617,7 @@ pub(crate) fn compute_env_sync_diff(
 /// blob-store hashes, then updates the cell-local `resolved_assets` maps so
 /// isolated markdown rendering can rewrite those refs to blob URLs.
 pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
-    let notebook_path = room
-        .file_binding
-        .path
-        .read()
-        .await
-        .clone()
-        .filter(|p| p.exists());
+    let notebook_path = room.file_binding.path().await.filter(|p| p.exists());
     // Fork BEFORE async resolution so the fork's baseline predates
     // any concurrent edits. Asset updates on the fork are treated as
     // concurrent with user edits via Automerge's CRDT merge.

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -108,7 +108,7 @@ where
     // Auto-launch kernel if this is the first peer and notebook is trusted
     if peers == 1 {
         // Check if notebook_id is a UUID (new unsaved notebook) vs a file path
-        let path_snapshot = room.file_binding.path.read().await.clone();
+        let path_snapshot = room.file_binding.path().await;
         let is_new_notebook = path_snapshot.as_ref().is_none_or(|p| !p.exists())
             && uuid::Uuid::parse_str(&notebook_id).is_ok();
 

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -179,9 +179,9 @@ pub(super) async fn handle_peer_disconnect(
             }; // rooms lock dropped here
 
             // Clean up path_index entry (separate lock, after rooms lock is dropped).
-            // Use remove_by_uuid rather than reading room.file_binding.path — a concurrent writer
-            // A concurrent save-path-update could hold room.file_binding.path.write() and a
-            // try_read() would silently return None, leaking the path_index entry.
+            // Use remove_by_uuid rather than reading the room binding path; a
+            // concurrent save-path update can hold the binding write lock, and
+            // a try_read() would silently return None, leaking the path_index entry.
             if should_teardown {
                 if let Some(uuid) = evicted_uuid {
                     path_index_for_eviction.lock().await.remove_by_uuid(uuid);
@@ -235,17 +235,13 @@ pub(super) async fn handle_peer_disconnect(
                     }
                 }
 
-                // Stop file watcher if running. `watcher_shutdown_tx` is
-                // always present on `RoomPersistence`, but the Option inside
-                // is None until a watcher is actually spawned.
-                if let Some(shutdown_tx) = room_for_eviction
+                // Stop file watcher if running. `NotebookFileBinding` owns
+                // the lifecycle slot; it is empty until a watcher is spawned.
+                if room_for_eviction
                     .file_binding
-                    .watcher_shutdown_tx
-                    .lock()
+                    .shutdown_notebook_watcher()
                     .await
-                    .take()
                 {
-                    let _ = shutdown_tx.send(());
                     debug!(
                         "[notebook-sync] Stopped file watcher for {}",
                         notebook_id_for_eviction
@@ -256,15 +252,10 @@ pub(super) async fn handle_peer_disconnect(
                 // when `refresh_project_context` actually found a project
                 // file to watch; untitled / bare-dir notebooks leave it
                 // unset.
-                if let Some(shutdown_tx) = room_for_eviction
+                room_for_eviction
                     .file_binding
-                    .project_file_watcher_shutdown_tx
-                    .lock()
-                    .await
-                    .take()
-                {
-                    let _ = shutdown_tx.send(());
-                }
+                    .shutdown_project_file_watcher()
+                    .await;
 
                 // Flush launched_config deps → metadata.runt.{uv,conda}.dependencies
                 // before env cleanup and final save. This captures any packages
@@ -286,7 +277,7 @@ pub(super) async fn handle_peer_disconnect(
                 let mut flushed_runtime: Option<CapturedEnvRuntime> = None;
                 let mut save_succeeded = false;
                 if let Some(ref launched) = launched_snapshot {
-                    let has_saved_path = room_for_eviction.file_binding.path.read().await.is_some();
+                    let has_saved_path = room_for_eviction.file_binding.has_saved_path().await;
                     let env_source = room_for_eviction
                         .state
                         .read(|sd| sd.read_state().kernel.env_source.clone())
@@ -406,8 +397,7 @@ pub(super) async fn handle_peer_disconnect(
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        let has_saved_path =
-                            room_for_eviction.file_binding.path.read().await.is_some();
+                        let has_saved_path = room_for_eviction.file_binding.has_saved_path().await;
                         let metadata = {
                             let doc = room_for_eviction.doc.read().await;
                             doc.get_metadata_snapshot()

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -212,10 +212,8 @@ pub(super) async fn persist_terminal_execution_records(
 ) {
     let notebook_path = room
         .file_binding
-        .path
-        .read()
+        .path()
         .await
-        .as_ref()
         .map(|p| p.to_string_lossy().to_string());
     let context_id = notebook_execution_context_id(room, notebook_path.as_deref());
     let records = room

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -28,7 +28,7 @@ pub(crate) async fn save_notebook_to_disk(
         "[save] save_notebook_to_disk entered: target_path={:?}, room.id={}, room.file_binding.path={:?}",
         target_path,
         room.id,
-        room.file_binding.path.read().await.as_deref()
+        room.file_binding.path().await.as_deref()
     );
     // Determine the actual save path
     let notebook_path = match target_path {
@@ -51,7 +51,7 @@ pub(crate) async fn save_notebook_to_disk(
                 PathBuf::from(format!("{}.ipynb", p))
             }
         }
-        None => match room.file_binding.path.read().await.clone() {
+        None => match room.file_binding.path().await {
             Some(p) => p,
             None => {
                 return Err(SaveError::Unrecoverable(
@@ -225,7 +225,10 @@ pub(crate) async fn save_notebook_to_disk(
             );
             // Still update save baselines so the file watcher stays consistent.
             let is_primary_path = target_path.is_none()
-                || room.file_binding.path.read().await.as_deref() == Some(notebook_path.as_path());
+                || room
+                    .file_binding
+                    .path_matches(notebook_path.as_path())
+                    .await;
             if is_primary_path {
                 let mut saved = HashMap::with_capacity(cells.len());
                 for cell in &cells {
@@ -277,7 +280,10 @@ pub(crate) async fn save_notebook_to_disk(
     // to the primary path - saving to an alternate path (Save As) must not
     // corrupt the baseline for the file watcher.
     let is_primary_path = target_path.is_none()
-        || room.file_binding.path.read().await.as_deref() == Some(notebook_path.as_path());
+        || room
+            .file_binding
+            .path_matches(notebook_path.as_path())
+            .await;
     if is_primary_path {
         let mut saved = HashMap::with_capacity(cells.len());
         for cell in &cells {

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -81,26 +81,16 @@ pub(super) async fn refresh_project_context_async(room: &Arc<NotebookRoom>, path
 /// result (NotFound / Unreadable with missing file) leaves the slot
 /// empty; the next refresh trigger will re-evaluate.
 async fn rearm_project_file_watcher(room: &Arc<NotebookRoom>, detected_path: Option<PathBuf>) {
-    if let Some(tx) = room
-        .file_binding
-        .project_file_watcher_shutdown_tx
-        .lock()
-        .await
-        .take()
-    {
-        let _ = tx.send(());
-    }
+    room.file_binding.shutdown_project_file_watcher().await;
 
     let Some(watch_path) = detected_path else {
         return;
     };
 
     let (shutdown_tx, ready_rx) = spawn_project_file_watcher(watch_path, room.clone());
-    *room
-        .file_binding
-        .project_file_watcher_shutdown_tx
-        .lock()
-        .await = Some(shutdown_tx);
+    room.file_binding
+        .install_project_file_watcher_shutdown_tx(shutdown_tx)
+        .await;
     // Block until the watcher task has actually installed its
     // subscription (or failed trying). Without this, events that land
     // between "we returned from this function" and "notify attached
@@ -215,7 +205,7 @@ fn spawn_project_file_watcher(
                             // path: the notebook may have been moved such
                             // that a closer project file now wins, or the
                             // detected file may have been deleted.
-                            let notebook_path = room.file_binding.path.read().await.clone();
+                            let notebook_path = room.file_binding.path().await;
                             refresh_project_context_async(&room, notebook_path.as_deref()).await;
                         }
                         Err(e) => {

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -30,18 +30,24 @@ impl RoomIdentity {
 /// saved-as to a new path.
 pub struct NotebookFileBinding {
     /// The canonical `.ipynb` path, when this room is file-backed.
-    pub path: RwLock<Option<PathBuf>>,
+    path: RwLock<Option<PathBuf>>,
     /// Whether this notebook is ephemeral (in-memory only, no .ipynb on disk).
-    pub is_ephemeral: AtomicBool,
+    is_ephemeral: AtomicBool,
     /// Shutdown signal for the `.ipynb` file watcher task.
-    pub watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     /// Shutdown signal for the project-file watcher task.
     ///
     /// This watcher is derived from the bound notebook path and is rearmed when
     /// the binding moves to a new path.
-    pub project_file_watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    project_file_watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     /// Shutdown/flush request channel for the `.ipynb` autosave task.
-    pub autosave_shutdown_tx: Mutex<Option<mpsc::UnboundedSender<AutosaveShutdownRequest>>>,
+    autosave_shutdown_tx: Mutex<Option<mpsc::UnboundedSender<AutosaveShutdownRequest>>>,
+}
+
+pub struct NotebookFileBindingSaveSnapshot {
+    pub was_untitled: bool,
+    pub old_path: Option<PathBuf>,
+    pub is_ephemeral: bool,
 }
 
 impl NotebookFileBinding {
@@ -53,6 +59,54 @@ impl NotebookFileBinding {
             project_file_watcher_shutdown_tx: Mutex::new(None),
             autosave_shutdown_tx: Mutex::new(None),
         }
+    }
+
+    pub async fn path(&self) -> Option<PathBuf> {
+        self.path.read().await.clone()
+    }
+
+    pub async fn has_saved_path(&self) -> bool {
+        self.path.read().await.is_some()
+    }
+
+    pub fn is_ephemeral(&self) -> bool {
+        self.is_ephemeral.load(Ordering::Relaxed)
+    }
+
+    pub async fn path_matches(&self, path: &Path) -> bool {
+        self.path.read().await.as_deref() == Some(path)
+    }
+
+    pub async fn save_snapshot(&self) -> NotebookFileBindingSaveSnapshot {
+        let old_path = self.path.read().await.clone();
+        NotebookFileBindingSaveSnapshot {
+            was_untitled: old_path.is_none(),
+            old_path,
+            is_ephemeral: self.is_ephemeral(),
+        }
+    }
+
+    async fn set_bound_path(&self, canonical: PathBuf) {
+        *self.path.write().await = Some(canonical);
+    }
+
+    fn mark_file_backed(&self) {
+        self.is_ephemeral.store(false, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub async fn set_path_for_test(&self, path: Option<PathBuf>) {
+        *self.path.write().await = path;
+    }
+
+    #[cfg(test)]
+    pub async fn has_project_file_watcher_for_test(&self) -> bool {
+        self.project_file_watcher_shutdown_tx.lock().await.is_some()
+    }
+
+    #[cfg(test)]
+    pub async fn has_autosave_shutdown_tx_for_test(&self) -> bool {
+        self.autosave_shutdown_tx.lock().await.is_some()
     }
 
     pub async fn claim_path(
@@ -99,10 +153,8 @@ impl NotebookFileBinding {
     }
 
     pub async fn promote_after_save(room: &Arc<NotebookRoom>, canonical: PathBuf) {
-        *room.file_binding.path.write().await = Some(canonical.clone());
-        room.file_binding
-            .is_ephemeral
-            .store(false, Ordering::Relaxed);
+        room.file_binding.set_bound_path(canonical.clone()).await;
+        room.file_binding.mark_file_backed();
         Self::set_runtime_path(room, &canonical).await;
         room.file_binding
             .start_file_lifecycle(room, &canonical)
@@ -112,7 +164,7 @@ impl NotebookFileBinding {
     }
 
     pub async fn rebind_after_save_as(room: &Arc<NotebookRoom>, canonical: PathBuf) {
-        *room.file_binding.path.write().await = Some(canonical.clone());
+        room.file_binding.set_bound_path(canonical.clone()).await;
         Self::set_runtime_path(room, &canonical).await;
         room.file_binding
             .start_file_lifecycle(room, &canonical)
@@ -125,14 +177,48 @@ impl NotebookFileBinding {
         if canonical.extension().is_some_and(|ext| ext == "ipynb") {
             let shutdown_tx =
                 spawn_notebook_file_watcher(canonical.to_path_buf(), Arc::clone(room));
-            if let Some(previous_tx) = self.watcher_shutdown_tx.lock().await.replace(shutdown_tx) {
-                let _ = previous_tx.send(());
-            }
+            self.install_notebook_watcher_shutdown_tx(shutdown_tx).await;
         }
 
         let shutdown_tx =
             spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
         self.install_autosave_shutdown_tx(shutdown_tx).await;
+    }
+
+    pub async fn install_notebook_watcher_shutdown_tx(&self, shutdown_tx: oneshot::Sender<()>) {
+        let previous_tx = self.watcher_shutdown_tx.lock().await.replace(shutdown_tx);
+        if let Some(previous_tx) = previous_tx {
+            let _ = previous_tx.send(());
+        }
+    }
+
+    pub async fn shutdown_notebook_watcher(&self) -> bool {
+        let shutdown_tx = self.watcher_shutdown_tx.lock().await.take();
+        let Some(shutdown_tx) = shutdown_tx else {
+            return false;
+        };
+        let _ = shutdown_tx.send(());
+        true
+    }
+
+    pub async fn install_project_file_watcher_shutdown_tx(&self, shutdown_tx: oneshot::Sender<()>) {
+        let previous_tx = self
+            .project_file_watcher_shutdown_tx
+            .lock()
+            .await
+            .replace(shutdown_tx);
+        if let Some(previous_tx) = previous_tx {
+            let _ = previous_tx.send(());
+        }
+    }
+
+    pub async fn shutdown_project_file_watcher(&self) -> bool {
+        let shutdown_tx = self.project_file_watcher_shutdown_tx.lock().await.take();
+        let Some(shutdown_tx) = shutdown_tx else {
+            return false;
+        };
+        let _ = shutdown_tx.send(());
+        true
     }
 
     pub async fn install_autosave_shutdown_tx(

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -180,7 +180,7 @@ async fn untitled_room_has_path_none() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
     let room = NotebookRoom::new_fresh(Uuid::new_v4(), None, tmp.path(), blob_store, false);
-    assert!(room.file_binding.path.read().await.is_none());
+    assert!(room.file_binding.path().await.is_none());
 }
 
 #[tokio::test]
@@ -195,8 +195,10 @@ async fn file_backed_room_has_path_some() {
         blob_store,
         false,
     );
-    let guard = room.file_binding.path.read().await;
-    assert_eq!(guard.as_deref(), Some(fake_path.as_path()));
+    assert_eq!(
+        room.file_binding.path().await.as_deref(),
+        Some(fake_path.as_path())
+    );
 }
 
 #[tokio::test]
@@ -494,10 +496,7 @@ async fn test_ephemeral_room_skips_persistence() {
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, true);
 
     assert!(room.persistence.debouncer.is_none());
-    assert!(room
-        .file_binding
-        .is_ephemeral
-        .load(std::sync::atomic::Ordering::Relaxed));
+    assert!(room.file_binding.is_ephemeral());
 
     // No .automerge file should exist
     let filename = notebook_doc_filename(&notebook_uuid.to_string());
@@ -512,10 +511,7 @@ async fn test_session_room_persists() {
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, false);
 
     assert!(room.persistence.debouncer.is_some());
-    assert!(!room
-        .file_binding
-        .is_ephemeral
-        .load(std::sync::atomic::Ordering::Relaxed));
+    assert!(!room.file_binding.is_ephemeral());
 }
 
 #[tokio::test(start_paused = true)]
@@ -3049,13 +3045,15 @@ async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
         .await
         .insert(canonical.clone(), room.id)
         .unwrap();
-    *room.file_binding.path.write().await = Some(canonical.clone());
+    room.file_binding
+        .set_path_for_test(Some(canonical.clone()))
+        .await;
 
     // UUID key unchanged, path_index populated, room.file_binding.path set.
     assert!(rooms.lock().await.contains_key(&uuid));
     assert_eq!(path_index.lock().await.lookup(&canonical), Some(uuid));
     assert_eq!(
-        room.file_binding.path.read().await.as_deref(),
+        room.file_binding.path().await.as_deref(),
         Some(canonical.as_path())
     );
 }
@@ -3101,7 +3099,7 @@ async fn saving_to_already_open_path_returns_path_already_open_error() {
 
     // room.file_binding.path must NOT have been mutated on error.
     assert!(
-        room.file_binding.path.read().await.is_none(),
+        room.file_binding.path().await.is_none(),
         "room.file_binding.path should still be None after a failed claim"
     );
 }
@@ -3211,7 +3209,7 @@ async fn test_promote_untitled_starts_autosave() {
         "UUID key should still be present after promotion"
     );
     assert_eq!(
-        room.file_binding.path.read().await.as_deref(),
+        room.file_binding.path().await.as_deref(),
         Some(canonical.as_path()),
         "room.file_binding.path should be set after promotion"
     );
@@ -3221,7 +3219,7 @@ async fn test_promote_untitled_starts_autosave() {
         "path_index should contain the room's UUID"
     );
     assert!(
-        !room.file_binding.is_ephemeral.load(Ordering::Relaxed),
+        !room.file_binding.is_ephemeral(),
         "is_ephemeral should be cleared after promotion"
     );
 
@@ -6801,10 +6799,7 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
         .expect("clone room should be registered");
 
     // Ephemeral.
-    assert!(clone_room
-        .file_binding
-        .is_ephemeral
-        .load(std::sync::atomic::Ordering::Acquire));
+    assert!(clone_room.file_binding.is_ephemeral());
 
     // working_dir seeded on the room.
     assert_eq!(
@@ -7235,12 +7230,7 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
     assert_eq!(parsed.dependencies, vec!["pandas".to_string()]);
 
     // Sanity: watcher state is armed.
-    assert!(room
-        .file_binding
-        .project_file_watcher_shutdown_tx
-        .lock()
-        .await
-        .is_some());
+    assert!(room.file_binding.has_project_file_watcher_for_test().await);
 
     // External edit: add a dep. `refresh_project_context_async`
     // already awaited the watcher's ready signal before returning, so
@@ -7276,15 +7266,7 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
     );
 
     // Tear down the watcher so the temp dir can drop cleanly.
-    let shutdown = room
-        .file_binding
-        .project_file_watcher_shutdown_tx
-        .lock()
-        .await
-        .take();
-    if let Some(tx) = shutdown {
-        let _ = tx.send(());
-    }
+    room.file_binding.shutdown_project_file_watcher().await;
 }
 
 /// Kernel launch can fail before the kernel ever connects to the
@@ -7626,11 +7608,7 @@ async fn test_autosave_shutdown_flushes_pending_doc_change() {
         "shutdown final save should include the edit made inside the debounce window; got: {sources:?}"
     );
     assert!(
-        room.file_binding
-            .autosave_shutdown_tx
-            .lock()
-            .await
-            .is_none(),
+        !room.file_binding.has_autosave_shutdown_tx_for_test().await,
         "shutdown should consume the autosave lifecycle handle"
     );
 }
@@ -7690,7 +7668,9 @@ async fn test_save_as_rebind_replaces_file_lifecycle_and_runtime_path() {
     std::fs::write(&new_path, "{}").unwrap();
 
     let (old_watcher_tx, old_watcher_rx) = oneshot::channel::<()>();
-    *room.file_binding.watcher_shutdown_tx.lock().await = Some(old_watcher_tx);
+    room.file_binding
+        .install_notebook_watcher_shutdown_tx(old_watcher_tx)
+        .await;
 
     let (old_autosave_tx, mut old_autosave_rx) =
         mpsc::unbounded_channel::<AutosaveShutdownRequest>();
@@ -7714,7 +7694,7 @@ async fn test_save_as_rebind_replaces_file_lifecycle_and_runtime_path() {
     autosave_ack_task.await.unwrap();
 
     assert_eq!(
-        room.file_binding.path.read().await.as_deref(),
+        room.file_binding.path().await.as_deref(),
         Some(new_path.as_path())
     );
     let runtime_path = room
@@ -7727,9 +7707,7 @@ async fn test_save_as_rebind_replaces_file_lifecycle_and_runtime_path() {
         Some(expected_runtime_path.as_str())
     );
 
-    if let Some(shutdown_tx) = room.file_binding.watcher_shutdown_tx.lock().await.take() {
-        let _ = shutdown_tx.send(());
-    }
+    room.file_binding.shutdown_notebook_watcher().await;
     assert!(
         shutdown_autosave_debouncer(&room, &new_path.to_string_lossy(), Duration::from_secs(1))
             .await,
@@ -7767,7 +7745,9 @@ async fn test_autosave_shutdown_during_loading_returns_false_without_write() {
     let canonical = tokio::fs::canonicalize(&written)
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
-    *room.file_binding.path.write().await = Some(canonical.clone());
+    room.file_binding
+        .set_path_for_test(Some(canonical.clone()))
+        .await;
     let shutdown_tx =
         spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(&room));
     room.file_binding

--- a/crates/runtimed/src/requests/approve_project_environment.rs
+++ b/crates/runtimed/src/requests/approve_project_environment.rs
@@ -75,7 +75,7 @@ async fn resolve_project_file(
         return Ok(crate::project_file::DetectedProjectFile { path, kind });
     }
 
-    let notebook_path = room.file_binding.path.read().await.clone();
+    let notebook_path = room.file_binding.path().await;
     let working_dir = room.identity.working_dir.read().await.clone();
     let detection_path = notebook_path.as_ref().or(working_dir.as_ref());
     let Some(path) = detection_path else {

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -108,7 +108,8 @@ pub(crate) async fn handle_inner(
 /// if file-backed, or the explicit working_dir stored on the room for
 /// untitled rooms. None only if both are absent.
 async fn derive_working_dir(room: &NotebookRoom) -> Option<PathBuf> {
-    if let Some(path) = room.file_binding.path.read().await.as_ref() {
+    let notebook_path = room.file_binding.path().await;
+    if let Some(path) = notebook_path.as_ref() {
         if let Some(parent) = path.parent() {
             return Some(parent.to_path_buf());
         }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -51,10 +51,8 @@ pub(crate) async fn handle(
         Some(p) => Some(p),
         None => room
             .file_binding
-            .path
-            .read()
+            .path()
             .await
-            .as_ref()
             .map(|p| p.to_string_lossy().into_owned()),
     };
     // Check RuntimeStateDoc for launch serialization.

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -1,7 +1,6 @@
 //! `NotebookRequest::SaveNotebook` handler.
 
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use tracing::warn;
@@ -26,12 +25,9 @@ pub(crate) async fn handle(
         }
     }
 
-    // Capture was_untitled and old_path in a single critical section to
-    // avoid a TOCTOU race between the two reads.
-    let (was_untitled, old_path) = {
-        let p = room.file_binding.path.read().await;
-        (p.is_none(), p.clone())
-    };
+    let binding_snapshot = room.file_binding.save_snapshot().await;
+    let was_untitled = binding_snapshot.was_untitled;
+    let old_path = binding_snapshot.old_path;
 
     // For any save that writes to a NEW path (untitled promotion or
     // save-as rename), claim path_index BEFORE touching disk. Writing
@@ -41,7 +37,7 @@ pub(crate) async fn handle(
     //
     // Compute the pre-write canonical target. For untitled rooms a path
     // is required; for file-backed rooms we only need a pre-write claim
-    // if the caller specified a path different from room.file_binding.path.
+    // if the caller specified a path different from the current bound path.
     let target_for_claim: Option<PathBuf> = match (&path, was_untitled) {
         (Some(p), _) => match crate::paths::normalize_save_target(p) {
             Ok(normalized) => Some(canonical_target_path(&normalized).await),
@@ -87,9 +83,7 @@ pub(crate) async fn handle(
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
-            if room.file_binding.is_ephemeral.load(Ordering::Relaxed)
-                && room.persistence.debouncer.is_none()
-            {
+            if binding_snapshot.is_ephemeral && room.persistence.debouncer.is_none() {
                 let bytes = room.doc.write().await.save();
                 persist_notebook_bytes(&bytes, &room.identity.persist_path);
                 warn!(
@@ -139,7 +133,7 @@ pub(crate) async fn handle(
         let path_changed = old != &canonical;
         if path_changed {
             // Save-as rename: new path already claimed above; remove
-            // the old path_index entry and update room.file_binding.path.
+            // the old path_index entry and rebind the room to the new path.
             NotebookFileBinding::release_path(&daemon.path_index, old).await;
             NotebookFileBinding::rebind_after_save_as(room, canonical.clone()).await;
         }


### PR DESCRIPTION
## Summary
- make NotebookFileBinding internals private behind owned/snapshot accessors
- route watcher, project watcher, and autosave lifecycle operations through binding methods
- update save, load, launch, eviction, metadata, and tests to avoid direct lock reach-through

## Verification
- cargo xtask lint --fix
- cargo check -p runtimed
- cargo test -p runtimed --lib saving_to_already_open_path_returns_path_already_open_error
- cargo test -p runtimed --lib test_save_as_rebind_replaces_file_lifecycle_and_runtime_path
- cargo test -p runtimed --lib autosave
- cargo test -p runtimed --lib project_file_watcher_refreshes_context_on_external_edit
- git diff --check

## External Review
- Claude Bedrock Opus 4.6 review was clear before rebase; rerunning against the pushed PR diff.