### PR TITLE
fix(xtask): auto-wire brew LLVM clang for wasm builds

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -32,6 +32,30 @@ support `wasm32-unknown-unknown`, causing `zstd-sys` (and similar C deps) to
 fail. If you have `RUSTC_WRAPPER=sccache` in your shell profile, remove it or
 xtask will strip it automatically for `wasm-pack` invocations.
 
+## WASM Prerequisite on macOS
+
+`sift-wasm` links `zstd-sys` (via parquet's `zstd` feature — needed to read
+pandas/duckdb/spark output) and cross-compiles it to `wasm32-unknown-unknown`.
+Apple's Xcode clang has no wasm backend registered, so the default system
+toolchain fails with `'No available targets are compatible with triple
+"wasm32-unknown-unknown"'`. Install Homebrew LLVM once:
+
+```bash
+brew install llvm
+```
+
+`cargo xtask wasm` auto-detects `/opt/homebrew/opt/llvm/bin/clang` (or the
+Intel-brew path) and exports `CC_wasm32_unknown_unknown` for the wasm-pack
+subprocess. If your LLVM lives elsewhere, set it yourself:
+
+```bash
+export CC_wasm32_unknown_unknown=/path/to/clang
+export AR_wasm32_unknown_unknown=/path/to/llvm-ar
+```
+
+If no wasm-capable clang is found, xtask bails with this instruction block
+instead of dumping a 2000-line cc-rs error.
+
 ## Windows Target Checks From macOS
 
 Use [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin) when validating

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2483,6 +2483,7 @@ fn run_cmd(cmd: &str, args: &[&str]) {
     }
     if cmd == "wasm-pack" {
         strip_rustc_wrapper_for_wasm(&mut command);
+        ensure_wasm_c_toolchain(&mut command);
     }
 
     let status = command.status().unwrap_or_else(|e| {
@@ -2656,6 +2657,92 @@ fn strip_rustc_wrapper_for_wasm(command: &mut Command) {
         );
         command.env_remove("RUSTC_WRAPPER");
     }
+}
+
+/// Point `cc-rs` at a clang that knows about `wasm32-unknown-unknown`.
+///
+/// `zstd-sys` (pulled in by `parquet` with the `zstd` feature, which we need
+/// to read pandas/duckdb/spark parquet in `sift-wasm`) compiles C for
+/// `wasm32-unknown-unknown`. Apple's Xcode clang has no wasm backend —
+/// `clang --print-targets` lists only AArch64/ARM/x86 — so the build fails
+/// with `'No available targets are compatible with triple "wasm32-unknown-unknown"'`.
+/// Homebrew's `llvm` formula ships a clang that does have wasm32/wasm64
+/// registered; we detect it and point `cc-rs` at it via the per-target
+/// env vars it honors.
+///
+/// Order:
+///   1. If the user already set `CC_wasm32_unknown_unknown` (or the dashed
+///      variant), honor it and do nothing.
+///   2. Probe known brew prefixes then `clang` on PATH, picking the first
+///      whose `--print-targets` mentions `wasm32`.
+///   3. If nothing qualifies, bail with install instructions. We do NOT
+///      run `brew install` — that's the user's call.
+fn ensure_wasm_c_toolchain(command: &mut Command) {
+    if env::var_os("CC_wasm32_unknown_unknown").is_some()
+        || env::var_os("CC_wasm32-unknown-unknown").is_some()
+    {
+        return;
+    }
+
+    let candidates = [
+        "/opt/homebrew/opt/llvm/bin/clang",
+        "/usr/local/opt/llvm/bin/clang",
+        "clang",
+    ];
+
+    for candidate in candidates {
+        if !clang_supports_wasm32(candidate) {
+            continue;
+        }
+        command.env("CC_wasm32_unknown_unknown", candidate);
+        if let Some(ar) = sibling_llvm_ar(candidate) {
+            command.env("AR_wasm32_unknown_unknown", ar);
+        }
+        eprintln!(
+            "Note: using {candidate} as CC_wasm32_unknown_unknown \
+             (Xcode clang has no wasm backend)"
+        );
+        return;
+    }
+
+    eprintln!(
+        "Error: no clang with a wasm32 backend was found.\n\
+         \n\
+         zstd-sys (via parquet's `zstd` feature in sift-wasm) cross-compiles\n\
+         C to wasm32-unknown-unknown. Apple's Xcode clang does not register\n\
+         the wasm32 target, so the build fails with:\n\
+         \n\
+           'No available targets are compatible with triple \"wasm32-unknown-unknown\"'\n\
+         \n\
+         Fix (macOS): install Homebrew LLVM, which ships a clang with the\n\
+         wasm32 backend:\n\
+         \n\
+           brew install llvm\n\
+         \n\
+         Or, if LLVM is already installed elsewhere, point cc-rs at it:\n\
+         \n\
+           export CC_wasm32_unknown_unknown=/path/to/clang\n\
+           export AR_wasm32_unknown_unknown=/path/to/llvm-ar"
+    );
+    exit(1);
+}
+
+fn clang_supports_wasm32(clang: &str) -> bool {
+    let output = Command::new(clang)
+        .arg("--print-targets")
+        .stderr(Stdio::null())
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).contains("wasm32"),
+        _ => false,
+    }
+}
+
+fn sibling_llvm_ar(clang: &str) -> Option<PathBuf> {
+    let path = Path::new(clang);
+    let dir = path.parent()?;
+    let ar = dir.join("llvm-ar");
+    ar.exists().then_some(ar)
 }
 
 fn apply_rust_log_env(command: &mut Command) {


### PR DESCRIPTION
## Summary
- `cargo xtask wasm` on a fresh macOS devbox failed with a 2000-line cc-rs dump: `'No available targets are compatible with triple "wasm32-unknown-unknown"'`. Apple's Xcode clang has no wasm backend registered, and `zstd-sys` (pulled via parquet's `zstd` feature in `sift-wasm`, which we need to read pandas/duckdb/spark parquet) cross-compiles C to wasm32-unknown-unknown.
- Added `ensure_wasm_c_toolchain()` next to `strip_rustc_wrapper_for_wasm()` in `crates/xtask/src/main.rs`. Honors pre-set `CC_wasm32_unknown_unknown`, else probes `/opt/homebrew/opt/llvm/bin/clang` → `/usr/local/opt/llvm/bin/clang` → PATH `clang`, picking the first whose `--print-targets` lists `wasm32`, and exports `CC_wasm32_unknown_unknown` (+ sibling `AR_wasm32_unknown_unknown`) on the wasm-pack child. Bails with a `brew install llvm` hint if nothing qualifies. Does not run brew itself.
- Documented the prerequisite in `contributing/development.md` next to the existing sccache-clang note.

## Why we can't just drop the `zstd` parquet feature
The pipeline is `df → IPython → ipykernel (writes parquet) → runtime daemon → RuntimeStateDoc → frontend`. Inputs to `load_parquet` / `summarize_parquet` can be zstd-compressed by pandas/duckdb/spark, so the reader side has to keep the `zstd` feature. The writer in `sift-wasm` also emits `Compression::ZSTD(3)`.

## Test plan
- [x] `cargo build -p xtask` clean
- [x] `cargo xtask wasm sift --skip-renderer-plugins` succeeds from a fresh state — prints `Note: using /opt/homebrew/opt/llvm/bin/clang as CC_wasm32_unknown_unknown` and `zstd-sys` / `parquet` compile cleanly
- [ ] Someone without `brew install llvm` (or with `CC_wasm32_unknown_unknown` unset and LLVM missing from the two brew prefixes) sees the bail message instead of the cc-rs dump
- [ ] Pre-set `CC_wasm32_unknown_unknown=/custom/clang` is still respected (not clobbered by xtask)

🪶 Generated with Quill Agent