### PR TITLE
fix(ci): stabilize runtimed eviction test setup

### DIFF
--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1166,6 +1166,11 @@ async fn test_untitled_notebook_persists_through_eviction() {
         wait_for_session_ready(&client3, SESSION_READY_TIMEOUT).await,
         "reconnected client should reach session-ready state within 2s"
     );
+    assert!(
+        wait_for_cell_count(&client3, 2, SESSION_READY_TIMEOUT).await,
+        "reconnected client should receive persisted cells within {:?}",
+        SESSION_READY_TIMEOUT
+    );
 
     let cells = client3.get_cells();
     assert_eq!(

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -222,6 +222,10 @@ Other:
 /// worktree hash (no singleton conflicts), and runs pytest against it.
 /// The daemon is cleaned up when tests finish.
 fn cmd_integration(filter: Option<String>) {
+    // runtimed embeds gitignored renderer-plugin artifacts; make this xtask
+    // entry point self-healing in fresh Codex/worktree sessions.
+    ensure_build_artifacts();
+
     // 1. Build the daemon
     println!("Building runtimed for integration tests...");
     let status = Command::new("cargo")
@@ -2348,6 +2352,10 @@ fn cmd_lint(fix: bool) {
 fn cmd_clippy() {
     println!("Running clippy...");
     println!();
+
+    // Match the build/dev entry points: raw cargo will fail in runtimed's
+    // build.rs when gitignored renderer-plugin artifacts are absent.
+    ensure_build_artifacts();
 
     // Exclude runtimed-py to avoid the pyo3/maturin compile cost locally.
     // CI covers it in the runtimed-py-integration job.


### PR DESCRIPTION
## Summary

- wait for persisted cells to arrive before asserting untitled notebook eviction reload contents
- make local xtask integration/clippy paths build gitignored runtime artifacts before compiling runtimed

## Verification

- `cargo xtask wasm`
- `cargo fmt --check`
- `cargo check -p xtask`
- `cargo test -p runtimed --test integration test_untitled_notebook_persists_through_eviction -- --exact --nocapture`
- `cargo test -p runtimed --test integration test_eviction_flushes_before_reconnect -- --exact --nocapture`
- `cargo xtask lint --fix`

## Review

- Claude Bedrock review (`global.anthropic.claude-opus-4-6-v1`): clear, no actionable findings
- GitHub CI: all checks green
