### PR TITLE
docs(protocol): refresh protocol architecture docs

### DIFF
--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -5,189 +5,36 @@ paths:
 
 # Frontend Architecture
 
-## Directory Layout
+Canonical frontend architecture documentation lives in
+`contributing/frontend-architecture.md`. Keep this rule file short and use the
+contributing guide for directory layout, host abstraction details, data flow,
+and file maps.
 
-```
-/
-├── src/                          <- Shared components (path alias @/)
-│   ├── bindings/                 <- TypeScript types generated from Rust
-│   ├── components/
-│   │   ├── cell/                 <- Cell container, controls, execution count
-│   │   ├── editor/               <- CodeMirror wrappers, extensions, themes
-│   │   ├── isolated/             <- Iframe security isolation
-│   │   ├── outputs/              <- Output renderers (MediaRouter, AnsiOutput, etc.)
-│   │   ├── widgets/              <- ipywidgets and anywidget implementations
-│   │   └── ui/                   <- shadcn components (Button, Dialog, etc.)
-│   ├── hooks/                    <- Shared hooks (useSyncedSettings, useTheme)
-│   ├── isolated-renderer/        <- Code that runs INSIDE isolated iframe
-│   ├── lib/                      <- Shared utilities (utils.ts with cn())
-│   └── styles/                   <- Global stylesheets
-│
-├── apps/
-│   ├── notebook/src/             <- Notebook app (path alias ~/)
-│   │   ├── components/           <- App-specific components (toolbar, banners)
-│   │   ├── contexts/             <- React contexts (PresenceContext)
-│   │   ├── hooks/                <- Notebook-specific hooks
-│   │   ├── lib/                  <- App-specific utilities
-│   │   ├── wasm/                 <- WASM bindings (runtimed-wasm)
-│   │   ├── App.tsx               <- Root component
-│   │   └── types.ts              <- App types
-│   ├── notebook/feedback/         <- Feedback sub-app
-│   ├── notebook/onboarding/      <- Onboarding sub-app
-│   ├── notebook/settings/        <- Settings sub-app
-│   └── notebook/upgrade/         <- Upgrade sub-app
-```
+## Invariants
 
-## Path Aliases
+- React code uses `@nteract/notebook-host` for host-platform effects. Do not add
+  direct `@tauri-apps/*` imports outside the Tauri host implementation and
+  narrow relay glue.
+- `host.transport` is shared by `SyncEngine` and `NotebookClient`. Notebook
+  request/response traffic goes through typed protocol frames, not new
+  per-request Tauri commands.
+- `useAutomergeNotebook` is the single daemon-frame ingress for notebook state:
+  it passes frames to WASM `receive_frame()`, then dispatches materialization,
+  broadcasts, and presence through app-local stores/buses.
+- Cell editing mutates the WASM Automerge handle first for local responsiveness;
+  flush pending source sync before execute/save.
+- Persistent runtime state comes from RuntimeStateDoc projections. Broadcasts
+  are for ephemeral events only.
+- Preserve split cell-store behavior: update individual cells by id when
+  possible, and reserve full replacement for structural changes.
+- For notebook cell rendering, keep stable DOM order in `NotebookView.tsx` and
+  use CSS `order` for visual positioning so iframe outputs are not destroyed on
+  reorder.
 
-| Alias | Resolves To | Use For |
-|-------|-------------|---------|
-| `@/*` | `../../src/*` | Shared components, hooks, utilities |
-| `~/*` | `./src/*` | App-specific code |
+## When Editing
 
-## Shared vs App-Specific
-
-Put code in `src/` (shared) when:
-- It is a pure UI component with no Tauri/daemon dependencies
-- It could be reused by future apps
-- It is a generic utility (cn(), theme helpers)
-
-Put code in `apps/notebook/src/` when:
-- It uses the `NotebookHost` interface (see below)
-- It interacts with the daemon (kernel execution, notebook sync)
-- It is specific to the notebook editing experience
-
-## NotebookHost (the Tauri/Electron abstraction)
-
-The frontend goes through `@nteract/notebook-host` for every host-platform
-side effect. **Do not import `@tauri-apps/*` directly** — that's what the
-host abstraction exists to prevent. The only places that may import
-`@tauri-apps/*` are `packages/notebook-host/src/tauri/` and the daemon
-relay glue in `apps/notebook/src/lib/` (frame pipeline, Tauri transport).
-
-| Namespace | Role |
-|-----------|------|
-| `host.transport` | `NotebookTransport` shared by SyncEngine / NotebookClient |
-| `host.daemon` | `isConnected`, `reconnect`, `getInfo`, `getReadyInfo` (cached `daemon:ready` payload) |
-| `host.daemonEvents` | `onReady` / `onProgress` / `onDisconnected` / `onUnavailable` subscriptions (webview events) |
-| `host.relay` | `notifySyncReady()` outbound signal |
-| `host.blobs` | `port()` — daemon blob-server port |
-| `host.trust` | `verify()`, `approve()` |
-| `host.deps` | `checkTyposquats()` (deps-edit API will grow) |
-| `host.notebook` | `applyPathChanged` / `markClean` (legacy shadow, going away) |
-| `host.window` | `getTitle` / `setTitle` / `onFocusChange` |
-| `host.system` | `getGitInfo`, `getUsername` |
-| `host.dialog` | `openFile` / `saveFile` (plugin-dialog wrap) |
-| `host.externalLinks` | `open(url)` (plugin-shell wrap) |
-| `host.updater` | `check()` (plugin-updater wrap) |
-| `host.commands` | Typed command bus — menus + keyboard + (future) palette |
-| `host.log` | `debug/info/warn/error` (plugin-log wrap) |
-
-**React code** — use `const host = useNotebookHost();` from `@nteract/notebook-host`.
-
-**Module-level helpers** (can't call hooks) — use the setter pattern:
-- `setLoggerHost(host)` in `logger.ts`
-- `setBlobPortHost(host)` in `blob-port.ts`
-- `setOpenUrlHost(host)` in `open-url.ts`
-- `setMetadataTransport(host.transport)` in `notebook-metadata.ts`
-
-All setters are called once from `main.tsx` right after `createTauriHost()`.
-
-**Still-direct `invoke(...)` calls** live in `notebook-file-ops.ts`,
-`useUpdater.ts`, `useDaemonKernel.ts`, `useDependencies{,Conda,Pixi,Deno}.ts`,
-`useHistorySearch.ts`, `kernel-completion.ts`, `PoolErrorBanner.tsx`.
-These are the `*_via_daemon` thin wrappers + env-detection + save/clone
-helpers. They'll migrate to `transport.sendRequest(NotebookRequest)` /
-daemon-owned detection in subsequent PRs. See
-`.context/tauri-daemon-audit.md` for the full queue.
-
-**Canonical surface**: `packages/notebook-host/src/types.ts`.
-**Tauri implementation**: `packages/notebook-host/src/tauri/index.ts`.
-
-## Key Shared Components
-
-| Component | Location | Role |
-|-----------|----------|------|
-| `CellContainer` | `src/components/cell/` | Wrapper with selection, focus, drag handles |
-| `CellControls` | `src/components/cell/` | Play button, cell type indicator |
-| `OutputArea` | `src/components/cell/` | Cell output rendering (routes to isolated frames) |
-| `MediaRouter` | `src/components/outputs/` | Output type dispatch by MIME type |
-| `CodeMirror editor` | `src/components/editor/` | Main editor component |
-
-## Key App-Specific Hooks
-
-| Hook | Role |
-|------|------|
-| `useAutomergeNotebook` | Owns WASM NotebookHandle, `scheduleMaterialize`, `CellChangeset` dispatch |
-| `useDaemonKernel` | Kernel execution, status broadcasts, widget comm routing |
-| `usePresence` | Remote cursor/selection tracking via presence frames |
-| `useDependencies` | UV dependency management |
-| `useCondaDependencies` | Conda dependency management |
-| `usePixiDetection` | Pixi project detection (pixi.toml is the source of truth) |
-| `usePoolState` | Daemon pool state via PoolDoc sync |
-| `useCrdtBridge` | CodeMirror ↔ CRDT character-level sync |
-| `useManifestResolver` | Resolves blob hashes to output data |
-| `useCellKeyboardNavigation` | Arrow keys, enter/escape modes |
-| `useEditorRegistry` | CodeMirror editor instance registry |
-| `useGlobalFind` | Global find-and-replace across cells |
-| `useTrust` | Notebook trust verification state |
-
-## Data Flow
-
-The frontend has a single ingress point for daemon frames. All data flows through WASM demux before reaching React:
-
-1. Tauri relay sends `notebook:frame` events containing typed frame bytes.
-2. `useAutomergeNotebook` receives frames, passes to WASM `receive_frame()` for demux.
-3. WASM returns `FrameEvent[]` with sync results, broadcasts, and presence.
-4. Sync results include `CellChangeset` with field-level granularity.
-5. Broadcasts and presence are dispatched via in-memory frame bus (`notebook-frame-bus.ts`).
-
-## Incremental Sync Pipeline
-
-1. **useAutomergeNotebook** -- Single ingress. WASM `receive_frame()` returns `CellChangeset` with per-field flags. Broadcasts dispatched via `emitBroadcast()` / `emitPresence()`.
-
-2. **scheduleMaterialize** -- Coalesces within 32ms via `mergeChangesets()`:
-   - Structural changes (add/remove/reorder) -> full `cellSnapshotsToNotebookCells()` from `get_cells_json()`
-   - Output changes -> per-cell cache-aware resolution (cache hits use `materializeCellFromWasm()`, misses resolve async)
-   - Source/metadata/execution_count only -> per-cell `materializeCellFromWasm()` via O(1) WASM accessors
-
-3. **Split cell store** (`notebook-cells.ts`):
-   - `useCell(id)` -- re-renders only when that specific cell changes
-   - `useCellIds()` -- re-renders only on structural changes
-   - `updateCellById()` -- O(1) map update, notifies only that cell's subscribers
-   - `replaceNotebookCells()` -- full replacement with `cellsEqual()` diffing
-
-4. **Runtime state projection** -- `useDaemonKernel` consumes ephemeral broadcast events; persistent kernel/env/project state is projected from RuntimeStateDoc through runtime-state stores and hooks such as `useEnvProgress`
-
-5. **usePresence** -- Subscribes via `subscribePresence()` from frame bus. Maintains peer map.
-
-6. **cursor-registry.ts** -- Independent frame bus subscriber. Dispatches `setRemoteCursors()`/`setRemoteSelections()` as CodeMirror `StateEffect`s directly to `EditorView` instances, bypassing React.
-
-## Mutation Flow
-
-Cell mutations go through the WASM handle for instant response. Source edits are batched via `engine.scheduleFlush()` (20ms debounce), with `engine.flush()` before execute/save. Fast path for typing: `updateCellSource()` -> WASM `update_source()` -> `updateCellById()` (one cell, one subscriber) -> debounced sync.
-
-Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_via_daemon`, etc.). These are scheduled to migrate onto `host.transport.sendRequest(NotebookRequest)` in a follow-up; for now they still `invoke(...)` directly.
-
-## CellChangeset Types
-
-Defined in `notebook-doc/src/diff.rs`, with TypeScript types in `packages/runtimed/src/cell-changeset.ts` (re-exported via `apps/notebook/src/lib/cell-changeset.ts`):
-- `CellChangeset` -- `{ changed, added, removed, order_changed }`
-- `ChangedCell` -- `{ cell_id, fields }` where `fields` has boolean flags: `source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`
-- `mergeChangesets()` -- union semantics for the coalescing window
-
-## Key Files
-
-| File | Role |
-|------|------|
-| `apps/notebook/src/App.tsx` | Root component, provider setup |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle, scheduleMaterialize, CellChangeset |
-| `apps/notebook/src/lib/materialize-cells.ts` | WASM -> React conversion |
-| `apps/notebook/src/lib/notebook-cells.ts` | Split cell store, per-cell subscriptions |
-| `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcasts and presence |
-| `packages/runtimed/src/transport.ts` | Shared `FrameType` constants and transport interface |
-| `apps/notebook/src/lib/frame-pipeline.ts` | App-side frame event processing and materialization planning |
-| `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, broadcast handling |
-| `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
-| `src/components/outputs/media-router.tsx` | Output type dispatch |
-| `src/components/editor/codemirror-editor.tsx` | Main editor |
+- Read `contributing/frontend-architecture.md` before changing notebook app
+  data flow, host boundaries, sync/materialization, runtime-state projection, or
+  cell rendering.
+- Read `contributing/protocol.md` for transport, frame, and request/response
+  changes.

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -24,7 +24,8 @@ and file maps.
 - Cell editing mutates the WASM Automerge handle first for local responsiveness;
   flush pending source sync before execute/save.
 - Persistent runtime state comes from RuntimeStateDoc projections. Broadcasts
-  are for ephemeral events only.
+  are for ephemeral events only. Frontend writes to RuntimeStateDoc should stay
+  limited to the approved widget comm-state path.
 - Preserve split cell-store behavior: update individual cells by id when
   possible, and reserve full replacement for structural changes.
 - For notebook cell rendering, keep stable DOM order in `NotebookView.tsx` and

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -3,6 +3,9 @@ paths:
   - crates/notebook-wire/**
   - crates/notebook-protocol/**
   - crates/notebook-sync/**
+  - crates/runtime-doc/**
+  - crates/runtimed/src/notebook_sync_server/**
+  - crates/runtimed/src/requests/**
   - packages/runtimed/src/transport.ts
   - packages/runtimed/src/protocol-contract.ts
   - packages/runtimed/src/request-types.ts
@@ -12,190 +15,44 @@ paths:
 
 # Wire Protocol
 
-## Compatibility
+Canonical protocol documentation lives in `contributing/protocol.md`. Keep this
+rule file short: it is loaded often, and the contributing guide is the source of
+truth for frame bytes, handshakes, request/response shapes, RuntimeStateDoc, and
+frontend transport flow.
 
-Two independent version numbers, separate from the artifact version:
+## Invariants
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection/handshake.rs`, re-exported by `connection.rs`, currently `4`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v4 removes legacy environment-sync request/response variants and requires current clients.
-- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) -- governs Automerge document compatibility. Bump when document structure changes.
+- `notebook-wire` owns frame bytes, preamble constants, frame caps, typed-frame
+  enum values, and session-control status shapes.
+- `notebook-protocol` owns handshakes and JSON wire types:
+  `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, and the
+  runtime-agent request/response envelopes.
+- `notebook-doc` owns the NotebookDoc Automerge schema. Bump
+  `SCHEMA_VERSION` only with a migration plan that preserves real user data.
+- `runtime-doc` owns daemon-authored runtime state. The daemon/runtime agent are
+  the only writers; frontend and Python peers consume it as read-only sync.
+- Protocol version and NotebookDoc schema version are independent integers.
+  Bump `PROTOCOL_VERSION` for breaking framing, handshake, or serialization
+  changes; bump `SCHEMA_VERSION` for document schema changes.
+- Every connection starts with the 5-byte magic/version preamble. `Pool` remains
+  version-tolerant for daemon upgrade probes; notebook/runtime channels require
+  `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
+- Request/response frames use `NotebookRequestEnvelope` and
+  `NotebookResponseEnvelope`; overlapping requests must route responses by id.
+- Runtime state, outputs, queue, kernel lifecycle, trust, env drift, env
+  progress snapshots, path, save state, and widget state belong in
+  `RuntimeStateDoc`, not room-wide state broadcasts. Broadcasts are for
+  ephemeral comm messages and high-frequency env progress events.
+- Steady-state frame readers must keep draining. Register waiters/pending
+  requests instead of blocking inside command paths.
+- The runtimed socket is same-UID trusted, not app-private. New handshake
+  variants must account for any same-user process holding the socket path.
 
-These are just incrementing integers that evolve independently from each other and from the artifact version.
+## When Editing
 
-## Connection Preamble
-
-Every connection starts with 5 bytes before the JSON handshake:
-
-| Bytes | Content |
-|-------|---------|
-| 0-3 | Magic: `0xC0 0xDE 0x01 0xAC` |
-| 4 | Protocol version (currently `4`) |
-
-There is no no-preamble fallback. The daemon validates magic bytes before reading the handshake. Protocol version is checked after parsing the handshake channel: the Pool channel accepts any version so older stable apps can ping during upgrade and read `protocol_version` / `daemon_version` from `Pong`; all other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
-
-## Connection Lifecycle
-
-1. **Opening** -- Frontend invokes Tauri command; relay connects to daemon Unix socket and sends handshake.
-2. **Handshake** -- JSON with `channel`, `notebook_id`, `protocol`. Daemon responds with `NotebookConnectionInfo` (protocol, notebook_id, cell_count, needs_trust_approval). The `Handshake` enum uses `#[serde(tag = "channel")]` -- flat wire format with `"channel"` discriminator.
-3. **Initial sync** -- Both sides exchange Automerge sync messages until convergence. Frontend starts empty; all state comes from daemon. v4 clients receive `SessionControl::SyncStatus` frames for notebook-doc, runtime-state, and initial-load readiness.
-4. **Steady state** -- Concurrent Automerge sync, request/response, RuntimeStateDoc sync, PoolDoc sync, presence, broadcasts, and session-control frames. The frame consumer must stay hot: request and confirmation waits belong in pending maps/waiter lists, not blocking `recv()` loops.
-5. **Disconnection** -- Relay emits `daemon:disconnected`. Generation counter prevents stale callbacks.
-
-## Wire Format
-
-Length-prefixed frames: 4-byte big-endian u32 length + N bytes payload. Max: 100 MiB data frames, 64 KiB control/handshake.
-
-### Typed Frames
-
-After handshake, frames are typed by first byte:
-
-| Type byte | Name | Payload format |
-|-----------|------|----------------|
-| `0x00` | AutomergeSync | Binary (raw Automerge sync message) |
-| `0x01` | NotebookRequest | JSON |
-| `0x02` | NotebookResponse | JSON |
-| `0x03` | NotebookBroadcast | JSON |
-| `0x04` | Presence | Binary (CBOR) |
-| `0x05` | RuntimeStateSync | Binary (raw Automerge sync for RuntimeStateDoc) |
-| `0x06` | PoolStateSync | Binary (raw Automerge sync for PoolDoc — global daemon pool state) |
-| `0x07` | SessionControl | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
-
-Frontend/relay outbound frames are `0x00` (AutomergeSync), `0x01` (NotebookRequest), `0x04` (Presence), `0x05` (RuntimeStateSync), and `0x06` (PoolStateSync). `0x02` responses, `0x03` broadcasts, and `0x07` session-control frames are daemon-originated.
-
-Notebook request and response frames use `NotebookRequestEnvelope` and `NotebookResponseEnvelope`. Every overlapping request must carry an `id`, and responses must route by id rather than by receive order.
-
-## Key Request Types
-
-| Request | Purpose |
-|---------|---------|
-| `LaunchKernel` | Start a kernel with environment config |
-| `ExecuteCell { cell_id }` | Queue cell for execution (daemon reads source from synced doc) |
-| `ClearOutputs { cell_id }` | Clear a cell's outputs |
-| `InterruptExecution` | Send SIGINT to running kernel |
-| `ShutdownKernel` | Stop the kernel process |
-| `RunAllCells` | Execute all code cells in order |
-| `SaveNotebook { format_cells, path? }` | Persist Automerge doc to `.ipynb`, optionally save-as to `path` |
-| `SyncEnvironment` | Hot-install packages into running kernel |
-| `ApproveTrust` / `ApproveProjectEnvironment` | Record user approval for dependency or project-file environments |
-| `CloneAsEphemeral { source_notebook_id }` | Fork an existing loaded notebook into a new in-memory room |
-| `GetDocBytes` | Fetch canonical Automerge bytes to bootstrap a WASM peer |
-| `SendComm { message }` | Send comm message to kernel (widget interactions) |
-| `Complete { code, cursor_pos }` | Code completions from kernel |
-| `GetHistory { pattern, n, unique }` | Search kernel input history |
-
-## Key Response Types
-
-| Response | Meaning |
-|----------|---------|
-| `KernelLaunched { env_source }` | Kernel started, includes environment origin label |
-| `CellQueued` | Cell added to execution queue |
-| `NotebookSaved { path }` | File written to disk |
-| `HistoryResult { entries }` | Kernel input history search results |
-| `CompletionResult { items, cursor_start, cursor_end }` | Code completion results |
-| `Error { error }` | Something went wrong |
-
-## Key Broadcast Types
-
-After progressively migrating room state to `RuntimeStateDoc`, broadcasts are now narrow: kernel comm messages and env-install progress. Kernel state, execution lifecycle, queue, outputs, the notebook's `path`, and `last_saved` timestamp all live in `RuntimeStateDoc` (frame `0x05`).
-
-| Broadcast | Purpose |
-|-----------|---------|
-| `Comm { msg_type, content, buffers }` | Jupyter comm message (widget). Custom one-shot events; widget *state* syncs via RuntimeStateDoc. |
-| `EnvProgress { env_type, phase }` | Environment install/solve/download progress (high-frequency stream). |
-
-## SessionControl
-
-`SessionControl` frames (`0x07`) are connection-local daemon messages, not room
-broadcasts. Today they carry `SessionControlMessage::SyncStatus`, a full
-readiness snapshot with:
-
-- `notebook_doc`: `pending | syncing | interactive`
-- `runtime_state`: `pending | syncing | ready`
-- `initial_load`: `not_needed | streaming | ready | failed`
-
-The daemon emits the full current state on transitions.
-
-## Tauri Event Bridge
-
-| Event | Direction | Payload | Purpose |
-|-------|-----------|---------|---------|
-| `notebook:frame` | Relay -> Frontend | `number[]` (typed frame bytes) | All daemon frames via unified pipe |
-| `daemon:ready` | Relay -> Frontend | `DaemonReadyPayload` | Connection established |
-| `daemon:disconnected` | Relay -> Frontend | -- | Connection lost |
-
-Outgoing: `sendFrame(frameType, payload)` where `payload` is `Uint8Array` passed as raw binary via `tauri::ipc::Request`.
-
-## In-Memory Frame Bus
-
-After WASM `receive_frame()` demuxes frames, broadcasts and presence are dispatched via `notebook-frame-bus.ts` (synchronous, in-process, no serialization):
-
-| Function | Purpose |
-|----------|---------|
-| `emitBroadcast(payload)` | Called after WASM demux for type `0x03` frames |
-| `subscribeBroadcast(cb)` | Used by `useDaemonKernel` for ephemeral runtime events; persistent env state is RuntimeStateDoc-backed |
-| `emitPresence(payload)` | Called after WASM CBOR decode for type `0x04` frames |
-| `subscribePresence(cb)` | Used by `usePresence`, `cursor-registry` |
-
-## Output Storage
-
-Inline manifest system with blob offload for large payloads. When daemon receives kernel output:
-1. Convert to nbformat JSON, create output manifest as an **inline Automerge Map** in RuntimeStateDoc (`output_store.rs`)
-2. Each MIME type → `ContentRef`: `Inline` for ≤ 1KB, `Blob { hash, size }` for > 1KB
-3. Large content stored in blob store (SHA-256 hashes, `~/.cache/runt/blobs/`)
-4. MIME types and small payloads are readable directly from the CRDT without any blob fetch
-5. Clients resolve large blobs from daemon's HTTP blob server (`GET /blob/{hash}`)
-
-## RuntimeStateDoc (Shipped)
-
-State-carrying broadcasts (kernel status, queue, env sync, trust) have been replaced by a **daemon-authoritative, per-notebook Automerge document** synced via frame type `0x05`. Clients read via `useRuntimeState()`.
-
-Schema (in `crates/runtime-doc/src/doc.rs`):
-
-| Path | Type | Description |
-|------|------|-------------|
-| `kernel.lifecycle` | Str | Typed lifecycle: `"NotStarted"`, `"AwaitingTrust"`, `"AwaitingEnvBuild"`, `"Resolving"`, `"PreparingEnv"`, `"Launching"`, `"Connecting"`, `"Running"`, `"Error"`, `"Shutdown"` |
-| `kernel.activity` | Str | `""`, `"Unknown"`, `"Idle"`, `"Busy"`; meaningful when lifecycle is `Running` |
-| `kernel.error_reason`, `kernel.error_details` | Str | Typed and free-form error context when lifecycle is `Error` |
-| `kernel.runtime_agent_id` | Str | Runtime agent subprocess currently owning the kernel |
-| `kernel.name`, `kernel.language`, `kernel.env_source` | Str | Kernel metadata |
-| `queue.executing` | Str\|null | Cell ID currently executing |
-| `queue.executing_execution_id` | Str\|null | Execution ID for the executing cell |
-| `queue.queued` | List[Str] | Queued cell IDs |
-| `queue.queued_execution_ids` | List[Str] | Parallel execution IDs for queued entries |
-| `executions.{execution_id}` | Map | `{ cell_id, status, execution_count, success, outputs[], source?, seq }`; `outputs[]` are inline output manifests with blob refs |
-| `env.in_sync`, `env.added`, `env.removed`, `env.channels_changed`, `env.deno_changed` | bool/List | Environment drift state |
-| `env.prewarmed_packages`, `env.progress` | List/Map | Current prewarmed package snapshot and latest env progress |
-| `trust.status`, `trust.needs_approval` | Str/bool | Trust state |
-| `project_context` | Map | Daemon-observed project-file detection and parsed dependency context |
-| `display_index` | Map | `display_id` -> ordered `"execution_id\0output_id"` entries |
-| `comms` | Map | Widget state keyed by `comm_id` |
-| `last_saved` | Str\|null | ISO timestamp of last save |
-
-`kernel.status` and `kernel.starting_phase` remain source-compatible Rust `KernelState` projection fields computed at read time from `kernel.lifecycle`. They are not separate persisted CRDT fields in the typed schema, and new code should read `kernel.lifecycle` and `kernel.activity`. The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
-
-### Execution ID Tracking
-
-Each cell execution is assigned a unique `execution_id` (UUID). The `QueueEntry` struct pairs `cell_id` with `execution_id`, enabling:
-- Multiple executions of the same cell to be tracked independently
-- Python `Execution` handle to poll for lifecycle state
-- Frontend to display per-execution progress
-
-## Architectural Direction
-
-**Comms in doc (#761)** -- Done. Widget state lives in `doc.comms/` in RuntimeStateDoc. `CommSync` broadcast has been removed. New clients receive widget state via normal CRDT sync.
-
-## Key Source Files
-
-| File | Role |
-|------|------|
-| `crates/notebook-wire/src/lib.rs` | Frame bytes, preamble constants, frame caps, typed-frame enum, session-control status shapes |
-| `crates/notebook-protocol/src/connection.rs` | Public connection API facade and compatibility re-exports |
-| `crates/notebook-protocol/src/connection/framing.rs` | Frame protocol I/O, preamble validation, typed frames, frame caps |
-| `crates/notebook-protocol/src/connection/handshake.rs` | Protocol version, handshake, capabilities, connection info |
-| `crates/notebook-protocol/src/protocol.rs` | Wire types: requests, responses, broadcasts |
-| `crates/notebook-sync/src/relay.rs` | Relay handle for sync connections |
-| `crates/notebook-sync/src/connect.rs` | Connection setup |
-| `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync, per-cell accessors |
-| `crates/runtime-doc/src/doc.rs` | `RuntimeStateDoc` schema |
-| `packages/runtimed/src/transport.ts` | TypeScript `FrameType` constants and transport boundary |
-| `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub |
-| `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + hook |
+- Update Rust protocol types and generated `packages/runtimed` TypeScript
+  surfaces in the same patch.
+- Run `cargo test -p notebook-protocol` for protocol-surface changes. Add the
+  focused package tests when TypeScript transport or generated contracts move.
+- Read `contributing/protocol.md` before making changes that affect sync,
+  RuntimeStateDoc, frame handling, request routing, or socket authority.

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - crates/notebook-wire/**
+  - crates/notebook-doc/**
   - crates/notebook-protocol/**
   - crates/notebook-sync/**
   - crates/runtime-doc/**
@@ -29,8 +30,10 @@ frontend transport flow.
   runtime-agent request/response envelopes.
 - `notebook-doc` owns the NotebookDoc Automerge schema. Bump
   `SCHEMA_VERSION` only with a migration plan that preserves real user data.
-- `runtime-doc` owns daemon-authored runtime state. The daemon/runtime agent are
-  the only writers; frontend and Python peers consume it as read-only sync.
+- `runtime-doc` owns runtime-state schema. Kernel lifecycle, queue, outputs,
+  env, trust, project, path, and save state are daemon/runtime-agent authored;
+  widget comm state under `comms/` has an intentional frontend write path via
+  the approved comm CRDT writer.
 - Protocol version and NotebookDoc schema version are independent integers.
   Bump `PROTOCOL_VERSION` for breaking framing, handshake, or serialization
   changes; bump `SCHEMA_VERSION` for document schema changes.

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -99,11 +99,17 @@ next. The abstraction lives in `packages/notebook-host/src/`.
 - `setOpenUrlHost(host)` — `open-url.ts`
 - `setMetadataTransport(host.transport)` — `notebook-metadata.ts`
 
-**Not yet migrated** — a pile of `invoke(...)` calls for kernel / save /
-clone / dependency-detection. Those are slated to swap onto
-`host.transport.sendRequest(NotebookRequest)` (direct protocol dispatch)
-and daemon-owned file detection in subsequent PRs. See
-`.context/tauri-daemon-audit.md` for the full audit + migration queue.
+Notebook request/response traffic is sent through `NotebookClient` on
+`host.transport`, which encodes `NotebookRequestEnvelope` values and delivers
+them as typed protocol frames (`0x01`) through the relay. The corresponding
+responses return as `0x02` frames on the unified `notebook:frame` event and are
+resolved by request id.
+
+Some direct `invoke(...)` calls remain for host-side work that is not a notebook
+request/response frame: save/open dialogs, app update flows, dependency
+validation helpers, daemon reconnect/status commands, and other narrow platform
+effects. Prefer extending `NotebookRequest` for daemon-owned notebook behavior,
+and prefer adding host methods for platform behavior.
 
 **Canonical surface**: `packages/notebook-host/src/types.ts`.
 **Tauri implementation**: `packages/notebook-host/src/tauri/index.ts`.
@@ -247,7 +253,10 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 
 Cell mutations (add, delete, edit) go through the WASM handle for instant response. Source edits are batched via `engine.scheduleFlush()` (20ms debounce), with `engine.flush()` before execute/save. The fast path for typing: `updateCellSource()` → WASM `update_source()` → `updateCellById()` (one cell, one subscriber) → debounced sync to daemon.
 
-Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_via_daemon`, etc.). These are slated to migrate onto `host.transport.sendRequest(NotebookRequest)` in a follow-up — for now they still `invoke(...)` directly.
+Execution requests go through `NotebookClient` on `host.transport`, which sends
+`NotebookRequest` frames over the existing notebook relay. The daemon reads cell
+source from the synced Automerge document, so callers must flush pending source
+sync before execute/save.
 
 ### CellChangeset types
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -400,19 +400,46 @@ Stream outputs (stdout/stderr) are special: text is fed through a terminal emula
 
 **Multi-window:** Multiple windows join the same room as separate Automerge peers. Each gets sync frames and broadcasts independently. The daemon tracks `active_peers` per room for eviction.
 
-## Architectural Direction
+## Runtime State
 
-### RuntimeStateDoc (PR #977)
+### RuntimeStateDoc
 
-Several broadcast variants carry **state** (kernel status, env sync diff, queue) rather than **events**. State-carrying broadcasts suffer from silent drops, no initial state for late joiners, and ordering races between windows. The `RuntimeStateDoc` replaces these with a daemon-authoritative, per-notebook Automerge document synced via frame type `0x05` on the existing notebook connection.
+State-carrying broadcasts (kernel status, env sync diff, queue) have been
+replaced because they suffer from silent drops, no initial state for late
+joiners, and ordering races between windows. `RuntimeStateDoc` is the
+daemon-authoritative, per-notebook Automerge document synced via frame type
+`0x05` on the existing notebook connection.
 
 The daemon writes kernel status, execution queue, environment progress, project context, and trust state. Clients receive updates via normal Automerge sync — read-only enforced by stripping client changes. The frontend reads via `useRuntimeState()` and the project runtime stores.
 
 **Key files:** `crates/runtime-doc/src/doc.rs` (schema + setters), `crates/runtime-doc/src/handle.rs` (handle), `apps/notebook/src/lib/runtime-state.ts` (frontend store + hook).
 
-### Comms in doc (#761) — Done
+### Widget comm state
 
 Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes comm entries from kernel IOPub, and new clients receive widget state via normal CRDT sync. `CommSync` broadcast has been removed. The `Comm` broadcast variant is limited to custom messages (ephemeral events like button clicks). Frontend-originated widget state updates write to the CRDT, and the runtime agent diffs comm state on each sync to forward deltas to the kernel.
+
+## Runtime Agent Subprotocol
+
+Runtime agents are same-socket peers that connect with
+`Handshake::RuntimeAgent`. They use the shared framing layer but carry a
+different JSON subprotocol on request/response frame types:
+
+| Frame | Runtime-agent payload |
+|-------|-----------------------|
+| `0x00` | NotebookDoc Automerge sync |
+| `0x01` | `RuntimeAgentRequestEnvelope` |
+| `0x02` | `RuntimeAgentResponseEnvelope` |
+| `0x05` | RuntimeStateDoc Automerge sync |
+
+Coordinator-to-agent RPC covers kernel lifecycle and query-style operations
+such as launch, restart, shutdown, completion, history, comm sends, interrupts,
+and hot environment sync. Cell execution itself is CRDT-driven: the coordinator
+writes execution entries into RuntimeStateDoc, and the runtime agent discovers
+and executes queued entries through RuntimeStateDoc sync.
+
+Because the daemon socket is a same-UID trusted API, the runtime-agent handshake
+must be treated as a powerful attach operation. Do not add runtime-agent
+authority under the assumption that only the desktop app can reach the socket.
 
 ## Key Source Files
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -410,7 +410,13 @@ joiners, and ordering races between windows. `RuntimeStateDoc` is the
 daemon-authoritative, per-notebook Automerge document synced via frame type
 `0x05` on the existing notebook connection.
 
-The daemon writes kernel status, execution queue, environment progress, project context, and trust state. Clients receive updates via normal Automerge sync — read-only enforced by stripping client changes. The frontend reads via `useRuntimeState()` and the project runtime stores.
+The daemon writes kernel status, execution queue, environment progress, project
+context, trust state, path/save state, and outputs. Clients receive those fields
+via normal Automerge sync, with unexpected client changes stripped. Widget comm
+state is the intentional exception: frontend-originated widget state updates
+write under `doc.comms/` through the approved comm CRDT writer, and the runtime
+agent forwards those deltas to the kernel. The frontend reads runtime state via
+`useRuntimeState()` and the project runtime stores.
 
 **Key files:** `crates/runtime-doc/src/doc.rs` (schema + setters), `crates/runtime-doc/src/handle.rs` (handle), `apps/notebook/src/lib/runtime-state.ts` (frontend store + hook).
 


### PR DESCRIPTION
## Summary

- Slim the auto-loaded Claude protocol/frontend rule docs down to invariants and links to canonical contributing guides.
- Update frontend architecture docs to reflect current `NotebookClient` / typed-frame request flow.
- Refresh protocol docs around RuntimeStateDoc and runtime-agent subprotocol authority.

## Verification

- `cargo xtask lint --fix`
- Claude Bedrock Opus 4.6 review rerun: clear
- GitHub CI: passed

## Review

- Ready for review.
