### PR TITLE
fix(mcp): add timeouts to prevent MCP proxy deadlocks under concurrent load

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -30,6 +30,7 @@
 //! ```
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use automerge::{AutoCommit, ReadDoc, Value};
 use log::debug;
@@ -101,6 +102,13 @@ impl std::fmt::Debug for DocHandle {
 }
 
 impl DocHandle {
+    /// Default timeout for status-based waits (`await_session_ready`,
+    /// `await_notebook_interactive`, etc.). Prevents indefinite hangs when
+    /// the daemon is overloaded or the session never reaches the expected
+    /// state. 120 s is well above normal session setup time (~2-10 s) but
+    /// short enough to prevent permanent deadlocks under concurrent load.
+    const DEFAULT_STATUS_TIMEOUT: Duration = Duration::from_secs(120);
+
     /// Create a new `DocHandle` from shared state and channels.
     ///
     /// This is called by the connection/split logic, not by end users.
@@ -650,16 +658,34 @@ impl DocHandle {
     where
         F: Fn(&SyncStatus) -> bool,
     {
-        let mut rx = self.status_rx.clone();
-        loop {
-            let status = rx.borrow().clone();
-            if predicate(&status) {
-                return Ok(());
+        self.wait_for_status_timeout(predicate, Self::DEFAULT_STATUS_TIMEOUT)
+            .await
+    }
+
+    async fn wait_for_status_timeout<F>(
+        &self,
+        predicate: F,
+        timeout: Duration,
+    ) -> Result<(), SyncError>
+    where
+        F: Fn(&SyncStatus) -> bool,
+    {
+        let fut = async {
+            let mut rx = self.status_rx.clone();
+            loop {
+                let status = rx.borrow().clone();
+                if predicate(&status) {
+                    return Ok(());
+                }
+                if let Some(err) = Self::readiness_error(&status) {
+                    return Err(err);
+                }
+                rx.changed().await.map_err(|_| SyncError::Disconnected)?;
             }
-            if let Some(err) = Self::readiness_error(&status) {
-                return Err(err);
-            }
-            rx.changed().await.map_err(|_| SyncError::Disconnected)?;
+        };
+        match tokio::time::timeout(timeout, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(SyncError::Timeout),
         }
     }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -113,6 +113,15 @@ pub struct McpProxy {
 }
 
 impl McpProxy {
+    /// Outer timeout for tool calls forwarded to the child process.
+    ///
+    /// Set above the child's inner maximum (300 s for LaunchKernel /
+    /// SyncEnvironment) so inner timeouts fire first under normal operation.
+    /// This is a safety net for cases where the child's tool handler blocks
+    /// before reaching the request layer (e.g. `await_session_ready` when
+    /// the daemon is overloaded).
+    const TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(360);
+
     /// Create a new proxy. Does not spawn the child yet — call `init_child()`
     /// or use the background init pattern.
     pub fn new(config: ProxyConfig, tool_list_changed_tx: Option<mpsc::Sender<()>>) -> Self {
@@ -667,10 +676,37 @@ impl McpProxy {
             .as_ref()
             .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
 
-        client
-            .call_tool(params.clone())
-            .await
-            .map_err(|e| McpError::internal_error(format!("Child tool call failed: {e}"), None))
+        // Defense-in-depth timeout. The child's inner request layer has its
+        // own per-request-type timeouts (up to 300s for LaunchKernel /
+        // SyncEnvironment), but if the child's tool handler blocks before
+        // reaching the request layer (e.g. await_session_ready with no
+        // daemon response), the rmcp call_tool() would wait forever because
+        // PeerRequestOptions::no_options() sets timeout to None. This outer
+        // timeout is set above the inner maximum so inner timeouts fire first
+        // under normal operation.
+        match tokio::time::timeout(Self::TOOL_CALL_TIMEOUT, client.call_tool(params.clone())).await
+        {
+            Ok(result) => result.map_err(|e| {
+                McpError::internal_error(format!("Child tool call failed: {e}"), None)
+            }),
+            Err(_) => {
+                warn!(
+                    tool = %params.name,
+                    "Tool call to child timed out after {}s",
+                    Self::TOOL_CALL_TIMEOUT.as_secs()
+                );
+                Err(McpError::internal_error(
+                    format!(
+                        "Tool call '{}' timed out after {}s. The nteract daemon may be \
+                         overloaded or the session failed to initialize. Try again, or \
+                         use the 'reconnect' tool to restart the MCP connection.",
+                        params.name,
+                        Self::TOOL_CALL_TIMEOUT.as_secs()
+                    ),
+                    None,
+                ))
+            }
+        }
     }
 
     async fn try_forward_read_resource(
@@ -683,10 +719,20 @@ impl McpProxy {
             .as_ref()
             .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
 
-        client
-            .read_resource(params.clone())
-            .await
-            .map_err(|e| McpError::internal_error(format!("Child resource read failed: {e}"), None))
+        match tokio::time::timeout(
+            Self::TOOL_CALL_TIMEOUT,
+            client.read_resource(params.clone()),
+        )
+        .await
+        {
+            Ok(result) => result.map_err(|e| {
+                McpError::internal_error(format!("Child resource read failed: {e}"), None)
+            }),
+            Err(_) => Err(McpError::internal_error(
+                "Resource read timed out. The nteract daemon may be overloaded.",
+                None,
+            )),
+        }
     }
 
     async fn track_session(&self, params: &CallToolRequestParams, result: &CallToolResult) {


### PR DESCRIPTION
## Summary

- Add 120s default timeout to `DocHandle::wait_for_status()` — all status-based waits (`await_session_ready`, `await_notebook_interactive`, `await_runtime_state_ready`, `await_initial_load_ready`) now return `SyncError::Timeout` instead of hanging indefinitely
- Add 360s defense-in-depth timeout to `McpProxy::try_forward_tool_call()` and `try_forward_read_resource()` — set above the inner 300s maximum so inner timeouts fire first

## Problem

Under concurrent conda load (batch-size 6 gremlin suite), 5 gremlins deadlocked for 2h50m+ with MCP proxy processes at 0% CPU. Root cause: three missing timeouts in the proxy → child → daemon chain.

1. **`await_session_ready()` had no timeout** — if the daemon was saturated with concurrent conda solves and the session never reached Ready, the `runt mcp` tool handler blocked indefinitely
2. **`client.call_tool()` in the proxy had no timeout** — rmcp's `PeerRequestOptions::no_options()` sets `timeout: None`, so `await_response()` waits forever
3. **No outer timeout on forwarded tool calls** — the proxy's 60s child-readiness wait existed, but the actual forwarded call was unbounded

The inner request layer (relay) has per-request-type timeouts (300s for LaunchKernel/SyncEnvironment, 30s default) that work correctly, but they're bypassed when the blockage is at the session-readiness level.

## Test plan

- [x] `cargo test -p notebook-sync` — 50 passed
- [x] `cargo test -p runt-mcp-proxy` — 92 passed
- [x] `cargo xtask lint --fix` — clean
- [ ] CI checks pass
- [ ] Nightly gremlin replay with concurrent conda suite confirms no more deadlocks