### PR TITLE
feat(ci): add Windows code signing via Azure Trusted Signing

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -646,8 +646,8 @@ jobs:
           Set-ExecutionPolicy Unrestricted -Scope Process -Force
           iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
-      - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+      - name: Install Tauri CLI and trusted-signing-cli
+        run: cargo binstall tauri-cli trusted-signing-cli --no-confirm --locked --force
 
       - name: Set version in tauri.conf.json
         shell: pwsh
@@ -703,6 +703,9 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         with:
           projectPath: crates/notebook
           args: --bundles nsis --config '{"build":{"beforeBuildCommand":""}}'
@@ -1497,7 +1500,7 @@ jobs:
             echo "| Windows | x64 | \`nteract-${VERSION_SUFFIX}-windows-x64.exe\` |"
             echo "| Linux | x64 | \`nteract-${VERSION_SUFFIX}-linux-x64.AppImage\` |"
             echo ''
-            echo "macOS builds are signed and notarized. Windows is not code signed — expect a SmartScreen prompt. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
+            echo "macOS and Windows builds are signed. macOS builds are also notarized. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
             echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,7 +100,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: crates/notebook
-          args: --bundles nsis --config '{"build":{"beforeBuildCommand":""},"bundle":{"windows":{"signCommand":""}}}'
+          args: --bundles nsis --config '{"build":{"beforeBuildCommand":""},"bundle":{"windows":{"signCommand":null}}}'
           includeUpdaterJson: false
 
       - name: Locate installer

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,7 +100,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: crates/notebook
-          args: --bundles nsis --config '{"build":{"beforeBuildCommand":""}}'
+          args: --bundles nsis --config '{"build":{"beforeBuildCommand":""},"bundle":{"windows":{"signCommand":""}}}'
           includeUpdaterJson: false
 
       - name: Locate installer

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -40,6 +40,7 @@
       "minimumSystemVersion": "10.13"
     },
     "windows": {
+      "signCommand": "trusted-signing-cli -e https://eus.codesigning.azure.net -a NumFOCUS -c TrustedCertificateProfileForALLNumFOCUS -d nteract %1",
       "nsis": {
         "installerIcon": "icons/icon.ico",
         "installMode": "currentUser",


### PR DESCRIPTION
NumFOCUS provisioned an Azure Trusted Signing account for nteract. This wires it into the Windows release build so installers are code-signed and SmartScreen stops flagging them.

## What changed

- `crates/notebook/tauri.conf.json`: added `bundle.windows.signCommand` pointing at `trusted-signing-cli` with the NumFOCUS signing account and cert profile.
- `release-common.yml`: install `trusted-signing-cli` via cargo-binstall alongside tauri-cli, pass the three Azure auth env vars (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) to the tauri-action step. Updated release notes to reflect Windows is now signed.
- `smoke.yml`: override `signCommand` to empty in the `--config` JSON so smoke tests don't attempt Azure signing.

Six GitHub secrets were set from the 1Password `nteractAzure` entry: `AZURE_ENDPOINT`, `AZURE_CODE_SIGNING_NAME`, `AZURE_CERT_PROFILE_NAME`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`. The endpoint, account name, and cert profile are also baked into the `signCommand` string in tauri.conf.json. Only the three auth secrets need to be in the CI environment.

## Test plan

- [ ] Trigger a nightly release and confirm the Windows `.exe` is signed (right-click > Properties > Digital Signatures on a Windows machine, or `signtool verify /pa`)
- [ ] Confirm smoke test still passes without signing creds
