### PR TITLE
fix(mcp): harden concurrency diagnostics

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -30,9 +30,10 @@
 //! ```
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use automerge::{AutoCommit, ReadDoc, Value};
-use log::debug;
+use log::{debug, warn};
 use tokio::sync::{mpsc, oneshot, watch};
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
@@ -663,6 +664,29 @@ impl DocHandle {
         }
     }
 
+    async fn wait_for_status_timeout<F>(
+        &self,
+        label: &str,
+        predicate: F,
+        timeout: Duration,
+    ) -> Result<(), SyncError>
+    where
+        F: Fn(&SyncStatus) -> bool,
+    {
+        match tokio::time::timeout(timeout, self.wait_for_status(predicate)).await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    "[notebook-sync] {label} timed out after {:?} for {} with latest status: {:?}",
+                    timeout,
+                    self.notebook_id,
+                    self.status()
+                );
+                Err(SyncError::Timeout)
+            }
+        }
+    }
+
     /// Return the latest connection/bootstrap status.
     pub fn status(&self) -> SyncStatus {
         self.status_rx.borrow().clone()
@@ -697,9 +721,35 @@ impl DocHandle {
         .await
     }
 
+    /// Bounded variant of [`Self::await_initial_load_ready`] for agent-facing
+    /// entry points where returning a diagnostic timeout is better than
+    /// waiting indefinitely.
+    pub async fn await_initial_load_ready_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<(), SyncError> {
+        self.wait_for_status_timeout(
+            "await_initial_load_ready",
+            |status| {
+                matches!(
+                    status.initial_load,
+                    InitialLoadPhase::NotNeeded | InitialLoadPhase::Ready
+                )
+            },
+            timeout,
+        )
+        .await
+    }
+
     /// Wait until notebook doc, runtime state, and initial load are ready.
     pub async fn await_session_ready(&self) -> Result<(), SyncError> {
         self.wait_for_status(SyncStatus::session_ready).await
+    }
+
+    /// Bounded variant of [`Self::await_session_ready`] for MCP session setup.
+    pub async fn await_session_ready_timeout(&self, timeout: Duration) -> Result<(), SyncError> {
+        self.wait_for_status_timeout("await_session_ready", SyncStatus::session_ready, timeout)
+            .await
     }
 
     /// Get all connected peer IDs and labels, sorted by peer ID for stable ordering.

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -17,6 +17,7 @@ mod tests {
     use crate::status::{
         ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase, SyncStatus,
     };
+    use crate::SyncError;
 
     /// Create a DocHandle wired up with channels but no sync task.
     /// Good for testing the handle's local behavior in isolation.
@@ -281,6 +282,17 @@ mod tests {
         .await
         .expect("await_initial_load_ready should finish after explicit NotNeeded status")
         .expect("explicit NotNeeded status should be treated as ready");
+    }
+
+    #[tokio::test]
+    async fn bounded_readiness_wait_times_out_with_latest_status() {
+        let (handle, _status_tx, _changed_rx, _cmd_rx) = test_handle_with_status();
+
+        let result = handle
+            .await_initial_load_ready_timeout(std::time::Duration::from_millis(5))
+            .await;
+
+        assert!(matches!(result, Err(SyncError::Timeout)));
     }
 
     #[test]

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -346,14 +346,11 @@ impl McpProxy {
 
                 let tool_list_changed_tx = {
                     let mut state = self.state.write().await;
-                    let divergence_tx = if let (Some(ref old), Some(ref new)) =
-                        (&old_tools, &state.cached_tools)
-                    {
+                    if let (Some(ref old), Some(ref new)) = (&old_tools, &state.cached_tools) {
                         match tools::detect_divergence(old, new) {
-                            ToolDivergence::Same => None,
+                            ToolDivergence::Same => {}
                             ToolDivergence::Superset { ref added } => {
                                 info!("New tools available after restart: {added:?}");
-                                state.tool_list_changed_tx.clone()
                             }
                             ToolDivergence::Incompatible {
                                 ref removed,
@@ -366,12 +363,9 @@ impl McpProxy {
                                 state.should_exit = true;
                                 // Signal the exit so nteract-mcp can shut down
                                 self.exit_signal.notify_waiters();
-                                None
                             }
                         }
-                    } else {
-                        None
-                    };
+                    }
 
                     // The new child told us the daemon version it saw on its
                     // startup handshake. Compare it with what the previous
@@ -396,7 +390,7 @@ impl McpProxy {
                         _ => ReconnectionEvent::ChildRestart { session_rejoined },
                     };
                     state.reconnection_message = Some(reconnection_event.message());
-                    state.tool_list_changed_tx.clone().or(divergence_tx)
+                    state.tool_list_changed_tx.clone()
                 };
 
                 // Spawn new monitor for the restarted child
@@ -1127,6 +1121,7 @@ mod tests {
         let proxy = McpProxy::new(test_config(), None);
         let state = proxy.state.read().await;
         assert!(state.child_client.is_none());
+        assert_eq!(state.child_generation, 0);
         assert_eq!(state.restart_count, 0);
         assert!(state.last_notebook_id.is_none());
         assert!(state.reconnection_message.is_none());
@@ -1422,6 +1417,39 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.message.contains("not running"));
+    }
+
+    #[tokio::test]
+    async fn child_peer_snapshot_fails_without_child() {
+        let proxy = McpProxy::new(test_config(), None);
+
+        let result = proxy.child_peer_snapshot().await;
+
+        match result {
+            Ok(_) => panic!("snapshot should fail without a child"),
+            Err(err) => assert!(err.message.contains("not running")),
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_tool_cache_refresh_without_child_is_noop() {
+        let proxy = McpProxy::new(test_config(), None);
+        let cached = vec![rmcp::model::Tool::new(
+            "cached_tool".to_string(),
+            "A cached tool".to_string(),
+            serde_json::Map::new(),
+        )];
+        proxy.state.write().await.cached_tools = Some(cached);
+
+        proxy.refresh_tool_cache_for_generation(42).await;
+
+        let state = proxy.state.read().await;
+        let tools = state
+            .cached_tools
+            .as_ref()
+            .expect("cache should remain set");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name.as_ref(), "cached_tool");
     }
 
     // ── child_tools falls back to cache ───────────────────────────────

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -14,7 +14,7 @@ use rmcp::model::{
     ListResourcesResult, ListToolsResult, ReadResourceRequestParams, ReadResourceResult,
     ServerCapabilities, ServerInfo, Tool,
 };
-use rmcp::service::{NotificationContext, RequestContext, RoleServer};
+use rmcp::service::{NotificationContext, Peer, RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
 use tokio::sync::{mpsc, Mutex, Notify, RwLock};
 use tracing::{error, info, warn};
@@ -28,6 +28,7 @@ use crate::version::ReconnectionEvent;
 /// Env var name passed to a freshly respawned child to seed its rejoin
 /// target. Must match `runt_mcp::daemon_watch::REJOIN_ENV_VAR`.
 const REJOIN_ENV_VAR: &str = "NTERACT_MCP_REJOIN_NOTEBOOK";
+const SLOW_CHILD_CALL: Duration = Duration::from_secs(30);
 
 /// Extract the daemon version from a freshly-initialized child's MCP
 /// `ServerInfo`. `runt mcp` stamps the daemon version into
@@ -73,6 +74,11 @@ pub struct ProxyConfig {
 pub struct ProxyState {
     /// rmcp client connected to the child process.
     pub child_client: Option<RunningChild>,
+    /// Monotonic generation for the child transport.
+    ///
+    /// Forwarded calls snapshot this with a cloned child peer so stale calls
+    /// cannot commit state after the proxy has restarted the child.
+    pub child_generation: u64,
     /// Number of times the child has been restarted.
     pub restart_count: u32,
     /// Circuit breaker for crash detection.
@@ -129,6 +135,7 @@ impl McpProxy {
         Self {
             state: Arc::new(RwLock::new(ProxyState {
                 child_client: None,
+                child_generation: 0,
                 restart_count: 0,
                 circuit_breaker: CircuitBreaker::new(),
                 cached_tools,
@@ -189,16 +196,16 @@ impl McpProxy {
         // crates/runt-mcp/src/lib.rs::get_info).
         let daemon_version = extract_daemon_version(&client);
 
-        let mut state = self.state.write().await;
-        state.child_client = Some(client);
-        state.child_spawn_time = Some(Instant::now());
+        let generation = {
+            let mut state = self.state.write().await;
+            state.child_generation = state.child_generation.wrapping_add(1);
+            state.child_client = Some(client);
+            state.child_spawn_time = Some(Instant::now());
+            state.last_daemon_version = daemon_version;
+            state.child_generation
+        };
 
-        // Refresh tool cache from the new child
-        self.refresh_tool_cache_locked(&mut state).await;
-
-        state.last_daemon_version = daemon_version;
-
-        drop(state);
+        self.refresh_tool_cache_for_generation(generation).await;
 
         // Spawn background task to monitor child lifecycle
         self.spawn_child_monitor();
@@ -224,12 +231,12 @@ impl McpProxy {
         drop(restart_lock);
 
         // Phase 1: Drop old client, check circuit breaker
-        let child_was_dead = {
+        let (child_was_dead, old_child) = {
             let mut state = self.state.write().await;
             let was_dead = state.child_client.is_none();
-
-            if let Some(old) = state.child_client.take() {
-                let _ = old.cancel().await;
+            let old_child = state.child_client.take();
+            if old_child.is_some() {
+                state.child_generation = state.child_generation.wrapping_add(1);
             }
 
             let uptime = state
@@ -252,12 +259,16 @@ impl McpProxy {
                            so a fresh MCP connection is established. You may also need to \
                            reinstall the nteract extension.";
                 state.reconnection_message = Some(msg.to_string());
-                *self.restart_in_progress.lock().await = false;
+                drop(state);
+                self.clear_restart_in_progress().await;
                 return Err(msg.to_string());
             }
 
-            was_dead
+            (was_dead, old_child)
         };
+        if let Some(old) = old_child {
+            let _ = old.cancel().await;
+        }
 
         // Phase 2: Backoff (skip for daemon upgrade exits)
         if !child_was_dead {
@@ -282,6 +293,8 @@ impl McpProxy {
                 error!("{msg}");
                 let mut state = self.state.write().await;
                 state.reconnection_message = Some(msg.clone());
+                drop(state);
+                self.clear_restart_in_progress().await;
                 return Err(msg);
             }
         };
@@ -318,77 +331,84 @@ impl McpProxy {
                 // ServerInfo.title before moving the client into state.
                 let new_version = extract_daemon_version(&client);
 
-                let mut state = self.state.write().await;
-                state.child_client = Some(client);
-                state.restart_count += 1;
-                state.child_spawn_time = Some(Instant::now());
-                state.last_restart_time = Some(Instant::now());
+                let (old_tools, generation) = {
+                    let mut state = self.state.write().await;
+                    state.child_generation = state.child_generation.wrapping_add(1);
+                    state.child_client = Some(client);
+                    state.restart_count += 1;
+                    state.child_spawn_time = Some(Instant::now());
+                    state.last_restart_time = Some(Instant::now());
+                    (state.cached_tools.clone(), state.child_generation)
+                };
 
                 // Refresh tool cache and check for divergence
-                let old_tools = state.cached_tools.clone();
-                self.refresh_tool_cache_locked(&mut state).await;
+                self.refresh_tool_cache_for_generation(generation).await;
 
-                if let (Some(ref old), Some(ref new)) = (&old_tools, &state.cached_tools) {
-                    match tools::detect_divergence(old, new) {
-                        ToolDivergence::Same => {}
-                        ToolDivergence::Superset { ref added } => {
-                            info!("New tools available after restart: {added:?}");
-                            if let Some(ref tx) = state.tool_list_changed_tx {
-                                let _ = tx.send(()).await;
+                let tool_list_changed_tx = {
+                    let mut state = self.state.write().await;
+                    let divergence_tx = if let (Some(ref old), Some(ref new)) =
+                        (&old_tools, &state.cached_tools)
+                    {
+                        match tools::detect_divergence(old, new) {
+                            ToolDivergence::Same => None,
+                            ToolDivergence::Superset { ref added } => {
+                                info!("New tools available after restart: {added:?}");
+                                state.tool_list_changed_tx.clone()
+                            }
+                            ToolDivergence::Incompatible {
+                                ref removed,
+                                ref added,
+                            } => {
+                                warn!(
+                                    "Tool list incompatible after restart — removed: {removed:?}, added: {added:?}. \
+                                     Exiting so the MCP client can restart with the new tool set."
+                                );
+                                state.should_exit = true;
+                                // Signal the exit so nteract-mcp can shut down
+                                self.exit_signal.notify_waiters();
+                                None
                             }
                         }
-                        ToolDivergence::Incompatible {
-                            ref removed,
-                            ref added,
-                        } => {
-                            warn!(
-                                "Tool list incompatible after restart — removed: {removed:?}, added: {added:?}. \
-                                 Exiting so the MCP client can restart with the new tool set."
-                            );
-                            state.should_exit = true;
-                            // Signal the exit so nteract-mcp can shut down
-                            self.exit_signal.notify_waiters();
-                        }
-                    }
-                }
+                    } else {
+                        None
+                    };
 
-                // The new child told us the daemon version it saw on its
-                // startup handshake. Compare it with what the previous
-                // child reported to detect a daemon upgrade across the
-                // restart. If either side is unknown we degrade to the
-                // generic ChildRestart banner below.
-                state.last_daemon_version = new_version.clone();
+                    // The new child told us the daemon version it saw on its
+                    // startup handshake. Compare it with what the previous
+                    // child reported to detect a daemon upgrade across the
+                    // restart. If either side is unknown we degrade to the
+                    // generic ChildRestart banner below.
+                    state.last_daemon_version = new_version.clone();
 
-                // Session rejoin is now the child's responsibility
-                // (`daemon_watch` consumes the seeded REJOIN env var on
-                // its first `Connected` event). We still record whether
-                // we handed off a target so reconnection messages are
-                // informative.
-                let session_rejoined = rejoin_target.is_some();
-                let reconnection_event = match (old_version.as_deref(), new_version.as_deref()) {
-                    (Some(old), Some(new)) if old != new => ReconnectionEvent::DaemonUpgrade {
-                        old_version: old.to_string(),
-                        new_version: new.to_string(),
-                        session_rejoined,
-                    },
-                    _ => ReconnectionEvent::ChildRestart { session_rejoined },
+                    // Session rejoin is now the child's responsibility
+                    // (`daemon_watch` consumes the seeded REJOIN env var on
+                    // its first `Connected` event). We still record whether
+                    // we handed off a target so reconnection messages are
+                    // informative.
+                    let session_rejoined = rejoin_target.is_some();
+                    let reconnection_event = match (old_version.as_deref(), new_version.as_deref())
+                    {
+                        (Some(old), Some(new)) if old != new => ReconnectionEvent::DaemonUpgrade {
+                            old_version: old.to_string(),
+                            new_version: new.to_string(),
+                            session_rejoined,
+                        },
+                        _ => ReconnectionEvent::ChildRestart { session_rejoined },
+                    };
+                    state.reconnection_message = Some(reconnection_event.message());
+                    state.tool_list_changed_tx.clone().or(divergence_tx)
                 };
-                state.reconnection_message = Some(reconnection_event.message());
-
-                drop(state);
 
                 // Spawn new monitor for the restarted child
                 self.spawn_child_monitor();
 
                 // Notify upstream client to keep connection alive
-                let state = self.state.read().await;
-                if let Some(ref tx) = state.tool_list_changed_tx {
+                if let Some(tx) = tool_list_changed_tx {
                     let _ = tx.send(()).await;
                     info!("Notified upstream client of tool list change to keep connection alive");
                 }
-                drop(state);
 
-                *self.restart_in_progress.lock().await = false;
+                self.clear_restart_in_progress().await;
                 self.child_ready.notify_waiters();
                 info!("Child restarted successfully");
                 Ok(())
@@ -397,7 +417,8 @@ impl McpProxy {
                 let mut state = self.state.write().await;
                 state.reconnection_message = Some(format!("Child restart failed: {e}"));
                 error!("Failed to restart child: {e}");
-                *self.restart_in_progress.lock().await = false;
+                drop(state);
+                self.clear_restart_in_progress().await;
                 Err(e)
             }
         }
@@ -580,20 +601,48 @@ impl McpProxy {
     /// a bare `runt mcp` against a missing daemon returns `{tools: []}`, and
     /// without the fallback the MCP client would see zero tools and stick.
     pub async fn child_tools(&self) -> Vec<Tool> {
-        let state = self.state.read().await;
-        if let Some(ref client) = state.child_client {
-            match client.list_tools(None).await {
-                Ok(result) if !result.tools.is_empty() => return result.tools,
+        if let Ok(snapshot) = self.child_peer_snapshot().await {
+            let start = Instant::now();
+            match snapshot.peer.list_tools(None).await {
+                Ok(result) if !result.tools.is_empty() => {
+                    self.log_child_call_if_slow(
+                        "list_tools",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
+                    return result.tools;
+                }
                 Ok(_) => {
+                    self.log_child_call_if_slow(
+                        "list_tools",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
                     warn!("Child returned empty tool list — falling back to cached tools");
                 }
                 Err(e) => {
+                    self.log_child_call_if_slow(
+                        "list_tools",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
                     warn!("Failed to list child tools: {e}");
                 }
             }
         }
         // Fall back to cache
-        state.cached_tools.clone().unwrap_or_default()
+        self.state
+            .read()
+            .await
+            .cached_tools
+            .clone()
+            .unwrap_or_default()
     }
 
     /// List child resources (pass-through).
@@ -601,11 +650,29 @@ impl McpProxy {
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
     ) -> ListResourcesResult {
-        let state = self.state.read().await;
-        if let Some(ref client) = state.child_client {
-            match client.list_resources(request).await {
-                Ok(result) => return result,
-                Err(e) => warn!("Failed to list child resources: {e}"),
+        if let Ok(snapshot) = self.child_peer_snapshot().await {
+            let start = Instant::now();
+            match snapshot.peer.list_resources(request).await {
+                Ok(result) => {
+                    self.log_child_call_if_slow(
+                        "list_resources",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
+                    return result;
+                }
+                Err(e) => {
+                    self.log_child_call_if_slow(
+                        "list_resources",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
+                    warn!("Failed to list child resources: {e}");
+                }
             }
         }
         ListResourcesResult::default()
@@ -616,11 +683,29 @@ impl McpProxy {
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
     ) -> ListResourceTemplatesResult {
-        let state = self.state.read().await;
-        if let Some(ref client) = state.child_client {
-            match client.list_resource_templates(request).await {
-                Ok(result) => return result,
-                Err(e) => warn!("Failed to list child resource templates: {e}"),
+        if let Ok(snapshot) = self.child_peer_snapshot().await {
+            let start = Instant::now();
+            match snapshot.peer.list_resource_templates(request).await {
+                Ok(result) => {
+                    self.log_child_call_if_slow(
+                        "list_resource_templates",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
+                    return result;
+                }
+                Err(e) => {
+                    self.log_child_call_if_slow(
+                        "list_resource_templates",
+                        None,
+                        snapshot.generation,
+                        start.elapsed(),
+                    )
+                    .await;
+                    warn!("Failed to list child resource templates: {e}");
+                }
             }
         }
         ListResourceTemplatesResult::default()
@@ -661,32 +746,47 @@ impl McpProxy {
         &self,
         params: &CallToolRequestParams,
     ) -> Result<CallToolResult, McpError> {
-        let state = self.state.read().await;
-        let client = state
-            .child_client
-            .as_ref()
-            .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
+        let snapshot = self.child_peer_snapshot().await?;
+        let generation = snapshot.generation;
+        let start = Instant::now();
 
-        client
-            .call_tool(params.clone())
-            .await
-            .map_err(|e| McpError::internal_error(format!("Child tool call failed: {e}"), None))
+        let result =
+            snapshot.peer.call_tool(params.clone()).await.map_err(|e| {
+                McpError::internal_error(format!("Child tool call failed: {e}"), None)
+            });
+        self.log_child_call_if_slow(
+            "call_tool",
+            Some(params.name.as_ref()),
+            generation,
+            start.elapsed(),
+        )
+        .await;
+        result
     }
 
     async fn try_forward_read_resource(
         &self,
         params: &ReadResourceRequestParams,
     ) -> Result<ReadResourceResult, McpError> {
-        let state = self.state.read().await;
-        let client = state
-            .child_client
-            .as_ref()
-            .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
+        let snapshot = self.child_peer_snapshot().await?;
+        let generation = snapshot.generation;
+        let start = Instant::now();
 
-        client
+        let result = snapshot
+            .peer
             .read_resource(params.clone())
             .await
-            .map_err(|e| McpError::internal_error(format!("Child resource read failed: {e}"), None))
+            .map_err(|e| {
+                McpError::internal_error(format!("Child resource read failed: {e}"), None)
+            });
+        self.log_child_call_if_slow(
+            "read_resource",
+            Some(params.uri.as_ref()),
+            generation,
+            start.elapsed(),
+        )
+        .await;
+        result
     }
 
     async fn track_session(&self, params: &CallToolRequestParams, result: &CallToolResult) {
@@ -706,30 +806,92 @@ impl McpProxy {
         }
     }
 
-    async fn refresh_tool_cache_locked(&self, state: &mut ProxyState) {
-        if let Some(ref client) = state.child_client {
-            match client.list_tools(None).await {
-                Ok(child_tools) => {
-                    // Never enshrine an empty list. An old/broken child that
-                    // transiently returns `{tools: []}` would otherwise poison
-                    // the on-disk cache — `load_cached_tools` treats an empty
-                    // file as valid, so every subsequent start would read
-                    // zero tools and skip the built-in fallback.
-                    if child_tools.tools.is_empty() {
-                        warn!("Child returned empty tool list — keeping prior cache");
-                    } else {
+    async fn refresh_tool_cache_for_generation(&self, generation: u64) {
+        let snapshot = match self.child_peer_snapshot().await {
+            Ok(snapshot) if snapshot.generation == generation => snapshot,
+            _ => return,
+        };
+        let start = Instant::now();
+        match snapshot.peer.list_tools(None).await {
+            Ok(child_tools) => {
+                // Never enshrine an empty list. An old/broken child that
+                // transiently returns `{tools: []}` would otherwise poison
+                // the on-disk cache — `load_cached_tools` treats an empty
+                // file as valid, so every subsequent start would read
+                // zero tools and skip the built-in fallback.
+                if child_tools.tools.is_empty() {
+                    warn!("Child returned empty tool list — keeping prior cache");
+                } else {
+                    let tools = child_tools.tools;
+                    let mut state = self.state.write().await;
+                    if state.child_generation == generation {
                         if let Some(ref cache_dir) = self.config.cache_dir {
-                            tools::save_tool_cache(cache_dir, &child_tools.tools);
+                            tools::save_tool_cache(cache_dir, &tools);
                         }
-                        state.cached_tools = Some(child_tools.tools);
+                        state.cached_tools = Some(tools);
                     }
                 }
-                Err(e) => {
-                    warn!("Failed to refresh tool cache: {e}");
-                }
+            }
+            Err(e) => {
+                warn!("Failed to refresh tool cache: {e}");
             }
         }
+        self.log_child_call_if_slow("refresh_tool_cache", None, generation, start.elapsed())
+            .await;
     }
+
+    async fn child_peer_snapshot(&self) -> Result<ChildPeerSnapshot, McpError> {
+        let state = self.state.read().await;
+        let client = state
+            .child_client
+            .as_ref()
+            .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
+        Ok(ChildPeerSnapshot {
+            peer: client.peer().clone(),
+            generation: state.child_generation,
+        })
+    }
+
+    async fn log_child_call_if_slow(
+        &self,
+        operation: &str,
+        target: Option<&str>,
+        generation: u64,
+        elapsed: Duration,
+    ) {
+        if elapsed < SLOW_CHILD_CALL {
+            return;
+        }
+        let (transport_closed, restart_count) = {
+            let state = self.state.read().await;
+            (
+                if state.child_generation == generation {
+                    state.child_client.as_ref().map(|c| c.is_transport_closed())
+                } else {
+                    None
+                },
+                state.restart_count,
+            )
+        };
+        warn!(
+            operation,
+            target,
+            generation,
+            elapsed_ms = elapsed.as_millis(),
+            ?transport_closed,
+            restart_count,
+            "Slow child MCP call"
+        );
+    }
+
+    async fn clear_restart_in_progress(&self) {
+        *self.restart_in_progress.lock().await = false;
+    }
+}
+
+struct ChildPeerSnapshot {
+    peer: Peer<child::RoleChild>,
+    generation: u64,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -38,6 +38,7 @@ pub const REJOIN_ENV_VAR: &str = "NTERACT_MCP_REJOIN_NOTEBOOK";
 
 const REJOIN_RETRY_DELAY: Duration = Duration::from_secs(1);
 const REJOIN_MAX_RETRIES: u32 = 3;
+const REJOIN_INITIAL_LOAD_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// What the watch loop should do in response to a `DaemonEvent`.
 #[derive(Debug, PartialEq, Eq)]
@@ -315,7 +316,10 @@ async fn rejoin(
                 Ok(r) => {
                     let handle = r.handle;
                     let broadcast_rx = r.broadcast_rx;
-                    if let Err(e) = handle.await_initial_load_ready().await {
+                    if let Err(e) = handle
+                        .await_initial_load_ready_timeout(REJOIN_INITIAL_LOAD_TIMEOUT)
+                        .await
+                    {
                         Err(e)
                     } else {
                         let cell_count = handle.get_cells().len();
@@ -335,7 +339,10 @@ async fn rejoin(
                 Ok(r) => {
                     let handle = r.handle;
                     let broadcast_rx = r.broadcast_rx;
-                    if let Err(e) = handle.await_initial_load_ready().await {
+                    if let Err(e) = handle
+                        .await_initial_load_ready_timeout(REJOIN_INITIAL_LOAD_TIMEOUT)
+                        .await
+                    {
                         Err(e)
                     } else {
                         let cell_count = handle.get_cells().len();

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -32,6 +32,8 @@ pub mod tools;
 
 use session::{NotebookSession, SessionDropInfo};
 
+const SLOW_MCP_TOOL_CALL: Duration = Duration::from_secs(30);
+
 /// The nteract MCP server.
 pub struct NteractMcp {
     socket_path: PathBuf,
@@ -234,8 +236,16 @@ impl ServerHandler for NteractMcp {
         }
         let start = std::time::Instant::now();
         let result = tools::dispatch(self, &request).await;
+        let elapsed = start.elapsed();
+        if elapsed >= SLOW_MCP_TOOL_CALL {
+            tracing::warn!(
+                tool = %request.name,
+                elapsed_ms = elapsed.as_millis(),
+                success = result.is_ok(),
+                "Slow runt-mcp tool call"
+            );
+        }
         if tracing::enabled!(tracing::Level::DEBUG) {
-            let elapsed = start.elapsed();
             log_mcp_response(&request.name, elapsed, &result);
         }
         result

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -1,6 +1,7 @@
 //! Session management tools: list, join, open notebooks.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
 use rmcp::ErrorData as McpError;
@@ -12,6 +13,8 @@ use runtimed_client::client::PoolClient;
 use crate::formatting;
 use crate::session::{NotebookSession, SessionDropInfo, SessionDropReason};
 use crate::NteractMcp;
+
+const MCP_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Read the current session's notebook_id (if any) before replacing it.
 async fn previous_notebook_id(server: &NteractMcp) -> Option<String> {
@@ -414,7 +417,10 @@ pub async fn open_notebook(
             Ok(result) => {
                 let handle = &result.handle;
                 let notebook_id = handle.notebook_id().to_string();
-                if let Err(e) = handle.await_session_ready().await {
+                if let Err(e) = handle
+                    .await_session_ready_timeout(MCP_SESSION_READY_TIMEOUT)
+                    .await
+                {
                     return tool_error(&format!("Notebook opened but did not become ready: {}", e));
                 }
 
@@ -483,7 +489,10 @@ pub async fn open_notebook(
         {
             Ok(result) => {
                 let handle = &result.handle;
-                if let Err(e) = handle.await_session_ready().await {
+                if let Err(e) = handle
+                    .await_session_ready_timeout(MCP_SESSION_READY_TIMEOUT)
+                    .await
+                {
                     return tool_error(&format!(
                         "Notebook connected but did not become ready: {}",
                         e
@@ -573,7 +582,11 @@ pub async fn create_notebook(
     .await
     {
         Ok(result) => {
-            if let Err(e) = result.handle.await_session_ready().await {
+            if let Err(e) = result
+                .handle
+                .await_session_ready_timeout(MCP_SESSION_READY_TIMEOUT)
+                .await
+            {
                 return tool_error(&format!("Notebook created but did not become ready: {}", e));
             }
 
@@ -604,13 +617,14 @@ pub async fn create_notebook(
             };
             *server.session.write().await = Some(session);
 
-            let runtime_info = {
+            let runtime_info_handle = {
                 let guard = server.session.read().await;
-                if let Some(s) = guard.as_ref() {
-                    collect_runtime_info(&s.handle).await
-                } else {
-                    serde_json::json!({ "language": runtime })
-                }
+                guard.as_ref().map(|s| s.handle.clone())
+            };
+            let runtime_info = if let Some(handle) = runtime_info_handle {
+                collect_runtime_info(&handle).await
+            } else {
+                serde_json::json!({ "language": runtime })
             };
 
             let all_deps = {
@@ -756,6 +770,7 @@ pub async fn show_notebook(
             match session.as_ref() {
                 Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
                 None => {
+                    drop(session);
                     return super::no_session_error(server).await;
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -11,6 +11,7 @@ use crate::requests::{handle_notebook_request, request_label};
 
 pub(super) const PEER_OUTBOUND_QUEUE_CAPACITY: usize = 1024;
 const PEER_REQUEST_QUEUE_CAPACITY: usize = 64;
+const SLOW_PEER_REQUEST: std::time::Duration = std::time::Duration::from_secs(30);
 
 struct OutboundFrame {
     frame_type: NotebookFrameType,
@@ -157,6 +158,19 @@ pub(super) fn spawn_peer_request_worker(
             let start = std::time::Instant::now();
             let response = handle_notebook_request(&room, envelope.request, daemon.clone()).await;
             let elapsed = start.elapsed();
+            if elapsed >= SLOW_PEER_REQUEST {
+                let response_kind = std::mem::discriminant(&response);
+                warn!(
+                    request = label,
+                    id = req_id,
+                    peer = %peer_id,
+                    notebook = %notebook_id,
+                    elapsed_ms = elapsed.as_millis(),
+                    writer_queue_depth,
+                    ?response_kind,
+                    "Slow notebook peer request"
+                );
+            }
             debug!(
                 "[notebook-sync] Request {} id={} completed in {:?}",
                 label, req_id, elapsed,


### PR DESCRIPTION
## Summary

Supersedes #2427 with a narrower concurrency hardening pass: remove lock-across-child-call convoy risks, add bounded readiness waits only at MCP entry points, and add diagnostics that identify which layer stalled.

## Lab Evidence

Reviewed `/Users/kyle/Downloads/mcp-deadlock-diagnostic.tar.gz`.

- Five reports (`conda`, `conda-sequential`, `conda-lifecycle`, `media`, `restart-resilience`) were killed after 160+ minutes with `turns: 0`, no tool errors, and MCP connection deadlock.
- The archive analysis classifies the hang as child readiness wait: proxy/child processes had essentially no CPU after the initial forwarded call.
- Daemon logs show conda `LaunchKernel` requests completing in about 5-6s for the affected notebooks, so the replacement PR should not be only a broad parent timeout.
- PR #2427's patch globally timed out `DocHandle::wait_for_status` and wrapped child calls, but did not remove proxy state-lock convoy hazards or include latest `SyncStatus` diagnostics.

## Changes

- Refactor the parent MCP proxy to snapshot a cloned child `Peer` plus child generation under short locks, then perform child tool/resource/list awaits outside `self.state`.
- Guard cache/restart commits with child-generation checks and cancel old children outside the state write lock.
- Add parent slow-call diagnostics with operation/target, child generation, elapsed time, transport-closed state, and restart count.
- Add bounded `DocHandle` readiness helpers while leaving existing unbounded `await_*` semantics unchanged.
- Use bounded readiness only in MCP session establishment and daemon-watch rejoin paths.
- Fix `create_notebook` so runtime info collection does not hold `server.session` while awaiting.
- Add slow-tool logging in child `runt-mcp` dispatch.
- Add daemon peer-request slow logging with request label, correlation id, peer id, notebook id, elapsed time, writer queue depth, and response kind.

## Test Plan

- `cargo test -p notebook-sync`
- `cargo test -p runt-mcp`
- `cargo test -p runt-mcp-proxy`
- `cargo test -p runtimed --test rpc_routing`
- `cargo xtask lint --fix`

Note: `cargo test -p runtimed --test rpc_routing` initially hit the expected missing gitignored renderer plugin artifacts. I ran `cargo xtask wasm` to rebuild them, then reran the target successfully.
