### PR TITLE
fix(ci): detect signtool and Azure CLI paths for Windows signing

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -699,6 +699,25 @@ jobs:
           cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
           cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
 
+      - name: Locate signing tools
+        shell: pwsh
+        run: |
+          # Find signtool.exe from the Windows SDK
+          $sdkRoot = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots" -Name KitsRoot10).KitsRoot10
+          $signtool = Get-ChildItem -Path "$sdkRoot\bin" -Recurse -Filter "signtool.exe" |
+            Where-Object { $_.FullName -match "\\x64\\" } |
+            Sort-Object { [version]($_.FullName -replace '.*\\(\d+\.\d+\.\d+\.\d+)\\.*','$1') } -Descending |
+            Select-Object -First 1
+          if (-not $signtool) { throw "signtool.exe not found" }
+          Write-Host "Found signtool: $($signtool.FullName)"
+          "SIGNTOOL_PATH=$($signtool.FullName)" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
+          # Find Azure CLI
+          $azCmd = (Get-Command az -ErrorAction SilentlyContinue).Source
+          if (-not $azCmd) { throw "Azure CLI not found" }
+          Write-Host "Found Azure CLI: $azCmd"
+          "AZURE_CLI_PATH=$azCmd" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
`trusted-signing-cli` hardcodes default paths for `signtool.exe` (`10.0.26100.0`) and Azure CLI (`C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.cmd`). If the runner has a different SDK version or CLI location, the tool fails with a generic `failed to run trusted-signing-cli` error (tauri-bundler swallows the actual stderr).

This adds a "Locate signing tools" step that:
- Finds `signtool.exe` from the Windows SDK registry key, picks the newest x64 version
- Finds `az` from PATH via `Get-Command`
- Exports both as `SIGNTOOL_PATH` and `AZURE_CLI_PATH` env vars that `trusted-signing-cli` reads

Follows up on #2428 which added Azure Trusted Signing but didn't account for tool path detection.

## Test plan

- [ ] Trigger a nightly release and confirm the "Locate signing tools" step succeeds
- [ ] Confirm the signing step completes without `failed to run trusted-signing-cli`
