### PR TITLE
fix(build): stabilize embedded git metadata

### DIFF
--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -69,6 +69,8 @@ jobs:
     name: Build ${{ inputs.target_os == 'linux' && 'Linux x64' || inputs.target_os == 'macos' && 'macOS' || 'Windows x64' }} binary
     needs: [resolve-pr]
     runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-14-xlarge' || 'windows-latest' }}
+    env:
+      NTERACT_BUILD_GIT_HASH: ${{ needs.resolve-pr.outputs.head_sha }}
 
     steps:
       - name: Checkout pinned PR commit

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -52,6 +52,7 @@ env:
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
   RUNT_BUILD_CHANNEL: ${{ inputs.version_suffix }}
+  NTERACT_BUILD_GIT_HASH: ${{ github.sha }}
 
 jobs:
   compute-version:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-metadata"
+version = "0.1.0"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,6 +4499,7 @@ name = "notebook"
 version = "2.3.5"
 dependencies = [
  "anyhow",
+ "build-metadata",
  "chrono",
  "clap",
  "cocoa",
@@ -6932,6 +6937,7 @@ name = "runt"
 version = "2.3.5"
 dependencies = [
  "anyhow",
+ "build-metadata",
  "chrono",
  "clap",
  "colored",
@@ -7047,6 +7053,7 @@ dependencies = [
  "async-rust-lsp",
  "automerge",
  "base64 0.22.1",
+ "build-metadata",
  "bytes",
  "chrono",
  "clap",
@@ -7107,6 +7114,7 @@ version = "2.3.5"
 dependencies = [
  "automerge",
  "base64 0.22.1",
+ "build-metadata",
  "chrono",
  "dirs",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/build-metadata",
     "crates/runt",
     "crates/runt-trust",
     "crates/runt-workspace",

--- a/crates/build-metadata/Cargo.toml
+++ b/crates/build-metadata/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "build-metadata"
+version = "0.1.0"
+edition.workspace = true
+description = "Shared build-script metadata helpers for nteract desktop"
+repository.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true

--- a/crates/build-metadata/src/lib.rs
+++ b/crates/build-metadata/src/lib.rs
@@ -45,8 +45,8 @@ pub fn collect_git_metadata() -> GitMetadata {
 }
 
 pub fn write_git_hash(out_dir: &Path) {
-    let metadata = collect_git_metadata();
-    write_if_changed(&out_dir.join("git_hash.txt"), &metadata.hash);
+    let hash = git_hash();
+    write_if_changed(&out_dir.join("git_hash.txt"), &hash);
 }
 
 pub fn write_git_metadata(out_dir: &Path) {
@@ -73,8 +73,10 @@ pub fn normalized_short_hash(value: &str) -> Option<String> {
 
     if hex_len >= 7 {
         Some(candidate[..7].to_string())
-    } else {
+    } else if hex_len == candidate.len() {
         Some(candidate.to_string())
+    } else {
+        None
     }
 }
 
@@ -147,8 +149,18 @@ mod tests {
     }
 
     #[test]
+    fn very_short_hex_sha_is_preserved() {
+        assert_eq!(normalized_short_hash("abc123").as_deref(), Some("abc123"));
+    }
+
+    #[test]
     fn empty_hash_is_unknown_to_caller() {
         assert_eq!(normalized_short_hash("  "), None);
+    }
+
+    #[test]
+    fn non_hex_hash_is_unknown_to_caller() {
+        assert_eq!(normalized_short_hash("not-hex-at-all"), None);
     }
 
     #[test]

--- a/crates/build-metadata/src/lib.rs
+++ b/crates/build-metadata/src/lib.rs
@@ -66,6 +66,10 @@ pub fn normalized_short_hash(value: &str) -> Option<String> {
     let candidate = without_dirty
         .split_once('+')
         .map_or(without_dirty, |(_, hash)| hash);
+    if candidate.is_empty() {
+        return None;
+    }
+
     let hex_len = candidate
         .bytes()
         .take_while(|byte| byte.is_ascii_hexdigit())
@@ -161,6 +165,11 @@ mod tests {
     #[test]
     fn non_hex_hash_is_unknown_to_caller() {
         assert_eq!(normalized_short_hash("not-hex-at-all"), None);
+    }
+
+    #[test]
+    fn dirty_only_hash_is_unknown_to_caller() {
+        assert_eq!(normalized_short_hash("+dirty"), None);
     }
 
     #[test]

--- a/crates/build-metadata/src/lib.rs
+++ b/crates/build-metadata/src/lib.rs
@@ -1,0 +1,165 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const GIT_HASH_ENV: &str = "NTERACT_BUILD_GIT_HASH";
+const GIT_DATE_ENV: &str = "NTERACT_BUILD_GIT_DATE";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitMetadata {
+    pub hash: String,
+    pub branch: String,
+    pub date: String,
+}
+
+pub fn emit_git_rerun_hints() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed={GIT_HASH_ENV}");
+    println!("cargo:rerun-if-env-changed={GIT_DATE_ENV}");
+
+    if let Some(path) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    if let Some(ref_name) = git_output(&["rev-parse", "--symbolic-full-name", "HEAD"]) {
+        if ref_name != "HEAD" {
+            if let Some(path) = git_path(&ref_name) {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+
+    if let Some(path) = git_path("packed-refs") {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+pub fn collect_git_metadata() -> GitMetadata {
+    GitMetadata {
+        hash: git_hash(),
+        branch: git_output(&["rev-parse", "--abbrev-ref", "HEAD"])
+            .unwrap_or_else(|| "unknown".to_string()),
+        date: git_date(),
+    }
+}
+
+pub fn write_git_hash(out_dir: &Path) {
+    let metadata = collect_git_metadata();
+    write_if_changed(&out_dir.join("git_hash.txt"), &metadata.hash);
+}
+
+pub fn write_git_metadata(out_dir: &Path) {
+    let metadata = collect_git_metadata();
+    write_if_changed(&out_dir.join("git_hash.txt"), &metadata.hash);
+    write_if_changed(&out_dir.join("git_branch.txt"), &metadata.branch);
+    write_if_changed(&out_dir.join("git_date.txt"), &metadata.date);
+}
+
+pub fn normalized_short_hash(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let without_dirty = trimmed.strip_suffix("+dirty").unwrap_or(trimmed);
+    let candidate = without_dirty
+        .split_once('+')
+        .map_or(without_dirty, |(_, hash)| hash);
+    let hex_len = candidate
+        .bytes()
+        .take_while(|byte| byte.is_ascii_hexdigit())
+        .count();
+
+    if hex_len >= 7 {
+        Some(candidate[..7].to_string())
+    } else {
+        Some(candidate.to_string())
+    }
+}
+
+fn git_hash() -> String {
+    env::var(GIT_HASH_ENV)
+        .ok()
+        .and_then(|value| normalized_short_hash(&value))
+        .or_else(|| git_output(&["rev-parse", "--short=7", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn git_date() -> String {
+    env::var(GIT_DATE_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| git_output(&["show", "-s", "--format=%cs", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn git_path(path: &str) -> Option<PathBuf> {
+    git_output(&["rev-parse", "--path-format=absolute", "--git-path", path]).map(PathBuf::from)
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.trim().to_string())
+        .filter(|stdout| !stdout.is_empty())
+}
+
+fn write_if_changed(path: &Path, content: &str) {
+    let needs_write = match fs::read_to_string(path) {
+        Ok(existing) => existing != content,
+        Err(_) => true,
+    };
+
+    if needs_write {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        fs::write(path, content).unwrap_or_else(|err| {
+            panic!(
+                "failed to write build metadata to {}: {err}",
+                path.display()
+            )
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_short_hash;
+
+    #[test]
+    fn full_sha_shortens_to_seven_chars() {
+        assert_eq!(
+            normalized_short_hash("20a81f6098a0669071b94a66f3842ffac08da508").as_deref(),
+            Some("20a81f6")
+        );
+    }
+
+    #[test]
+    fn short_sha_is_preserved() {
+        assert_eq!(normalized_short_hash("abc1234").as_deref(), Some("abc1234"));
+    }
+
+    #[test]
+    fn empty_hash_is_unknown_to_caller() {
+        assert_eq!(normalized_short_hash("  "), None);
+    }
+
+    #[test]
+    fn dirty_suffix_is_ignored_for_build_identity() {
+        assert_eq!(
+            normalized_short_hash("2.3.5+20a81f6+dirty").as_deref(),
+            Some("20a81f6")
+        );
+        assert_eq!(
+            normalized_short_hash("20a81f6098a0669071b94a66f3842ffac08da508+dirty").as_deref(),
+            Some("20a81f6")
+        );
+    }
+}

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -81,6 +81,7 @@ e2e-webdriver = ["tauri-plugin-webdriver"]
 tempfile = "3"
 
 [build-dependencies]
+build-metadata = { path = "../build-metadata" }
 serde_json = { workspace = true }
 tauri-build = { version = "2", features = [] }
 

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -77,7 +77,7 @@ fn maybe_disable_external_bin_for_local_checks() {
 }
 
 fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_dir = out_dir();
     build_metadata::emit_git_rerun_hints();
     build_metadata::write_git_metadata(&out_dir);
 
@@ -89,4 +89,11 @@ fn main() {
     maybe_disable_external_bin_for_local_checks();
 
     tauri_build::build()
+}
+
+fn out_dir() -> PathBuf {
+    match env::var("OUT_DIR") {
+        Ok(value) => PathBuf::from(value),
+        Err(err) => panic!("OUT_DIR is required for build metadata: {err}"),
+    }
 }

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -1,7 +1,6 @@
 use serde_json::{json, Value};
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 fn merge_json(base: &mut Value, overlay: Value) {
     match (base, overlay) {
@@ -78,9 +77,9 @@ fn maybe_disable_external_bin_for_local_checks() {
 }
 
 fn main() {
-    // Write git metadata to $OUT_DIR files, skipping writes when content
-    // hasn't changed to avoid unnecessary recompilation.
-    write_git_metadata();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    build_metadata::emit_git_rerun_hints();
+    build_metadata::write_git_metadata(&out_dir);
 
     // Re-run if frontend dist changes (ensures fresh frontend is embedded).
     // This is the only non-git watcher — Phase 2 builds the frontend, then
@@ -90,59 +89,4 @@ fn main() {
     maybe_disable_external_bin_for_local_checks();
 
     tauri_build::build()
-}
-
-/// Write git metadata to `$OUT_DIR/git_{hash,branch,date}.txt`, skipping
-/// writes when content hasn't changed. See `crates/runtimed/build.rs` for
-/// the rationale — this avoids recompilation when the metadata is unchanged.
-///
-/// The hash is suffixed `+dirty` when the worktree has uncommitted changes
-/// at build time, so the embedded version honestly identifies what was
-/// compiled in. Matches the convention in the other build scripts.
-#[allow(clippy::unwrap_used)]
-fn write_git_metadata() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    let mut hash = git_output(&["rev-parse", "--short=7", "HEAD"]);
-    if hash != "unknown" && git_worktree_is_dirty() {
-        hash.push_str("+dirty");
-    }
-    let branch = git_output(&["rev-parse", "--abbrev-ref", "HEAD"]);
-    let date = git_output(&["show", "-s", "--format=%cs", "HEAD"]);
-
-    write_if_changed(&out_dir.join("git_hash.txt"), &hash);
-    write_if_changed(&out_dir.join("git_branch.txt"), &branch);
-    write_if_changed(&out_dir.join("git_date.txt"), &date);
-}
-
-/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
-fn git_worktree_is_dirty() -> bool {
-    Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false)
-}
-
-#[allow(clippy::unwrap_used)]
-fn write_if_changed(path: &PathBuf, content: &str) {
-    let needs_write = match std::fs::read_to_string(path) {
-        Ok(existing) => existing != content,
-        Err(_) => true,
-    };
-    if needs_write {
-        std::fs::write(path, content).unwrap();
-    }
-}
-
-fn git_output(args: &[&str]) -> String {
-    Command::new("git")
-        .args(args)
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -42,5 +42,8 @@ walkdir = "2"
 [dev-dependencies]
 tempfile = "3"
 
+[build-dependencies]
+build-metadata = { path = "../build-metadata" }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/runt/build.rs
+++ b/crates/runt/build.rs
@@ -5,7 +5,14 @@ fn main() {
     println!("cargo:rustc-env=RUNT_VARIANT={variant}");
     println!("cargo:rerun-if-env-changed=RUNT_VARIANT");
 
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = out_dir();
     build_metadata::emit_git_rerun_hints();
     build_metadata::write_git_hash(&out_dir);
+}
+
+fn out_dir() -> PathBuf {
+    match std::env::var("OUT_DIR") {
+        Ok(value) => PathBuf::from(value),
+        Err(err) => panic!("OUT_DIR is required for build metadata: {err}"),
+    }
 }

--- a/crates/runt/build.rs
+++ b/crates/runt/build.rs
@@ -1,66 +1,11 @@
-use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
     let variant = std::env::var("RUNT_VARIANT").unwrap_or_default();
     println!("cargo:rustc-env=RUNT_VARIANT={variant}");
     println!("cargo:rerun-if-env-changed=RUNT_VARIANT");
 
-    // Also rerun when this build script changes (since we emit
-    // rerun-if-changed above, cargo won't use its default behavior).
-    println!("cargo:rerun-if-changed=build.rs");
-
-    write_git_hash();
-}
-
-/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
-/// if the content hasn't changed. See `crates/runtimed/build.rs` for the
-/// rationale — this avoids recompilation when the hash doesn't change.
-#[allow(clippy::unwrap_used)]
-fn write_git_hash() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let hash_file = out_dir.join("git_hash.txt");
-    let hash = git_commit_short();
-
-    let needs_write = match fs::read_to_string(&hash_file) {
-        Ok(existing) => existing != hash,
-        Err(_) => true,
-    };
-
-    if needs_write {
-        fs::write(&hash_file, &hash).unwrap();
-    }
-}
-
-fn git_commit_short() -> String {
-    let hash = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    if hash == "unknown" {
-        return hash;
-    }
-
-    if git_worktree_is_dirty() {
-        format!("{hash}+dirty")
-    } else {
-        hash
-    }
-}
-
-/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
-fn git_worktree_is_dirty() -> bool {
-    Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false)
+    build_metadata::emit_git_rerun_hints();
+    build_metadata::write_git_hash(&out_dir);
 }

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -43,3 +43,6 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[build-dependencies]
+build-metadata = { path = "../build-metadata" }

--- a/crates/runtimed-client/build.rs
+++ b/crates/runtimed-client/build.rs
@@ -1,62 +1,7 @@
-use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
-    write_git_hash();
-
-    // No rerun-if-changed directives — cargo's default behavior reruns
-    // this script when any file in the package changes, which is exactly
-    // when we want a fresh commit hash check.
-}
-
-/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
-/// if the content hasn't changed. See `crates/runtimed/build.rs` for the
-/// rationale — this avoids recompilation when the hash doesn't change.
-#[allow(clippy::unwrap_used)]
-fn write_git_hash() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let hash_file = out_dir.join("git_hash.txt");
-    let hash = git_commit_short();
-
-    let needs_write = match fs::read_to_string(&hash_file) {
-        Ok(existing) => existing != hash,
-        Err(_) => true,
-    };
-
-    if needs_write {
-        fs::write(&hash_file, &hash).unwrap();
-    }
-}
-
-fn git_commit_short() -> String {
-    let hash = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    if hash == "unknown" {
-        return hash;
-    }
-
-    if git_worktree_is_dirty() {
-        format!("{hash}+dirty")
-    } else {
-        hash
-    }
-}
-
-/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
-fn git_worktree_is_dirty() -> bool {
-    Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false)
+    build_metadata::emit_git_rerun_hints();
+    build_metadata::write_git_hash(&out_dir);
 }

--- a/crates/runtimed-client/build.rs
+++ b/crates/runtimed-client/build.rs
@@ -1,7 +1,14 @@
 use std::path::PathBuf;
 
 fn main() {
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = out_dir();
     build_metadata::emit_git_rerun_hints();
     build_metadata::write_git_hash(&out_dir);
+}
+
+fn out_dir() -> PathBuf {
+    match std::env::var("OUT_DIR") {
+        Ok(value) => PathBuf::from(value),
+        Err(err) => panic!("OUT_DIR is required for build metadata: {err}"),
+    }
 }

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -108,6 +108,8 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 libc = "0.2"
 nix = { version = "0.31", features = ["signal", "process"] }
 
+[build-dependencies]
+build-metadata = { path = "../build-metadata" }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_JobObjects", "Win32_System_Threading"] }
 

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -110,6 +110,7 @@ nix = { version = "0.31", features = ["signal", "process"] }
 
 [build-dependencies]
 build-metadata = { path = "../build-metadata" }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_JobObjects", "Win32_System_Threading"] }
 

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -1,6 +1,4 @@
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 fn main() {
     // The renderer plugin bundles + sift wasm are gitignored build
@@ -33,87 +31,7 @@ fn main() {
         }
     }
 
-    // Also rerun when this build script changes (since we emit
-    // rerun-if-changed above, cargo won't use its default behavior).
-    println!("cargo:rerun-if-changed=build.rs");
-
-    // Re-run whenever the current HEAD moves so the embedded git hash
-    // reflects the tree actually being compiled. Without this, a `git
-    // checkout` or merge leaves cargo happy to reuse a stale OUT_DIR
-    // whose `git_hash.txt` points at a previous commit — the daemon
-    // then mis-reports its version (e.g. 7583085 after landing bf42cea)
-    // and anyone reading the status thinks the binary is out of date.
-    //
-    // `.git/HEAD` covers branch switches. `.git/refs/heads/<branch>`
-    // covers new commits on the current branch; we tell cargo to watch
-    // the packed-refs file too for the common "refs compacted" case.
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/index");
-    println!("cargo:rerun-if-changed=../../.git/packed-refs");
-
-    write_git_hash();
-}
-
-/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
-/// if the content hasn't changed. Consumer code uses:
-///
-///     include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
-///
-/// Because cargo tracks file modification times on included files, an
-/// unchanged hash file means no recompilation — even after a rebase that
-/// doesn't touch this crate's source. This replaces the old
-/// `cargo:rustc-env=GIT_COMMIT=...` approach which forced recompilation
-/// every time the build script ran.
-#[allow(clippy::unwrap_used)]
-fn write_git_hash() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let hash_file = out_dir.join("git_hash.txt");
-    let hash = git_commit_short();
-
-    // Only write if the content actually changed — preserves mtime so
-    // cargo's incremental compilation skips dependent rustc invocations.
-    let needs_write = match fs::read_to_string(&hash_file) {
-        Ok(existing) => existing != hash,
-        Err(_) => true,
-    };
-
-    if needs_write {
-        fs::write(&hash_file, &hash).unwrap();
-    }
-}
-
-fn git_commit_short() -> String {
-    let hash = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    if hash == "unknown" {
-        return hash;
-    }
-
-    if git_worktree_is_dirty() {
-        format!("{hash}+dirty")
-    } else {
-        hash
-    }
-}
-
-/// Returns true if `git status --porcelain` reports any uncommitted changes.
-/// A binary built from a dirty worktree gets its embedded hash marked
-/// `<sha>+dirty` so the running version honestly identifies what was
-/// compiled in. Returns false on any git failure (no repo, no git
-/// binary) so the absence of git doesn't lie about cleanliness.
-fn git_worktree_is_dirty() -> bool {
-    Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| !o.stdout.is_empty())
-        .unwrap_or(false)
+    build_metadata::emit_git_rerun_hints();
+    build_metadata::write_git_hash(&out_dir);
 }

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -31,7 +31,14 @@ fn main() {
         }
     }
 
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = out_dir();
     build_metadata::emit_git_rerun_hints();
     build_metadata::write_git_hash(&out_dir);
+}
+
+fn out_dir() -> PathBuf {
+    match std::env::var("OUT_DIR") {
+        Ok(value) => PathBuf::from(value),
+        Err(err) => panic!("OUT_DIR is required for build metadata: {err}"),
+    }
 }


### PR DESCRIPTION
## Summary

- add a shared `build-metadata` build helper crate for stable commit/date metadata
- remove build-time dirty checks from `runt`, `runtimed`, `runtimed-client`, and `notebook`
- pass `NTERACT_BUILD_GIT_HASH` through release and PR binary workflows so version stamping does not dirty embedded identity

## Verification

- `cargo fmt --all --check`
- `cargo test -p build-metadata` (7 tests)
- `NTERACT_BUILD_GIT_HASH=20a81f6098a0669071b94a66f3842ffac08da508 cargo check -p runt --bin runt`
- `NTERACT_BUILD_GIT_HASH=20a81f6098a0669071b94a66f3842ffac08da508 cargo check -p runtimed --bin runtimed`
- `NTERACT_BUILD_GIT_HASH=$(git rev-parse HEAD) cargo check -p notebook`
- `NTERACT_BUILD_GIT_HASH=$(git rev-parse HEAD) cargo run -p runt -- --version`
- `NTERACT_BUILD_GIT_HASH=$(git rev-parse HEAD) cargo run -p runtimed -- --version`
- `NTERACT_BUILD_GIT_HASH=not-hex-at-all cargo check -p runt --bin runt`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `cargo clippy -p notebook --all-targets -- -D warnings`
- rebased onto `origin/main`
- Claude Bedrock review pass, with follow-up fixes applied for hash-only helper work, invalid env hash handling, and dirty-only override handling

## Notes

`+dirty` remains supported in version comparison and debug notebook runtime Git info, but compiled build identity now stays commit-based.
