### PR TITLE
fix(notebook): refresh trust fingerprint after stale approval

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -729,6 +729,29 @@ function AppContent() {
     [],
   );
 
+  const refreshPendingActionDependencyFingerprint = useCallback(
+    (action: PendingTrustAction | null) => {
+      if (!action) return;
+      const dependencyFingerprint = captureDependencyFingerprint();
+      const refreshed: PendingTrustAction =
+        action.kind === "sync_deps"
+          ? {
+              ...action,
+              provenance: {
+                ...action.provenance,
+                dependency_fingerprint: dependencyFingerprint,
+              },
+            }
+          : {
+              ...action,
+              dependencyFingerprint,
+            };
+      pendingTrustActionRef.current = refreshed;
+      setPendingTrustAction(refreshed);
+    },
+    [captureDependencyFingerprint],
+  );
+
   // Check trust and start kernel if trusted, otherwise show dialog.
   // Returns true if kernel was started, false if trust dialog opened or error.
   const tryStartKernel = useCallback(
@@ -1000,6 +1023,9 @@ function AppContent() {
     const success = await approveTrust(
       dependencyFingerprint ? { dependencyFingerprint } : undefined,
     );
+    if (!success) {
+      refreshPendingActionDependencyFingerprint(action);
+    }
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
       setTrustApprovalHandoffPending(true);
@@ -1015,6 +1041,7 @@ function AppContent() {
     approveTrust,
     handleTrustApprovedLaunch,
     pendingActionDependencyFingerprint,
+    refreshPendingActionDependencyFingerprint,
     runTrustApprovedAction,
     setBlockedTrustAction,
   ]);
@@ -1025,6 +1052,9 @@ function AppContent() {
     const success = await approveTrust(
       dependencyFingerprint ? { dependencyFingerprint } : undefined,
     );
+    if (!success) {
+      refreshPendingActionDependencyFingerprint(action);
+    }
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
       setTrustApprovalHandoffPending(true);
@@ -1038,6 +1068,7 @@ function AppContent() {
     approveTrust,
     handleTrustApprovedLaunch,
     pendingActionDependencyFingerprint,
+    refreshPendingActionDependencyFingerprint,
     setBlockedTrustAction,
   ]);
 

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -63,6 +63,11 @@ import {
 } from "./lib/cell-ui-state";
 import { startCursorDispatch } from "./lib/cursor-registry";
 import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kernel-status";
+import {
+  type PendingTrustAction,
+  pendingActionDependencyFingerprint,
+  refreshPendingActionDependencyFingerprint,
+} from "./lib/trust-actions";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { getNotebookCellsSnapshot } from "./lib/notebook-cells";
@@ -73,20 +78,6 @@ import type { JupyterOutput } from "./types";
 
 /** MIME bundle type for output data */
 export type MimeBundle = Record<string, unknown>;
-
-type PendingTrustAction =
-  | {
-      kind: "execute_cell";
-      cellId: string;
-      provenance: GuardedNotebookProvenance;
-      dependencyFingerprint: string;
-    }
-  | {
-      kind: "run_all";
-      provenance: GuardedNotebookProvenance;
-      dependencyFingerprint: string;
-    }
-  | { kind: "sync_deps"; provenance: DependencyGuard };
 
 const EMPTY_DEPENDENCY_FINGERPRINT = "{}";
 
@@ -719,33 +710,13 @@ function AppContent() {
     };
   }, [captureDependencyFingerprint, captureNotebookProvenance]);
 
-  const pendingActionDependencyFingerprint = useCallback(
-    (action: PendingTrustAction | null): string | undefined => {
-      if (!action) return undefined;
-      return action.kind === "sync_deps"
-        ? action.provenance.dependency_fingerprint
-        : action.dependencyFingerprint;
-    },
-    [],
-  );
-
-  const refreshPendingActionDependencyFingerprint = useCallback(
+  const refreshBlockedTrustActionDependencyFingerprint = useCallback(
     (action: PendingTrustAction | null) => {
       if (!action) return;
-      const dependencyFingerprint = captureDependencyFingerprint();
-      const refreshed: PendingTrustAction =
-        action.kind === "sync_deps"
-          ? {
-              ...action,
-              provenance: {
-                ...action.provenance,
-                dependency_fingerprint: dependencyFingerprint,
-              },
-            }
-          : {
-              ...action,
-              dependencyFingerprint,
-            };
+      const refreshed = refreshPendingActionDependencyFingerprint(
+        action,
+        captureDependencyFingerprint(),
+      );
       pendingTrustActionRef.current = refreshed;
       setPendingTrustAction(refreshed);
     },
@@ -1024,7 +995,7 @@ function AppContent() {
       dependencyFingerprint ? { dependencyFingerprint } : undefined,
     );
     if (!success) {
-      refreshPendingActionDependencyFingerprint(action);
+      refreshBlockedTrustActionDependencyFingerprint(action);
     }
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
@@ -1040,8 +1011,7 @@ function AppContent() {
   }, [
     approveTrust,
     handleTrustApprovedLaunch,
-    pendingActionDependencyFingerprint,
-    refreshPendingActionDependencyFingerprint,
+    refreshBlockedTrustActionDependencyFingerprint,
     runTrustApprovedAction,
     setBlockedTrustAction,
   ]);
@@ -1053,7 +1023,7 @@ function AppContent() {
       dependencyFingerprint ? { dependencyFingerprint } : undefined,
     );
     if (!success) {
-      refreshPendingActionDependencyFingerprint(action);
+      refreshBlockedTrustActionDependencyFingerprint(action);
     }
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
@@ -1067,8 +1037,7 @@ function AppContent() {
   }, [
     approveTrust,
     handleTrustApprovedLaunch,
-    pendingActionDependencyFingerprint,
-    refreshPendingActionDependencyFingerprint,
+    refreshBlockedTrustActionDependencyFingerprint,
     setBlockedTrustAction,
   ]);
 

--- a/apps/notebook/src/lib/__tests__/trust-actions.test.ts
+++ b/apps/notebook/src/lib/__tests__/trust-actions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  pendingActionDependencyFingerprint,
+  refreshPendingActionDependencyFingerprint,
+  type PendingTrustAction,
+} from "../trust-actions";
+
+const observedHeads = ["head-a"];
+
+describe("trust-actions", () => {
+  it("refreshes execute-cell action dependency fingerprints", () => {
+    const action: PendingTrustAction = {
+      kind: "execute_cell",
+      cellId: "cell-1",
+      provenance: { observed_heads: observedHeads },
+      dependencyFingerprint: "deps-old",
+    };
+
+    const refreshed = refreshPendingActionDependencyFingerprint(action, "deps-current");
+
+    expect(pendingActionDependencyFingerprint(refreshed)).toBe("deps-current");
+    expect(refreshed).toMatchObject({
+      kind: "execute_cell",
+      cellId: "cell-1",
+      provenance: { observed_heads: observedHeads },
+    });
+  });
+
+  it("refreshes run-all action dependency fingerprints", () => {
+    const action: PendingTrustAction = {
+      kind: "run_all",
+      provenance: { observed_heads: observedHeads },
+      dependencyFingerprint: "deps-old",
+    };
+
+    const refreshed = refreshPendingActionDependencyFingerprint(action, "deps-current");
+
+    expect(pendingActionDependencyFingerprint(refreshed)).toBe("deps-current");
+    expect(refreshed).toMatchObject({
+      kind: "run_all",
+      provenance: { observed_heads: observedHeads },
+    });
+  });
+
+  it("refreshes sync action dependency fingerprints inside the dependency guard", () => {
+    const action: PendingTrustAction = {
+      kind: "sync_deps",
+      provenance: {
+        observed_heads: observedHeads,
+        dependency_fingerprint: "deps-old",
+      },
+    };
+
+    const refreshed = refreshPendingActionDependencyFingerprint(action, "deps-current");
+
+    expect(pendingActionDependencyFingerprint(refreshed)).toBe("deps-current");
+    expect(refreshed).toMatchObject({
+      kind: "sync_deps",
+      provenance: {
+        observed_heads: observedHeads,
+        dependency_fingerprint: "deps-current",
+      },
+    });
+  });
+});

--- a/apps/notebook/src/lib/trust-actions.ts
+++ b/apps/notebook/src/lib/trust-actions.ts
@@ -1,0 +1,58 @@
+import type { DependencyGuard, GuardedNotebookProvenance } from "runtimed";
+
+export type PendingTrustAction =
+  | {
+      kind: "execute_cell";
+      cellId: string;
+      provenance: GuardedNotebookProvenance;
+      dependencyFingerprint: string;
+    }
+  | {
+      kind: "run_all";
+      provenance: GuardedNotebookProvenance;
+      dependencyFingerprint: string;
+    }
+  | { kind: "sync_deps"; provenance: DependencyGuard };
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled trust action kind: ${JSON.stringify(value)}`);
+}
+
+export function pendingActionDependencyFingerprint(
+  action: PendingTrustAction | null,
+): string | undefined {
+  if (!action) return undefined;
+  switch (action.kind) {
+    case "execute_cell":
+    case "run_all":
+      return action.dependencyFingerprint;
+    case "sync_deps":
+      return action.provenance.dependency_fingerprint;
+    default:
+      return assertNever(action);
+  }
+}
+
+export function refreshPendingActionDependencyFingerprint(
+  action: PendingTrustAction,
+  dependencyFingerprint: string,
+): PendingTrustAction {
+  switch (action.kind) {
+    case "execute_cell":
+    case "run_all":
+      return {
+        ...action,
+        dependencyFingerprint,
+      };
+    case "sync_deps":
+      return {
+        ...action,
+        provenance: {
+          ...action.provenance,
+          dependency_fingerprint: dependencyFingerprint,
+        },
+      };
+    default:
+      return assertNever(action);
+  }
+}


### PR DESCRIPTION
## Summary

- refresh the pending trust action dependency fingerprint after a stale approval rejection
- keep the first stale rejection as a review gate while allowing the next click to approve the current dependency state

## Verification

- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm test:run apps/notebook/src/lib/__tests__/trust-actions.test.ts apps/notebook/src/hooks/__tests__/useTrust.test.tsx apps/notebook/src/components/__tests__/trust-dialog.test.tsx`

## Notes

- Nightly diagnostics showed the daemon receiving repeated `ApproveTrust` requests, consistent with the UI retrying the same stale fingerprint.
