### PR TITLE
fix(notebook): allow iframe output scroll chaining

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -558,7 +558,7 @@ export function OutputArea({
                 colorTheme={colorTheme}
                 minHeight={24}
                 maxHeight={maxHeight ?? 2000}
-                allowWheelBoundaryScroll={false}
+                allowWheelBoundaryScroll
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}
                 onMouseDown={onIframeMouseDown}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -114,11 +114,11 @@ describe("OutputArea iframe theme sync", () => {
     });
   });
 
-  it("does not forward iframe wheel boundary scroll from notebook outputs", () => {
+  it("forwards iframe wheel boundary scroll from notebook outputs", () => {
     const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
 
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
-      "false",
+      "true",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Re-enable iframe wheel-boundary forwarding for isolated notebook outputs.
- Update the OutputArea regression test to assert notebook outputs allow boundary scroll forwarding.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/scroll-boundary.test.ts src/components/isolated/__tests__/frame-html.test.ts`
