### PR TITLE
fix(onboarding): stabilize setup flow

### DIFF
--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -259,13 +259,19 @@ export default function App() {
       while (!cancelled) {
         attempts += 1;
         try {
-          const state = await invoke<{
-            uv: { available: number; warming: number };
-            conda: { available: number; warming: number };
-            pixi: { available: number; warming: number };
-          }>("get_pool_status");
+          const state = await invoke<
+            Partial<
+              Record<
+                PythonEnv,
+                {
+                  available: number;
+                  warming: number;
+                }
+              >
+            >
+          >("get_pool_status");
 
-          const selected = state[pythonEnv];
+          const selected = state[pythonEnv] ?? { available: 0, warming: 0 };
           const available = selected.available;
           const warming = selected.warming;
 

--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -2,8 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { AlertTriangle, ArrowLeft, Check, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+import { type MouseEvent, useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
@@ -152,17 +151,24 @@ const BRAND_COLORS = {
 
 const IDLE_POOL_POLL_ATTEMPTS = 10;
 const WARMING_POOL_POLL_ATTEMPTS = 180;
+const LEARN_MORE_URL = "https://nteract.io/telemetry";
+const PYTHON_ENV_LABELS: Record<PythonEnv, string> = {
+  uv: "UV",
+  conda: "Conda",
+  pixi: "Pixi",
+};
 
 /**
  * First-launch onboarding screen with paged wizard.
  *
  * Page 1: Runtime selection (Python vs Deno)
- * Page 2: Python environment manager (UV vs Conda)
+ * Page 2: Python environment manager (UV vs Conda vs Pixi)
+ * Page 3: Telemetry decision and launch
  *
  * Daemon installation runs in background throughout.
  */
 export default function App() {
-  const [page, setPage] = useState<1 | 2>(1);
+  const [page, setPage] = useState<1 | 2 | 3>(1);
   const [runtime, setRuntime] = useState<Runtime | null>(null);
   const [pythonEnv, setPythonEnv] = useState<PythonEnv | null>(null);
   const [steps, setSteps] = useState<SetupStep[]>([
@@ -189,7 +195,7 @@ export default function App() {
               return { ...s, status: "completed" };
             }
             if (s.id === "tools" && s.status !== "completed") {
-              return { ...s, label: "Checking environments", status: "in_progress" };
+              return { ...s, label: "Choose environment", status: "pending" };
             }
             return s;
           }),
@@ -231,14 +237,21 @@ export default function App() {
     };
   }, []);
 
-  // Poll for pool readiness once daemon is ready. The pool is useful progress
-  // detail, but first-run onboarding should not block on prewarming: a ready
-  // daemon can create notebooks and launch kernels while environments continue
-  // warming in the background.
+  // Poll for readiness of the environment the user selected. The pool is useful
+  // progress detail, but first-run onboarding should not block on prewarming:
+  // a ready daemon can create notebooks and launch kernels while environments
+  // continue warming in the background.
   useEffect(() => {
-    if (!daemonReady) return;
+    if (!daemonReady || !pythonEnv) return;
 
-    setSteps((prev) => prev.map((s) => (s.id === "tools" ? { ...s, status: "in_progress" } : s)));
+    const envLabel = PYTHON_ENV_LABELS[pythonEnv];
+    setSteps((prev) =>
+      prev.map((s) =>
+        s.id === "tools"
+          ? { ...s, label: `Checking ${envLabel} runtime`, status: "in_progress" }
+          : s,
+      ),
+    );
 
     let cancelled = false;
     let attempts = 0;
@@ -252,13 +265,16 @@ export default function App() {
             pixi: { available: number; warming: number };
           }>("get_pool_status");
 
-          const available = state.uv.available + state.conda.available + state.pixi.available;
-          const warming = state.uv.warming + state.conda.warming + state.pixi.warming;
+          const selected = state[pythonEnv];
+          const available = selected.available;
+          const warming = selected.warming;
 
           if (available > 0) {
             setSteps((prev) =>
               prev.map((s) =>
-                s.id === "tools" ? { ...s, label: "Environments ready", status: "completed" } : s,
+                s.id === "tools"
+                  ? { ...s, label: `${envLabel} runtime ready`, status: "completed" }
+                  : s,
               ),
             );
             return;
@@ -268,7 +284,7 @@ export default function App() {
             setSteps((prev) =>
               prev.map((s) =>
                 s.id === "tools"
-                  ? { ...s, label: "Warming environments", status: "in_progress" }
+                  ? { ...s, label: `Warming ${envLabel} runtime`, status: "in_progress" }
                   : s,
               ),
             );
@@ -306,7 +322,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [daemonReady]);
+  }, [daemonReady, pythonEnv]);
 
   // Handle runtime selection
   const handleRuntimeSelect = useCallback((selected: Runtime) => {
@@ -323,18 +339,40 @@ export default function App() {
   // Handle Python env selection with auto-advance to ready state
   const handlePythonEnvSelect = useCallback((selected: PythonEnv) => {
     setPythonEnv(selected);
+    setSteps((prev) =>
+      prev.map((s) =>
+        s.id === "tools"
+          ? {
+              ...s,
+              label: `Checking ${PYTHON_ENV_LABELS[selected]} runtime`,
+              status: "in_progress",
+            }
+          : s,
+      ),
+    );
   }, []);
 
-  // Go back to page 1
+  const handleEnvironmentContinue = useCallback(() => {
+    if (pythonEnv) {
+      setPage(3);
+    }
+  }, [pythonEnv]);
+
+  // Go back one page
   const handleBack = useCallback(() => {
-    setPage(1);
+    setPage((current) => (current === 3 ? 2 : 1));
+  }, []);
+
+  const openTelemetryDetails = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    openExternal(LEARN_MORE_URL).catch(() => {
+      window.open(LEARN_MORE_URL, "_blank", "noopener,noreferrer");
+    });
   }, []);
 
   // Record the user's telemetry decision and complete onboarding. Called from
-  // either CTA on page 2 — the `telemetryEnabled` argument captures which
-  // button was pressed ("You can count on me!" → true, "Opt out of metrics" →
-  // false). Both paths flip `telemetry_consent_recorded` to true so
-  // heartbeats can fire (when enabled).
+  // either CTA on page 3. Both paths flip `telemetry_consent_recorded` to true
+  // so heartbeats can fire when enabled.
   const handleChoice = useCallback(
     async (telemetryEnabled: boolean) => {
       if (!runtime || !pythonEnv) return;
@@ -414,8 +452,9 @@ export default function App() {
   const totalSteps = steps.length;
   const progressPercent = (completedSteps / totalSteps) * 100;
 
+  const canContinueToTelemetry = page === 2 && pythonEnv !== null;
   const canProceed =
-    page === 2 && runtime !== null && pythonEnv !== null && daemonReady && !setupComplete;
+    page === 3 && runtime !== null && pythonEnv !== null && daemonReady && !setupComplete;
 
   // Page titles based on selections
   const page2Title = runtime === "deno" ? "Ok but if you did use Python..." : "Python Environment";
@@ -453,7 +492,7 @@ export default function App() {
             </div>
 
             <div className="flex justify-center">
-              <PageDots current={1} total={2} />
+              <PageDots current={1} total={3} />
             </div>
 
             {/* Next button */}
@@ -503,47 +542,83 @@ export default function App() {
                 <ArrowLeft className="h-4 w-4" />
                 Back
               </Button>
-              <PageDots current={2} total={2} />
+              <PageDots current={2} total={3} />
               <div className="w-[60px]" /> {/* Spacer for centering */}
             </div>
 
-            {/* Telemetry decision: replaces the pre-checked toggle with an
-                explicit two-button CTA. The primary is a warm "you're in"
-                framing; the secondary is always visible so opting out stays
-                a one-click action. Both record consent. */}
-            <div className="space-y-3">
-              <TelemetryDisclosureCard
-                onOpenLearnMore={(url) => {
-                  openExternal(url).catch(() => {
-                    // Tauri shell unavailable — the href on the <a> is still
-                    // set, so the browser falls through to that.
-                  });
-                }}
-              />
+            <Button
+              onClick={handleEnvironmentContinue}
+              disabled={!canContinueToTelemetry}
+              className="w-full"
+              size="lg"
+            >
+              {pythonEnv === null ? "Select a package manager" : "Continue"}
+            </Button>
 
+            {/* Continue anyway button when daemon fails */}
+            {daemonFailed && !setupComplete && (
+              <Button onClick={handleSkip} variant="ghost" className="w-full" size="sm">
+                Continue anyway
+              </Button>
+            )}
+          </>
+        )}
+
+        {/* Page 3: Telemetry */}
+        {page === 3 && (
+          <>
+            <div className="text-center space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight">Help improve nteract</h1>
+              <p className="text-muted-foreground">
+                Share one anonymous daily health ping so we know which installs are working.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-border/70 bg-card p-5 space-y-3">
+              <p className="text-sm leading-6 text-foreground">
+                It includes app version, OS, architecture, and release channel. It never includes
+                notebook contents, code, paths, package names, or personal information.
+              </p>
+              <a
+                href={LEARN_MORE_URL}
+                onClick={openTelemetryDetails}
+                rel="noreferrer"
+                target="_blank"
+                className="inline-block text-xs text-primary underline hover:text-foreground"
+              >
+                See exactly what is sent
+              </a>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Button variant="ghost" size="sm" onClick={handleBack} className="gap-1">
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </Button>
+              <PageDots current={3} total={3} />
+              <div className="w-[60px]" />
+            </div>
+
+            <div className="space-y-3">
               <Button
                 onClick={() => handleChoice(true)}
                 disabled={!canProceed || isSubmitting}
                 className="w-full"
                 size="lg"
               >
-                {setupComplete
-                  ? "All set!"
-                  : canProceed
-                    ? "You can count on me!"
-                    : pythonEnv === null
-                      ? "Select a package manager"
-                      : "Setting up..."}
+                {setupComplete ? "All set!" : canProceed ? "Share ping and start" : "Setting up..."}
               </Button>
 
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => handleChoice(false)}
                 disabled={!canProceed || isSubmitting}
-                className="w-full text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50 py-1"
+                className="w-full"
+                size="sm"
               >
-                Opt out of metrics, continue
-              </button>
+                Don&apos;t share, start
+              </Button>
             </div>
 
             {/* Continue anyway button when daemon fails */}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1183,7 +1183,7 @@ function AppContent() {
 
   const handleAddCell = useCallback(
     (type: "code" | "markdown" | "raw", afterCellId?: string | null) => {
-      addCell(type, afterCellId);
+      return addCell(type, afterCellId);
     },
     [addCell],
   );

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -177,6 +177,7 @@ function AppContent() {
   const {
     cellIds,
     isLoading,
+    canAcceptCellMutations,
     loadError,
     focusedCellId,
     setFocusedCellId,
@@ -1807,6 +1808,7 @@ function AppContent() {
           <NotebookView
             cellIds={cellIds}
             isLoading={isLoading}
+            canAcceptCellMutations={canAcceptCellMutations}
             loadError={loadError}
             runtime={runtime}
             sessionRuntimeState={sessionStatus?.runtime_state ?? null}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -37,6 +37,7 @@ import { RawCell } from "./RawCell";
 interface NotebookViewProps {
   cellIds: string[];
   isLoading?: boolean;
+  canAcceptCellMutations?: boolean;
   loadError?: string | null;
   runtime?: Runtime | null;
   sessionRuntimeState?: string | null;
@@ -344,6 +345,7 @@ function SortableCell({
 function NotebookViewContent({
   cellIds,
   isLoading = false,
+  canAcceptCellMutations = false,
   loadError = null,
   runtime = "python",
   sessionRuntimeState = null,
@@ -528,7 +530,7 @@ function NotebookViewContent({
   // processes the focusedCellId update from onAddCell.
   const didAutoSeed = useRef(false);
   useEffect(() => {
-    if (isLoading || focusedCellId !== null) return;
+    if (isLoading || focusedCellId !== null || !canAcceptCellMutations) return;
     if (cellIds.length === 0) {
       if (!didAutoSeed.current) {
         didAutoSeed.current = true;
@@ -537,7 +539,7 @@ function NotebookViewContent({
     } else {
       onFocusCell(cellIds[0]);
     }
-  }, [isLoading, cellIds, focusedCellId, onFocusCell, onAddCell]);
+  }, [isLoading, canAcceptCellMutations, cellIds, focusedCellId, onFocusCell, onAddCell]);
 
   const renderCell = useCallback(
     (

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -34,7 +34,7 @@ import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
 
-type AddCellResult = NotebookCell | null | void;
+type AddCellResult = NotebookCell | null;
 type AddCellHandler = (type: "code" | "markdown", afterCellId?: string | null) => AddCellResult;
 
 interface NotebookViewProps {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -34,6 +34,9 @@ import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
 
+type AddCellResult = NotebookCell | null | void;
+type AddCellHandler = (type: "code" | "markdown", afterCellId?: string | null) => AddCellResult;
+
 interface NotebookViewProps {
   cellIds: string[];
   isLoading?: boolean;
@@ -45,7 +48,7 @@ interface NotebookViewProps {
   onExecuteCell: (cellId: string) => void;
   onInterruptKernel: () => void;
   onDeleteCell: (cellId: string) => void;
-  onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
+  onAddCell: AddCellHandler;
   onMoveCell: (cellId: string, afterCellId?: string | null) => void;
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
   onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
@@ -75,7 +78,7 @@ function CellAdder({
   cellType = "code",
 }: {
   afterCellId?: string | null;
-  onAdd: (type: "code" | "markdown", afterCellId?: string | null) => void;
+  onAdd: AddCellHandler;
   cellType?: string;
 }) {
   const ribbonClass = adderRibbonClasses[cellType] ?? defaultAdderRibbonClass;
@@ -286,7 +289,7 @@ function SortableCell({
     dragHandleProps?: Record<string, unknown>,
     isDragging?: boolean,
   ) => React.ReactNode;
-  onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
+  onAddCell: AddCellHandler;
   onDeleteCell: (cellId: string) => void;
   isHiddenInGroup?: boolean;
 }) {
@@ -533,8 +536,10 @@ function NotebookViewContent({
     if (isLoading || focusedCellId !== null || !canAcceptCellMutations) return;
     if (cellIds.length === 0) {
       if (!didAutoSeed.current) {
-        didAutoSeed.current = true;
-        onAddCell("code");
+        const seeded = onAddCell("code");
+        if (seeded !== null) {
+          didAutoSeed.current = true;
+        }
       }
     } else {
       onFocusCell(cellIds[0]);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -70,6 +70,7 @@ export function useAutomergeNotebook() {
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [canAcceptCellMutations, setCanAcceptCellMutations] = useState(false);
 
   const handleRef = useRef<NotebookHandle | null>(null);
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
@@ -155,6 +156,12 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
+  const refreshCanAcceptCellMutations = useCallback((handle = handleRef.current) => {
+    const canAccept = handle?.has_cells_map() ?? false;
+    setCanAcceptCellMutations(canAccept);
+    return canAccept;
+  }, []);
+
   /**
    * Guard + commit helper for WASM mutations.
    * After the mutation callback runs, re-materializes and syncs.
@@ -201,6 +208,7 @@ export function useAutomergeNotebook() {
 
     interactiveReadyRef.current = false;
     latestSessionStatusRef.current = null;
+    setCanAcceptCellMutations(false);
     setLoadError(null);
     setIsLoading(true);
 
@@ -255,6 +263,7 @@ export function useAutomergeNotebook() {
       }
 
       setLoadError(null);
+      refreshCanAcceptCellMutations();
       if (interactiveReadyRef.current) {
         setIsLoading(isInitialLoadStreaming(status.initial_load));
       }
@@ -280,6 +289,7 @@ export function useAutomergeNotebook() {
             // existing eager output visibility until the authoritative
             // runtime-state projection lands.
             seedOutputStoresFromHandle(handle, cellIdList);
+            refreshCanAcceptCellMutations(handle);
             // Project whatever RuntimeState snapshot has landed so far
             // on top. If the runtime-state frame arrived first this is
             // the authoritative pass; otherwise it's a no-op that the
@@ -319,6 +329,7 @@ export function useAutomergeNotebook() {
                 // RuntimeStateDoc entry happened to land last.
                 const handle = handleRef.current;
                 if (!handle) return;
+                refreshCanAcceptCellMutations(handle);
                 const pointerRefresh = planCellPointerRefresh(changeset);
                 if (pointerRefresh.kind === "touched") {
                   updateCellExecutionPointersFromHandle(handle, pointerRefresh.cell_ids);
@@ -386,6 +397,7 @@ export function useAutomergeNotebook() {
           resetRuntimeState();
           resetRuntimeStoresProjection();
           resetPoolState();
+          setCanAcceptCellMutations(false);
           outputCacheRef.current.clear();
           setIsLoading(true);
           setLoadError(null);
@@ -428,11 +440,12 @@ export function useAutomergeNotebook() {
       resetRuntimeState();
       resetRuntimeStoresProjection();
       resetPoolState();
+      setCanAcceptCellMutations(false);
       setNotebookHandle(null);
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [bootstrap, host, materializeCells]);
+  }, [bootstrap, host, materializeCells, refreshCanAcceptCellMutations]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 
@@ -452,10 +465,9 @@ export function useAutomergeNotebook() {
     (cellType: "code" | "markdown" | "raw", afterCellId?: string | null) => {
       const handle = handleRef.current;
       const engine = engineRef.current;
-
-      if (!handle || !engine) {
-        const placeholderId = crypto.randomUUID();
-        return cellType === "code"
+      const placeholderId = crypto.randomUUID();
+      const placeholder =
+        cellType === "code"
           ? {
               cell_type: "code" as const,
               id: placeholderId,
@@ -470,10 +482,26 @@ export function useAutomergeNotebook() {
               source: "",
               metadata: {},
             };
+
+      if (!handle || !engine) {
+        logger.debug("[automerge-notebook] addCell skipped: no handle/engine");
+        return placeholder;
+      }
+
+      if (!handle.has_cells_map()) {
+        logger.debug("[automerge-notebook] addCell skipped: cells map not synced yet");
+        setCanAcceptCellMutations(false);
+        return placeholder;
       }
 
       const cellId = crypto.randomUUID();
-      handle.add_cell_after(cellId, cellType, afterCellId ?? null);
+      try {
+        handle.add_cell_after(cellId, cellType, afterCellId ?? null);
+      } catch (error) {
+        logger.warn("[automerge-notebook] addCell failed:", error);
+        refreshCanAcceptCellMutations(handle);
+        return placeholder;
+      }
       rematerializeCellsSync(handle);
       engine.flush();
       setFocusedCellId(cellId);
@@ -489,7 +517,7 @@ export function useAutomergeNotebook() {
         }
       );
     },
-    [rematerializeCellsSync],
+    [refreshCanAcceptCellMutations, rematerializeCellsSync],
   );
 
   const moveCell = useCallback(
@@ -662,6 +690,7 @@ export function useAutomergeNotebook() {
   return {
     cellIds,
     isLoading,
+    canAcceptCellMutations,
     focusedCellId,
     setFocusedCellId,
     updateCellSource,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -45,7 +45,7 @@ import {
   setRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
-import type { JupyterOutput } from "../types";
+import type { JupyterOutput, NotebookCell } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 // Module-level WASM init — runs before React renders.
@@ -462,36 +462,19 @@ export function useAutomergeNotebook() {
   }, []);
 
   const addCell = useCallback(
-    (cellType: "code" | "markdown" | "raw", afterCellId?: string | null) => {
+    (cellType: "code" | "markdown" | "raw", afterCellId?: string | null): NotebookCell | null => {
       const handle = handleRef.current;
       const engine = engineRef.current;
-      const placeholderId = crypto.randomUUID();
-      const placeholder =
-        cellType === "code"
-          ? {
-              cell_type: "code" as const,
-              id: placeholderId,
-              source: "",
-              outputs: [],
-              execution_count: null,
-              metadata: {},
-            }
-          : {
-              cell_type: cellType,
-              id: placeholderId,
-              source: "",
-              metadata: {},
-            };
 
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] addCell skipped: no handle/engine");
-        return placeholder;
+        return null;
       }
 
       if (!handle.has_cells_map()) {
         logger.debug("[automerge-notebook] addCell skipped: cells map not synced yet");
         setCanAcceptCellMutations(false);
-        return placeholder;
+        return null;
       }
 
       const cellId = crypto.randomUUID();
@@ -500,22 +483,30 @@ export function useAutomergeNotebook() {
       } catch (error) {
         logger.warn("[automerge-notebook] addCell failed:", error);
         refreshCanAcceptCellMutations(handle);
-        return placeholder;
+        return null;
       }
       rematerializeCellsSync(handle);
       engine.flush();
       setFocusedCellId(cellId);
 
       const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
-      return (
-        cell ?? {
-          cell_type: cellType,
+      if (cell) return cell;
+      if (cellType === "code") {
+        return {
+          cell_type: "code",
           id: cellId,
           source: "",
-          ...(cellType === "code" ? { outputs: [], execution_count: null } : {}),
+          outputs: [],
+          execution_count: null,
           metadata: {},
-        }
-      );
+        };
+      }
+      return {
+        cell_type: cellType,
+        id: cellId,
+        source: "",
+        metadata: {},
+      };
     },
     [refreshCanAcceptCellMutations, rematerializeCellsSync],
   );

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1066,6 +1066,11 @@ impl NotebookDoc {
         }
     }
 
+    /// Return true once the daemon-authored cells map has synced into this doc.
+    pub fn has_cells_map(&self) -> bool {
+        self.cells_map_id().is_some()
+    }
+
     /// Get all cells as snapshots, sorted by position.
     pub fn get_cells(&self) -> Vec<CellSnapshot> {
         let cells_id = match self.cells_map_id() {
@@ -2555,6 +2560,7 @@ mod tests {
         let doc = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "test");
         assert_eq!(doc.notebook_id(), None);
         assert_eq!(doc.cell_count(), 0);
+        assert!(!doc.has_cells_map());
         assert_eq!(doc.get_cells(), vec![]);
         assert_eq!(doc.schema_version(), Some(SCHEMA_VERSION));
         // No metadata map exists before sync — reads return None gracefully.
@@ -2599,6 +2605,7 @@ mod tests {
         }
 
         assert_eq!(empty.cell_count(), 1);
+        assert!(empty.has_cells_map());
         let cell = empty.get_cell("cell-1").unwrap();
         assert_eq!(cell.source, "print('hello')");
         assert_eq!(empty.notebook_id(), Some("test-notebook".to_string()));

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -540,6 +540,11 @@ impl NotebookHandle {
         self.doc.cell_count()
     }
 
+    /// Return true once the daemon-authored cells map is present.
+    pub fn has_cells_map(&self) -> bool {
+        self.doc.has_cells_map()
+    }
+
     /// Get all cells as an array of JsCell objects.
     ///
     /// Outputs are fetched from `RuntimeStateDoc` keyed by each cell's

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -86,10 +86,27 @@ function syncUntilConvergedReportingChange(
 
 Deno.test("NotebookHandle: create new empty doc", () => {
   const handle = new NotebookHandle("test-notebook");
+  assertEquals(handle.has_cells_map(), true);
   assertEquals(handle.cell_count(), 0);
   assertEquals(handle.get_cells().length, 0);
   assertEquals(handle.get_cells_json(), "[]");
   handle.free();
+});
+
+Deno.test("NotebookHandle: bootstrap reports cells map readiness after sync", () => {
+  const daemon = new NotebookHandle("readiness-test");
+  const frontend = NotebookHandle.create_bootstrap("human:test");
+
+  assertEquals(frontend.has_cells_map(), false);
+
+  syncHandles(daemon, frontend);
+
+  assertEquals(frontend.has_cells_map(), true);
+  frontend.add_cell_after("cell-1", "code", null);
+  assertEquals(frontend.cell_count(), 1);
+
+  daemon.free();
+  frontend.free();
 });
 
 // Regression guard: the committed WASM bundle must emit a RuntimeState


### PR DESCRIPTION
## Summary

- move onboarding telemetry into a third finish step with the new "Share ping and start" CTA
- track setup progress against the selected Python environment pool only
- gate empty-notebook auto-seeding until the synced Automerge doc has the daemon-authored cells map

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm test:run`
- `cargo test -p notebook-doc test_empty_doc`
- `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/deno_smoke_test.ts`
- `cargo xtask e2e build`
- `cargo xtask e2e test`
