### PR TITLE
fix(notebook): resnap focused cell during output growth

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -24,7 +24,7 @@ import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
-import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
+import { useExecutingCellIds, useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
 import { logger } from "../lib/logger";
 import { getNotebookCellsSnapshot, useCell, useMaterializeVersion } from "../lib/notebook-cells";
 import { getCellOutputsSnapshot, useOutputsVersion } from "../lib/notebook-outputs";
@@ -367,13 +367,16 @@ function NotebookViewContent({
 
   // Read transient UI state from the store instead of props
   const focusedCellId = useFocusedCellId();
+  const executingCellIds = useExecutingCellIds();
   const searchCurrentMatch = useSearchCurrentMatch();
+  const executionResnapUntilRef = useRef(0);
+  const previousExecutingSizeRef = useRef(executingCellIds.size);
   // Ref for cellIds so renderCell can read the latest list without
   // depending on the array identity. This prevents recreating
   // renderCell (and remounting widget iframes) on structural changes.
   const cellIdsRef = useRef(cellIds);
   cellIdsRef.current = cellIds;
-  const { focusCell } = useEditorRegistry();
+  const { focusCell, resnapCell } = useEditorRegistry();
 
   // Track full materializations for cross-cell derived state
   const materializeVersion = useMaterializeVersion();
@@ -524,6 +527,26 @@ function NotebookViewContent({
       cellEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
     }
   }, [searchCurrentMatch]);
+
+  useEffect(() => {
+    const previousSize = previousExecutingSizeRef.current;
+    previousExecutingSizeRef.current = executingCellIds.size;
+    if (executingCellIds.size > 0) {
+      executionResnapUntilRef.current = Date.now() + 3500;
+    } else if (previousSize > 0) {
+      executionResnapUntilRef.current = Date.now() + 2000;
+    }
+  }, [executingCellIds]);
+
+  useEffect(() => {
+    if (!focusedCellId || outputsVersion === 0) return;
+    if (executingCellIds.size > 0) {
+      executionResnapUntilRef.current = Date.now() + 3500;
+    } else if (Date.now() > executionResnapUntilRef.current) {
+      return;
+    }
+    resnapCell(focusedCellId);
+  }, [executingCellIds, focusedCellId, outputsVersion, resnapCell]);
 
   // ── Auto-seed first cell for empty notebooks ───────────────────────
   // For new notebooks the daemon creates zero cells. Once sync completes
@@ -765,6 +788,7 @@ function NotebookViewContent({
       ref={containerRef}
       className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
       style={{ contain: "paint", overflowAnchor: "none" }}
+      data-notebook-scroll-container="true"
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { useExecutingCellIds, useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
+import { decideExecutionResnap } from "../lib/execution-resnap";
 import { logger } from "../lib/logger";
 import { getNotebookCellsSnapshot, useCell, useMaterializeVersion } from "../lib/notebook-cells";
 import { getCellOutputsSnapshot, useOutputsVersion } from "../lib/notebook-outputs";
@@ -370,6 +371,7 @@ function NotebookViewContent({
   const executingCellIds = useExecutingCellIds();
   const searchCurrentMatch = useSearchCurrentMatch();
   const executionResnapUntilRef = useRef(0);
+  const executionResnapCancelledRef = useRef(false);
   const previousExecutingSizeRef = useRef(executingCellIds.size);
   // Ref for cellIds so renderCell can read the latest list without
   // depending on the array identity. This prevents recreating
@@ -531,15 +533,26 @@ function NotebookViewContent({
   useEffect(() => {
     const previousSize = previousExecutingSizeRef.current;
     previousExecutingSizeRef.current = executingCellIds.size;
-    if (executingCellIds.size > 0) {
+    if (executingCellIds.size === 0) {
+      if (previousSize > 0 && !executionResnapCancelledRef.current) {
+        executionResnapUntilRef.current = Date.now() + 2000;
+      }
+      executionResnapCancelledRef.current = false;
+    } else if (previousSize === 0) {
+      executionResnapCancelledRef.current = false;
       executionResnapUntilRef.current = Date.now() + 3500;
-    } else if (previousSize > 0) {
-      executionResnapUntilRef.current = Date.now() + 2000;
+    } else if (!executionResnapCancelledRef.current) {
+      executionResnapUntilRef.current = Date.now() + 3500;
     }
   }, [executingCellIds]);
 
+  useEffect(() => {
+    executionResnapCancelledRef.current = false;
+  }, [focusedCellId]);
+
   const cancelExecutionResnap = useCallback(() => {
-    if (executionResnapUntilRef.current === 0) return;
+    if (executionResnapUntilRef.current === 0 && executionResnapCancelledRef.current) return;
+    executionResnapCancelledRef.current = true;
     executionResnapUntilRef.current = 0;
     cancelResnapCell();
   }, [cancelResnapCell]);
@@ -579,10 +592,16 @@ function NotebookViewContent({
   }, [cancelExecutionResnap]);
 
   useEffect(() => {
-    if (!focusedCellId || outputsVersion === 0) return;
-    if (executingCellIds.size > 0) {
-      executionResnapUntilRef.current = Date.now() + 3500;
-    } else if (Date.now() > executionResnapUntilRef.current) {
+    const decision = decideExecutionResnap({
+      focusedCellId,
+      outputsVersion,
+      executingCellCount: executingCellIds.size,
+      resnapCancelled: executionResnapCancelledRef.current,
+      resnapUntil: executionResnapUntilRef.current,
+      now: Date.now(),
+    });
+    executionResnapUntilRef.current = decision.nextResnapUntil;
+    if (!decision.shouldResnap || !focusedCellId) {
       return;
     }
     resnapCell(focusedCellId);

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -376,7 +376,7 @@ function NotebookViewContent({
   // renderCell (and remounting widget iframes) on structural changes.
   const cellIdsRef = useRef(cellIds);
   cellIdsRef.current = cellIds;
-  const { focusCell, resnapCell } = useEditorRegistry();
+  const { cancelResnapCell, focusCell, resnapCell } = useEditorRegistry();
 
   // Track full materializations for cross-cell derived state
   const materializeVersion = useMaterializeVersion();
@@ -537,6 +537,46 @@ function NotebookViewContent({
       executionResnapUntilRef.current = Date.now() + 2000;
     }
   }, [executingCellIds]);
+
+  const cancelExecutionResnap = useCallback(() => {
+    if (executionResnapUntilRef.current === 0) return;
+    executionResnapUntilRef.current = 0;
+    cancelResnapCell();
+  }, [cancelResnapCell]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as Element | null;
+      if (
+        target?.closest(".cm-content") ||
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.getAttribute("contenteditable") === "true"
+      ) {
+        return;
+      }
+      if (
+        event.key === "PageUp" ||
+        event.key === "PageDown" ||
+        event.key === "Home" ||
+        event.key === "End"
+      ) {
+        cancelExecutionResnap();
+      }
+    };
+
+    container.addEventListener("wheel", cancelExecutionResnap, { passive: true });
+    container.addEventListener("touchmove", cancelExecutionResnap, { passive: true });
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      container.removeEventListener("wheel", cancelExecutionResnap);
+      container.removeEventListener("touchmove", cancelExecutionResnap);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [cancelExecutionResnap]);
 
   useEffect(() => {
     if (!focusedCellId || outputsVersion === 0) return;

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { startFocusedCellResnap } from "../useEditorRegistry";
+
+type ResizeObserverCallback = ConstructorParameters<typeof ResizeObserver>[0];
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+
+  observe = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+describe("startFocusedCellResnap", () => {
+  let originalResizeObserver: typeof window.ResizeObserver | undefined;
+  let originalMutationObserver: typeof window.MutationObserver | undefined;
+
+  beforeEach(() => {
+    FakeResizeObserver.instances = [];
+
+    originalResizeObserver = window.ResizeObserver;
+    originalMutationObserver = window.MutationObserver;
+
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: FakeResizeObserver,
+    });
+    Object.defineProperty(window, "MutationObserver", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: originalResizeObserver,
+    });
+    Object.defineProperty(window, "MutationObserver", {
+      configurable: true,
+      value: originalMutationObserver,
+    });
+    document.body.replaceChildren();
+  });
+
+  it("snaps the focused cell back into view while the DOM is settling", async () => {
+    const list = document.createElement("div");
+    const cell = document.createElement("section");
+    const scrollIntoView = vi.fn();
+    cell.scrollIntoView = scrollIntoView;
+    list.append(cell);
+    document.body.append(list);
+
+    const cleanup = startFocusedCellResnap(cell);
+
+    expect(FakeResizeObserver.instances).toHaveLength(1);
+    expect(FakeResizeObserver.instances[0].observe).toHaveBeenCalledWith(list);
+
+    FakeResizeObserver.instances[0].trigger();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+
+    cleanup();
+  });
+
+  it("disconnects automatically after the resnap window closes", async () => {
+    const cell = document.createElement("section");
+    const scrollIntoView = vi.fn();
+    cell.scrollIntoView = scrollIntoView;
+    document.body.append(cell);
+
+    startFocusedCellResnap(cell, { durationMs: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(FakeResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+
+    FakeResizeObserver.instances[0].trigger();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("stops resnapping when focus moves elsewhere", async () => {
+    const cell = document.createElement("section");
+    const scrollIntoView = vi.fn();
+    cell.scrollIntoView = scrollIntoView;
+    document.body.append(cell);
+
+    const cleanup = startFocusedCellResnap(cell);
+    cleanup();
+
+    FakeResizeObserver.instances[0].trigger();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(FakeResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts
@@ -52,6 +52,11 @@ describe("startFocusedCellResnap", () => {
 
   it("snaps the focused cell back into view while the DOM is settling", async () => {
     const list = document.createElement("div");
+    list.dataset.notebookScrollContainer = "true";
+    const scrollListener = vi.fn();
+    const resizeListener = vi.fn();
+    list.addEventListener("scroll", scrollListener);
+    window.addEventListener("resize", resizeListener);
     const cell = document.createElement("section");
     const scrollIntoView = vi.fn();
     cell.scrollIntoView = scrollIntoView;
@@ -67,8 +72,11 @@ describe("startFocusedCellResnap", () => {
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
     expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+    expect(scrollListener).toHaveBeenCalled();
+    expect(resizeListener).toHaveBeenCalled();
 
     cleanup();
+    window.removeEventListener("resize", resizeListener);
   });
 
   it("disconnects automatically after the resnap window closes", async () => {

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -4,6 +4,7 @@ import { logger } from "../lib/logger";
 
 interface EditorRegistryContextType {
   focusCell: (cellId: string, cursorPosition: "start" | "end") => void;
+  resnapCell: (cellId: string) => void;
 }
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
@@ -13,6 +14,21 @@ export const FOCUSED_CELL_RESNAP_DURATION_MS = 2500;
 type FocusedCellResnapOptions = {
   durationMs?: number;
 };
+
+function pulseLayoutForCell(cellElement: Element): void {
+  const win = cellElement.ownerDocument.defaultView;
+  if (!win) return;
+
+  const scrollContainer = cellElement.closest('[data-notebook-scroll-container="true"]');
+  scrollContainer?.dispatchEvent(new Event("scroll", { bubbles: true }));
+  win.dispatchEvent(new Event("resize"));
+}
+
+function snapCellIntoView(cellElement: Element): void {
+  if (!cellElement.isConnected) return;
+  cellElement.scrollIntoView({ block: "nearest", behavior: "auto" });
+  pulseLayoutForCell(cellElement);
+}
 
 // Outputs often render after Shift-Enter navigation. Keep the newly focused
 // cell pinned briefly while the notebook DOM settles, then release manual scroll.
@@ -32,7 +48,7 @@ export function startFocusedCellResnap(
     animationFrame = win.requestAnimationFrame(() => {
       animationFrame = null;
       if (!active || !cellElement.isConnected) return;
-      cellElement.scrollIntoView({ block: "nearest", behavior: "auto" });
+      snapCellIntoView(cellElement);
     });
   };
 
@@ -74,6 +90,18 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
     return () => stopFocusedCellResnapRef.current?.();
   }, []);
 
+  const resnapCell = useCallback((cellId: string) => {
+    const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
+    if (!cellElement) {
+      logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
+      return;
+    }
+
+    stopFocusedCellResnapRef.current?.();
+    stopFocusedCellResnapRef.current = startFocusedCellResnap(cellElement);
+    snapCellIntoView(cellElement);
+  }, []);
+
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
   const focusCell = useCallback((cellId: string, cursorPosition: "start" | "end") => {
     // Find the cell element by data attribute
@@ -85,6 +113,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
 
     stopFocusedCellResnapRef.current?.();
     stopFocusedCellResnapRef.current = startFocusedCellResnap(cellElement);
+    pulseLayoutForCell(cellElement);
 
     // Scroll the cell container into the notebook viewport
     cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
@@ -115,7 +144,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <EditorRegistryContext.Provider value={{ focusCell }}>
+    <EditorRegistryContext.Provider value={{ focusCell, resnapCell }}>
       {children}
     </EditorRegistryContext.Provider>
   );

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { createContext, type ReactNode, useCallback, useContext } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef } from "react";
 import { logger } from "../lib/logger";
 
 interface EditorRegistryContextType {
@@ -8,7 +8,72 @@ interface EditorRegistryContextType {
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
 
+export const FOCUSED_CELL_RESNAP_DURATION_MS = 2500;
+
+type FocusedCellResnapOptions = {
+  durationMs?: number;
+};
+
+// Outputs often render after Shift-Enter navigation. Keep the newly focused
+// cell pinned briefly while the notebook DOM settles, then release manual scroll.
+export function startFocusedCellResnap(
+  cellElement: Element,
+  options: FocusedCellResnapOptions = {},
+): () => void {
+  const win = cellElement.ownerDocument.defaultView;
+  if (!win) return () => {};
+
+  let active = true;
+  let animationFrame: number | null = null;
+  let timeoutId: number | null = null;
+
+  const snapIntoView = () => {
+    if (!active || animationFrame !== null) return;
+    animationFrame = win.requestAnimationFrame(() => {
+      animationFrame = null;
+      if (!active || !cellElement.isConnected) return;
+      cellElement.scrollIntoView({ block: "nearest", behavior: "auto" });
+    });
+  };
+
+  const observedElement = cellElement.parentElement ?? cellElement;
+  const resizeObserver =
+    typeof win.ResizeObserver === "function" ? new win.ResizeObserver(snapIntoView) : null;
+  resizeObserver?.observe(observedElement);
+
+  const mutationObserver =
+    typeof win.MutationObserver === "function" ? new win.MutationObserver(snapIntoView) : null;
+  mutationObserver?.observe(observedElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  const cleanup = () => {
+    active = false;
+    if (animationFrame !== null) {
+      win.cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+    }
+    if (timeoutId !== null) {
+      win.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    resizeObserver?.disconnect();
+    mutationObserver?.disconnect();
+  };
+
+  timeoutId = win.setTimeout(cleanup, options.durationMs ?? FOCUSED_CELL_RESNAP_DURATION_MS);
+
+  return cleanup;
+}
+
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
+  const stopFocusedCellResnapRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => stopFocusedCellResnapRef.current?.();
+  }, []);
+
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
   const focusCell = useCallback((cellId: string, cursorPosition: "start" | "end") => {
     // Find the cell element by data attribute
@@ -17,6 +82,9 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
       return;
     }
+
+    stopFocusedCellResnapRef.current?.();
+    stopFocusedCellResnapRef.current = startFocusedCellResnap(cellElement);
 
     // Scroll the cell container into the notebook viewport
     cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -10,7 +10,7 @@ interface EditorRegistryContextType {
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
 
-export const FOCUSED_CELL_RESNAP_DURATION_MS = 2500;
+export const FOCUSED_CELL_RESNAP_DURATION_MS = 4000;
 
 type FocusedCellResnapOptions = {
   durationMs?: number;

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -5,6 +5,7 @@ import { logger } from "../lib/logger";
 interface EditorRegistryContextType {
   focusCell: (cellId: string, cursorPosition: "start" | "end") => void;
   resnapCell: (cellId: string) => void;
+  cancelResnapCell: () => void;
 }
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
@@ -13,6 +14,7 @@ export const FOCUSED_CELL_RESNAP_DURATION_MS = 2500;
 
 type FocusedCellResnapOptions = {
   durationMs?: number;
+  onStop?: () => void;
 };
 
 function pulseLayoutForCell(cellElement: Element): void {
@@ -65,6 +67,7 @@ export function startFocusedCellResnap(
   });
 
   const cleanup = () => {
+    if (!active) return;
     active = false;
     if (animationFrame !== null) {
       win.cancelAnimationFrame(animationFrame);
@@ -76,6 +79,7 @@ export function startFocusedCellResnap(
     }
     resizeObserver?.disconnect();
     mutationObserver?.disconnect();
+    options.onStop?.();
   };
 
   timeoutId = win.setTimeout(cleanup, options.durationMs ?? FOCUSED_CELL_RESNAP_DURATION_MS);
@@ -85,66 +89,105 @@ export function startFocusedCellResnap(
 
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
   const stopFocusedCellResnapRef = useRef<(() => void) | null>(null);
+  const resnappingCellElementRef = useRef<Element | null>(null);
 
   useEffect(() => {
     return () => stopFocusedCellResnapRef.current?.();
   }, []);
 
-  const resnapCell = useCallback((cellId: string) => {
-    const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
-    if (!cellElement) {
-      logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
+  const cancelResnapCell = useCallback(() => {
+    stopFocusedCellResnapRef.current?.();
+  }, []);
+
+  const startOrReuseCellResnap = useCallback((cellElement: Element, snapNow: boolean) => {
+    if (stopFocusedCellResnapRef.current && resnappingCellElementRef.current === cellElement) {
+      if (snapNow) {
+        snapCellIntoView(cellElement);
+      } else {
+        pulseLayoutForCell(cellElement);
+      }
       return;
     }
 
     stopFocusedCellResnapRef.current?.();
-    stopFocusedCellResnapRef.current = startFocusedCellResnap(cellElement);
-    snapCellIntoView(cellElement);
+    resnappingCellElementRef.current = cellElement;
+    let cleanup: () => void = () => {};
+    cleanup = startFocusedCellResnap(cellElement, {
+      onStop: () => {
+        if (resnappingCellElementRef.current === cellElement) {
+          resnappingCellElementRef.current = null;
+        }
+        if (stopFocusedCellResnapRef.current === cleanup) {
+          stopFocusedCellResnapRef.current = null;
+        }
+      },
+    });
+    stopFocusedCellResnapRef.current = cleanup;
+
+    if (snapNow) {
+      snapCellIntoView(cellElement);
+    } else {
+      pulseLayoutForCell(cellElement);
+    }
   }, []);
+
+  const resnapCell = useCallback(
+    (cellId: string) => {
+      const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
+      if (!cellElement) {
+        logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
+        return;
+      }
+
+      startOrReuseCellResnap(cellElement, true);
+    },
+    [startOrReuseCellResnap],
+  );
 
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
-  const focusCell = useCallback((cellId: string, cursorPosition: "start" | "end") => {
-    // Find the cell element by data attribute
-    const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
-    if (!cellElement) {
-      logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
-      return;
-    }
+  const focusCell = useCallback(
+    (cellId: string, cursorPosition: "start" | "end") => {
+      // Find the cell element by data attribute
+      const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
+      if (!cellElement) {
+        logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
+        return;
+      }
 
-    stopFocusedCellResnapRef.current?.();
-    stopFocusedCellResnapRef.current = startFocusedCellResnap(cellElement);
-    pulseLayoutForCell(cellElement);
+      startOrReuseCellResnap(cellElement, false);
 
-    // Scroll the cell container into the notebook viewport
-    cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      // Scroll the cell container into the notebook viewport
+      cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
 
-    // Find CodeMirror's content element inside the cell
-    const cmContent = cellElement.querySelector(".cm-content");
-    if (!cmContent) {
-      // Might be a markdown cell in view mode - no editor to focus
-      logger.debug(`[cell-nav] No CM content in cell (markdown?): ${cellId.slice(0, 8)}`);
-      return;
-    }
+      // Find CodeMirror's content element inside the cell
+      const cmContent = cellElement.querySelector(".cm-content");
+      if (!cmContent) {
+        // Might be a markdown cell in view mode - no editor to focus
+        logger.debug(`[cell-nav] No CM content in cell (markdown?): ${cellId.slice(0, 8)}`);
+        return;
+      }
 
-    // Use CodeMirror's API to find the EditorView from DOM
-    const view = EditorView.findFromDOM(cmContent as HTMLElement);
-    if (!view) {
-      logger.warn(`[cell-nav] EditorView not found for: ${cellId.slice(0, 8)}`);
-      return;
-    }
+      // Use CodeMirror's API to find the EditorView from DOM
+      const view = EditorView.findFromDOM(cmContent as HTMLElement);
+      if (!view) {
+        logger.warn(`[cell-nav] EditorView not found for: ${cellId.slice(0, 8)}`);
+        return;
+      }
 
-    // Set cursor position and focus
-    const doc = view.state.doc;
-    const pos = cursorPosition === "start" ? 0 : doc.length;
-    view.dispatch({
-      selection: { anchor: pos, head: pos },
-      scrollIntoView: true,
-    });
-    view.focus();
-  }, []);
+      // Set cursor position and focus
+      const doc = view.state.doc;
+      const pos = cursorPosition === "start" ? 0 : doc.length;
+      view.dispatch({
+        selection: { anchor: pos, head: pos },
+        scrollIntoView: true,
+      });
+      view.focus();
+    },
+    [startOrReuseCellResnap],
+  );
 
   return (
-    <EditorRegistryContext.Provider value={{ focusCell, resnapCell }}>
+    <EditorRegistryContext.Provider value={{ cancelResnapCell, focusCell, resnapCell }}>
       {children}
     </EditorRegistryContext.Provider>
   );

--- a/apps/notebook/src/lib/__tests__/execution-resnap.test.ts
+++ b/apps/notebook/src/lib/__tests__/execution-resnap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import { decideExecutionResnap } from "../execution-resnap";
 
 describe("decideExecutionResnap", () => {

--- a/apps/notebook/src/lib/__tests__/execution-resnap.test.ts
+++ b/apps/notebook/src/lib/__tests__/execution-resnap.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { decideExecutionResnap } from "../execution-resnap";
+
+describe("decideExecutionResnap", () => {
+  it("does not resnap after user cancellation during active execution", () => {
+    expect(
+      decideExecutionResnap({
+        focusedCellId: "cell-1",
+        outputsVersion: 2,
+        executingCellCount: 1,
+        resnapCancelled: true,
+        resnapUntil: 0,
+        now: 1000,
+      }),
+    ).toEqual({ shouldResnap: false, nextResnapUntil: 0 });
+  });
+
+  it("extends the active resnap window while execution is running", () => {
+    expect(
+      decideExecutionResnap({
+        focusedCellId: "cell-1",
+        outputsVersion: 2,
+        executingCellCount: 1,
+        resnapCancelled: false,
+        resnapUntil: 0,
+        now: 1000,
+        activeWindowMs: 3500,
+      }),
+    ).toEqual({ shouldResnap: true, nextResnapUntil: 4500 });
+  });
+
+  it("keeps resnapping during the post-execution cooldown", () => {
+    expect(
+      decideExecutionResnap({
+        focusedCellId: "cell-1",
+        outputsVersion: 3,
+        executingCellCount: 0,
+        resnapCancelled: false,
+        resnapUntil: 3000,
+        now: 2000,
+      }),
+    ).toEqual({ shouldResnap: true, nextResnapUntil: 3000 });
+  });
+
+  it("stops after the post-execution cooldown expires", () => {
+    expect(
+      decideExecutionResnap({
+        focusedCellId: "cell-1",
+        outputsVersion: 3,
+        executingCellCount: 0,
+        resnapCancelled: false,
+        resnapUntil: 3000,
+        now: 3001,
+      }),
+    ).toEqual({ shouldResnap: false, nextResnapUntil: 3000 });
+  });
+
+  it("ignores initial output state and missing focus", () => {
+    expect(
+      decideExecutionResnap({
+        focusedCellId: "cell-1",
+        outputsVersion: 0,
+        executingCellCount: 1,
+        resnapCancelled: false,
+        resnapUntil: 0,
+        now: 1000,
+      }).shouldResnap,
+    ).toBe(false);
+
+    expect(
+      decideExecutionResnap({
+        focusedCellId: null,
+        outputsVersion: 1,
+        executingCellCount: 1,
+        resnapCancelled: false,
+        resnapUntil: 0,
+        now: 1000,
+      }).shouldResnap,
+    ).toBe(false);
+  });
+});

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -96,11 +96,19 @@ export function getFocusedCellId(): string | null {
   return _focusedCellId;
 }
 
+export function getExecutingCellIdsSnapshot(): Set<string> {
+  return _executingCellIds;
+}
+
 // ── Hooks ───────────────────────────────────────────────────────────────
 
 /** Subscribe to the focused cell ID. */
 export function useFocusedCellId(): string | null {
   return useSyncExternalStore(subscribeFocus, getFocusSnapshot);
+}
+
+export function useExecutingCellIds(): Set<string> {
+  return useSyncExternalStore(subscribeExecuting, getExecutingCellIdsSnapshot);
 }
 
 /** Returns true only when this specific cell is focused. */
@@ -181,6 +189,11 @@ export function useIsGroupExecuting(
 function subscribeFocus(cb: () => void): () => void {
   _focusSubscribers.add(cb);
   return () => _focusSubscribers.delete(cb);
+}
+
+function subscribeExecuting(cb: () => void): () => void {
+  _executingSubscribers.add(cb);
+  return () => _executingSubscribers.delete(cb);
 }
 
 function getFocusSnapshot(): string | null {

--- a/apps/notebook/src/lib/execution-resnap.ts
+++ b/apps/notebook/src/lib/execution-resnap.ts
@@ -1,0 +1,38 @@
+export interface ExecutionResnapDecisionInput {
+  focusedCellId: string | null;
+  outputsVersion: number;
+  executingCellCount: number;
+  resnapCancelled: boolean;
+  resnapUntil: number;
+  now: number;
+  activeWindowMs?: number;
+}
+
+export interface ExecutionResnapDecision {
+  shouldResnap: boolean;
+  nextResnapUntil: number;
+}
+
+export function decideExecutionResnap({
+  focusedCellId,
+  outputsVersion,
+  executingCellCount,
+  resnapCancelled,
+  resnapUntil,
+  now,
+  activeWindowMs = 3500,
+}: ExecutionResnapDecisionInput): ExecutionResnapDecision {
+  if (!focusedCellId || outputsVersion === 0 || resnapCancelled) {
+    return { shouldResnap: false, nextResnapUntil: resnapUntil };
+  }
+
+  if (executingCellCount > 0) {
+    return { shouldResnap: true, nextResnapUntil: now + activeWindowMs };
+  }
+
+  if (now > resnapUntil) {
+    return { shouldResnap: false, nextResnapUntil: resnapUntil };
+  }
+
+  return { shouldResnap: true, nextResnapUntil: resnapUntil };
+}

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -198,7 +198,8 @@ type MessageHandler = (type: string, payload: unknown) => void;
 
 let messageHandler: MessageHandler | null = null;
 
-const LAYOUT_PULSE_DELAYS_MS = [0, 32, 96, 192, 384, 768, 1200];
+const LAYOUT_PULSE_DELAYS_MS = [0, 160, 600];
+let layoutPulseTimers: number[] = [];
 
 function pulseRendererLayout(): void {
   window.dispatchEvent(new Event("resize"));
@@ -215,10 +216,15 @@ function pulseRendererLayout(): void {
 }
 
 function scheduleRendererLayoutPulses(): void {
+  for (const timer of layoutPulseTimers) {
+    window.clearTimeout(timer);
+  }
+  layoutPulseTimers = [];
   for (const delay of LAYOUT_PULSE_DELAYS_MS) {
-    window.setTimeout(() => {
+    const timer = window.setTimeout(() => {
       requestAnimationFrame(pulseRendererLayout);
     }, delay);
+    layoutPulseTimers.push(timer);
   }
 }
 

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -198,6 +198,30 @@ type MessageHandler = (type: string, payload: unknown) => void;
 
 let messageHandler: MessageHandler | null = null;
 
+const LAYOUT_PULSE_DELAYS_MS = [0, 32, 96, 192, 384, 768, 1200];
+
+function pulseRendererLayout(): void {
+  window.dispatchEvent(new Event("resize"));
+  window.dispatchEvent(new Event("scroll"));
+  document.dispatchEvent(new Event("scroll", { bubbles: true }));
+  document.body?.dispatchEvent(new Event("scroll", { bubbles: true }));
+  window.parent.postMessage(
+    {
+      type: "resize",
+      payload: { height: document.body.scrollHeight },
+    },
+    "*",
+  );
+}
+
+function scheduleRendererLayoutPulses(): void {
+  for (const delay of LAYOUT_PULSE_DELAYS_MS) {
+    window.setTimeout(() => {
+      requestAnimationFrame(pulseRendererLayout);
+    }, delay);
+  }
+}
+
 function setupMessageListener() {
   // Create JSON-RPC transport — handles nteract/* methods from the host
   rpcTransport = new JsonRpcTransport(window.parent, window.parent);
@@ -297,6 +321,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
       }
 
@@ -324,6 +349,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
       }
 
@@ -338,6 +364,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
 
       case "theme": {


### PR DESCRIPTION
## Summary

- Add a short-lived DOM resnap window after notebook keyboard navigation focuses a cell.
- Watch the notebook cell list for resize and child-list changes, then re-apply `scrollIntoView({ block: "nearest" })` without stacking smooth-scroll animations.
- Re-arm focused-cell resnapping from execution-scoped output changes so same-shaped reruns still get a layout nudge.
- Preserve user scroll intent by cancelling execution resnaps until the current execution set drains or focus changes.
- Emit short resize/scroll pulses from the isolated renderer after output render/clear so virtualized outputs can settle without manual scrolling.
- Cover the resnap helpers with jsdom/pure tests for resize-triggered snaps, timeout cleanup, focus cancellation, execution cooldown, and user-scroll cancellation.

Fixes #1212.

## Verification

- `pnpm test:run apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts`
- `pnpm test:run apps/notebook/src/lib/__tests__/execution-resnap.test.ts apps/notebook/src/hooks/__tests__/useEditorRegistry.test.ts apps/notebook/src/lib/__tests__/use-cell-outputs.test.tsx`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/frame-bridge.test.ts`
- `cargo xtask lint --fix`

## Review

- Claude Bedrock reviewer (`global.anthropic.claude-opus-4-6-v1`) is clear after follow-up fixes.
- GitHub CI is green.
