### PR TITLE
fix(notebook): pin focused cell during output growth

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -764,6 +764,9 @@ function NotebookViewContent({
     <div
       ref={containerRef}
       className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
+      // Native scroll anchoring helps Chromium/Firefox today. WebKit ignores
+      // this property, so focused-cell keyboard navigation also uses a
+      // short-lived ResizeObserver pin in useEditorRegistry.
       style={{ contain: "paint", overflowAnchor: "auto" }}
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -764,7 +764,7 @@ function NotebookViewContent({
     <div
       ref={containerRef}
       className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
-      style={{ contain: "paint", overflowAnchor: "none" }}
+      style={{ contain: "paint", overflowAnchor: "auto" }}
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
@@ -156,4 +156,70 @@ describe("EditorRegistryProvider", () => {
     expect(MockResizeObserver.instances[0].disconnect).toHaveBeenCalled();
     expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
   });
+
+  it("stops pinning when the user scrolls with the keyboard", () => {
+    const { editor, scrollContainer } = appendNotebookDom();
+    vi.mocked(EditorView.findFromDOM).mockReturnValue({
+      dom: editor,
+      focus: () => editor.focus(),
+      state: { doc: { length: 12 } },
+      dispatch: vi.fn(),
+    } as unknown as EditorView);
+
+    renderRegistry();
+    fireEvent.click(screen.getByRole("button", { name: "focus" }));
+    vi.mocked(editor.scrollIntoView).mockClear();
+    fireEvent.keyDown(scrollContainer, { key: "PageDown" });
+
+    act(() => {
+      MockResizeObserver.instances[0].trigger();
+    });
+
+    expect(MockResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+    expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+  });
+
+  it("stops pinning after the time window elapses", () => {
+    const { editor } = appendNotebookDom();
+    vi.mocked(EditorView.findFromDOM).mockReturnValue({
+      dom: editor,
+      focus: () => editor.focus(),
+      state: { doc: { length: 12 } },
+      dispatch: vi.fn(),
+    } as unknown as EditorView);
+
+    renderRegistry();
+    fireEvent.click(screen.getByRole("button", { name: "focus" }));
+    vi.mocked(editor.scrollIntoView).mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+      MockResizeObserver.instances[0].trigger();
+    });
+
+    expect(MockResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+    expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+  });
+
+  it("cleans up active pinning when the provider unmounts", () => {
+    const { editor } = appendNotebookDom();
+    vi.mocked(EditorView.findFromDOM).mockReturnValue({
+      dom: editor,
+      focus: () => editor.focus(),
+      state: { doc: { length: 12 } },
+      dispatch: vi.fn(),
+    } as unknown as EditorView);
+
+    const { unmount } = renderRegistry();
+    fireEvent.click(screen.getByRole("button", { name: "focus" }));
+    vi.mocked(editor.scrollIntoView).mockClear();
+    unmount();
+
+    act(() => {
+      MockResizeObserver.instances[0].trigger();
+    });
+
+    expect(MockResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+    expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+  });
 });

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
@@ -1,0 +1,159 @@
+import { EditorView } from "@codemirror/view";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { EditorRegistryProvider, useEditorRegistry } from "../useEditorRegistry";
+
+vi.mock("@codemirror/view", () => ({
+  EditorView: {
+    findFromDOM: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+  callback: ResizeObserverCallback;
+  observe = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.push(this);
+  }
+
+  trigger() {
+    this.callback([], this);
+  }
+}
+
+function FocusButton() {
+  const { focusCell } = useEditorRegistry();
+  return (
+    <button type="button" onClick={() => focusCell("cell-1", "start")}>
+      focus
+    </button>
+  );
+}
+
+function renderRegistry() {
+  return render(
+    <EditorRegistryProvider>
+      <FocusButton />
+    </EditorRegistryProvider>,
+  );
+}
+
+function appendNotebookDom() {
+  const scrollContainer = document.createElement("div");
+  scrollContainer.style.overflowY = "auto";
+  Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 200 });
+  Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1000 });
+  scrollContainer.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        top: 0,
+        bottom: 200,
+      }) as DOMRect,
+  );
+
+  const content = document.createElement("div");
+  const cell = document.createElement("div");
+  cell.dataset.cellId = "cell-1";
+  cell.scrollIntoView = vi.fn();
+
+  const editor = document.createElement("div");
+  editor.tabIndex = -1;
+  editor.scrollIntoView = vi.fn();
+  editor.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        top: 260,
+        bottom: 300,
+      }) as DOMRect,
+  );
+
+  const cmContent = document.createElement("div");
+  cmContent.className = "cm-content";
+  editor.appendChild(cmContent);
+  cell.appendChild(editor);
+  content.appendChild(cell);
+  scrollContainer.appendChild(content);
+  document.body.appendChild(scrollContainer);
+
+  return { cell, editor, cmContent, scrollContainer };
+}
+
+describe("EditorRegistryProvider", () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockResizeObserver.instances = [];
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    globalThis.ResizeObserver = originalResizeObserver;
+    document.body.innerHTML = "";
+  });
+
+  it("keeps the focused editor visible while notebook content resizes", () => {
+    const { cell, editor, cmContent } = appendNotebookDom();
+    vi.mocked(EditorView.findFromDOM).mockReturnValue({
+      dom: editor,
+      focus: () => editor.focus(),
+      state: { doc: { length: 12 } },
+      dispatch: vi.fn(),
+    } as unknown as EditorView);
+
+    renderRegistry();
+    fireEvent.click(screen.getByRole("button", { name: "focus" }));
+
+    expect(cell.scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
+    expect(EditorView.findFromDOM).toHaveBeenCalledWith(cmContent);
+    expect(MockResizeObserver.instances).toHaveLength(1);
+
+    act(() => {
+      MockResizeObserver.instances[0].trigger();
+    });
+
+    expect(editor.scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+  });
+
+  it("stops pinning when the user starts scrolling manually", () => {
+    const { editor, scrollContainer } = appendNotebookDom();
+    vi.mocked(EditorView.findFromDOM).mockReturnValue({
+      dom: editor,
+      focus: () => editor.focus(),
+      state: { doc: { length: 12 } },
+      dispatch: vi.fn(),
+    } as unknown as EditorView);
+
+    renderRegistry();
+    fireEvent.click(screen.getByRole("button", { name: "focus" }));
+    vi.mocked(editor.scrollIntoView).mockClear();
+    fireEvent.wheel(scrollContainer);
+
+    act(() => {
+      MockResizeObserver.instances[0].trigger();
+    });
+
+    expect(MockResizeObserver.instances[0].disconnect).toHaveBeenCalled();
+    expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+  });
+});

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
@@ -127,6 +127,8 @@ describe("EditorRegistryProvider", () => {
     expect(cell.scrollIntoView).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
     expect(EditorView.findFromDOM).toHaveBeenCalledWith(cmContent);
     expect(MockResizeObserver.instances).toHaveLength(1);
+    expect(editor.scrollIntoView).not.toHaveBeenCalledWith({ block: "nearest", behavior: "auto" });
+    vi.mocked(editor.scrollIntoView).mockClear();
 
     act(() => {
       MockResizeObserver.instances[0].trigger();

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -7,6 +7,100 @@ interface EditorRegistryContextType {
 }
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
+const SCROLL_PIN_DURATION_MS = 2500;
+const SCROLL_PIN_MARGIN_PX = 12;
+
+let cancelActiveScrollPin: (() => void) | null = null;
+
+function getNearestScrollContainer(element: Element): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    const { overflowY } = window.getComputedStyle(current);
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function getScrollContentElement(container: HTMLElement, cellElement: Element): Element {
+  let current = cellElement;
+  while (current.parentElement && current.parentElement !== container) {
+    current = current.parentElement;
+  }
+  return current.parentElement === container ? current : (container.firstElementChild ?? container);
+}
+
+function isAnchorVisible(container: HTMLElement, anchor: Element): boolean {
+  const containerRect = container.getBoundingClientRect();
+  const anchorRect = anchor.getBoundingClientRect();
+  return (
+    anchorRect.top >= containerRect.top + SCROLL_PIN_MARGIN_PX &&
+    anchorRect.bottom <= containerRect.bottom - SCROLL_PIN_MARGIN_PX
+  );
+}
+
+function startScrollPin(cellElement: Element, anchorElement: Element) {
+  cancelActiveScrollPin?.();
+  cancelActiveScrollPin = null;
+
+  const scrollContainer = getNearestScrollContainer(cellElement);
+  if (!scrollContainer || typeof ResizeObserver === "undefined") return;
+
+  const contentElement = getScrollContentElement(scrollContainer, cellElement);
+  let frameId: number | null = null;
+  let timeoutId: number | null = null;
+  let isCancelled = false;
+
+  const keepAnchorVisible = () => {
+    frameId = null;
+    if (isCancelled) return;
+    if (!cellElement.isConnected || !anchorElement.isConnected) {
+      cleanup();
+      return;
+    }
+    if (
+      cellElement.contains(document.activeElement) &&
+      !isAnchorVisible(scrollContainer, anchorElement)
+    ) {
+      anchorElement.scrollIntoView({ block: "nearest", behavior: "auto" });
+    }
+  };
+
+  const scheduleKeepVisible = () => {
+    if (frameId !== null || isCancelled) return;
+    frameId = window.requestAnimationFrame(keepAnchorVisible);
+  };
+
+  const observer = new ResizeObserver(scheduleKeepVisible);
+
+  function cleanup() {
+    if (isCancelled) return;
+    isCancelled = true;
+    observer.disconnect();
+    scrollContainer.removeEventListener("wheel", cleanup);
+    scrollContainer.removeEventListener("touchstart", cleanup);
+    if (frameId !== null) {
+      window.cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    if (cancelActiveScrollPin === cleanup) {
+      cancelActiveScrollPin = null;
+    }
+  }
+
+  observer.observe(contentElement);
+  scrollContainer.addEventListener("wheel", cleanup, { passive: true });
+  scrollContainer.addEventListener("touchstart", cleanup, { passive: true });
+  timeoutId = window.setTimeout(cleanup, SCROLL_PIN_DURATION_MS);
+  scheduleKeepVisible();
+  cancelActiveScrollPin = cleanup;
+}
 
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
@@ -44,6 +138,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       scrollIntoView: true,
     });
     view.focus();
+    startScrollPin(cellElement, view.dom);
   }, []);
 
   return (

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -118,7 +118,6 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
   scrollContainer.addEventListener("touchstart", cleanup, { passive: true });
   scrollContainer.addEventListener("keydown", cleanupOnKeydown);
   timeoutId = window.setTimeout(cleanup, SCROLL_PIN_DURATION_MS);
-  scheduleKeepVisible();
   cancelActiveScrollPin = cleanup;
 }
 

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -61,7 +61,8 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
   const scrollContainer = getNearestScrollContainer(cellElement);
   if (!scrollContainer || typeof ResizeObserver === "undefined") return;
 
-  const contentElement = getScrollContentElement(scrollContainer, cellElement);
+  const container = scrollContainer;
+  const contentElement = getScrollContentElement(container, cellElement);
   let frameId: number | null = null;
   let timeoutId: number | null = null;
   let isCancelled = false;
@@ -75,7 +76,7 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
     }
     if (
       cellElement.contains(document.activeElement) &&
-      !isAnchorVisible(scrollContainer, anchorElement)
+      !isAnchorVisible(container, anchorElement)
     ) {
       anchorElement.scrollIntoView({ block: "nearest", behavior: "auto" });
     }
@@ -97,9 +98,9 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
     if (isCancelled) return;
     isCancelled = true;
     observer.disconnect();
-    scrollContainer.removeEventListener("wheel", cleanup);
-    scrollContainer.removeEventListener("touchstart", cleanup);
-    scrollContainer.removeEventListener("keydown", cleanupOnKeydown);
+    container.removeEventListener("wheel", cleanup);
+    container.removeEventListener("touchstart", cleanup);
+    container.removeEventListener("keydown", cleanupOnKeydown);
     if (frameId !== null) {
       window.cancelAnimationFrame(frameId);
       frameId = null;
@@ -114,9 +115,9 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
   }
 
   observer.observe(contentElement);
-  scrollContainer.addEventListener("wheel", cleanup, { passive: true });
-  scrollContainer.addEventListener("touchstart", cleanup, { passive: true });
-  scrollContainer.addEventListener("keydown", cleanupOnKeydown);
+  container.addEventListener("wheel", cleanup, { passive: true });
+  container.addEventListener("touchstart", cleanup, { passive: true });
+  container.addEventListener("keydown", cleanupOnKeydown);
   timeoutId = window.setTimeout(cleanup, SCROLL_PIN_DURATION_MS);
   cancelActiveScrollPin = cleanup;
 }

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { createContext, type ReactNode, useCallback, useContext } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect } from "react";
 import { logger } from "../lib/logger";
 
 interface EditorRegistryContextType {
@@ -11,6 +11,7 @@ const SCROLL_PIN_DURATION_MS = 2500;
 const SCROLL_PIN_MARGIN_PX = 12;
 
 let cancelActiveScrollPin: (() => void) | null = null;
+const SCROLL_KEYS = new Set(["PageUp", "PageDown", "Home", "End", " "]);
 
 function getNearestScrollContainer(element: Element): HTMLElement | null {
   let current = element.parentElement;
@@ -38,6 +39,18 @@ function isAnchorVisible(container: HTMLElement, anchor: Element): boolean {
   return (
     anchorRect.top >= containerRect.top + SCROLL_PIN_MARGIN_PX &&
     anchorRect.bottom <= containerRect.bottom - SCROLL_PIN_MARGIN_PX
+  );
+}
+
+function shouldCancelScrollPinForKey(event: KeyboardEvent): boolean {
+  if (!SCROLL_KEYS.has(event.key)) return false;
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return true;
+  return (
+    target === event.currentTarget ||
+    !target.isContentEditable ||
+    event.key === "PageUp" ||
+    event.key === "PageDown"
   );
 }
 
@@ -74,6 +87,11 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
   };
 
   const observer = new ResizeObserver(scheduleKeepVisible);
+  const cleanupOnKeydown = (event: KeyboardEvent) => {
+    if (shouldCancelScrollPinForKey(event)) {
+      cleanup();
+    }
+  };
 
   function cleanup() {
     if (isCancelled) return;
@@ -81,6 +99,7 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
     observer.disconnect();
     scrollContainer.removeEventListener("wheel", cleanup);
     scrollContainer.removeEventListener("touchstart", cleanup);
+    scrollContainer.removeEventListener("keydown", cleanupOnKeydown);
     if (frameId !== null) {
       window.cancelAnimationFrame(frameId);
       frameId = null;
@@ -97,12 +116,19 @@ function startScrollPin(cellElement: Element, anchorElement: Element) {
   observer.observe(contentElement);
   scrollContainer.addEventListener("wheel", cleanup, { passive: true });
   scrollContainer.addEventListener("touchstart", cleanup, { passive: true });
+  scrollContainer.addEventListener("keydown", cleanupOnKeydown);
   timeoutId = window.setTimeout(cleanup, SCROLL_PIN_DURATION_MS);
   scheduleKeepVisible();
   cancelActiveScrollPin = cleanup;
 }
 
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    return () => {
+      cancelActiveScrollPin?.();
+    };
+  }, []);
+
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
   const focusCell = useCallback((cellId: string, cursorPosition: "start" | "end") => {
     // Find the cell element by data attribute

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -523,6 +523,7 @@ export function OutputArea({
     <div
       data-slot="output-area"
       className={cn("output-area pl-6 pr-3", isPreloadOnly && "hidden", className)}
+      style={{ overflowAnchor: "none" }}
     >
       {/* Collapse toggle */}
       {hasCollapseControl && (

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -523,6 +523,8 @@ export function OutputArea({
     <div
       data-slot="output-area"
       className={cn("output-area pl-6 pr-3", isPreloadOnly && "hidden", className)}
+      // Keep browsers that support scroll anchoring from choosing growing
+      // outputs as the anchor. WebKit currently ignores overflow-anchor.
       style={{ overflowAnchor: "none" }}
     >
       {/* Collapse toggle */}


### PR DESCRIPTION
## Summary

- enable native scroll anchoring on the notebook scroll container while opting output areas out as anchors
- add a short-lived WebKit-friendly scroll pin after keyboard focus moves to a cell
- cover the scroll pin and manual-scroll cancellation behavior with jsdom tests

## Verification

- `pnpm test:run apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- Draft while external Bedrock Claude review and CI are pending.
- Closes #1212.
