### PR TITLE
fix(dx): install parquet encoder for bootstrap envs

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -53,7 +53,13 @@ pub fn default_cache_dir_conda() -> PathBuf {
 /// runtimed) and by the unified env design's capture step (`strip_base`) so
 /// the notebook's metadata records only user-level deps. Keep this in sync
 /// with the warmer.
-pub const CONDA_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat"];
+pub const CONDA_BASE_PACKAGES: &[&str] = &[
+    "ipykernel",
+    "ipywidgets",
+    "anywidget",
+    "nbformat",
+    "pyarrow>=14",
+];
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
 /// reopen path from the unified env resolution design (see
@@ -445,9 +451,15 @@ async fn install_conda_env(
     specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
     specs.push(MatchSpec::from_str("anywidget", match_spec_options)?);
     specs.push(MatchSpec::from_str("nbformat", match_spec_options)?);
+    specs.push(MatchSpec::from_str("pyarrow>=14", match_spec_options)?);
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
+        if dep != "ipykernel"
+            && dep != "ipywidgets"
+            && dep != "anywidget"
+            && dep != "nbformat"
+            && dep != "pyarrow>=14"
+        {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
@@ -862,10 +874,16 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
         MatchSpec::from_str("ipywidgets", match_spec_options)?,
         MatchSpec::from_str("anywidget", match_spec_options)?,
         MatchSpec::from_str("nbformat", match_spec_options)?,
+        MatchSpec::from_str("pyarrow>=14", match_spec_options)?,
     ];
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
+        if dep != "ipykernel"
+            && dep != "ipywidgets"
+            && dep != "anywidget"
+            && dep != "nbformat"
+            && dep != "pyarrow>=14"
+        {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
@@ -1014,9 +1032,15 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
     specs.push("ipywidgets".to_string());
     specs.push("anywidget".to_string());
     specs.push("nbformat".to_string());
+    specs.push("pyarrow>=14".to_string());
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
+        if dep != "ipykernel"
+            && dep != "ipywidgets"
+            && dep != "anywidget"
+            && dep != "nbformat"
+            && dep != "pyarrow>=14"
+        {
             specs.push(dep.clone());
         }
     }

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -159,6 +159,7 @@ mod strip_base_tests {
             "ipywidgets",
             "anywidget",
             "nbformat",
+            "pyarrow>=14",
             "uv",
             "pandas",
             "numpy",
@@ -172,10 +173,17 @@ mod strip_base_tests {
 
     #[test]
     fn strips_conda_base_leaves_user_defaults() {
-        let installed: Vec<String> = ["ipykernel", "ipywidgets", "anywidget", "nbformat", "scipy"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let installed: Vec<String> = [
+            "ipykernel",
+            "ipywidgets",
+            "anywidget",
+            "nbformat",
+            "pyarrow>=14",
+            "scipy",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
         let result = strip_base(&installed, CONDA_BASE_PACKAGES);
         assert_eq!(result, vec!["scipy".to_string()]);
     }

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -68,7 +68,14 @@ pub async fn check_uv_available() -> bool {
 /// `nteract_kernel_launcher` package that the daemon injects via PYTHONPATH.
 /// The `bootstrap_dx` feature flag now gates launcher-vs-vanilla, not a
 /// PyPI install.
-pub const UV_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat", "uv"];
+pub const UV_BASE_PACKAGES: &[&str] = &[
+    "ipykernel",
+    "ipywidgets",
+    "anywidget",
+    "nbformat",
+    "pyarrow>=14",
+    "uv",
+];
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
 /// reopen path from the unified env resolution design (see
@@ -269,6 +276,7 @@ pub async fn prepare_environment_in(
         "ipywidgets".to_string(),
         "anywidget".to_string(),
         "nbformat".to_string(),
+        "pyarrow>=14".to_string(),
         "uv".to_string(), // For %uv magic in notebooks
     ];
     packages.extend(deps.dependencies.iter().cloned());

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -386,7 +386,9 @@ struct Pool {
 const MIN_WARM_BASES: usize = 2;
 
 fn package_name(dep: &str) -> &str {
-    dep.trim()
+    let trimmed = dep.trim();
+    let after_channel = trimmed.rsplit("::").next().unwrap_or(trimmed);
+    after_channel
         .split(['<', '>', '=', '!', '~', '[', ';', ' '])
         .next()
         .unwrap_or("")
@@ -5168,11 +5170,47 @@ impl Daemon {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use notebook_protocol::protocol::FeatureFlags;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    fn bootstrap_dx_flags() -> FeatureFlags {
+        FeatureFlags { bootstrap_dx: true }
+    }
+
+    #[test]
+    fn test_package_name_strips_conda_channel_qualifier() {
+        assert_eq!(package_name("conda-forge::pyarrow>=14"), "pyarrow");
+        assert_eq!(package_name("defaults::PyArrow"), "PyArrow");
+        assert_eq!(package_name("pyarrow >= 15"), "pyarrow");
+    }
+
+    #[test]
+    fn test_uv_prewarmed_packages_adds_pyarrow_for_bootstrap_dx() {
+        assert!(uv_prewarmed_packages(&[], FeatureFlags::default())
+            .iter()
+            .all(|pkg| !package_name(pkg).eq_ignore_ascii_case("pyarrow")));
+
+        let packages = uv_prewarmed_packages(&[], bootstrap_dx_flags());
+        assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+    }
+
+    #[test]
+    fn test_conda_prewarmed_packages_does_not_duplicate_channel_qualified_pyarrow() {
+        let packages = conda_prewarmed_packages(
+            &["conda-forge::pyarrow>=15".to_string()],
+            bootstrap_dx_flags(),
+        );
+        let pyarrow_count = packages
+            .iter()
+            .filter(|pkg| package_name(pkg).eq_ignore_ascii_case("pyarrow"))
+            .count();
+        assert_eq!(pyarrow_count, 1);
+        assert!(!packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -385,16 +385,6 @@ struct Pool {
 
 const MIN_WARM_BASES: usize = 2;
 
-fn package_name(dep: &str) -> &str {
-    let trimmed = dep.trim();
-    let after_channel = trimmed.rsplit("::").next().unwrap_or(trimmed);
-    after_channel
-        .split(['<', '>', '=', '!', '~', '[', ';', ' '])
-        .next()
-        .unwrap_or("")
-        .trim()
-}
-
 fn add_dx_bootstrap_packages(
     packages: &mut Vec<String>,
     feature_flags: notebook_protocol::protocol::FeatureFlags,
@@ -405,7 +395,11 @@ fn add_dx_bootstrap_packages(
 
     let has_pyarrow = packages
         .iter()
-        .any(|pkg| package_name(pkg).eq_ignore_ascii_case("pyarrow"));
+        .filter_map(|pkg| {
+            crate::inline_env::extract_conda_package_name(pkg)
+                .map(crate::inline_env::normalize_package_name)
+        })
+        .any(|pkg| pkg == "pyarrow");
     if !has_pyarrow {
         packages.push("pyarrow>=14".to_string());
     }
@@ -1797,9 +1791,8 @@ impl Daemon {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
 
-            let uv_pkgs =
-                uv_prewarmed_packages(&synced.uv.default_packages, synced.feature_flags());
             let feature_flags = synced.feature_flags();
+            let uv_pkgs = uv_prewarmed_packages(&synced.uv.default_packages, feature_flags);
             let conda_pkgs =
                 conda_prewarmed_packages(&synced.conda.default_packages, feature_flags);
             let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages, feature_flags);
@@ -5182,17 +5175,11 @@ mod tests {
     }
 
     #[test]
-    fn test_package_name_strips_conda_channel_qualifier() {
-        assert_eq!(package_name("conda-forge::pyarrow>=14"), "pyarrow");
-        assert_eq!(package_name("defaults::PyArrow"), "PyArrow");
-        assert_eq!(package_name("pyarrow >= 15"), "pyarrow");
-    }
-
-    #[test]
     fn test_uv_prewarmed_packages_adds_pyarrow_for_bootstrap_dx() {
         assert!(uv_prewarmed_packages(&[], FeatureFlags::default())
             .iter()
-            .all(|pkg| !package_name(pkg).eq_ignore_ascii_case("pyarrow")));
+            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
+            .all(|pkg| crate::inline_env::normalize_package_name(pkg) != "pyarrow"));
 
         let packages = uv_prewarmed_packages(&[], bootstrap_dx_flags());
         assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
@@ -5206,7 +5193,23 @@ mod tests {
         );
         let pyarrow_count = packages
             .iter()
-            .filter(|pkg| package_name(pkg).eq_ignore_ascii_case("pyarrow"))
+            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
+            .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "pyarrow")
+            .count();
+        assert_eq!(pyarrow_count, 1);
+        assert!(!packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+    }
+
+    #[test]
+    fn test_conda_prewarmed_packages_does_not_duplicate_direct_ref_pyarrow() {
+        let packages = conda_prewarmed_packages(
+            &["pyarrow@https://example.invalid/pyarrow.whl".to_string()],
+            bootstrap_dx_flags(),
+        );
+        let pyarrow_count = packages
+            .iter()
+            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
+            .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "pyarrow")
             .count();
         assert_eq!(pyarrow_count, 1);
         assert!(!packages.iter().any(|pkg| pkg == "pyarrow>=14"));

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -385,12 +385,36 @@ struct Pool {
 
 const MIN_WARM_BASES: usize = 2;
 
+fn package_name(dep: &str) -> &str {
+    dep.trim()
+        .split(['<', '>', '=', '!', '~', '[', ';', ' '])
+        .next()
+        .unwrap_or("")
+        .trim()
+}
+
+fn add_dx_bootstrap_packages(
+    packages: &mut Vec<String>,
+    feature_flags: notebook_protocol::protocol::FeatureFlags,
+) {
+    if !feature_flags.bootstrap_dx {
+        return;
+    }
+
+    let has_pyarrow = packages
+        .iter()
+        .any(|pkg| package_name(pkg).eq_ignore_ascii_case("pyarrow"));
+    if !has_pyarrow {
+        packages.push("pyarrow>=14".to_string());
+    }
+}
+
 fn uv_prewarmed_packages(
     extra: &[String],
-    _feature_flags: notebook_protocol::protocol::FeatureFlags,
+    feature_flags: notebook_protocol::protocol::FeatureFlags,
 ) -> Vec<String> {
-    // The launcher package is vendored post-creation; `bootstrap_dx` no
-    // longer adds a PyPI dep to the prewarm set.
+    // The launcher package is vendored post-creation. When bootstrap_dx is on,
+    // pandas still needs pyarrow so the formatter can emit parquet for Sift.
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
@@ -399,10 +423,14 @@ fn uv_prewarmed_packages(
         "uv".to_string(),
     ];
     packages.extend(extra.iter().cloned());
+    add_dx_bootstrap_packages(&mut packages, feature_flags);
     packages
 }
 
-fn conda_prewarmed_packages(extra: &[String]) -> Vec<String> {
+fn conda_prewarmed_packages(
+    extra: &[String],
+    feature_flags: notebook_protocol::protocol::FeatureFlags,
+) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
@@ -410,10 +438,14 @@ fn conda_prewarmed_packages(extra: &[String]) -> Vec<String> {
         "nbformat".to_string(),
     ];
     packages.extend(extra.iter().cloned());
+    add_dx_bootstrap_packages(&mut packages, feature_flags);
     packages
 }
 
-fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
+fn pixi_prewarmed_packages(
+    extra: &[String],
+    feature_flags: notebook_protocol::protocol::FeatureFlags,
+) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
@@ -421,6 +453,7 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
         "nbformat".to_string(),
     ];
     packages.extend(extra.iter().cloned());
+    add_dx_bootstrap_packages(&mut packages, feature_flags);
     packages
 }
 
@@ -1056,7 +1089,7 @@ impl Daemon {
     pub async fn conda_pool_packages(&self) -> Vec<String> {
         let settings = self.settings.read().await;
         let synced = settings.get_all();
-        conda_prewarmed_packages(&synced.conda.default_packages)
+        conda_prewarmed_packages(&synced.conda.default_packages, synced.feature_flags())
     }
 
     /// Create a new daemon with the given configuration.
@@ -1764,8 +1797,10 @@ impl Daemon {
 
             let uv_pkgs =
                 uv_prewarmed_packages(&synced.uv.default_packages, synced.feature_flags());
-            let conda_pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
-            let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
+            let feature_flags = synced.feature_flags();
+            let conda_pkgs =
+                conda_prewarmed_packages(&synced.conda.default_packages, feature_flags);
+            let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages, feature_flags);
 
             (uv_pkgs, conda_pkgs, pixi_pkgs)
         };
@@ -4005,7 +4040,10 @@ impl Daemon {
                         as usize
                 };
                 let synced = settings.get_all();
-                let pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
+                let pkgs = conda_prewarmed_packages(
+                    &synced.conda.default_packages,
+                    synced.feature_flags(),
+                );
                 (target, pkgs)
             };
 
@@ -4127,7 +4165,8 @@ impl Daemon {
                         as usize
                 };
                 let synced = settings.get_all();
-                let pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
+                let pkgs =
+                    pixi_prewarmed_packages(&synced.pixi.default_packages, synced.feature_flags());
                 (target, pkgs)
             };
 
@@ -4286,10 +4325,14 @@ impl Daemon {
         };
 
         // Read default conda packages from synced settings
-        let extra_conda_packages: Vec<String> = {
+        let (extra_conda_packages, feature_flags): (
+            Vec<String>,
+            notebook_protocol::protocol::FeatureFlags,
+        ) = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            synced.conda.default_packages
+            let feature_flags = synced.feature_flags();
+            (synced.conda.default_packages, feature_flags)
         };
 
         if !extra_conda_packages.is_empty() {
@@ -4300,7 +4343,7 @@ impl Daemon {
         }
 
         // Build specs: python + notebook essentials + user-configured defaults
-        let conda_install_packages = conda_prewarmed_packages(&extra_conda_packages);
+        let conda_install_packages = conda_prewarmed_packages(&extra_conda_packages, feature_flags);
 
         let match_spec_options = ParseMatchSpecOptions::strict();
         let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
@@ -4664,17 +4707,19 @@ impl Daemon {
         info!("[runtimed] Creating Pixi environment at {:?}", project_dir);
 
         // Build package list
-        let mut packages = pixi_prewarmed_packages(&[]);
-        {
-            let pixi_defaults = self.default_pixi_packages().await;
+        let packages = {
+            let settings = self.settings.read().await;
+            let synced = settings.get_all();
+            let feature_flags = synced.feature_flags();
+            let pixi_defaults = synced.pixi.default_packages;
             if !pixi_defaults.is_empty() {
                 info!(
                     "[runtimed] Including default pixi packages: {:?}",
                     pixi_defaults
                 );
-                packages.extend(pixi_defaults);
             }
-        }
+            pixi_prewarmed_packages(&pixi_defaults, feature_flags)
+        };
         let prewarmed_packages = packages.clone();
 
         // Create environment using rattler (pixi-compatible layout)

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -385,71 +385,59 @@ struct Pool {
 
 const MIN_WARM_BASES: usize = 2;
 
-fn add_dx_bootstrap_packages(
-    packages: &mut Vec<String>,
-    feature_flags: notebook_protocol::protocol::FeatureFlags,
-) {
-    if !feature_flags.bootstrap_dx {
-        return;
-    }
-
-    let has_pyarrow = packages
+fn has_package_named(packages: &[String], name: &str) -> bool {
+    packages
         .iter()
         .filter_map(|pkg| {
             crate::inline_env::extract_conda_package_name(pkg)
                 .map(crate::inline_env::normalize_package_name)
         })
-        .any(|pkg| pkg == "pyarrow");
-    if !has_pyarrow {
+        .any(|pkg| pkg == name)
+}
+
+fn extend_default_packages(packages: &mut Vec<String>, extra: &[String]) {
+    for pkg in extra {
+        packages.push(pkg.clone());
+    }
+    if !has_package_named(packages, "nbformat") {
+        packages.push("nbformat".to_string());
+    }
+    if !has_package_named(packages, "pyarrow") {
         packages.push("pyarrow>=14".to_string());
     }
 }
 
-fn uv_prewarmed_packages(
-    extra: &[String],
-    feature_flags: notebook_protocol::protocol::FeatureFlags,
-) -> Vec<String> {
-    // The launcher package is vendored post-creation. When bootstrap_dx is on,
-    // pandas still needs pyarrow so the formatter can emit parquet for Sift.
+fn uv_prewarmed_packages(extra: &[String]) -> Vec<String> {
+    // The launcher package is vendored post-creation. pyarrow and nbformat are
+    // part of the managed notebook runtime so rich display formatters work by
+    // default; user defaults can still override either package by name.
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
-        "nbformat".to_string(),
         "uv".to_string(),
     ];
-    packages.extend(extra.iter().cloned());
-    add_dx_bootstrap_packages(&mut packages, feature_flags);
+    extend_default_packages(&mut packages, extra);
     packages
 }
 
-fn conda_prewarmed_packages(
-    extra: &[String],
-    feature_flags: notebook_protocol::protocol::FeatureFlags,
-) -> Vec<String> {
+fn conda_prewarmed_packages(extra: &[String]) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
-        "nbformat".to_string(),
     ];
-    packages.extend(extra.iter().cloned());
-    add_dx_bootstrap_packages(&mut packages, feature_flags);
+    extend_default_packages(&mut packages, extra);
     packages
 }
 
-fn pixi_prewarmed_packages(
-    extra: &[String],
-    feature_flags: notebook_protocol::protocol::FeatureFlags,
-) -> Vec<String> {
+fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
-        "nbformat".to_string(),
     ];
-    packages.extend(extra.iter().cloned());
-    add_dx_bootstrap_packages(&mut packages, feature_flags);
+    extend_default_packages(&mut packages, extra);
     packages
 }
 
@@ -527,8 +515,8 @@ impl Pool {
     ///
     /// Compares `PooledEnv::prewarmed_packages` as a sorted list against the
     /// caller-provided expected list. This catches changes to `uv.default_packages`,
-    /// `conda.default_packages`, `pixi.default_packages`, and feature flags that
-    /// affect the install set (e.g. `bootstrap_dx` adding `dx` to UV envs).
+    /// `conda.default_packages`, `pixi.default_packages`, and managed runtime
+    /// package defaults.
     ///
     /// Returned paths are normalised via [`pool_env_root`] so callers delete the
     /// top-level pool directory (Pixi envs are nested under `.pixi/envs/default`
@@ -994,7 +982,7 @@ impl Daemon {
     pub async fn uv_pool_packages(&self) -> Vec<String> {
         let settings = self.settings.read().await;
         let synced = settings.get_all();
-        uv_prewarmed_packages(&synced.uv.default_packages, synced.feature_flags())
+        uv_prewarmed_packages(&synced.uv.default_packages)
     }
 
     /// Snapshot the user's feature-flag settings.
@@ -1085,7 +1073,7 @@ impl Daemon {
     pub async fn conda_pool_packages(&self) -> Vec<String> {
         let settings = self.settings.read().await;
         let synced = settings.get_all();
-        conda_prewarmed_packages(&synced.conda.default_packages, synced.feature_flags())
+        conda_prewarmed_packages(&synced.conda.default_packages)
     }
 
     /// Create a new daemon with the given configuration.
@@ -1791,11 +1779,9 @@ impl Daemon {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
 
-            let feature_flags = synced.feature_flags();
-            let uv_pkgs = uv_prewarmed_packages(&synced.uv.default_packages, feature_flags);
-            let conda_pkgs =
-                conda_prewarmed_packages(&synced.conda.default_packages, feature_flags);
-            let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages, feature_flags);
+            let uv_pkgs = uv_prewarmed_packages(&synced.uv.default_packages);
+            let conda_pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
+            let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
 
             (uv_pkgs, conda_pkgs, pixi_pkgs)
         };
@@ -3919,8 +3905,7 @@ impl Daemon {
                         as usize
                 };
                 let synced = settings.get_all();
-                let pkgs =
-                    uv_prewarmed_packages(&synced.uv.default_packages, synced.feature_flags());
+                let pkgs = uv_prewarmed_packages(&synced.uv.default_packages);
                 (target, pkgs)
             };
 
@@ -4035,10 +4020,7 @@ impl Daemon {
                         as usize
                 };
                 let synced = settings.get_all();
-                let pkgs = conda_prewarmed_packages(
-                    &synced.conda.default_packages,
-                    synced.feature_flags(),
-                );
+                let pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
                 (target, pkgs)
             };
 
@@ -4160,8 +4142,7 @@ impl Daemon {
                         as usize
                 };
                 let synced = settings.get_all();
-                let pkgs =
-                    pixi_prewarmed_packages(&synced.pixi.default_packages, synced.feature_flags());
+                let pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
                 (target, pkgs)
             };
 
@@ -4320,14 +4301,10 @@ impl Daemon {
         };
 
         // Read default conda packages from synced settings
-        let (extra_conda_packages, feature_flags): (
-            Vec<String>,
-            notebook_protocol::protocol::FeatureFlags,
-        ) = {
+        let extra_conda_packages = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            let feature_flags = synced.feature_flags();
-            (synced.conda.default_packages, feature_flags)
+            synced.conda.default_packages
         };
 
         if !extra_conda_packages.is_empty() {
@@ -4338,7 +4315,7 @@ impl Daemon {
         }
 
         // Build specs: python + notebook essentials + user-configured defaults
-        let conda_install_packages = conda_prewarmed_packages(&extra_conda_packages, feature_flags);
+        let conda_install_packages = conda_prewarmed_packages(&extra_conda_packages);
 
         let match_spec_options = ParseMatchSpecOptions::strict();
         let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
@@ -4705,7 +4682,6 @@ impl Daemon {
         let packages = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            let feature_flags = synced.feature_flags();
             let pixi_defaults = synced.pixi.default_packages;
             if !pixi_defaults.is_empty() {
                 info!(
@@ -4713,7 +4689,7 @@ impl Daemon {
                     pixi_defaults
                 );
             }
-            pixi_prewarmed_packages(&pixi_defaults, feature_flags)
+            pixi_prewarmed_packages(&pixi_defaults)
         };
         let prewarmed_packages = packages.clone();
 
@@ -4938,17 +4914,16 @@ impl Daemon {
         }
 
         // Read default uv packages from synced settings
-        let (user_default_packages, feature_flags) = {
+        let user_default_packages = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            let flags = synced.feature_flags();
             let configured = synced.uv.default_packages;
             if !configured.is_empty() {
                 info!("[runtimed] Including default uv packages: {:?}", configured);
             }
-            (configured, flags)
+            configured
         };
-        let install_packages = uv_prewarmed_packages(&user_default_packages, feature_flags);
+        let install_packages = uv_prewarmed_packages(&user_default_packages);
 
         // Install packages (180 second timeout)
         // Use hardlink mode to share files from uv's global cache,
@@ -5163,49 +5138,45 @@ impl Daemon {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notebook_protocol::protocol::FeatureFlags;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
-    fn bootstrap_dx_flags() -> FeatureFlags {
-        FeatureFlags { bootstrap_dx: true }
-    }
-
     #[test]
-    fn test_uv_prewarmed_packages_adds_pyarrow_for_bootstrap_dx() {
-        assert!(uv_prewarmed_packages(&[], FeatureFlags::default())
-            .iter()
-            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
-            .all(|pkg| crate::inline_env::normalize_package_name(pkg) != "pyarrow"));
-
-        let packages = uv_prewarmed_packages(&[], bootstrap_dx_flags());
+    fn test_uv_prewarmed_packages_include_required_display_deps() {
+        let packages = uv_prewarmed_packages(&[]);
+        assert!(packages.iter().any(|pkg| pkg == "nbformat"));
         assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
     }
 
     #[test]
-    fn test_conda_prewarmed_packages_does_not_duplicate_channel_qualified_pyarrow() {
-        let packages = conda_prewarmed_packages(
-            &["conda-forge::pyarrow>=15".to_string()],
-            bootstrap_dx_flags(),
-        );
+    fn test_prewarmed_packages_do_not_duplicate_overrides() {
+        let packages = conda_prewarmed_packages(&[
+            "nbformat==5.10.4".to_string(),
+            "conda-forge::pyarrow>=15".to_string(),
+        ]);
         let pyarrow_count = packages
             .iter()
             .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
             .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "pyarrow")
             .count();
+        let nbformat_count = packages
+            .iter()
+            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
+            .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "nbformat")
+            .count();
         assert_eq!(pyarrow_count, 1);
+        assert_eq!(nbformat_count, 1);
         assert!(!packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+        assert!(!packages.iter().any(|pkg| pkg == "nbformat"));
     }
 
     #[test]
     fn test_conda_prewarmed_packages_does_not_duplicate_direct_ref_pyarrow() {
-        let packages = conda_prewarmed_packages(
-            &["pyarrow@https://example.invalid/pyarrow.whl".to_string()],
-            bootstrap_dx_flags(),
-        );
+        let packages =
+            conda_prewarmed_packages(&["pyarrow@https://example.invalid/pyarrow.whl".to_string()]);
         let pyarrow_count = packages
             .iter()
             .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -156,17 +156,14 @@ fn has_dep_named(deps: &[String], name: &str) -> bool {
         .any(|bare| bare == name)
 }
 
-/// Return inline deps plus the parquet encoder needed by the dx bootstrap.
-///
-/// Historically this appended `dx` when `bootstrap_dx` was set, so the
-/// PyPI package would land in the inline env and the dep-hash would
-/// distinguish bootstrap and non-bootstrap caches. The launcher package now
-/// ships inside the daemon binary, but pandas DataFrames still need pyarrow
-/// available in the kernel env so the bootstrap formatter can emit parquet
-/// for the Sift renderer instead of falling back to classic pandas HTML.
-pub(crate) fn inline_deps_with_bootstrap(deps: &[String], bootstrap_dx: bool) -> Vec<String> {
+/// Return inline deps plus the managed runtime packages expected by notebook
+/// display helpers. User-provided versions win by package name.
+pub(crate) fn inline_deps_with_required_packages(deps: &[String]) -> Vec<String> {
     let mut effective = deps.to_vec();
-    if bootstrap_dx && !has_dep_named(&effective, "pyarrow") {
+    if !has_dep_named(&effective, "nbformat") {
+        effective.push("nbformat".to_string());
+    }
+    if !has_dep_named(&effective, "pyarrow") {
         effective.push("pyarrow>=14".to_string());
     }
     effective
@@ -181,10 +178,9 @@ pub async fn prepare_uv_inline_env(
     deps: &[String],
     prerelease: Option<&str>,
     handler: Arc<dyn ProgressHandler>,
-    bootstrap_dx: bool,
 ) -> Result<PreparedEnv> {
     let uv_deps = kernel_env::UvDependencies {
-        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
+        dependencies: inline_deps_with_required_packages(deps),
         requires_python: Some(">=3.13".to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
@@ -206,10 +202,9 @@ pub async fn prepare_conda_inline_env(
     deps: &[String],
     channels: &[String],
     handler: Arc<dyn ProgressHandler>,
-    bootstrap_dx: bool,
 ) -> Result<PreparedEnv> {
     let conda_deps = kernel_env::CondaDependencies {
-        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
+        dependencies: inline_deps_with_required_packages(deps),
         channels: if channels.is_empty() {
             vec!["conda-forge".to_string()]
         } else {
@@ -244,10 +239,9 @@ pub async fn claim_pool_env_for_uv_inline_cache(
     env: &mut crate::PooledEnv,
     deps: &[String],
     prerelease: Option<&str>,
-    bootstrap_dx: bool,
 ) {
     let uv_deps = kernel_env::UvDependencies {
-        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
+        dependencies: inline_deps_with_required_packages(deps),
         requires_python: Some(">=3.13".to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
@@ -263,9 +257,8 @@ pub async fn claim_pool_env_for_conda_inline_cache(
     env: &mut crate::PooledEnv,
     deps: &[String],
     channels: &[String],
-    bootstrap_dx: bool,
 ) {
-    let dependencies = inline_deps_with_bootstrap(deps, bootstrap_dx);
+    let dependencies = inline_deps_with_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
         dependencies,
         channels: if channels.is_empty() {
@@ -565,8 +558,8 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
 ///
 /// On hit, when `bootstrap_dx` is on, re-vendor the launcher into the
 /// cached venv before returning. This keeps cache entries with the correct
-/// bootstrap dependency set launchable even if they predate the current
-/// vendored launcher layout. `vendor_into_venv` is idempotent + cleans up the
+/// vendored launcher layout launchable even if they predate the current
+/// package layout. `vendor_into_venv` is idempotent + cleans up the
 /// legacy single-file module, so calling it on hit brings the cached env up to
 /// today's layout before the kernel boots.
 pub async fn check_uv_inline_cache(
@@ -575,7 +568,7 @@ pub async fn check_uv_inline_cache(
     bootstrap_dx: bool,
 ) -> Option<PreparedEnv> {
     let uv_deps = kernel_env::UvDependencies {
-        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
+        dependencies: inline_deps_with_required_packages(deps),
         requires_python: Some(">=3.13".to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
@@ -617,12 +610,8 @@ pub async fn check_uv_inline_cache(
 /// every requested package has a corresponding `conda-meta/` record.  A
 /// stale cache entry (e.g. created by a buggy build that dropped packages)
 /// is treated as a miss and removed so the next code path can rebuild it.
-pub fn check_conda_inline_cache(
-    deps: &[String],
-    channels: &[String],
-    bootstrap_dx: bool,
-) -> Option<PreparedEnv> {
-    let dependencies = inline_deps_with_bootstrap(deps, bootstrap_dx);
+pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<PreparedEnv> {
+    let dependencies = inline_deps_with_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
         dependencies: dependencies.clone(),
         channels: if channels.is_empty() {
@@ -1014,34 +1003,37 @@ mod tests {
     }
 
     #[test]
-    fn test_inline_deps_with_bootstrap_adds_pyarrow() {
+    fn test_inline_deps_with_required_packages_adds_display_deps() {
         let deps = vec!["pandas".to_string(), "numpy".to_string()];
         assert_eq!(
-            inline_deps_with_bootstrap(&deps, true),
+            inline_deps_with_required_packages(&deps),
             vec![
                 "pandas".to_string(),
                 "numpy".to_string(),
+                "nbformat".to_string(),
                 "pyarrow>=14".to_string()
             ]
         );
     }
 
     #[test]
-    fn test_inline_deps_with_bootstrap_does_not_duplicate_pyarrow() {
-        let deps = vec!["pandas".to_string(), "PyArrow>=15".to_string()];
-        assert_eq!(inline_deps_with_bootstrap(&deps, true), deps);
+    fn test_inline_deps_with_required_packages_does_not_duplicate_overrides() {
+        let deps = vec![
+            "pandas".to_string(),
+            "nbformat==5.10.4".to_string(),
+            "PyArrow>=15".to_string(),
+        ];
+        assert_eq!(inline_deps_with_required_packages(&deps), deps);
     }
 
     #[test]
-    fn test_inline_deps_with_bootstrap_does_not_duplicate_channel_qualified_pyarrow() {
-        let deps = vec!["pandas".to_string(), "conda-forge::pyarrow>=15".to_string()];
-        assert_eq!(inline_deps_with_bootstrap(&deps, true), deps);
-    }
-
-    #[test]
-    fn test_inline_deps_without_bootstrap_unchanged() {
-        let deps = vec!["pandas".to_string()];
-        assert_eq!(inline_deps_with_bootstrap(&deps, false), deps);
+    fn test_inline_deps_with_required_packages_does_not_duplicate_channel_qualified_pyarrow() {
+        let deps = vec![
+            "pandas".to_string(),
+            "nbformat".to_string(),
+            "conda-forge::pyarrow>=15".to_string(),
+        ];
+        assert_eq!(inline_deps_with_required_packages(&deps), deps);
     }
 
     #[test]

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -150,21 +150,28 @@ pub(crate) fn inline_cache_dir() -> std::path::PathBuf {
     runt_workspace::daemon_base_dir().join("inline-envs")
 }
 
-/// Return inline deps unchanged.
+fn has_dep_named(deps: &[String], name: &str) -> bool {
+    deps.iter()
+        .filter_map(|dep| {
+            split_bare_and_constraint(dep).map(|(bare, _)| normalize_package_name(bare))
+        })
+        .any(|bare| bare == name)
+}
+
+/// Return inline deps plus the parquet encoder needed by the dx bootstrap.
 ///
 /// Historically this appended `dx` when `bootstrap_dx` was set, so the
 /// PyPI package would land in the inline env and the dep-hash would
-/// distinguish bootstrap and non-bootstrap caches. Since 0.2.0 the
-/// launcher package (which carries everything dx used to provide)
-/// ships inside the daemon binary and is vendored via PYTHONPATH —
-/// the inline env contents are identical either way, and bootstrap
-/// vs non-bootstrap envs can share the cache.
-///
-/// Kept as a shim so callers don't all have to change on the same PR.
-/// `bootstrap_dx` is accepted and ignored — plan to drop the parameter
-/// once the field ripens into a pure launcher-module selector.
-pub(crate) fn inline_deps_with_bootstrap(deps: &[String], _bootstrap_dx: bool) -> Vec<String> {
-    deps.to_vec()
+/// distinguish bootstrap and non-bootstrap caches. The launcher package now
+/// ships inside the daemon binary, but pandas DataFrames still need pyarrow
+/// available in the kernel env so the bootstrap formatter can emit parquet
+/// for the Sift renderer instead of falling back to classic pandas HTML.
+pub(crate) fn inline_deps_with_bootstrap(deps: &[String], bootstrap_dx: bool) -> Vec<String> {
+    let mut effective = deps.to_vec();
+    if bootstrap_dx && !has_dep_named(&effective, "pyarrow") {
+        effective.push("pyarrow>=14".to_string());
+    }
+    effective
 }
 
 /// Prepare a cached UV environment with the given inline dependencies.
@@ -172,9 +179,6 @@ pub(crate) fn inline_deps_with_bootstrap(deps: &[String], _bootstrap_dx: bool) -
 /// If a cached environment with the same deps already exists, returns it
 /// immediately. Otherwise creates a new environment with uv venv + uv pip install.
 ///
-/// `bootstrap_dx` is accepted for call-site compatibility and currently
-/// ignored — launcher vendoring replaced the per-env `dx` PyPI install,
-/// so bootstrap and non-bootstrap envs are identical and share the cache.
 pub async fn prepare_uv_inline_env(
     deps: &[String],
     prerelease: Option<&str>,
@@ -204,9 +208,10 @@ pub async fn prepare_conda_inline_env(
     deps: &[String],
     channels: &[String],
     handler: Arc<dyn ProgressHandler>,
+    bootstrap_dx: bool,
 ) -> Result<PreparedEnv> {
     let conda_deps = kernel_env::CondaDependencies {
-        dependencies: deps.to_vec(),
+        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
         channels: if channels.is_empty() {
             vec!["conda-forge".to_string()]
         } else {
@@ -260,9 +265,11 @@ pub async fn claim_pool_env_for_conda_inline_cache(
     env: &mut crate::PooledEnv,
     deps: &[String],
     channels: &[String],
+    bootstrap_dx: bool,
 ) {
+    let dependencies = inline_deps_with_bootstrap(deps, bootstrap_dx);
     let conda_deps = kernel_env::CondaDependencies {
-        dependencies: deps.to_vec(),
+        dependencies,
         channels: if channels.is_empty() {
             vec!["conda-forge".to_string()]
         } else {
@@ -614,9 +621,14 @@ pub async fn check_uv_inline_cache(
 /// every requested package has a corresponding `conda-meta/` record.  A
 /// stale cache entry (e.g. created by a buggy build that dropped packages)
 /// is treated as a miss and removed so the next code path can rebuild it.
-pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<PreparedEnv> {
+pub fn check_conda_inline_cache(
+    deps: &[String],
+    channels: &[String],
+    bootstrap_dx: bool,
+) -> Option<PreparedEnv> {
+    let dependencies = inline_deps_with_bootstrap(deps, bootstrap_dx);
     let conda_deps = kernel_env::CondaDependencies {
-        dependencies: deps.to_vec(),
+        dependencies: dependencies.clone(),
         channels: if channels.is_empty() {
             vec!["conda-forge".to_string()]
         } else {
@@ -642,9 +654,9 @@ pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<
     // Verify that every requested package is actually installed.  The
     // python binary existing is necessary but not sufficient — a prior
     // buggy build may have cached an env missing some packages (#2137).
-    if !deps.is_empty() {
+    if !dependencies.is_empty() {
         let installed = conda_meta_package_names(&env_path);
-        for dep in deps {
+        for dep in &dependencies {
             let Some(name) = extract_conda_package_name(dep) else {
                 continue;
             };
@@ -1003,6 +1015,31 @@ mod tests {
         assert_eq!(normalize_package_name("Pandas"), "pandas");
         assert_eq!(normalize_package_name("scikit_learn"), "scikit-learn");
         assert_eq!(normalize_package_name("PyArrow"), "pyarrow");
+    }
+
+    #[test]
+    fn test_inline_deps_with_bootstrap_adds_pyarrow() {
+        let deps = vec!["pandas".to_string(), "numpy".to_string()];
+        assert_eq!(
+            inline_deps_with_bootstrap(&deps, true),
+            vec![
+                "pandas".to_string(),
+                "numpy".to_string(),
+                "pyarrow>=14".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_inline_deps_with_bootstrap_does_not_duplicate_pyarrow() {
+        let deps = vec!["pandas".to_string(), "PyArrow>=15".to_string()];
+        assert_eq!(inline_deps_with_bootstrap(&deps, true), deps);
+    }
+
+    #[test]
+    fn test_inline_deps_without_bootstrap_unchanged() {
+        let deps = vec!["pandas".to_string()];
+        assert_eq!(inline_deps_with_bootstrap(&deps, false), deps);
     }
 
     #[test]

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -437,7 +437,7 @@ fn inline_dep_forbids_pool_reuse(dep: &str) -> bool {
 /// - `"conda-forge::numpy>=1.24"` → `Some("numpy")`
 /// - `"conda-forge::numpy"` → `Some("numpy")`
 /// - `""` → `None`
-fn extract_conda_package_name(dep: &str) -> Option<&str> {
+pub(crate) fn extract_conda_package_name(dep: &str) -> Option<&str> {
     let trimmed = dep.trim();
     if trimmed.is_empty() {
         return None;
@@ -463,7 +463,7 @@ fn extract_conda_package_name(dep: &str) -> Option<&str> {
 }
 
 /// Normalize a package name for comparison: lowercase, replace `_` with `-`.
-fn normalize_package_name(name: &str) -> String {
+pub(crate) fn normalize_package_name(name: &str) -> String {
     name.to_lowercase().replace('_', "-")
 }
 
@@ -564,13 +564,11 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
 /// Returns `Some(PreparedEnv)` on cache hit, `None` on miss.
 ///
 /// On hit, when `bootstrap_dx` is on, re-vendor the launcher into the
-/// cached venv before returning. Reason: since 0.2.0,
-/// `inline_deps_with_bootstrap` is a no-op and the env hash no longer
-/// differs by feature flag, so a pre-upgrade non-bootstrap cache entry
-/// (or a pre-0.2.0 single-file-launcher bootstrap entry) can answer a
-/// bootstrap launch. `vendor_into_venv` is idempotent + cleans up the
-/// legacy single-file module, so calling it unconditionally on hit
-/// brings the cached env up to today's layout before the kernel boots.
+/// cached venv before returning. This keeps cache entries with the correct
+/// bootstrap dependency set launchable even if they predate the current
+/// vendored launcher layout. `vendor_into_venv` is idempotent + cleans up the
+/// legacy single-file module, so calling it on hit brings the cached env up to
+/// today's layout before the kernel boots.
 pub async fn check_uv_inline_cache(
     deps: &[String],
     prerelease: Option<&str>,

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -152,9 +152,7 @@ pub(crate) fn inline_cache_dir() -> std::path::PathBuf {
 
 fn has_dep_named(deps: &[String], name: &str) -> bool {
     deps.iter()
-        .filter_map(|dep| {
-            split_bare_and_constraint(dep).map(|(bare, _)| normalize_package_name(bare))
-        })
+        .filter_map(|dep| extract_conda_package_name(dep).map(normalize_package_name))
         .any(|bare| bare == name)
 }
 
@@ -1033,6 +1031,12 @@ mod tests {
     #[test]
     fn test_inline_deps_with_bootstrap_does_not_duplicate_pyarrow() {
         let deps = vec!["pandas".to_string(), "PyArrow>=15".to_string()];
+        assert_eq!(inline_deps_with_bootstrap(&deps, true), deps);
+    }
+
+    #[test]
+    fn test_inline_deps_with_bootstrap_does_not_duplicate_channel_qualified_pyarrow() {
+        let deps = vec!["pandas".to_string(), "conda-forge::pyarrow>=15".to_string()];
         assert_eq!(inline_deps_with_bootstrap(&deps, true), deps);
     }
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2246,9 +2246,8 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
-    // `inline_deps_with_bootstrap` is a shim since 0.2.0 — launcher
-    // vendoring replaced the `dx` PyPI install, so effective == inline.
-    // Kept so the call sites don't all have to shift on the same PR.
+    // `inline_deps_with_bootstrap` adds the bootstrap-only parquet encoder
+    // while keeping the launcher package itself vendored by the daemon.
     let effective_deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
 
     // Quick pre-check: if any dep has version specifiers, skip pool entirely

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3375,6 +3375,7 @@ pub(crate) async fn auto_launch_kernel(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
+        let deps = crate::inline_env::inline_deps_with_bootstrap(&deps, bootstrap_dx);
         if !deps.is_empty() {
             info!("[notebook-sync] pixi:inline deps for pixi exec: {:?}", deps);
             (None, Some(deps))
@@ -3384,8 +3385,9 @@ pub(crate) async fn auto_launch_kernel(
     } else if matches!(env_source, EnvSource::Pep723(PackageManager::Pixi)) {
         // PEP 723 deps via pixi exec -w (same mechanism as pixi:inline)
         if let Some(ref deps) = pep723_deps {
+            let deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
             info!("[notebook-sync] pixi:pep723 deps for pixi exec: {:?}", deps);
-            (None, Some(deps.clone()))
+            (None, Some(deps))
         } else {
             (pooled_env, None)
         }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2378,10 +2378,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
 pub(crate) async fn try_conda_pool_for_inline_deps(
     deps: &[String],
     channels: &[String],
+    bootstrap_dx: bool,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
+    let effective_deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
+
     // Only use pool for default conda-forge channel
     let is_default_channels =
         channels.is_empty() || (channels.len() == 1 && channels[0] == "conda-forge");
@@ -2396,7 +2399,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     // Quick pre-check: if any dep has version specifiers, skip pool entirely
     let settings_packages = daemon.conda_pool_packages().await;
     if matches!(
-        crate::inline_env::compare_deps_to_pool(deps, &settings_packages),
+        crate::inline_env::compare_deps_to_pool(&effective_deps, &settings_packages),
         crate::inline_env::PoolDepRelation::Independent
     ) {
         debug!("[notebook-sync] Conda inline deps have version constraints, skipping pool reuse");
@@ -2416,7 +2419,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     };
 
     let actual_packages = env.prewarmed_packages.clone();
-    let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
+    let relation = crate::inline_env::compare_deps_to_pool(&effective_deps, &actual_packages);
 
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {
@@ -2425,8 +2428,13 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             // restart cache-hits. See #2089 / #2083. The claim is
             // best-effort, so install runtime ownership before releasing
             // the lease (see try_uv_pool_for_inline_deps for rationale).
-            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
-                .await;
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(
+                &mut env,
+                deps,
+                channels,
+                bootstrap_dx,
+            )
+            .await;
             {
                 let mut ep = room.runtime_agent_env_path.write().await;
                 *ep = Some(env.venv_path.clone());
@@ -2449,7 +2457,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             // Passing only the delta would drop the original user packages
             // that are already installed in the pool env. See #2134.
             let conda_deps = kernel_env::CondaDependencies {
-                dependencies: deps.to_vec(),
+                dependencies: effective_deps.clone(),
                 channels: vec!["conda-forge".to_string()],
                 python: None,
                 env_id: None,
@@ -2469,7 +2477,10 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                     // caveat as the Subset arm — install runtime
                     // ownership before releasing.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                        &mut env, deps, channels,
+                        &mut env,
+                        deps,
+                        channels,
+                        bootstrap_dx,
                     )
                     .await;
                     {
@@ -3088,7 +3099,9 @@ pub(crate) async fn auto_launch_kernel(
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
+            if let Some(cached) =
+                crate::inline_env::check_conda_inline_cache(&deps, &channels, bootstrap_dx)
+            {
                 info!(
                     "[notebook-sync] Conda inline cache hit at {:?}",
                     cached.python_path
@@ -3105,6 +3118,7 @@ pub(crate) async fn auto_launch_kernel(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
+                    bootstrap_dx,
                     &daemon,
                     room,
                     progress_handler.clone(),
@@ -3126,6 +3140,7 @@ pub(crate) async fn auto_launch_kernel(
                             &deps,
                             &channels,
                             progress_handler.clone(),
+                            bootstrap_dx,
                         )
                         .await
                         {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2241,14 +2241,11 @@ pub(crate) async fn reset_starting_state(
 /// Returns `Ok((PooledEnv, actual_packages))` on success, `Err(())` on failure.
 pub(crate) async fn try_uv_pool_for_inline_deps(
     deps: &[String],
-    bootstrap_dx: bool,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
-    // `inline_deps_with_bootstrap` adds the bootstrap-only parquet encoder
-    // while keeping the launcher package itself vendored by the daemon.
-    let effective_deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
+    let effective_deps = crate::inline_env::inline_deps_with_required_packages(deps);
 
     // Quick pre-check: if any dep has version specifiers, skip pool entirely
     // (avoids consuming a pool env we'd have to discard)
@@ -2290,13 +2287,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // before releasing the lease — otherwise the sweep races
             // with the launch handler's later `runtime_agent_env_path`
             // write and can delete the env mid-launch.
-            crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                &mut env,
-                deps,
-                None,
-                bootstrap_dx,
-            )
-            .await;
+            crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None).await;
             {
                 let mut ep = room.runtime_agent_env_path.write().await;
                 *ep = Some(env.venv_path.clone());
@@ -2327,13 +2318,8 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     // the next restart cache-hits. See #2089 / #2083.
                     // Same claim-best-effort caveat as the Subset arm —
                     // install runtime ownership before releasing.
-                    crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                        &mut env,
-                        deps,
-                        None,
-                        bootstrap_dx,
-                    )
-                    .await;
+                    crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None)
+                        .await;
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
                         *ep = Some(env.venv_path.clone());
@@ -2377,12 +2363,11 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
 pub(crate) async fn try_conda_pool_for_inline_deps(
     deps: &[String],
     channels: &[String],
-    bootstrap_dx: bool,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
-    let effective_deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
+    let effective_deps = crate::inline_env::inline_deps_with_required_packages(deps);
 
     // Only use pool for default conda-forge channel
     let is_default_channels =
@@ -2427,13 +2412,8 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             // restart cache-hits. See #2089 / #2083. The claim is
             // best-effort, so install runtime ownership before releasing
             // the lease (see try_uv_pool_for_inline_deps for rationale).
-            crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                &mut env,
-                deps,
-                channels,
-                bootstrap_dx,
-            )
-            .await;
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
+                .await;
             {
                 let mut ep = room.runtime_agent_env_path.write().await;
                 *ep = Some(env.venv_path.clone());
@@ -2476,10 +2456,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                     // caveat as the Subset arm — install runtime
                     // ownership before releasing.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                        &mut env,
-                        deps,
-                        channels,
-                        bootstrap_dx,
+                        &mut env, deps, channels,
                     )
                     .await;
                     {
@@ -2935,8 +2912,8 @@ pub(crate) async fn auto_launch_kernel(
             room.state.clone(),
         ));
 
-    // Fetch feature flags now so inline env prep hashes match what the
-    // kernel will actually receive (bootstrap_dx changes the install set).
+    // Fetch feature flags now so inline cache hits can refresh vendored
+    // launcher files when bootstrap_dx is active.
     let feature_flags_for_inline = daemon.feature_flags().await;
     let bootstrap_dx = feature_flags_for_inline.bootstrap_dx;
 
@@ -2947,13 +2924,8 @@ pub(crate) async fn auto_launch_kernel(
                 "[notebook-sync] Preparing cached UV env for PEP 723 deps: {:?}",
                 deps
             );
-            match crate::inline_env::prepare_uv_inline_env(
-                deps,
-                None,
-                progress_handler.clone(),
-                bootstrap_dx,
-            )
-            .await
+            match crate::inline_env::prepare_uv_inline_env(deps, None, progress_handler.clone())
+                .await
             {
                 Ok(prepared) => {
                     info!(
@@ -3004,14 +2976,8 @@ pub(crate) async fn auto_launch_kernel(
                 (env, Some(deps))
             } else if prerelease.is_none() {
                 // Try pool reuse for bare deps without prerelease
-                match try_uv_pool_for_inline_deps(
-                    &deps,
-                    bootstrap_dx,
-                    &daemon,
-                    room,
-                    progress_handler.clone(),
-                )
-                .await
+                match try_uv_pool_for_inline_deps(&deps, &daemon, room, progress_handler.clone())
+                    .await
                 {
                     Ok((env, pool_pkgs)) => {
                         let mut pooled = env;
@@ -3028,7 +2994,6 @@ pub(crate) async fn auto_launch_kernel(
                             &deps,
                             prerelease.as_deref(),
                             progress_handler.clone(),
-                            bootstrap_dx,
                         )
                         .await
                         {
@@ -3063,7 +3028,6 @@ pub(crate) async fn auto_launch_kernel(
                     &deps,
                     prerelease.as_deref(),
                     progress_handler.clone(),
-                    bootstrap_dx,
                 )
                 .await
                 {
@@ -3098,9 +3062,7 @@ pub(crate) async fn auto_launch_kernel(
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) =
-                crate::inline_env::check_conda_inline_cache(&deps, &channels, bootstrap_dx)
-            {
+            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
                 info!(
                     "[notebook-sync] Conda inline cache hit at {:?}",
                     cached.python_path
@@ -3117,7 +3079,6 @@ pub(crate) async fn auto_launch_kernel(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
-                    bootstrap_dx,
                     &daemon,
                     room,
                     progress_handler.clone(),
@@ -3139,7 +3100,6 @@ pub(crate) async fn auto_launch_kernel(
                             &deps,
                             &channels,
                             progress_handler.clone(),
-                            bootstrap_dx,
                         )
                         .await
                         {
@@ -3375,7 +3335,7 @@ pub(crate) async fn auto_launch_kernel(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
-        let deps = crate::inline_env::inline_deps_with_bootstrap(&deps, bootstrap_dx);
+        let deps = crate::inline_env::inline_deps_with_required_packages(&deps);
         if !deps.is_empty() {
             info!("[notebook-sync] pixi:inline deps for pixi exec: {:?}", deps);
             (None, Some(deps))
@@ -3385,7 +3345,7 @@ pub(crate) async fn auto_launch_kernel(
     } else if matches!(env_source, EnvSource::Pep723(PackageManager::Pixi)) {
         // PEP 723 deps via pixi exec -w (same mechanism as pixi:inline)
         if let Some(ref deps) = pep723_deps {
-            let deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
+            let deps = crate::inline_env::inline_deps_with_required_packages(deps);
             info!("[notebook-sync] pixi:pep723 deps for pixi exec: {:?}", deps);
             (None, Some(deps))
         } else {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -634,8 +634,8 @@ pub(crate) async fn handle(
             room.state.clone(),
         ));
 
-    // Fetch feature flags up front so inline env hashing matches
-    // the kernel's install set (bootstrap_dx adds `dx`).
+    // Fetch feature flags up front so inline cache hits can refresh vendored
+    // launcher files when bootstrap_dx is active.
     let feature_flags_for_inline = daemon.feature_flags().await;
     let bootstrap_dx = feature_flags_for_inline.bootstrap_dx;
 
@@ -669,7 +669,6 @@ pub(crate) async fn handle(
                 &deps,
                 None,
                 launch_progress_handler.clone(),
-                bootstrap_dx,
             )
             .await
             {
@@ -730,7 +729,6 @@ pub(crate) async fn handle(
                 // Try pool reuse for bare deps without prerelease
                 match try_uv_pool_for_inline_deps(
                     &deps,
-                    bootstrap_dx,
                     daemon,
                     room,
                     launch_progress_handler.clone(),
@@ -752,7 +750,6 @@ pub(crate) async fn handle(
                             &deps,
                             prerelease.as_deref(),
                             launch_progress_handler.clone(),
-                            bootstrap_dx,
                         )
                         .await
                         {
@@ -784,7 +781,6 @@ pub(crate) async fn handle(
                     &deps,
                     prerelease.as_deref(),
                     launch_progress_handler.clone(),
-                    bootstrap_dx,
                 )
                 .await
                 {
@@ -816,9 +812,7 @@ pub(crate) async fn handle(
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) =
-                crate::inline_env::check_conda_inline_cache(&deps, &channels, bootstrap_dx)
-            {
+            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
                 info!(
                     "[notebook-sync] LaunchKernel: Conda inline cache hit at {:?}",
                     cached.python_path
@@ -835,7 +829,6 @@ pub(crate) async fn handle(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
-                    bootstrap_dx,
                     daemon,
                     room,
                     launch_progress_handler.clone(),
@@ -857,7 +850,6 @@ pub(crate) async fn handle(
                             &deps,
                             &channels,
                             launch_progress_handler.clone(),
-                            bootstrap_dx,
                         )
                         .await
                         {
@@ -1112,7 +1104,7 @@ pub(crate) async fn handle(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
-        let deps = crate::inline_env::inline_deps_with_bootstrap(&deps, bootstrap_dx);
+        let deps = crate::inline_env::inline_deps_with_required_packages(&deps);
         if !deps.is_empty() {
             info!(
                 "[notebook-sync] LaunchKernel: pixi:inline deps for pixi exec: {:?}",
@@ -1128,7 +1120,7 @@ pub(crate) async fn handle(
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
             Ok(Some(meta)) if !meta.dependencies.is_empty() => {
                 let deps =
-                    crate::inline_env::inline_deps_with_bootstrap(&meta.dependencies, bootstrap_dx);
+                    crate::inline_env::inline_deps_with_required_packages(&meta.dependencies);
                 info!("[notebook-sync] LaunchKernel: pixi:pep723 deps: {:?}", deps);
                 (None, Some(deps))
             }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -816,7 +816,9 @@ pub(crate) async fn handle(
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
+            if let Some(cached) =
+                crate::inline_env::check_conda_inline_cache(&deps, &channels, bootstrap_dx)
+            {
                 info!(
                     "[notebook-sync] LaunchKernel: Conda inline cache hit at {:?}",
                     cached.python_path
@@ -833,6 +835,7 @@ pub(crate) async fn handle(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
+                    bootstrap_dx,
                     daemon,
                     room,
                     launch_progress_handler.clone(),
@@ -854,6 +857,7 @@ pub(crate) async fn handle(
                             &deps,
                             &channels,
                             launch_progress_handler.clone(),
+                            bootstrap_dx,
                         )
                         .await
                         {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1112,6 +1112,7 @@ pub(crate) async fn handle(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
+        let deps = crate::inline_env::inline_deps_with_bootstrap(&deps, bootstrap_dx);
         if !deps.is_empty() {
             info!(
                 "[notebook-sync] LaunchKernel: pixi:inline deps for pixi exec: {:?}",
@@ -1126,11 +1127,10 @@ pub(crate) async fn handle(
         let cells = room.doc.read().await.get_cells();
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
             Ok(Some(meta)) if !meta.dependencies.is_empty() => {
-                info!(
-                    "[notebook-sync] LaunchKernel: pixi:pep723 deps: {:?}",
-                    meta.dependencies
-                );
-                (None, Some(meta.dependencies))
+                let deps =
+                    crate::inline_env::inline_deps_with_bootstrap(&meta.dependencies, bootstrap_dx);
+                info!("[notebook-sync] LaunchKernel: pixi:pep723 deps: {:?}", deps);
+                (None, Some(deps))
             }
             _ => (pooled_env, None),
         }


### PR DESCRIPTION
## Summary

- Make `nbformat` and `pyarrow>=14` managed runtime defaults for uv, conda, pixi, and inline/PEP 723 envs so rich display helpers work by default.
- Keep pyproject and named conda envs user-owned; those envs will still need users to declare display dependencies themselves.
- Deduplicate user-specified `nbformat`/`pyarrow` overrides by package name, including channel-qualified conda specs and direct references.

## Verification

- `cargo xtask wasm`
- `cargo test -p runtimed test_inline_deps --lib`
- `cargo test -p runtimed prewarmed_packages --lib`
- `cargo test -p kernel-env strip_base_tests --lib`
- `cargo xtask lint --fix`
- Claude Bedrock Opus review: no actionable findings.
- `.venv/bin/python` smoke test confirmed the launcher bootstrap emits `application/vnd.nteract.blob-ref+json` for pandas with `content_type = application/vnd.apache.parquet`.

## Notes

- Nightly diagnostics showed healthy daemon/pool state, but the uv and conda envs lacked `pyarrow`, causing the bootstrap formatter to fall back to classic pandas HTML instead of emitting parquet for Sift.
