### PR TITLE
fix(runtimed): lower default pool sizes

### DIFF
--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -11,7 +11,7 @@
 //!
 //! Uses `runtimed::settings_doc::SyncedSettings` as the canonical settings type.
 
-use runtimed::settings_doc::SyncedSettings;
+use runtimed::settings_doc::{default_pool_sizes_for_python_env, SyncedSettings};
 use std::path::PathBuf;
 
 // Re-export types that notebook code uses from runtimed
@@ -39,19 +39,21 @@ pub fn load_settings() -> SyncedSettings {
         Err(_) => return SyncedSettings::default(),
     };
 
-    // Fast path: if the whole file deserializes cleanly, use it directly.
-    if let Ok(settings) = serde_json::from_str::<SyncedSettings>(&contents) {
-        return settings;
-    }
-
-    // Slow path: parse as Value, extract each field individually so one bad
-    // value doesn't lose every other valid setting.
     let json: serde_json::Value = match serde_json::from_str(&contents) {
         Ok(v) => v,
         Err(_) => return SyncedSettings::default(),
     };
+
+    // Fast path: if the whole file deserializes cleanly, use it directly,
+    // then fill any missing pool-size keys from the selected Python env.
+    if let Ok(settings) = serde_json::from_value::<SyncedSettings>(json.clone()) {
+        return apply_selected_pool_defaults(settings, &json);
+    }
+
+    // Slow path: extract each field individually so one bad value doesn't lose
+    // every other valid setting.
     let defaults = SyncedSettings::default();
-    SyncedSettings {
+    let settings = SyncedSettings {
         theme: json
             .get("theme")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
@@ -128,7 +130,26 @@ pub fn load_settings() -> SyncedSettings {
         telemetry_last_mcp_ping_at: json
             .get("telemetry_last_mcp_ping_at")
             .and_then(|v| v.as_u64()),
+    };
+
+    apply_selected_pool_defaults(settings, &json)
+}
+
+fn apply_selected_pool_defaults(
+    mut settings: SyncedSettings,
+    json: &serde_json::Value,
+) -> SyncedSettings {
+    let (uv, conda, pixi) = default_pool_sizes_for_python_env(&settings.default_python_env);
+    if json.get("uv_pool_size").is_none() {
+        settings.uv_pool_size = uv;
     }
+    if json.get("conda_pool_size").is_none() {
+        settings.conda_pool_size = conda;
+    }
+    if json.get("pixi_pool_size").is_none() {
+        settings.pixi_pool_size = pixi;
+    }
+    settings
 }
 
 #[cfg(test)]
@@ -159,9 +180,9 @@ mod tests {
             pixi: PixiDefaults::default(),
             keep_alive_secs: 30,
             onboarding_completed: false,
-            uv_pool_size: 3,
-            conda_pool_size: 3,
-            pixi_pool_size: 2,
+            uv_pool_size: 4,
+            conda_pool_size: 5,
+            pixi_pool_size: 6,
             bootstrap_dx: false,
             ..SyncedSettings::default()
         };
@@ -197,6 +218,41 @@ mod tests {
         assert_eq!(parsed.theme, ThemeMode::System);
         assert!(parsed.uv.default_packages.is_empty());
         assert!(parsed.conda.default_packages.is_empty());
+    }
+
+    #[test]
+    fn test_missing_pool_sizes_follow_selected_python_env() {
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{"default_python_env": "conda"}"#).unwrap();
+        let settings = apply_selected_pool_defaults(
+            serde_json::from_value::<SyncedSettings>(json.clone()).unwrap(),
+            &json,
+        );
+
+        assert_eq!(settings.uv_pool_size, 1);
+        assert_eq!(settings.conda_pool_size, 2);
+        assert_eq!(settings.pixi_pool_size, 1);
+    }
+
+    #[test]
+    fn test_explicit_pool_sizes_override_selected_python_env_defaults() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "default_python_env": "pixi",
+                "uv_pool_size": 4,
+                "conda_pool_size": 5,
+                "pixi_pool_size": 6
+            }"#,
+        )
+        .unwrap();
+        let settings = apply_selected_pool_defaults(
+            serde_json::from_value::<SyncedSettings>(json.clone()).unwrap(),
+            &json,
+        );
+
+        assert_eq!(settings.uv_pool_size, 4);
+        assert_eq!(settings.conda_pool_size, 5);
+        assert_eq!(settings.pixi_pool_size, 6);
     }
 
     #[test]

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -139,15 +139,15 @@ fn apply_selected_pool_defaults(
     mut settings: SyncedSettings,
     json: &serde_json::Value,
 ) -> SyncedSettings {
-    let (uv, conda, pixi) = default_pool_sizes_for_python_env(&settings.default_python_env);
+    let pool_sizes = default_pool_sizes_for_python_env(&settings.default_python_env);
     if json.get("uv_pool_size").is_none() {
-        settings.uv_pool_size = uv;
+        settings.uv_pool_size = pool_sizes.uv_pool_size;
     }
     if json.get("conda_pool_size").is_none() {
-        settings.conda_pool_size = conda;
+        settings.conda_pool_size = pool_sizes.conda_pool_size;
     }
     if json.get("pixi_pool_size").is_none() {
-        settings.pixi_pool_size = pixi;
+        settings.pixi_pool_size = pool_sizes.pixi_pool_size;
     }
     settings
 }

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1106,10 +1106,10 @@ impl SettingsDoc {
 
         // Pool sizes: uv_pool_size, conda_pool_size, pixi_pool_size
         if let Some(uv_pool) = json.get("uv_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_all().uv_pool_size;
-            if current != uv_pool {
+            let current = self.get_u64("uv_pool_size");
+            if current != Some(uv_pool) {
                 info!(
-                    "[settings] apply_json_changes: uv_pool_size changed {} -> {}",
+                    "[settings] apply_json_changes: uv_pool_size changed {:?} -> {}",
                     current, uv_pool
                 );
                 self.put_u64("uv_pool_size", uv_pool);
@@ -1117,10 +1117,10 @@ impl SettingsDoc {
             }
         }
         if let Some(conda_pool) = json.get("conda_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_all().conda_pool_size;
-            if current != conda_pool {
+            let current = self.get_u64("conda_pool_size");
+            if current != Some(conda_pool) {
                 info!(
-                    "[settings] apply_json_changes: conda_pool_size changed {} -> {}",
+                    "[settings] apply_json_changes: conda_pool_size changed {:?} -> {}",
                     current, conda_pool
                 );
                 self.put_u64("conda_pool_size", conda_pool);
@@ -1128,10 +1128,10 @@ impl SettingsDoc {
             }
         }
         if let Some(pixi_pool) = json.get("pixi_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_all().pixi_pool_size;
-            if current != pixi_pool {
+            let current = self.get_u64("pixi_pool_size");
+            if current != Some(pixi_pool) {
                 info!(
-                    "[settings] apply_json_changes: pixi_pool_size changed {} -> {}",
+                    "[settings] apply_json_changes: pixi_pool_size changed {:?} -> {}",
                     current, pixi_pool
                 );
                 self.put_u64("pixi_pool_size", pixi_pool);
@@ -1300,6 +1300,24 @@ mod tests {
         assert_eq!(settings.uv_pool_size, 4);
         assert_eq!(settings.conda_pool_size, 5);
         assert_eq!(settings.pixi_pool_size, 6);
+    }
+
+    #[test]
+    fn test_apply_json_changes_persists_pool_size_matching_dynamic_default() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "uv_pool_size": DEFAULT_SELECTED_POOL_SIZE
+        })));
+        assert_eq!(
+            doc.get_u64("uv_pool_size"),
+            Some(DEFAULT_SELECTED_POOL_SIZE)
+        );
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "default_python_env": "conda"
+        })));
+        assert_eq!(doc.get_all().uv_pool_size, DEFAULT_SELECTED_POOL_SIZE);
     }
 
     #[test]
@@ -1733,12 +1751,14 @@ mod tests {
 
     #[test]
     fn test_apply_json_changes_no_change_when_matching() {
-        let doc = SettingsDoc::new();
+        let mut doc = SettingsDoc::new();
+        doc.put_u64("uv_pool_size", DEFAULT_SELECTED_POOL_SIZE);
+        doc.put_u64("conda_pool_size", DEFAULT_POOL_SIZE);
+        doc.put_u64("pixi_pool_size", DEFAULT_POOL_SIZE);
         let settings = doc.get_all();
 
-        // Write current values back — should detect no change
+        // Write current persisted values back — should detect no change.
         let json = serde_json::to_value(&settings).unwrap();
-        let mut doc = SettingsDoc::new();
         let changed = doc.apply_json_changes(&json);
         assert!(!changed);
     }

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -184,24 +184,35 @@ pub const DEFAULT_CONDA_POOL_SIZE: u64 = DEFAULT_POOL_SIZE;
 pub const DEFAULT_PIXI_POOL_SIZE: u64 = DEFAULT_POOL_SIZE;
 pub const MAX_POOL_SIZE: u64 = 20;
 
-pub fn default_pool_sizes_for_python_env(env: &PythonEnvType) -> (u64, u64, u64) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PoolSizeDefaults {
+    pub uv_pool_size: u64,
+    pub conda_pool_size: u64,
+    pub pixi_pool_size: u64,
+}
+
+pub fn default_pool_sizes_for_python_env(env: &PythonEnvType) -> PoolSizeDefaults {
     match env {
-        PythonEnvType::Uv => (
-            DEFAULT_SELECTED_POOL_SIZE,
-            DEFAULT_POOL_SIZE,
-            DEFAULT_POOL_SIZE,
-        ),
-        PythonEnvType::Conda => (
-            DEFAULT_POOL_SIZE,
-            DEFAULT_SELECTED_POOL_SIZE,
-            DEFAULT_POOL_SIZE,
-        ),
-        PythonEnvType::Pixi => (
-            DEFAULT_POOL_SIZE,
-            DEFAULT_POOL_SIZE,
-            DEFAULT_SELECTED_POOL_SIZE,
-        ),
-        PythonEnvType::Other(_) => (DEFAULT_POOL_SIZE, DEFAULT_POOL_SIZE, DEFAULT_POOL_SIZE),
+        PythonEnvType::Uv => PoolSizeDefaults {
+            uv_pool_size: DEFAULT_SELECTED_POOL_SIZE,
+            conda_pool_size: DEFAULT_POOL_SIZE,
+            pixi_pool_size: DEFAULT_POOL_SIZE,
+        },
+        PythonEnvType::Conda => PoolSizeDefaults {
+            uv_pool_size: DEFAULT_POOL_SIZE,
+            conda_pool_size: DEFAULT_SELECTED_POOL_SIZE,
+            pixi_pool_size: DEFAULT_POOL_SIZE,
+        },
+        PythonEnvType::Pixi => PoolSizeDefaults {
+            uv_pool_size: DEFAULT_POOL_SIZE,
+            conda_pool_size: DEFAULT_POOL_SIZE,
+            pixi_pool_size: DEFAULT_SELECTED_POOL_SIZE,
+        },
+        PythonEnvType::Other(_) => PoolSizeDefaults {
+            uv_pool_size: DEFAULT_POOL_SIZE,
+            conda_pool_size: DEFAULT_POOL_SIZE,
+            pixi_pool_size: DEFAULT_POOL_SIZE,
+        },
     }
 }
 
@@ -314,6 +325,7 @@ impl SyncedSettings {
 
 impl Default for SyncedSettings {
     fn default() -> Self {
+        let pool_sizes = default_pool_sizes_for_python_env(&PythonEnvType::default());
         Self {
             theme: ThemeMode::default(),
             color_theme: ColorTheme::default(),
@@ -324,9 +336,9 @@ impl Default for SyncedSettings {
             pixi: PixiDefaults::default(),
             keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
             onboarding_completed: false,
-            uv_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).0,
-            conda_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).1,
-            pixi_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).2,
+            uv_pool_size: pool_sizes.uv_pool_size,
+            conda_pool_size: pool_sizes.conda_pool_size,
+            pixi_pool_size: pool_sizes.pixi_pool_size,
             bootstrap_dx: false,
             install_id: String::new(),
             telemetry_enabled: true,
@@ -956,8 +968,7 @@ impl SettingsDoc {
             .get("default_python_env")
             .and_then(|s| s.parse().ok())
             .unwrap_or_default();
-        let (default_uv_pool_size, default_conda_pool_size, default_pixi_pool_size) =
-            default_pool_sizes_for_python_env(&default_python_env);
+        let pool_sizes = default_pool_sizes_for_python_env(&default_python_env);
 
         SyncedSettings {
             theme: self
@@ -991,13 +1002,15 @@ impl SettingsDoc {
                 // Check if this is an existing user by looking for other settings
                 self.get("theme").is_some() || self.get("default_runtime").is_some()
             }),
-            uv_pool_size: self.get_u64("uv_pool_size").unwrap_or(default_uv_pool_size),
+            uv_pool_size: self
+                .get_u64("uv_pool_size")
+                .unwrap_or(pool_sizes.uv_pool_size),
             conda_pool_size: self
                 .get_u64("conda_pool_size")
-                .unwrap_or(default_conda_pool_size),
+                .unwrap_or(pool_sizes.conda_pool_size),
             pixi_pool_size: self
                 .get_u64("pixi_pool_size")
-                .unwrap_or(default_pixi_pool_size),
+                .unwrap_or(pool_sizes.pixi_pool_size),
             bootstrap_dx: self
                 .get_bool("bootstrap_dx")
                 .unwrap_or(defaults.bootstrap_dx),

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -177,10 +177,33 @@ pub const MIN_KEEP_ALIVE_SECS: u64 = 5;
 /// Maximum keep-alive duration (7 days) for notebook rooms.
 pub const MAX_KEEP_ALIVE_SECS: u64 = 604800;
 
-pub const DEFAULT_UV_POOL_SIZE: u64 = 3;
-pub const DEFAULT_CONDA_POOL_SIZE: u64 = 3;
-pub const DEFAULT_PIXI_POOL_SIZE: u64 = 2;
+pub const DEFAULT_POOL_SIZE: u64 = 1;
+pub const DEFAULT_SELECTED_POOL_SIZE: u64 = 2;
+pub const DEFAULT_UV_POOL_SIZE: u64 = DEFAULT_POOL_SIZE;
+pub const DEFAULT_CONDA_POOL_SIZE: u64 = DEFAULT_POOL_SIZE;
+pub const DEFAULT_PIXI_POOL_SIZE: u64 = DEFAULT_POOL_SIZE;
 pub const MAX_POOL_SIZE: u64 = 20;
+
+pub fn default_pool_sizes_for_python_env(env: &PythonEnvType) -> (u64, u64, u64) {
+    match env {
+        PythonEnvType::Uv => (
+            DEFAULT_SELECTED_POOL_SIZE,
+            DEFAULT_POOL_SIZE,
+            DEFAULT_POOL_SIZE,
+        ),
+        PythonEnvType::Conda => (
+            DEFAULT_POOL_SIZE,
+            DEFAULT_SELECTED_POOL_SIZE,
+            DEFAULT_POOL_SIZE,
+        ),
+        PythonEnvType::Pixi => (
+            DEFAULT_POOL_SIZE,
+            DEFAULT_POOL_SIZE,
+            DEFAULT_SELECTED_POOL_SIZE,
+        ),
+        PythonEnvType::Other(_) => (DEFAULT_POOL_SIZE, DEFAULT_POOL_SIZE, DEFAULT_POOL_SIZE),
+    }
+}
 
 /// Snapshot of all synced settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -301,9 +324,9 @@ impl Default for SyncedSettings {
             pixi: PixiDefaults::default(),
             keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
             onboarding_completed: false,
-            uv_pool_size: DEFAULT_UV_POOL_SIZE,
-            conda_pool_size: DEFAULT_CONDA_POOL_SIZE,
-            pixi_pool_size: DEFAULT_PIXI_POOL_SIZE,
+            uv_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).0,
+            conda_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).1,
+            pixi_pool_size: default_pool_sizes_for_python_env(&PythonEnvType::default()).2,
             bootstrap_dx: false,
             install_id: String::new(),
             telemetry_enabled: true,
@@ -431,23 +454,6 @@ impl SettingsDoc {
 
         // nteract/dx kernel bootstrap (opt-in)
         let _ = doc.put(automerge::ROOT, "bootstrap_dx", defaults.bootstrap_dx);
-
-        // Pool sizes
-        let _ = doc.put(
-            automerge::ROOT,
-            "uv_pool_size",
-            defaults.uv_pool_size as i64,
-        );
-        let _ = doc.put(
-            automerge::ROOT,
-            "conda_pool_size",
-            defaults.conda_pool_size as i64,
-        );
-        let _ = doc.put(
-            automerge::ROOT,
-            "pixi_pool_size",
-            defaults.pixi_pool_size as i64,
-        );
 
         // Telemetry defaults (install_id left empty until first heartbeat)
         let _ = doc.put(automerge::ROOT, "install_id", "");
@@ -946,6 +952,13 @@ impl SettingsDoc {
             }
         };
 
+        let default_python_env = self
+            .get("default_python_env")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_default();
+        let (default_uv_pool_size, default_conda_pool_size, default_pixi_pool_size) =
+            default_pool_sizes_for_python_env(&default_python_env);
+
         SyncedSettings {
             theme: self
                 .get("theme")
@@ -959,10 +972,7 @@ impl SettingsDoc {
                 .get("default_runtime")
                 .and_then(|s| s.parse().ok())
                 .unwrap_or_default(),
-            default_python_env: self
-                .get("default_python_env")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or_default(),
+            default_python_env,
             uv: UvDefaults {
                 default_packages: uv_packages,
             },
@@ -981,15 +991,13 @@ impl SettingsDoc {
                 // Check if this is an existing user by looking for other settings
                 self.get("theme").is_some() || self.get("default_runtime").is_some()
             }),
-            uv_pool_size: self
-                .get_u64("uv_pool_size")
-                .unwrap_or(defaults.uv_pool_size),
+            uv_pool_size: self.get_u64("uv_pool_size").unwrap_or(default_uv_pool_size),
             conda_pool_size: self
                 .get_u64("conda_pool_size")
-                .unwrap_or(defaults.conda_pool_size),
+                .unwrap_or(default_conda_pool_size),
             pixi_pool_size: self
                 .get_u64("pixi_pool_size")
-                .unwrap_or(defaults.pixi_pool_size),
+                .unwrap_or(default_pixi_pool_size),
             bootstrap_dx: self
                 .get_bool("bootstrap_dx")
                 .unwrap_or(defaults.bootstrap_dx),
@@ -1098,10 +1106,10 @@ impl SettingsDoc {
 
         // Pool sizes: uv_pool_size, conda_pool_size, pixi_pool_size
         if let Some(uv_pool) = json.get("uv_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_u64("uv_pool_size");
-            if current != Some(uv_pool) {
+            let current = self.get_all().uv_pool_size;
+            if current != uv_pool {
                 info!(
-                    "[settings] apply_json_changes: uv_pool_size changed {:?} -> {}",
+                    "[settings] apply_json_changes: uv_pool_size changed {} -> {}",
                     current, uv_pool
                 );
                 self.put_u64("uv_pool_size", uv_pool);
@@ -1109,10 +1117,10 @@ impl SettingsDoc {
             }
         }
         if let Some(conda_pool) = json.get("conda_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_u64("conda_pool_size");
-            if current != Some(conda_pool) {
+            let current = self.get_all().conda_pool_size;
+            if current != conda_pool {
                 info!(
-                    "[settings] apply_json_changes: conda_pool_size changed {:?} -> {}",
+                    "[settings] apply_json_changes: conda_pool_size changed {} -> {}",
                     current, conda_pool
                 );
                 self.put_u64("conda_pool_size", conda_pool);
@@ -1120,10 +1128,10 @@ impl SettingsDoc {
             }
         }
         if let Some(pixi_pool) = json.get("pixi_pool_size").and_then(|v| v.as_u64()) {
-            let current = self.get_u64("pixi_pool_size");
-            if current != Some(pixi_pool) {
+            let current = self.get_all().pixi_pool_size;
+            if current != pixi_pool {
                 info!(
-                    "[settings] apply_json_changes: pixi_pool_size changed {:?} -> {}",
+                    "[settings] apply_json_changes: pixi_pool_size changed {} -> {}",
                     current, pixi_pool
                 );
                 self.put_u64("pixi_pool_size", pixi_pool);
@@ -1257,8 +1265,41 @@ mod tests {
         assert_eq!(settings.theme, ThemeMode::System);
         assert_eq!(settings.default_runtime, Runtime::Python);
         assert_eq!(settings.default_python_env, PythonEnvType::Uv);
+        assert_eq!(settings.uv_pool_size, DEFAULT_SELECTED_POOL_SIZE);
+        assert_eq!(settings.conda_pool_size, DEFAULT_POOL_SIZE);
+        assert_eq!(settings.pixi_pool_size, DEFAULT_POOL_SIZE);
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
+    }
+
+    #[test]
+    fn test_selected_python_env_gets_larger_default_pool() {
+        let mut doc = SettingsDoc::new();
+        doc.put("default_python_env", "conda");
+        let settings = doc.get_all();
+        assert_eq!(settings.uv_pool_size, DEFAULT_POOL_SIZE);
+        assert_eq!(settings.conda_pool_size, DEFAULT_SELECTED_POOL_SIZE);
+        assert_eq!(settings.pixi_pool_size, DEFAULT_POOL_SIZE);
+
+        doc.put("default_python_env", "pixi");
+        let settings = doc.get_all();
+        assert_eq!(settings.uv_pool_size, DEFAULT_POOL_SIZE);
+        assert_eq!(settings.conda_pool_size, DEFAULT_POOL_SIZE);
+        assert_eq!(settings.pixi_pool_size, DEFAULT_SELECTED_POOL_SIZE);
+    }
+
+    #[test]
+    fn test_explicit_pool_sizes_override_selected_env_defaults() {
+        let mut doc = SettingsDoc::new();
+        doc.put("default_python_env", "pixi");
+        doc.put_u64("uv_pool_size", 4);
+        doc.put_u64("conda_pool_size", 5);
+        doc.put_u64("pixi_pool_size", 6);
+
+        let settings = doc.get_all();
+        assert_eq!(settings.uv_pool_size, 4);
+        assert_eq!(settings.conda_pool_size, 5);
+        assert_eq!(settings.pixi_pool_size, 6);
     }
 
     #[test]

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -15,8 +15,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::connection::{self, Handshake};
 use crate::settings_doc::{
-    read_nested_list, split_comma_list, ColorTheme, CondaDefaults, PixiDefaults, SyncedSettings,
-    ThemeMode, UvDefaults,
+    default_pool_sizes_for_python_env, read_nested_list, split_comma_list, ColorTheme,
+    CondaDefaults, PixiDefaults, SyncedSettings, ThemeMode, UvDefaults,
 };
 
 /// Error type for sync client operations.
@@ -421,6 +421,11 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         }
     };
 
+    let default_python_env = get_str("default_python_env")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default();
+    let pool_sizes = default_pool_sizes_for_python_env(&default_python_env);
+
     SyncedSettings {
         theme: get_str("theme")
             .and_then(|s| serde_json::from_str::<ThemeMode>(&format!("\"{s}\"")).ok())
@@ -431,9 +436,7 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         default_runtime: get_str("default_runtime")
             .and_then(|s| s.parse().ok())
             .unwrap_or_default(),
-        default_python_env: get_str("default_python_env")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_default(),
+        default_python_env,
         uv: UvDefaults {
             default_packages: uv_packages,
         },
@@ -448,9 +451,9 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         // assume they're upgrading from before onboarding was added → treat as completed
         onboarding_completed: get_bool("onboarding_completed")
             .unwrap_or_else(|| get_str("theme").is_some() || get_str("default_runtime").is_some()),
-        uv_pool_size: get_u64("uv_pool_size").unwrap_or(defaults.uv_pool_size),
-        conda_pool_size: get_u64("conda_pool_size").unwrap_or(defaults.conda_pool_size),
-        pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(defaults.pixi_pool_size),
+        uv_pool_size: get_u64("uv_pool_size").unwrap_or(pool_sizes.uv_pool_size),
+        conda_pool_size: get_u64("conda_pool_size").unwrap_or(pool_sizes.conda_pool_size),
+        pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(pool_sizes.pixi_pool_size),
         bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
         install_id: get_str("install_id").unwrap_or_default(),
         telemetry_enabled: get_bool("telemetry_enabled").unwrap_or(true),
@@ -510,6 +513,18 @@ mod tests {
         assert_eq!(settings.theme, ThemeMode::Dark);
         assert_eq!(settings.default_runtime, Runtime::Deno);
         assert_eq!(settings.default_python_env, PythonEnvType::Conda);
+    }
+
+    #[test]
+    fn test_get_all_pool_defaults_follow_selected_python_env() {
+        let mut doc = AutoCommit::new();
+        doc.put(automerge::ROOT, "default_python_env", "pixi")
+            .unwrap();
+
+        let settings = get_all_from_doc(&doc);
+        assert_eq!(settings.uv_pool_size, 1);
+        assert_eq!(settings.conda_pool_size, 1);
+        assert_eq!(settings.pixi_pool_size, 2);
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -103,6 +103,9 @@ impl Default for DaemonConfig {
             execution_store_dir: crate::default_execution_store_dir(),
             notebook_docs_dir: crate::default_notebook_docs_dir(),
             trusted_packages_db_path: crate::trusted_packages_db_path(),
+            // These config defaults gate whether each warmer is enabled. The
+            // effective target comes from synced settings so the selected
+            // Python environment can default to a larger pool.
             uv_pool_size: runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
             conda_pool_size: runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
             pixi_pool_size: runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -103,9 +103,9 @@ impl Default for DaemonConfig {
             execution_store_dir: crate::default_execution_store_dir(),
             notebook_docs_dir: crate::default_notebook_docs_dir(),
             trusted_packages_db_path: crate::trusted_packages_db_path(),
-            uv_pool_size: 3,
-            conda_pool_size: 3,
-            pixi_pool_size: 2,
+            uv_pool_size: runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
+            conda_pool_size: runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
+            pixi_pool_size: runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
             max_age_secs: 172800, // 2 days
             lock_dir: None,
             room_eviction_delay_ms: None,
@@ -3895,16 +3895,15 @@ impl Daemon {
             // the settings lock across the pool lock.
             let (target, expected_packages) = {
                 let settings = self.settings.read().await;
+                let synced = settings.get_all();
                 let target = if self.config.uv_pool_size == 0 {
                     0 // Test mode: explicit 0 in config means don't warm
                 } else {
-                    settings
-                        .get_u64("uv_pool_size")
-                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE)
+                    synced
+                        .uv_pool_size
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let synced = settings.get_all();
                 let pkgs = uv_prewarmed_packages(&synced.uv.default_packages);
                 (target, pkgs)
             };
@@ -4000,16 +3999,15 @@ impl Daemon {
             // Snapshot expected package list and target pool size (issue #1915).
             let (target, expected_packages) = {
                 let settings = self.settings.read().await;
+                let synced = settings.get_all();
                 let target = if self.config.conda_pool_size == 0 {
                     0 // Test mode: explicit 0 in config means don't warm
                 } else {
-                    settings
-                        .get_u64("conda_pool_size")
-                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE)
+                    synced
+                        .conda_pool_size
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let synced = settings.get_all();
                 let pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
                 (target, pkgs)
             };
@@ -4112,16 +4110,15 @@ impl Daemon {
             // Snapshot expected package list and target pool size (issue #1915).
             let (target, expected_packages) = {
                 let settings = self.settings.read().await;
+                let synced = settings.get_all();
                 let target = if self.config.pixi_pool_size == 0 {
                     0 // Test mode: explicit 0 in config means don't warm
                 } else {
-                    settings
-                        .get_u64("pixi_pool_size")
-                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE)
+                    synced
+                        .pixi_pool_size
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let synced = settings.get_all();
                 let pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
                 (target, pkgs)
             };
@@ -5813,8 +5810,18 @@ mod tests {
     #[test]
     fn test_daemon_config_default() {
         let config = DaemonConfig::default();
-        assert_eq!(config.uv_pool_size, 3);
-        assert_eq!(config.conda_pool_size, 3);
+        assert_eq!(
+            config.uv_pool_size,
+            runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize
+        );
+        assert_eq!(
+            config.conda_pool_size,
+            runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize
+        );
+        assert_eq!(
+            config.pixi_pool_size,
+            runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize
+        );
         #[cfg(unix)]
         assert!(config
             .socket_path

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -64,16 +64,24 @@ enum Commands {
         blob_store_dir: Option<PathBuf>,
 
         /// Number of UV environments to maintain
-        #[arg(long, default_value = "3")]
+        #[arg(
+            long,
+            default_value_t = runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize
+        )]
         uv_pool_size: usize,
 
         /// Number of Conda environments to maintain
-        #[arg(long, default_value = "3")]
+        #[arg(
+            long,
+            default_value_t = runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize
+        )]
         conda_pool_size: usize,
 
         /// Number of Pixi environments to maintain
-        /// Default matches DEFAULT_PIXI_POOL_SIZE in settings_doc.rs
-        #[arg(long, default_value = "2")]
+        #[arg(
+            long,
+            default_value_t = runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize
+        )]
         pixi_pool_size: usize,
     },
 
@@ -313,7 +321,14 @@ async fn main() -> anyhow::Result<()> {
                         conda_pool_size,
                         pixi_pool_size,
                     ),
-                    _ => (None, None, None, 3, 3, 2),
+                    _ => (
+                        None,
+                        None,
+                        None,
+                        runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
+                        runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
+                        runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
+                    ),
                 };
 
             run_daemon(

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -63,21 +63,21 @@ enum Commands {
         #[arg(long)]
         blob_store_dir: Option<PathBuf>,
 
-        /// Number of UV environments to maintain
+        /// Initial UV pool gate; synced settings choose the effective target
         #[arg(
             long,
             default_value_t = runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize
         )]
         uv_pool_size: usize,
 
-        /// Number of Conda environments to maintain
+        /// Initial Conda pool gate; synced settings choose the effective target
         #[arg(
             long,
             default_value_t = runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize
         )]
         conda_pool_size: usize,
 
-        /// Number of Pixi environments to maintain
+        /// Initial Pixi pool gate; synced settings choose the effective target
         #[arg(
             long,
             default_value_t = runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2372,20 +2372,20 @@ async fn test_pool_size_config_honored() {
     // Test 2: Verify that apply_json_changes() correctly updates pool sizes
     let mut settings_doc2 = runtimed_client::settings_doc::SettingsDoc::new();
 
-    // Initially, pool sizes should have default values (3, 3, 2)
+    // Initially, pool sizes should have dynamic defaults: base 1, selected env 2.
     assert_eq!(
-        settings_doc2.get_u64("uv_pool_size"),
-        Some(3),
+        settings_doc2.get_all().uv_pool_size,
+        2,
         "UV pool should start with default value"
     );
     assert_eq!(
-        settings_doc2.get_u64("conda_pool_size"),
-        Some(3),
+        settings_doc2.get_all().conda_pool_size,
+        1,
         "Conda pool should start with default value"
     );
     assert_eq!(
-        settings_doc2.get_u64("pixi_pool_size"),
-        Some(2),
+        settings_doc2.get_all().pixi_pool_size,
+        1,
         "Pixi pool should start with default value"
     );
 


### PR DESCRIPTION
## Summary

- lower base UV/Conda/Pixi pool defaults to 1 environment each
- resolve the selected Python environment to a default pool size of 2 when no explicit size is configured
- preserve explicit pool-size settings, including larger values, across settings sync and JSON fallback loading

## Verification

- cargo test -p runtimed-client settings_doc
- cargo test -p runtimed --test integration test_pool_size_config_honored
- cargo test -p notebook settings
- cargo check -p runtimed
- cargo xtask lint --fix
