### PR TITLE
fix(runtime-doc): propagate schema seed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7040,6 +7040,7 @@ dependencies = [
  "automunge",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -372,7 +372,7 @@ where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
-    let mut shared_state = SharedDocState::new(doc, notebook_id.clone());
+    let mut shared_state = SharedDocState::try_new(doc, notebook_id.clone())?;
     shared_state.peer_state = peer_state;
 
     let shared = Arc::new(Mutex::new(shared_state));

--- a/crates/notebook-sync/src/error.rs
+++ b/crates/notebook-sync/src/error.rs
@@ -42,6 +42,10 @@ pub enum SyncError {
     /// Serialization/deserialization error.
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// Runtime state document setup or mutation failed.
+    #[error("Runtime state error: {0}")]
+    RuntimeState(#[from] runtime_doc::RuntimeStateError),
 }
 
 impl From<serde_json::Error> for SyncError {

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -38,15 +38,23 @@ pub struct SharedDocState {
 
 impl SharedDocState {
     /// Create a new shared state with the given document and notebook ID.
-    pub fn new(doc: AutoCommit, notebook_id: String) -> Self {
-        Self {
+    pub fn try_new(
+        doc: AutoCommit,
+        notebook_id: String,
+    ) -> Result<Self, runtime_doc::RuntimeStateError> {
+        Ok(Self {
             doc,
             peer_state: sync::State::new(),
             notebook_id,
             presence: PresenceState::new(),
-            state_doc: RuntimeStateDoc::new_empty(),
+            state_doc: RuntimeStateDoc::try_new_empty()?,
             state_peer_state: sync::State::new(),
-        }
+        })
+    }
+
+    pub fn new(doc: AutoCommit, notebook_id: String) -> Self {
+        Self::try_new(doc, notebook_id)
+            .unwrap_or_else(|err| panic!("create bootstrap runtime state doc: {err}"))
     }
 
     /// Get a reference to the notebook ID.

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1"
 automunge = { path = "../automunge" }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
+thiserror = { workspace = true }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -351,11 +351,10 @@ impl RuntimeStateDoc {
     /// Starts from the canonical runtime-state schema seed so every peer has
     /// the same root object IDs before the first sync round, then switches to
     /// the daemon actor for live runtime-state writes.
-    #[allow(clippy::expect_used, clippy::new_without_default)]
-    pub fn new() -> Self {
-        let mut doc = Self::schema_seed_doc();
+    pub fn try_new() -> Result<Self, RuntimeStateError> {
+        let mut doc = Self::schema_seed_doc()?;
         doc.set_actor(ActorId::from(b"runtimed:state" as &[u8]));
-        Self { doc }
+        Ok(Self { doc })
     }
 
     /// Create a new `RuntimeStateDoc` with scaffolding and a custom actor.
@@ -363,11 +362,10 @@ impl RuntimeStateDoc {
     /// Used by the runtime agent to create its own doc with a unique actor
     /// for runtime-agent-authored writes. The schema scaffold remains the
     /// canonical seed history shared with the coordinator and frontend.
-    #[allow(clippy::expect_used)]
-    pub fn new_with_actor(actor_label: &str) -> Self {
-        let mut doc = Self::schema_seed_doc();
+    pub fn try_new_with_actor(actor_label: &str) -> Result<Self, RuntimeStateError> {
+        let mut doc = Self::schema_seed_doc()?;
         doc.set_actor(ActorId::from(actor_label.as_bytes()));
-        Self { doc }
+        Ok(Self { doc })
     }
 
     /// Create a bootstrap `RuntimeStateDoc` for read-only clients.
@@ -375,23 +373,36 @@ impl RuntimeStateDoc {
     /// The document starts from the canonical schema seed, not from an empty
     /// AutoCommit, so the first RuntimeStateSync frame can merge into the
     /// shared root scaffold instead of replacing local encoding/actor state.
-    pub fn new_empty() -> Self {
-        let mut doc = Self::schema_seed_doc();
+    pub fn try_new_empty() -> Result<Self, RuntimeStateError> {
+        let mut doc = Self::schema_seed_doc()?;
         doc.set_actor(ActorId::random());
-        Self { doc }
+        Ok(Self { doc })
     }
 
-    #[allow(clippy::expect_used)]
-    fn schema_seed_doc() -> AutoCommit {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::try_new().unwrap_or_else(|err| panic!("seed runtime state schema: {err}"))
+    }
+
+    pub fn new_with_actor(actor_label: &str) -> Self {
+        Self::try_new_with_actor(actor_label)
+            .unwrap_or_else(|err| panic!("seed runtime state schema: {err}"))
+    }
+
+    pub fn new_empty() -> Self {
+        Self::try_new_empty().unwrap_or_else(|err| panic!("seed runtime state schema: {err}"))
+    }
+
+    fn schema_seed_doc() -> Result<AutoCommit, RuntimeStateError> {
         let mut doc = AutoCommit::new();
         doc.set_actor(ActorId::from(RUNTIME_STATE_SCHEMA_SEED_ACTOR.as_bytes()));
-        scaffold_runtime_state_schema(&mut doc).expect("seed runtime state schema");
+        scaffold_runtime_state_schema(&mut doc)?;
         let _ = doc.commit_with(
             CommitOptions::default()
                 .with_message("Seed nteract runtime state schema")
                 .with_time(0),
         );
-        doc
+        Ok(doc)
     }
 
     /// Create a RuntimeStateDoc from a pre-existing Automerge document.

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -394,9 +394,15 @@ impl RuntimeStateDoc {
     }
 
     fn schema_seed_doc() -> Result<AutoCommit, RuntimeStateError> {
+        Self::schema_seed_doc_with(scaffold_runtime_state_schema)
+    }
+
+    fn schema_seed_doc_with(
+        scaffold: impl FnOnce(&mut AutoCommit) -> Result<(), RuntimeStateError>,
+    ) -> Result<AutoCommit, RuntimeStateError> {
         let mut doc = AutoCommit::new();
         doc.set_actor(ActorId::from(RUNTIME_STATE_SCHEMA_SEED_ACTOR.as_bytes()));
-        scaffold_runtime_state_schema(&mut doc)?;
+        scaffold(&mut doc)?;
         let _ = doc.commit_with(
             CommitOptions::default()
                 .with_message("Seed nteract runtime state schema")
@@ -2874,6 +2880,19 @@ mod tests {
         assert_eq!(state.trust.status, "no_dependencies");
         assert!(!state.trust.needs_approval);
         assert!(state.last_saved.is_none());
+    }
+
+    #[test]
+    fn schema_seed_doc_returns_scaffold_errors() {
+        let err = RuntimeStateDoc::schema_seed_doc_with(|_| {
+            Err(RuntimeStateError::MissingScaffold("injected"))
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RuntimeStateError::MissingScaffold("injected")
+        ));
     }
 
     #[test]

--- a/crates/runtime-doc/src/error.rs
+++ b/crates/runtime-doc/src/error.rs
@@ -1,32 +1,13 @@
 use automerge::AutomergeError;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum RuntimeStateError {
+    #[error("scaffold map '{0}' missing; doc may be corrupt")]
     MissingScaffold(&'static str),
+    #[error("env progress phase must serialize as an object")]
     InvalidProgressShape,
-    Automerge(AutomergeError),
+    #[error("automerge: {0}")]
+    Automerge(#[from] AutomergeError),
+    #[error("RuntimeStateDoc mutex poisoned")]
     LockPoisoned,
-}
-
-impl std::fmt::Display for RuntimeStateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MissingScaffold(name) => {
-                write!(f, "scaffold map '{name}' missing — doc may be corrupt")
-            }
-            Self::InvalidProgressShape => {
-                write!(f, "env progress phase must serialize as an object")
-            }
-            Self::Automerge(e) => write!(f, "automerge: {e}"),
-            Self::LockPoisoned => write!(f, "RuntimeStateDoc mutex poisoned"),
-        }
-    }
-}
-
-impl std::error::Error for RuntimeStateError {}
-
-impl From<AutomergeError> for RuntimeStateError {
-    fn from(e: AutomergeError) -> Self {
-        Self::Automerge(e)
-    }
 }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -430,14 +430,15 @@ fn walk_and_resolve_comm_state(
 impl NotebookHandle {
     /// Create a new empty notebook document.
     #[wasm_bindgen(constructor)]
-    pub fn new(notebook_id: &str) -> NotebookHandle {
-        NotebookHandle {
+    pub fn new(notebook_id: &str) -> Result<NotebookHandle, JsError> {
+        Ok(NotebookHandle {
             doc: NotebookDoc::new_with_encoding(
                 notebook_id,
                 notebook_doc::TextEncoding::Utf16CodeUnit,
             ),
             sync_state: sync::State::new(),
-            state_doc: RuntimeStateDoc::new_empty(),
+            state_doc: RuntimeStateDoc::try_new_empty()
+                .map_err(|e| JsError::new(&format!("create runtime state doc failed: {}", e)))?,
             state_sync_state: sync::State::new(),
             prev_execution_outputs: std::collections::HashMap::new(),
             prev_output_by_id: std::collections::HashMap::new(),
@@ -446,18 +447,19 @@ impl NotebookHandle {
             metadata_fingerprint_cache: None,
             mime_priority: Vec::new(),
             blob_port: None,
-        }
+        })
     }
 
     /// Create a bootstrap handle for sync — no notebook ID, just skeleton + encoding + actor.
     ///
     /// This is the preferred constructor for sync-only clients. The daemon
     /// populates the full document via Automerge sync.
-    pub fn create_bootstrap(actor_label: &str) -> NotebookHandle {
-        NotebookHandle {
+    pub fn create_bootstrap(actor_label: &str) -> Result<NotebookHandle, JsError> {
+        Ok(NotebookHandle {
             doc: NotebookDoc::bootstrap(notebook_doc::TextEncoding::Utf16CodeUnit, actor_label),
             sync_state: sync::State::new(),
-            state_doc: RuntimeStateDoc::new_empty(),
+            state_doc: RuntimeStateDoc::try_new_empty()
+                .map_err(|e| JsError::new(&format!("create runtime state doc failed: {}", e)))?,
             state_sync_state: sync::State::new(),
             prev_execution_outputs: std::collections::HashMap::new(),
             prev_output_by_id: std::collections::HashMap::new(),
@@ -466,21 +468,21 @@ impl NotebookHandle {
             metadata_fingerprint_cache: None,
             mime_priority: Vec::new(),
             blob_port: None,
-        }
+        })
     }
 
     /// Create a handle with the bootstrap skeleton for sync.
     ///
     /// Deprecated — use [`create_bootstrap()`](Self::create_bootstrap) which
     /// requires an actor label.
-    pub fn create_empty() -> NotebookHandle {
+    pub fn create_empty() -> Result<NotebookHandle, JsError> {
         Self::create_bootstrap("anonymous")
     }
 
     /// Create a bootstrap handle with a specific actor identity.
     ///
     /// Deprecated — use [`create_bootstrap()`](Self::create_bootstrap).
-    pub fn create_empty_with_actor(actor_label: &str) -> NotebookHandle {
+    pub fn create_empty_with_actor(actor_label: &str) -> Result<NotebookHandle, JsError> {
         Self::create_bootstrap(actor_label)
     }
 
@@ -491,7 +493,8 @@ impl NotebookHandle {
         Ok(NotebookHandle {
             doc,
             sync_state: sync::State::new(),
-            state_doc: RuntimeStateDoc::new_empty(),
+            state_doc: RuntimeStateDoc::try_new_empty()
+                .map_err(|e| JsError::new(&format!("create runtime state doc failed: {}", e)))?,
             state_sync_state: sync::State::new(),
             prev_execution_outputs: std::collections::HashMap::new(),
             prev_output_by_id: std::collections::HashMap::new(),

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2045,7 +2045,7 @@ impl Daemon {
                             None => (uuid::Uuid::new_v4(), Some(canonical)),
                         }
                     };
-                    crate::notebook_sync_server::get_or_create_room(
+                    crate::notebook_sync_server::get_or_create_room_result(
                         &self.notebook_rooms,
                         &self.path_index,
                         ns_uuid,
@@ -2057,7 +2057,7 @@ impl Daemon {
                             trusted_packages: self.trusted_packages.clone(),
                         },
                     )
-                    .await
+                    .await?
                 };
                 self.mark_rooms_ever_seen();
                 let (reader, writer) = tokio::io::split(stream);
@@ -2344,7 +2344,7 @@ impl Daemon {
             } else {
                 let uuid = uuid::Uuid::new_v4();
                 let path = Some(canonical_path.clone());
-                crate::notebook_sync_server::get_or_create_room(
+                crate::notebook_sync_server::get_or_create_room_result(
                     &self.notebook_rooms,
                     &self.path_index,
                     uuid,
@@ -2356,7 +2356,7 @@ impl Daemon {
                         trusted_packages: self.trusted_packages.clone(),
                     },
                 )
-                .await
+                .await?
             }
         };
         self.mark_rooms_ever_seen();
@@ -2530,7 +2530,7 @@ impl Daemon {
         // always a UUID (new room) or an existing UUID (session restore).
         let docs_dir = self.config.notebook_docs_dir.clone();
         let uuid = uuid::Uuid::parse_str(&notebook_id).unwrap_or_else(|_| uuid::Uuid::new_v4());
-        let room = crate::notebook_sync_server::get_or_create_room(
+        let room = crate::notebook_sync_server::get_or_create_room_result(
             &self.notebook_rooms,
             &self.path_index,
             uuid,
@@ -2542,7 +2542,7 @@ impl Daemon {
                 trusted_packages: self.trusted_packages.clone(),
             },
         )
-        .await;
+        .await?;
         self.mark_rooms_ever_seen();
 
         // Populate the room's doc with the empty notebook content — but only if the

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -34,17 +34,29 @@ pub async fn find_room_by_path(
 ///
 /// For .ipynb files, a file watcher is spawned to detect external changes.
 /// Also inserts an entry into `path_index` when `path` is `Some`.
+#[cfg(test)]
 pub async fn get_or_create_room(
     rooms: &NotebookRooms,
     path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
     uuid: uuid::Uuid,
     options: RoomCreationOptions<'_>,
 ) -> Arc<NotebookRoom> {
+    get_or_create_room_result(rooms, path_index, uuid, options)
+        .await
+        .unwrap_or_else(|err| panic!("create notebook room runtime state: {err}"))
+}
+
+pub async fn get_or_create_room_result(
+    rooms: &NotebookRooms,
+    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
+    uuid: uuid::Uuid,
+    options: RoomCreationOptions<'_>,
+) -> anyhow::Result<Arc<NotebookRoom>> {
     // Fast path: room already exists.
     {
         let rooms_guard = rooms.lock().await;
         if let Some(existing) = rooms_guard.get(&uuid) {
-            return existing.clone();
+            return Ok(existing.clone());
         }
     }
 
@@ -57,14 +69,14 @@ pub async fn get_or_create_room(
         options.blob_store,
         options.ephemeral,
         options.trusted_packages,
-    ));
+    )?);
 
     {
         let mut rooms_guard = rooms.lock().await;
         // Double-check in case of a race: another task may have created the room
         // between our unlock above and acquiring the write lock here.
         if let Some(existing) = rooms_guard.get(&uuid) {
-            return existing.clone();
+            return Ok(existing.clone());
         }
         rooms_guard.insert(uuid, room.clone());
     }
@@ -94,5 +106,5 @@ pub async fn get_or_create_room(
         NotebookFileBinding::bind_existing(&room, notebook_path).await;
     }
 
-    room
+    Ok(room)
 }

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -522,6 +522,7 @@ impl NotebookRoom {
             ephemeral,
             crate::trusted_packages::TrustedPackageStore::unavailable("not configured"),
         )
+        .expect("create test notebook room runtime state")
     }
 
     pub fn new_fresh_with_trusted_packages(
@@ -531,7 +532,7 @@ impl NotebookRoom {
         blob_store: Arc<BlobStore>,
         ephemeral: bool,
         trusted_packages: crate::trusted_packages::TrustedPackageStore,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let id = uuid;
         // Use uuid string as the notebook_id for doc filename derivation and NotebookDoc construction.
         let notebook_id_str = uuid.to_string();
@@ -632,7 +633,11 @@ impl NotebookRoom {
         );
 
         let (state_changed_tx, _) = broadcast::channel(16);
-        let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
+        let state = runtime_doc::RuntimeStateHandle::new(
+            RuntimeStateDoc::try_new()
+                .map_err(|e| anyhow::anyhow!("create runtime state doc: {e}"))?,
+            state_changed_tx,
+        );
 
         // Seed path on the runtime-state doc so connecting peers see it via sync.
         if let Some(p) = path.as_ref() {
@@ -645,7 +650,7 @@ impl NotebookRoom {
             None => RoomPersistence::ephemeral(),
         };
 
-        Self {
+        Ok(Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
             broadcasts: RoomBroadcasts::default(),
@@ -665,7 +670,7 @@ impl NotebookRoom {
             runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
-        }
+        })
     }
 
     /// Create a new room by loading a persisted document or creating a fresh one.

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -16,7 +16,9 @@ use uuid::Uuid;
 
 use crate::blob_store::BlobStore;
 use crate::daemon::Daemon;
-use crate::notebook_sync_server::{get_or_create_room, NotebookRoom, NotebookRooms, PathIndex};
+use crate::notebook_sync_server::{
+    get_or_create_room_result, NotebookRoom, NotebookRooms, PathIndex,
+};
 use crate::protocol::NotebookResponse;
 
 /// Dispatcher entry point — unwraps the Daemon pieces for the inner fn.
@@ -68,7 +70,7 @@ pub(crate) async fn handle_inner(
     let clone_uuid = Uuid::new_v4();
 
     // 4. Create the new ephemeral room (empty).
-    let clone_room = get_or_create_room(
+    let clone_room = match get_or_create_room_result(
         rooms,
         path_index,
         clone_uuid,
@@ -80,7 +82,15 @@ pub(crate) async fn handle_inner(
             trusted_packages: source_room.trusted_packages.clone(),
         },
     )
-    .await;
+    .await
+    {
+        Ok(room) => room,
+        Err(e) => {
+            return NotebookResponse::Error {
+                error: format!("Failed to create clone runtime state: {e}"),
+            };
+        }
+    };
 
     // 5. Seed the room's working_dir so project-file resolution finds the
     //    same pyproject.toml / environment.yml / pixi.toml the source uses.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -89,7 +89,8 @@ pub async fn run_runtime_agent(
 
     // -- 2. Bootstrap RuntimeStateDoc ---------------------------------------
 
-    let state_doc = RuntimeStateDoc::new_with_actor(&runtime_agent_id);
+    let state_doc = RuntimeStateDoc::try_new_with_actor(&runtime_agent_id)
+        .map_err(|e| anyhow::anyhow!("create runtime-agent state doc: {e}"))?;
     let mut coordinator_sync_state = automerge::sync::State::new();
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
     // Keep a clone of the sender for the reconnect "kick" path that needs


### PR DESCRIPTION
## Summary

- add fallible `RuntimeStateDoc::try_new*` constructors and derive `RuntimeStateError` with `thiserror`
- propagate runtime-state schema-seed failures through notebook-sync setup, daemon room creation, clone creation, runtime-agent bootstrap, and WASM constructors
- keep compatibility constructors for test/helper paths while moving production daemon-facing code onto fallible APIs

## Verification

- cargo check -p runtime-doc -p notebook-sync -p runtimed-wasm -p runtimed
- cargo test -p runtime-doc
- cargo test -p notebook-sync
- cargo test -p runtimed test_create_notebook -- --nocapture
- cargo xtask wasm
- deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/deno_smoke_test.ts
- cargo xtask lint --fix
