### PR TITLE
test(notebook-sync): probe runtime state sync concurrency

### DIFF
--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -8,6 +8,7 @@
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::AutoCommit;
+use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::RuntimeStateDoc;
 
@@ -119,7 +120,12 @@ impl SharedDocState {
     /// processing — the same recovery pattern as `rebuild_shared_doc_state`
     /// for the notebook doc, but targeting the state doc.
     pub fn rebuild_state_doc(&mut self) {
-        self.state_doc.rebuild_from_save();
+        if !self.state_doc.rebuild_from_save() {
+            warn!(
+                "[notebook-sync] Failed to rebuild RuntimeStateDoc after panic; \
+                 resetting state sync protocol only"
+            );
+        }
         self.state_peer_state = sync::State::new();
     }
 

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -34,6 +34,9 @@ pub struct SharedDocState {
 
     /// Automerge sync protocol state for the RuntimeStateDoc peer.
     pub(crate) state_peer_state: sync::State,
+
+    #[cfg(test)]
+    panic_on_next_state_sync: bool,
 }
 
 impl SharedDocState {
@@ -49,6 +52,8 @@ impl SharedDocState {
             presence: PresenceState::new(),
             state_doc: RuntimeStateDoc::try_new_empty()?,
             state_peer_state: sync::State::new(),
+            #[cfg(test)]
+            panic_on_next_state_sync: false,
         })
     }
 
@@ -96,6 +101,12 @@ impl SharedDocState {
         &mut self,
         message: sync::Message,
     ) -> Result<(), automerge::AutomergeError> {
+        #[cfg(test)]
+        if self.panic_on_next_state_sync {
+            self.panic_on_next_state_sync = false;
+            panic!("injected RuntimeStateSync panic");
+        }
+
         self.state_doc
             .doc_mut()
             .sync()
@@ -110,5 +121,45 @@ impl SharedDocState {
     pub fn rebuild_state_doc(&mut self) {
         self.state_doc.rebuild_from_save();
         self.state_peer_state = sync::State::new();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn panic_on_next_state_sync_for_test(&mut self) {
+        self.panic_on_next_state_sync = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rebuild_state_doc_preserves_state_and_restarts_sync_handshake() {
+        let mut state = SharedDocState::new(AutoCommit::new(), "test-notebook".into());
+        state
+            .state_doc
+            .create_execution_with_source("exec-1", "cell-1", "x = 1", 1)
+            .expect("execution created");
+
+        assert!(
+            state.generate_state_sync_message().is_some(),
+            "first sync round should advertise runtime-state changes"
+        );
+        assert!(
+            state.generate_state_sync_message().is_none(),
+            "peer state should suppress duplicate messages before rebuild"
+        );
+
+        state.rebuild_state_doc();
+
+        let runtime_state = state.state_doc.read_state();
+        assert!(
+            runtime_state.executions.contains_key("exec-1"),
+            "save/load rebuild must not drop runtime-state data"
+        );
+        assert!(
+            state.generate_state_sync_message().is_some(),
+            "reset sync state should force a fresh runtime-state handshake"
+        );
     }
 }

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -101,4 +101,14 @@ impl SharedDocState {
             .sync()
             .receive_sync_message(&mut self.state_peer_state, message)
     }
+
+    /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
+    ///
+    /// Used after catching an automerge panic during `RuntimeStateSync`
+    /// processing — the same recovery pattern as `rebuild_shared_doc_state`
+    /// for the notebook doc, but targeting the state doc.
+    pub fn rebuild_state_doc(&mut self) {
+        self.state_doc.rebuild_from_save();
+        self.state_peer_state = sync::State::new();
+    }
 }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -728,7 +728,7 @@ impl SyncReactor {
                             state.rebuild_state_doc();
                             return;
                         }
-                    }
+                    };
                     match std::panic::catch_unwind(AssertUnwindSafe(|| {
                         state.generate_state_sync_message().map(|msg| msg.encode())
                     })) {
@@ -1161,7 +1161,7 @@ mod tests {
     };
     use serde_json::json;
     use tokio::io::{BufReader, BufWriter};
-    use tokio::sync::{broadcast, mpsc, watch};
+    use tokio::sync::{broadcast, mpsc, oneshot, watch};
     use tokio::time::timeout;
 
     fn test_handle_and_config() -> (crate::DocHandle, SyncTaskConfig) {
@@ -1405,6 +1405,97 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
+    async fn runtime_state_sync_panic_is_caught_and_later_updates_still_apply() {
+        // Probe for a known recovery gap: catching an inbound RuntimeStateSync
+        // panic keeps the task alive, but the daemon peer state can still
+        // believe the client received the dropped change. A fuller fix likely
+        // needs a runtime-state peer reset/rejoin path, not just catch_unwind.
+        let mut reactor = test_reactor();
+        {
+            let mut state = reactor.io.doc.lock().unwrap();
+            state.panic_on_next_state_sync_for_test();
+        }
+
+        let mut daemon_state = SharedDocState::new(
+            notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+            "test-notebook".into(),
+        );
+        daemon_state.state_doc =
+            runtime_doc::RuntimeStateDoc::new_with_actor("runtimed-sync-panic-test");
+        daemon_state
+            .state_doc
+            .create_execution_with_source("exec-1", "cell-1", "x = 1", 1)
+            .expect("daemon creates queued execution");
+        let (client_reply_writer, daemon_reply_reader) = tokio::io::duplex(4096);
+        let mut writer = client_reply_writer;
+        let mut reply_reader =
+            connection::FramedReader::spawn(BufReader::new(daemon_reply_reader), 16);
+        let mut later_update_sent = false;
+
+        for _ in 0..8 {
+            let client_msg = {
+                let mut state = reactor.io.doc.lock().unwrap();
+                state.generate_state_sync_message()
+            };
+            if let Some(client_msg) = client_msg {
+                daemon_state
+                    .receive_state_sync_message(client_msg)
+                    .expect("daemon receives client runtime-state handshake");
+            }
+
+            if let Some(daemon_msg) = daemon_state.generate_state_sync_message() {
+                let frame = connection::TypedNotebookFrame {
+                    frame_type: NotebookFrameType::RuntimeStateSync,
+                    payload: daemon_msg.encode(),
+                };
+                reactor.handle_incoming_frame(&frame, &mut writer).await;
+
+                if !later_update_sent {
+                    daemon_state
+                        .state_doc
+                        .create_execution_with_source("exec-2", "cell-2", "y = 2", 2)
+                        .expect("daemon creates later queued execution");
+                    later_update_sent = true;
+                }
+            }
+
+            while let Ok(Some(Ok(reply))) =
+                timeout(Duration::from_millis(10), reply_reader.recv()).await
+            {
+                if reply.frame_type != NotebookFrameType::RuntimeStateSync {
+                    continue;
+                }
+                let msg = sync::Message::decode(&reply.payload)
+                    .expect("client runtime-state reply decodes");
+                daemon_state
+                    .receive_state_sync_message(msg)
+                    .expect("daemon receives client runtime-state reset reply");
+            }
+
+            let state = reactor.io.doc.lock().unwrap();
+            if state
+                .state_doc
+                .read_state()
+                .executions
+                .contains_key("exec-2")
+            {
+                return;
+            }
+        }
+
+        let state = reactor.io.doc.lock().unwrap();
+        assert!(
+            state
+                .state_doc
+                .read_state()
+                .executions
+                .contains_key("exec-2"),
+            "runtime-state replica should remain usable for later updates after caught panic"
+        );
+    }
+
+    #[tokio::test]
     async fn run_marks_status_disconnected_on_exit() {
         let shared = Arc::new(Mutex::new(SharedDocState::new(
             notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
@@ -1528,6 +1619,157 @@ mod tests {
         assert_eq!(daemon.await.expect("daemon task"), 10);
         drop(handle);
         sync_task.await.expect("sync task exits");
+    }
+
+    #[tokio::test]
+    async fn local_mutations_and_runtime_state_sync_pressure_converge() {
+        const CELL_COUNT: usize = 24;
+
+        let (handle, config) = test_handle_and_config();
+        let (client, server) = tokio::io::duplex(4096);
+        let (client_read, client_write) = tokio::io::split(client);
+        let (server_read, server_write) = tokio::io::split(server);
+        let (daemon_converged_tx, daemon_converged_rx) = oneshot::channel();
+
+        let sync_task = tokio::spawn(run(config, client_read, client_write));
+        let daemon = tokio::spawn(async move {
+            let mut reader = connection::FramedReader::spawn(BufReader::new(server_read), 128);
+            let mut writer = BufWriter::new(server_write);
+            let mut daemon_state = SharedDocState::new(
+                notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+                "test-notebook".into(),
+            );
+            daemon_state.state_doc =
+                runtime_doc::RuntimeStateDoc::new_with_actor("runtimed-sync-pressure");
+            let mut runtime_updates_sent = 0;
+            let mut daemon_converged_tx = Some(daemon_converged_tx);
+
+            loop {
+                let Some(frame) = timeout(Duration::from_secs(15), reader.recv())
+                    .await
+                    .expect("daemon received frame under pressure")
+                else {
+                    return notebook_doc::get_cells_from_doc(&daemon_state.doc).len();
+                };
+                let frame = frame.expect("client stayed connected under pressure");
+
+                match frame.frame_type {
+                    NotebookFrameType::AutomergeSync => {
+                        let msg = sync::Message::decode(&frame.payload)
+                            .expect("valid notebook sync message");
+                        daemon_state
+                            .receive_sync_message(msg)
+                            .expect("daemon receives notebook sync");
+
+                        if let Some(reply) = daemon_state.generate_sync_message() {
+                            connection::send_typed_frame(
+                                &mut writer,
+                                NotebookFrameType::AutomergeSync,
+                                &reply.encode(),
+                            )
+                            .await
+                            .expect("daemon sends notebook sync reply");
+                        }
+                    }
+                    NotebookFrameType::RuntimeStateSync => {
+                        let msg = sync::Message::decode(&frame.payload)
+                            .expect("valid runtime-state sync message");
+                        daemon_state
+                            .receive_state_sync_message(msg)
+                            .expect("daemon receives runtime-state sync");
+                    }
+                    _ => {}
+                }
+
+                if runtime_updates_sent < CELL_COUNT {
+                    let index = runtime_updates_sent;
+                    daemon_state
+                        .state_doc
+                        .create_execution_with_source(
+                            &format!("exec-{index}"),
+                            &format!("cell-{index}"),
+                            &format!("print({index})"),
+                            index as u64,
+                        )
+                        .expect("queued execution created");
+                    runtime_updates_sent += 1;
+                }
+
+                if let Some(reply) = daemon_state.generate_state_sync_message() {
+                    connection::send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &reply.encode(),
+                    )
+                    .await
+                    .expect("daemon sends runtime-state sync");
+                }
+
+                let cell_count = notebook_doc::get_cells_from_doc(&daemon_state.doc).len();
+                if cell_count >= CELL_COUNT && runtime_updates_sent >= CELL_COUNT {
+                    if let Some(tx) = daemon_converged_tx.take() {
+                        let _ = tx.send(cell_count);
+                    }
+                }
+            }
+        });
+
+        let mut cell_tasks = Vec::new();
+        for index in 0..CELL_COUNT {
+            let handle = handle.clone();
+            cell_tasks.push(tokio::spawn(async move {
+                let previous = index.checked_sub(1).map(|i| format!("cell-{i}"));
+                handle
+                    .add_cell_with_source(
+                        &format!("cell-{index}"),
+                        "code",
+                        previous.as_deref(),
+                        &format!("print({index})"),
+                    )
+                    .expect("cell added under pressure");
+                handle.confirm_sync().await
+            }));
+        }
+
+        let mut state_flush_tasks = Vec::new();
+        for _ in 0..CELL_COUNT {
+            let handle = handle.clone();
+            state_flush_tasks.push(tokio::spawn(
+                async move { handle.confirm_state_sync().await },
+            ));
+        }
+
+        timeout(Duration::from_secs(20), async {
+            for task in cell_tasks {
+                task.await.expect("cell task joined").expect("cell synced");
+            }
+            for task in state_flush_tasks {
+                task.await
+                    .expect("state flush task joined")
+                    .expect("state synced");
+            }
+
+            loop {
+                handle.confirm_state_sync().await.expect("final state sync");
+                let state = handle.get_runtime_state().expect("runtime state");
+                if state.queue.queued.len() >= CELL_COUNT {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("pressure run converged");
+
+        assert_eq!(
+            daemon_converged_rx
+                .await
+                .expect("daemon reported convergence"),
+            CELL_COUNT
+        );
+        drop(handle);
+        sync_task.await.expect("sync task exits");
+        assert_eq!(daemon.await.expect("daemon task"), CELL_COUNT);
     }
 
     #[tokio::test]

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -688,17 +688,61 @@ impl SyncReactor {
                     }
                 };
 
-                // Apply and generate reply — same pattern as AutomergeSync
+                // Apply and generate reply — same pattern as AutomergeSync.
+                //
+                // Wrapped in catch_unwind because automerge 0.7 can panic in
+                // receive_sync_message / generate_sync_message on the state
+                // doc under the same concurrent-sync conditions that trigger
+                // the notebook doc panic (automerge/automerge#1187). Without
+                // catch_unwind, the panic kills the sync task, which closes
+                // the socket and causes the MCP connection to drop — any
+                // locally-pending notebook mutations (e.g. a cell creation)
+                // that hadn't been synced yet are lost on reconnect.
                 let reply_bytes = {
                     let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
-                    if let Err(e) = state.receive_state_sync_message(msg) {
-                        warn!(
-                            "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
-                            self.io.notebook_id, e
-                        );
-                        return;
+                    let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        state.receive_state_sync_message(msg)
+                    }));
+                    match recv_result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            warn!(
+                                "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
+                                self.io.notebook_id, e
+                            );
+                            return;
+                        }
+                        Err(panic_payload) => {
+                            let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
+                                s.as_str()
+                            } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                                s
+                            } else {
+                                "unknown panic"
+                            };
+                            warn!(
+                                "[notebook-sync] Automerge panicked during RuntimeStateSync for {} \
+                                 (upstream bug automerge/automerge#1187): {}",
+                                self.io.notebook_id, msg
+                            );
+                            state.rebuild_state_doc();
+                            return;
+                        }
                     }
-                    state.generate_state_sync_message().map(|msg| msg.encode())
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        state.generate_state_sync_message().map(|msg| msg.encode())
+                    })) {
+                        Ok(bytes) => bytes,
+                        Err(_) => {
+                            warn!(
+                                "[notebook-sync] Automerge panicked in generate_state_sync_message \
+                                 for {} (upstream MissingOps bug)",
+                                self.io.notebook_id
+                            );
+                            state.rebuild_state_doc();
+                            None
+                        }
+                    }
                 };
 
                 if let Some(bytes) = reply_bytes {

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -1411,6 +1411,7 @@ mod tests {
         // panic keeps the task alive, but the daemon peer state can still
         // believe the client received the dropped change. A fuller fix likely
         // needs a runtime-state peer reset/rejoin path, not just catch_unwind.
+        // Remove #[ignore] once that peer reset/rejoin path exists.
         let mut reactor = test_reactor();
         {
             let mut state = reactor.io.doc.lock().unwrap();
@@ -1626,7 +1627,7 @@ mod tests {
         const CELL_COUNT: usize = 24;
 
         let (handle, config) = test_handle_and_config();
-        let (client, server) = tokio::io::duplex(4096);
+        let (client, server) = tokio::io::duplex(128 * 1024);
         let (client_read, client_write) = tokio::io::split(client);
         let (server_read, server_write) = tokio::io::split(server);
         let (daemon_converged_tx, daemon_converged_rx) = oneshot::channel();
@@ -1718,12 +1719,11 @@ mod tests {
         for index in 0..CELL_COUNT {
             let handle = handle.clone();
             cell_tasks.push(tokio::spawn(async move {
-                let previous = index.checked_sub(1).map(|i| format!("cell-{i}"));
                 handle
                     .add_cell_with_source(
                         &format!("cell-{index}"),
                         "code",
-                        previous.as_deref(),
+                        None,
                         &format!("print({index})"),
                     )
                     .expect("cell added under pressure");


### PR DESCRIPTION
## Summary

- cherry-pick the `RuntimeStateSync` Automerge panic guard from #2451 so the probes exercise the intended recovery boundary
- add a `SharedDocState::rebuild_state_doc()` regression test proving save/load rebuild preserves runtime-state data and resets the state sync handshake
- add an in-memory sync-task pressure test that interleaves local notebook mutations, concurrent `confirm_state_sync()` callers, and daemon-authored queued runtime executions
- add an ignored fault-injection probe documenting the remaining recovery gap after an inbound `RuntimeStateSync` panic

## Notes

This PR is intentionally stacked on the runtime-state sync guard from #2451. Once #2451 lands, this branch should be rebased so the first commit drops away and only the probe coverage remains.

The ignored probe is included because it found a real limit: catching an inbound runtime-state sync panic keeps the task alive, but the daemon peer state can still believe the client received the dropped change. A fuller fix likely needs a runtime-state peer reset or rejoin path rather than only `catch_unwind`.

## Test plan

- [x] `cargo test -p notebook-sync rebuild_state_doc_preserves_state_and_restarts_sync_handshake --lib`
- [x] `cargo test -p notebook-sync local_mutations_and_runtime_state_sync_pressure_converge --lib`
- [x] `cargo test -p notebook-sync runtime_state_sync_panic_is_caught_and_later_updates_still_apply --lib` (ignored probe compiles)
- [x] `cargo test -p notebook-sync --lib`
- [x] `cargo xtask lint --fix`
