### PR TITLE
fix(runtime): add rich runtime launch diagnostics

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -944,7 +944,6 @@ function AppContent() {
         if (response.result === "error") {
           logger.error("[App] kernel launch after trust approval failed:", response.error);
           setTrustApprovalHandoffPending(false);
-          setTrustActionNotice(response.error);
           return;
         }
         if (response.result === "guard_rejected") {
@@ -1597,6 +1596,9 @@ function AppContent() {
           errorReason={errorReason}
           kernelErrorMessage={errorDetails}
           envSource={envSource}
+          condaPython={condaDependencies?.python ?? null}
+          condaChannels={condaDependencies?.channels ?? null}
+          projectContext={runtimeState.project_context}
           envTypeHint={envTypeHint}
           envProgress={envProgress.isActive || envProgress.error ? envProgress : null}
           runtime={runtime}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -81,6 +81,14 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
+function isLaunchErrorHandledByRuntimeBanner(error: string): boolean {
+  return (
+    error.includes("ipykernel not found in pixi.toml") ||
+    error.includes("ipykernel not found in prepared ") ||
+    error.includes("environment.yml declares conda env")
+  );
+}
+
 /**
  * Update the daemon comm sender reference.
  * Called by AppContent when daemon kernel is initialized.
@@ -944,6 +952,9 @@ function AppContent() {
         if (response.result === "error") {
           logger.error("[App] kernel launch after trust approval failed:", response.error);
           setTrustApprovalHandoffPending(false);
+          if (!isLaunchErrorHandledByRuntimeBanner(response.error)) {
+            setTrustActionNotice(response.error);
+          }
           return;
         }
         if (response.result === "guard_rejected") {

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -30,6 +30,8 @@ export function shouldShowKernelLaunchErrorBanner(params: {
   if (params.lifecycle.lifecycle !== "Error") return false;
   if (!params.errorDetails || params.errorDetails.length === 0) return false;
   if (params.errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL) return false;
+  if (params.errorReason === KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL) return false;
+  if (params.errorReason === KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH) return false;
   if (params.errorReason === KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING) return false;
   if (params.runtime === "deno") return false;
   return true;

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useState, type ReactElement, type ReactNode } f
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
 import type { UpdateStatus } from "../hooks/useUpdater";
-import { KERNEL_ERROR_REASON, type EnvProgressState } from "runtimed";
+import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
 import {
   getStatusKeyLabel,
   KERNEL_STATUS,
@@ -35,6 +35,9 @@ interface NotebookToolbarProps {
   errorReason: string | null;
   kernelErrorMessage?: string | null;
   envSource: string | null;
+  condaPython?: string | null;
+  condaChannels?: string[] | null;
+  projectContext?: ProjectContext | null;
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
   envTypeHint?: EnvBadgeVariant | null;
   envProgress: EnvProgressState | null;
@@ -63,6 +66,9 @@ export function NotebookToolbar({
   errorReason,
   kernelErrorMessage,
   envSource,
+  condaPython = null,
+  condaChannels = null,
+  projectContext = null,
   envTypeHint,
   envProgress,
   runtime = null,
@@ -411,9 +417,15 @@ export function NotebookToolbar({
           then tell the user to restart. */}
       {runtime === "python" &&
         lifecycle.lifecycle === "Error" &&
-        errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL &&
         envSource &&
-        renderMissingIpykernelPrompt(envSource)}
+        renderIpykernelErrorPrompt({
+          envSource,
+          errorReason,
+          errorDetails: kernelErrorMessage ?? null,
+          condaPython,
+          condaChannels,
+          projectContext,
+        })}
       {showCondaEnvYmlMissingBanner && (
         <CondaEnvYmlMissingBanner
           details={kernelErrorMessage}
@@ -437,12 +449,26 @@ export function NotebookToolbar({
  * restart alone now re-hits the same broken cache. Until we add an
  * in-place repair, the way out is to bump the dep hash — add, pin, or
  * remove anything in the notebook's deps — or clear the daemon cache. */
-function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
+function renderIpykernelErrorPrompt({
+  envSource,
+  errorReason,
+  errorDetails,
+  condaPython,
+  condaChannels,
+  projectContext,
+}: {
+  envSource: string;
+  errorReason: string | null;
+  errorDetails: string | null;
+  condaPython: string | null;
+  condaChannels: string[] | null;
+  projectContext: ProjectContext | null;
+}): ReactElement | null {
   // Pixi project: the .toml is the source of truth; user must add
   // ipykernel explicitly.
-  if (envSource.startsWith("pixi:")) {
+  if (errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL && envSource.startsWith("pixi:")) {
     return (
-      <MissingIpykernelBanner
+      <RuntimeErrorBanner
         headline="ipykernel not found in pixi.toml."
         instruction={
           <>
@@ -453,12 +479,23 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
       />
     );
   }
+
+  const contextItems = buildCondaContextItems(
+    envSource,
+    condaPython,
+    condaChannels,
+    projectContext,
+  );
+
   // Inline / PEP 723 / inline conda: env is a shared content-addressed
   // cache — we can't safely delete it from the launch path. Bump the
   // hash instead.
-  if (envSource === "uv:inline" || envSource === "uv:pep723" || envSource === "conda:inline") {
+  if (
+    errorReason === KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL &&
+    (envSource === "uv:inline" || envSource === "uv:pep723" || envSource === "conda:inline")
+  ) {
     return (
-      <MissingIpykernelBanner
+      <RuntimeErrorBanner
         headline="Dependency cache is missing ipykernel."
         instruction={
           <>
@@ -466,10 +503,46 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
             or clear the daemon cache.
           </>
         }
+        contextItems={contextItems}
+        details={errorDetails}
+      />
+    );
+  }
+
+  if (errorReason === KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH) {
+    return (
+      <RuntimeErrorBanner
+        headline="Conda installed ipykernel outside this Python's import path."
+        instruction={
+          <>
+            Conda/Python ABI mismatch: pin Python in the dependency panel and rebuild the
+            environment, or clear the daemon cache.
+          </>
+        }
+        contextItems={contextItems}
+        details={errorDetails}
       />
     );
   }
   return null;
+}
+
+function buildCondaContextItems(
+  envSource: string,
+  condaPython: string | null,
+  condaChannels: string[] | null,
+  projectContext: ProjectContext | null,
+): string[] {
+  const items = [`Environment: ${envSource}`];
+  if (envSource.startsWith("conda:")) {
+    items.push(`Manager: conda`);
+    if (condaPython) items.push(`Python: ${condaPython}`);
+    if (condaChannels?.length) items.push(`Channels: ${condaChannels.join(", ")}`);
+  }
+  if (projectContext?.state === "Detected") {
+    items.push(`Project: ${projectContext.project_file.relative_to_notebook}`);
+  }
+  return items;
 }
 
 function CondaEnvYmlMissingBanner({
@@ -508,20 +581,38 @@ function CondaEnvYmlMissingBanner({
   );
 }
 
-function MissingIpykernelBanner({
+function RuntimeErrorBanner({
   headline,
   instruction,
+  contextItems = [],
+  details = null,
 }: {
   headline: string;
   instruction: ReactNode;
+  contextItems?: string[];
+  details?: string | null;
 }): ReactElement {
   return (
     <div className="border-t px-3 py-2">
       <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
         <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-        <span>
-          <span className="font-medium">{headline}</span> {instruction}
-        </span>
+        <div className="min-w-0 space-y-1">
+          <div>
+            <span className="font-medium">{headline}</span> {instruction}
+          </div>
+          {contextItems.length > 0 && (
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-amber-800/80 dark:text-amber-300/80">
+              {contextItems.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
+          )}
+          {details && (
+            <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words rounded bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-900 dark:text-amber-100">
+              {details}
+            </pre>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -125,6 +125,10 @@ export function NotebookToolbar({
   // has been smoothed over sub-60ms blips; every other sub-state (launching,
   // resolving, …) passes through untouched with its richer label.
   const kernelStatusText = getStatusKeyLabel(statusKey, errorReason);
+  const hasToolbarHandledIpykernelError =
+    errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL ||
+    errorReason === KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL ||
+    errorReason === KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH;
   const envErrorMessage = envProgress?.error ?? null;
   const envStatusText = envProgress?.statusText ?? kernelStatusText;
   const kernelStatusDescription = envProgress?.isActive
@@ -418,6 +422,7 @@ export function NotebookToolbar({
       {runtime === "python" &&
         lifecycle.lifecycle === "Error" &&
         envSource &&
+        hasToolbarHandledIpykernelError &&
         renderIpykernelErrorPrompt({
           envSource,
           errorReason,

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -121,12 +121,22 @@ describe("shouldShowKernelLaunchErrorBanner", () => {
     ).toBe(false);
   });
 
-  it("hides for MissingIpykernel (toolbar prompt owns that UX)", () => {
+  it.each([
+    [KERNEL_ERROR_REASON.MISSING_IPYKERNEL, "ipykernel not declared"],
+    [
+      KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL,
+      "ipykernel is not importable from the prepared inline environment",
+    ],
+    [
+      KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH,
+      "ipykernel is installed outside the interpreter's importable site-packages path",
+    ],
+  ])("hides for typed ipykernel reason %s (toolbar prompt owns that UX)", (reason, details) => {
     expect(
       shouldShowKernelLaunchErrorBanner({
         lifecycle: ERROR,
-        errorDetails: "ipykernel not declared",
-        errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
+        errorDetails: details,
+        errorReason: reason,
         runtime: "python",
       }),
     ).toBe(false);

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -409,7 +409,7 @@ describe("NotebookToolbar", () => {
       );
       // Prewarmed envs should never reach MissingIpykernel — defensive: render nothing.
       expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/ipykernel missing/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Dependency cache is missing ipykernel/)).not.toBeInTheDocument();
     });
   });
 
@@ -429,7 +429,7 @@ describe("NotebookToolbar", () => {
             runtime="python"
             kernelStatus={KERNEL_STATUS.ERROR}
             lifecycle={errorLifecycle}
-            errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+            errorReason={KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL}
             envSource={envSource}
           />,
         );
@@ -468,6 +468,78 @@ describe("NotebookToolbar", () => {
       );
       expect(screen.queryByText(/ipykernel missing from/)).not.toBeInTheDocument();
       expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
+    });
+
+    it("shows conda context and daemon diagnostics for stale inline caches", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL}
+          envSource="conda:inline"
+          condaPython="3.11"
+          condaChannels={["conda-forge"]}
+          projectContext={{
+            state: "Detected",
+            project_file: {
+              absolute_path: "/tmp/project/environment.yml",
+              relative_to_notebook: "environment.yml",
+              kind: "CondaEnvYml",
+            },
+            parsed: {
+              dependencies: ["numpy"],
+              dev_dependencies: [],
+              requires_python: "3.11",
+              prerelease: null,
+              extras: { kind: "EnvironmentYml", channels: ["conda-forge"], pip: [] },
+            },
+            observed_at: "2026-05-01T00:00:00Z",
+          }}
+          kernelErrorMessage={[
+            "ipykernel is not importable from the prepared conda:inline environment.",
+            "python: /tmp/env/bin/python",
+            "site-packages: /tmp/env/lib/python3.11/site-packages",
+          ].join("\n")}
+        />,
+      );
+
+      expect(screen.getByText("Environment: conda:inline")).toBeInTheDocument();
+      expect(screen.getByText("Manager: conda")).toBeInTheDocument();
+      expect(screen.getByText("Python: 3.11")).toBeInTheDocument();
+      expect(screen.getByText("Channels: conda-forge")).toBeInTheDocument();
+      expect(screen.getByText("Project: environment.yml")).toBeInTheDocument();
+      expect(screen.getByText(/site-packages: \/tmp\/env/)).toBeInTheDocument();
+    });
+
+    it("explains conda site-packages ABI mismatches with diagnostic details", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH}
+          envSource="conda:inline"
+          condaPython="3.14t"
+          condaChannels={["conda-forge"]}
+          kernelErrorMessage={[
+            "ipykernel is installed outside the interpreter's importable site-packages path.",
+            "interpreter site-packages: /tmp/env/lib/python3.14t/site-packages",
+            "found ipykernel under:",
+            "  - /tmp/env/lib/python3.14/site-packages/ipykernel",
+          ].join("\n")}
+        />,
+      );
+
+      expect(
+        screen.getByText(/Conda installed ipykernel outside this Python's import path/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Conda\/Python ABI mismatch/)).toBeInTheDocument();
+      expect(screen.getByText("Python: 3.14t")).toBeInTheDocument();
+      expect(screen.getByText(/python3\.14t\/site-packages/)).toBeInTheDocument();
+      expect(screen.queryByText("missing_ipykernel")).not.toBeInTheDocument();
     });
   });
 

--- a/apps/notebook/src/lib/__tests__/kernel-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/kernel-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { KERNEL_ERROR_REASON } from "runtimed";
 import {
   getTrustApprovalHandoffDisplayStatus,
   getLifecycleLabel,
@@ -81,10 +82,16 @@ describe("getLifecycleLabel", () => {
     }
   });
 
-  it("appends typed reason when lifecycle is Error", () => {
-    expect(getLifecycleLabel({ lifecycle: "Error" }, "missing_ipykernel")).toBe(
-      "error: missing_ipykernel",
+  it("shows a human typed reason label when lifecycle is Error", () => {
+    expect(getLifecycleLabel({ lifecycle: "Error" }, KERNEL_ERROR_REASON.MISSING_IPYKERNEL)).toBe(
+      "error: ipykernel missing",
     );
+    expect(
+      getLifecycleLabel(
+        { lifecycle: "Error" },
+        KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH,
+      ),
+    ).toBe("error: Python environment mismatch");
   });
 
   it("ignores reason for non-Error lifecycles", () => {
@@ -108,10 +115,16 @@ describe("getStatusKeyLabel", () => {
     }
   });
 
-  it("appends typed reason when key is error", () => {
-    expect(getStatusKeyLabel(RUNTIME_STATUS.ERROR, "missing_ipykernel")).toBe(
-      "error: missing_ipykernel",
+  it("shows a human typed reason label when key is error", () => {
+    expect(getStatusKeyLabel(RUNTIME_STATUS.ERROR, KERNEL_ERROR_REASON.MISSING_IPYKERNEL)).toBe(
+      "error: ipykernel missing",
     );
+    expect(
+      getStatusKeyLabel(
+        RUNTIME_STATUS.ERROR,
+        KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL,
+      ),
+    ).toBe("error: ipykernel missing");
   });
 
   it("ignores reason for non-error keys", () => {

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -17,6 +17,7 @@ export {
 } from "runtimed";
 
 import {
+  KERNEL_ERROR_REASON,
   KERNEL_STATUS,
   RUNTIME_STATUS,
   runtimeStatusKey,
@@ -24,6 +25,13 @@ import {
   type RuntimeLifecycle,
   type RuntimeStatusKey,
 } from "runtimed";
+
+const ERROR_REASON_LABELS: Record<string, string> = {
+  [KERNEL_ERROR_REASON.MISSING_IPYKERNEL]: "ipykernel missing",
+  [KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL]: "ipykernel missing",
+  [KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH]: "Python environment mismatch",
+  [KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING]: "Conda environment missing",
+};
 
 /**
  * User-facing label for each expanded [`RuntimeStatusKey`].
@@ -61,7 +69,7 @@ export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
  */
 export function getStatusKeyLabel(key: RuntimeStatusKey, errorReason: string | null): string {
   if (key === RUNTIME_STATUS.ERROR && errorReason && errorReason.length > 0) {
-    return `error: ${errorReason}`;
+    return `error: ${ERROR_REASON_LABELS[errorReason] ?? "kernel failed"}`;
   }
   return RUNTIME_STATUS_LABELS[key];
 }

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1290,6 +1290,15 @@ mod tests {
     }
 
     #[test]
+    fn free_threading_constraint_detection_is_explicit() {
+        assert!(conda_python_requests_free_threading("3.14t"));
+        assert!(conda_python_requests_free_threading(">=3.14t"));
+        assert!(conda_python_requests_free_threading(">=3.13,!=3.14t"));
+        assert!(!conda_python_requests_free_threading("3.14"));
+        assert!(!conda_python_requests_free_threading(">=3.13,<3.15"));
+    }
+
+    #[test]
     fn gil_policy_changes_cache_identity() {
         let gil_deps = CondaDependencies {
             dependencies: vec!["numpy".into()],

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -61,6 +61,30 @@ pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "pyarrow>=14",
 ];
 
+const CONDA_GIL_SELECTOR: &str = "python-gil";
+
+fn conda_python_requests_free_threading(python: &str) -> bool {
+    python
+        .split(|ch: char| {
+            ch == ','
+                || ch == '='
+                || ch == '<'
+                || ch == '>'
+                || ch == '!'
+                || ch == '~'
+                || ch.is_whitespace()
+        })
+        .filter(|part| !part.is_empty())
+        .any(|part| part.ends_with('t'))
+}
+
+fn should_enforce_gil_python(deps: &CondaDependencies) -> bool {
+    !deps
+        .python
+        .as_deref()
+        .is_some_and(conda_python_requests_free_threading)
+}
+
 /// Compute the unified env hash for a notebook. Used by the captured-deps
 /// reopen path from the unified env resolution design (see
 /// `docs/superpowers/specs/2026-04-20-unified-env-resolution.md`).
@@ -101,6 +125,10 @@ pub fn compute_env_hash(deps: &CondaDependencies) -> String {
     if let Some(ref py) = deps.python {
         hasher.update(b"python:");
         hasher.update(py.as_bytes());
+    }
+
+    if should_enforce_gil_python(deps) {
+        hasher.update(b"python-abi:gil\n");
     }
 
     if let Some(ref env_id) = deps.env_id {
@@ -445,6 +473,9 @@ async fn install_conda_env(
         )?);
     } else {
         specs.push(MatchSpec::from_str("python>=3.13", match_spec_options)?);
+    }
+    if should_enforce_gil_python(deps) {
+        specs.push(MatchSpec::from_str(CONDA_GIL_SELECTOR, match_spec_options)?);
     }
 
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
@@ -1027,6 +1058,9 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
     } else {
         specs.push("python>=3.13".to_string());
     }
+    if should_enforce_gil_python(deps) {
+        specs.push(CONDA_GIL_SELECTOR.to_string());
+    }
 
     specs.push("ipykernel".to_string());
     specs.push("ipywidgets".to_string());
@@ -1211,5 +1245,66 @@ mod tests {
         let h1 = compute_unified_env_hash(&deps, "notebook-1");
         let h2 = compute_unified_env_hash(&deps, "notebook-2");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn managed_specs_enforce_gil_python_by_default() {
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: None,
+            env_id: None,
+        };
+
+        let specs = build_spec_strings(&deps);
+        assert!(specs.contains(&"python>=3.13".to_string()));
+        assert!(specs.contains(&CONDA_GIL_SELECTOR.to_string()));
+    }
+
+    #[test]
+    fn managed_specs_enforce_gil_python_for_normal_pin() {
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: Some("3.11".into()),
+            env_id: None,
+        };
+
+        let specs = build_spec_strings(&deps);
+        assert!(specs.contains(&"python=3.11".to_string()));
+        assert!(specs.contains(&CONDA_GIL_SELECTOR.to_string()));
+    }
+
+    #[test]
+    fn explicit_free_threaded_pin_does_not_add_gil_selector() {
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: Some("3.14t".into()),
+            env_id: None,
+        };
+
+        let specs = build_spec_strings(&deps);
+        assert!(specs.contains(&"python=3.14t".to_string()));
+        assert!(!specs.contains(&CONDA_GIL_SELECTOR.to_string()));
+    }
+
+    #[test]
+    fn gil_policy_changes_cache_identity() {
+        let gil_deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: Some("3.14".into()),
+            env_id: None,
+        };
+        let free_threaded_deps = CondaDependencies {
+            python: Some("3.14t".into()),
+            ..gil_deps.clone()
+        };
+
+        assert_ne!(
+            compute_env_hash(&gil_deps),
+            compute_env_hash(&free_threaded_deps)
+        );
     }
 }

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -68,8 +68,48 @@ pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
         .collect()
 }
 
-/// Check if a prepared UV venv or Conda env has `ipykernel` installed in its
-/// site-packages.
+/// Diagnostic result for checking whether a prepared Python environment can
+/// import `ipykernel`.
+#[cfg(feature = "runtime")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IpykernelDiagnostic {
+    Present {
+        python_path: std::path::PathBuf,
+        purelib: std::path::PathBuf,
+    },
+    Missing {
+        python_path: std::path::PathBuf,
+        purelib: std::path::PathBuf,
+        import_error: Option<String>,
+    },
+    SitePackagesMismatch {
+        python_path: std::path::PathBuf,
+        purelib: std::path::PathBuf,
+        import_error: Option<String>,
+        candidates: Vec<std::path::PathBuf>,
+    },
+    InterpreterProbeFailed {
+        python_path: std::path::PathBuf,
+        message: String,
+    },
+}
+
+#[cfg(feature = "runtime")]
+impl IpykernelDiagnostic {
+    pub fn is_present(&self) -> bool {
+        matches!(self, Self::Present { .. })
+    }
+}
+
+#[cfg(feature = "runtime")]
+#[derive(Debug, serde::Deserialize)]
+struct IpykernelProbe {
+    purelib: String,
+    import_ok: bool,
+    error: Option<String>,
+}
+
+/// Check if a prepared UV venv or Conda env can import `ipykernel`.
 ///
 /// Used by the inline/pep723 launch paths to detect missing `ipykernel` before
 /// spawning the kernel. `prepare_environment_in` always adds `ipykernel` to
@@ -85,44 +125,85 @@ pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
 /// false-negative a working env. The subprocess adds ~50ms; kernel launch
 /// is already seconds.
 ///
-/// Returns `false` on any failure (interpreter missing, spawn error,
-/// non-zero exit, empty output) — conservative: we'd rather surface a
-/// misleading "missing ipykernel" than try to launch a broken env.
-///
-/// Scans for a direct child directory named `ipykernel` or any
-/// `ipykernel-*.dist-info` metadata dir under site-packages.
 #[cfg(feature = "runtime")]
-pub fn venv_has_ipykernel(python_path: &std::path::Path) -> bool {
-    let Some(site_packages) = resolve_site_packages(python_path) else {
-        return false;
+pub fn diagnose_ipykernel(python_path: &std::path::Path) -> IpykernelDiagnostic {
+    let probe = match probe_ipykernel(python_path) {
+        Ok(probe) => probe,
+        Err(message) => {
+            return IpykernelDiagnostic::InterpreterProbeFailed {
+                python_path: python_path.to_path_buf(),
+                message,
+            };
+        }
     };
-    site_packages_has_ipykernel(&site_packages)
+
+    let purelib = std::path::PathBuf::from(probe.purelib);
+    if probe.import_ok {
+        return IpykernelDiagnostic::Present {
+            python_path: python_path.to_path_buf(),
+            purelib,
+        };
+    }
+
+    let candidates = sibling_site_packages_with_ipykernel(&purelib);
+    if !candidates.is_empty() {
+        return IpykernelDiagnostic::SitePackagesMismatch {
+            python_path: python_path.to_path_buf(),
+            purelib,
+            import_error: probe.error,
+            candidates,
+        };
+    }
+
+    IpykernelDiagnostic::Missing {
+        python_path: python_path.to_path_buf(),
+        purelib,
+        import_error: probe.error,
+    }
 }
 
-/// Ask the given interpreter for its site-packages path.
-///
-/// Uses `sysconfig.get_paths()['purelib']` which is the canonical
-/// pure-Python install target for that interpreter. Returns `None` if
-/// the interpreter cannot be executed or if the output is unexpected.
+/// Backward-compatible boolean wrapper for callers/tests that only need a gate.
 #[cfg(feature = "runtime")]
-fn resolve_site_packages(python_path: &std::path::Path) -> Option<std::path::PathBuf> {
+pub fn venv_has_ipykernel(python_path: &std::path::Path) -> bool {
+    diagnose_ipykernel(python_path).is_present()
+}
+
+#[cfg(feature = "runtime")]
+fn probe_ipykernel(python_path: &std::path::Path) -> Result<IpykernelProbe, String> {
     let output = std::process::Command::new(python_path)
         .args([
             "-c",
-            "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+            r#"import json, sysconfig
+try:
+    import ipykernel  # noqa: F401
+    import_ok = True
+    error = None
+except Exception as exc:
+    import_ok = False
+    error = f"{type(exc).__name__}: {exc}"
+print(json.dumps({
+    "purelib": sysconfig.get_paths().get("purelib", ""),
+    "import_ok": import_ok,
+    "error": error,
+}))"#,
         ])
         .output()
-        .ok()?;
+        .map_err(|e| e.to_string())?;
     if !output.status.success() {
-        return None;
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("interpreter exited with status {}", output.status)
+        } else {
+            stderr
+        });
     }
-    let sp = String::from_utf8(output.stdout).ok()?;
-    let sp = sp.trim();
-    if sp.is_empty() {
-        return None;
+    let stdout = String::from_utf8(output.stdout).map_err(|e| e.to_string())?;
+    let probe: IpykernelProbe =
+        serde_json::from_str(stdout.trim()).map_err(|e| format!("parse probe output: {e}"))?;
+    if probe.purelib.trim().is_empty() {
+        return Err("interpreter returned empty purelib".to_string());
     }
-    let path = std::path::PathBuf::from(sp);
-    path.is_dir().then_some(path)
+    Ok(probe)
 }
 
 #[cfg(feature = "runtime")]
@@ -146,6 +227,38 @@ fn site_packages_has_ipykernel(site_packages: &std::path::Path) -> bool {
         }
     }
     false
+}
+
+#[cfg(feature = "runtime")]
+fn sibling_site_packages_with_ipykernel(purelib: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let Some(python_dir) = purelib.parent() else {
+        return Vec::new();
+    };
+    let Some(lib_dir) = python_dir.parent() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(lib_dir) else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == python_dir || !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("python") {
+            continue;
+        }
+        let site_packages = path.join("site-packages");
+        if site_packages != purelib && site_packages_has_ipykernel(&site_packages) {
+            candidates.push(site_packages);
+        }
+    }
+    candidates.sort();
+    candidates
 }
 
 #[cfg(all(test, feature = "runtime"))]
@@ -290,5 +403,28 @@ mod site_packages_has_ipykernel_tests {
         assert!(!venv_has_ipykernel(std::path::Path::new(
             "/definitely/not/a/python/interpreter"
         )));
+    }
+
+    #[test]
+    fn sibling_site_packages_detects_abi_mismatch_candidate() {
+        let tmp = TempDir::new().unwrap();
+        let purelib = tmp.path().join("lib/python3.14t/site-packages");
+        let sibling = tmp.path().join("lib/python3.14/site-packages");
+        std::fs::create_dir_all(&purelib).unwrap();
+        std::fs::create_dir_all(sibling.join("ipykernel")).unwrap();
+
+        assert_eq!(
+            sibling_site_packages_with_ipykernel(&purelib),
+            vec![sibling]
+        );
+    }
+
+    #[test]
+    fn sibling_site_packages_ignores_current_purelib() {
+        let tmp = TempDir::new().unwrap();
+        let purelib = tmp.path().join("lib/python3.14/site-packages");
+        std::fs::create_dir_all(purelib.join("ipykernel")).unwrap();
+
+        assert!(sibling_site_packages_with_ipykernel(&purelib).is_empty());
     }
 }

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -210,6 +210,12 @@ pub enum KernelErrorReason {
     /// Pixi-managed environment is missing the `ipykernel` package.
     /// `NotebookToolbar` gates its "install ipykernel" prompt on this.
     MissingIpykernel,
+    /// A prepared inline dependency cache has Python but no importable
+    /// `ipykernel` package. Usually caused by a stale or partial cache.
+    DependencyCacheMissingIpykernel,
+    /// `ipykernel` exists on disk, but outside the interpreter's importable
+    /// site-packages path (for example a free-threaded Python ABI mismatch).
+    IpykernelSitePackagesMismatch,
     /// environment.yml declares a conda env (by `name:` or `prefix:`) that
     /// isn't built on this machine. Daemon sets this instead of silently
     /// falling back to a pool env, so the frontend can tell the user what
@@ -222,6 +228,8 @@ impl KernelErrorReason {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::MissingIpykernel => "missing_ipykernel",
+            Self::DependencyCacheMissingIpykernel => "dependency_cache_missing_ipykernel",
+            Self::IpykernelSitePackagesMismatch => "ipykernel_site_packages_mismatch",
             Self::CondaEnvYmlMissing => "conda_env_yml_missing",
         }
     }
@@ -229,6 +237,8 @@ impl KernelErrorReason {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "missing_ipykernel" => Some(Self::MissingIpykernel),
+            "dependency_cache_missing_ipykernel" => Some(Self::DependencyCacheMissingIpykernel),
+            "ipykernel_site_packages_mismatch" => Some(Self::IpykernelSitePackagesMismatch),
             "conda_env_yml_missing" => Some(Self::CondaEnvYmlMissing),
             _ => None,
         }
@@ -447,6 +457,14 @@ mod tests {
             KernelErrorReason::CondaEnvYmlMissing.as_str(),
             "conda_env_yml_missing"
         );
+        assert_eq!(
+            KernelErrorReason::DependencyCacheMissingIpykernel.as_str(),
+            "dependency_cache_missing_ipykernel"
+        );
+        assert_eq!(
+            KernelErrorReason::IpykernelSitePackagesMismatch.as_str(),
+            "ipykernel_site_packages_mismatch"
+        );
     }
 
     #[test]
@@ -459,6 +477,14 @@ mod tests {
             KernelErrorReason::parse("conda_env_yml_missing"),
             Some(KernelErrorReason::CondaEnvYmlMissing)
         );
+        assert_eq!(
+            KernelErrorReason::parse("dependency_cache_missing_ipykernel"),
+            Some(KernelErrorReason::DependencyCacheMissingIpykernel)
+        );
+        assert_eq!(
+            KernelErrorReason::parse("ipykernel_site_packages_mismatch"),
+            Some(KernelErrorReason::IpykernelSitePackagesMismatch)
+        );
         assert_eq!(KernelErrorReason::parse(""), None);
         assert_eq!(KernelErrorReason::parse("bogus"), None);
         // Parse is case-sensitive — the CRDT and legacy phase channel
@@ -470,6 +496,8 @@ mod tests {
     fn error_reason_as_str_round_trips_through_parse() {
         let reasons = [
             KernelErrorReason::MissingIpykernel,
+            KernelErrorReason::DependencyCacheMissingIpykernel,
+            KernelErrorReason::IpykernelSitePackagesMismatch,
             KernelErrorReason::CondaEnvYmlMissing,
         ];
         for r in reasons {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4289,6 +4289,7 @@ impl Daemon {
         let match_spec_options = ParseMatchSpecOptions::strict();
         let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
             let mut specs = vec![MatchSpec::from_str("python>=3.13", match_spec_options)?];
+            specs.push(MatchSpec::from_str("python-gil", match_spec_options)?);
             for pkg in &conda_install_packages {
                 specs.push(MatchSpec::from_str(pkg, match_spec_options)?);
             }

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -201,6 +201,7 @@ pub async fn prepare_uv_inline_env(
 pub async fn prepare_conda_inline_env(
     deps: &[String],
     channels: &[String],
+    python: Option<&str>,
     handler: Arc<dyn ProgressHandler>,
 ) -> Result<PreparedEnv> {
     let conda_deps = kernel_env::CondaDependencies {
@@ -210,7 +211,7 @@ pub async fn prepare_conda_inline_env(
         } else {
             channels.to_vec()
         },
-        python: None,
+        python: python.map(str::to_string),
         env_id: None,
     };
 
@@ -257,6 +258,7 @@ pub async fn claim_pool_env_for_conda_inline_cache(
     env: &mut crate::PooledEnv,
     deps: &[String],
     channels: &[String],
+    python: Option<&str>,
 ) {
     let dependencies = inline_deps_with_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
@@ -266,7 +268,7 @@ pub async fn claim_pool_env_for_conda_inline_cache(
         } else {
             channels.to_vec()
         },
-        python: None,
+        python: python.map(str::to_string),
         env_id: None,
     };
     let hash = kernel_env::conda::compute_env_hash(&conda_deps);
@@ -610,7 +612,11 @@ pub async fn check_uv_inline_cache(
 /// every requested package has a corresponding `conda-meta/` record.  A
 /// stale cache entry (e.g. created by a buggy build that dropped packages)
 /// is treated as a miss and removed so the next code path can rebuild it.
-pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<PreparedEnv> {
+pub fn check_conda_inline_cache(
+    deps: &[String],
+    channels: &[String],
+    python: Option<&str>,
+) -> Option<PreparedEnv> {
     let dependencies = inline_deps_with_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
         dependencies: dependencies.clone(),
@@ -619,7 +625,7 @@ pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<
         } else {
             channels.to_vec()
         },
-        python: None,
+        python: python.map(str::to_string),
         env_id: None,
     };
 

--- a/crates/runtimed/src/ipykernel_error.rs
+++ b/crates/runtimed/src/ipykernel_error.rs
@@ -1,0 +1,104 @@
+use kernel_env::IpykernelDiagnostic;
+use runtime_doc::KernelErrorReason;
+
+pub(crate) fn classify_ipykernel_diagnostic(
+    diagnostic: &IpykernelDiagnostic,
+    env_source: &str,
+) -> (KernelErrorReason, String) {
+    match diagnostic {
+        IpykernelDiagnostic::Present { .. } => (
+            KernelErrorReason::MissingIpykernel,
+            "ipykernel diagnostic unexpectedly succeeded".to_string(),
+        ),
+        IpykernelDiagnostic::Missing {
+            python_path,
+            purelib,
+            import_error,
+        } => (
+            KernelErrorReason::DependencyCacheMissingIpykernel,
+            format!(
+                "ipykernel is not importable from the prepared {env_source} environment.\npython: {}\nsite-packages: {}{}",
+                python_path.display(),
+                purelib.display(),
+                import_error
+                    .as_ref()
+                    .map(|err| format!("\nimport error: {err}"))
+                    .unwrap_or_default()
+            ),
+        ),
+        IpykernelDiagnostic::SitePackagesMismatch {
+            python_path,
+            purelib,
+            import_error,
+            candidates,
+        } => {
+            let found = candidates
+                .iter()
+                .map(|path| format!("  - {}", path.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            (
+                KernelErrorReason::IpykernelSitePackagesMismatch,
+                format!(
+                    "ipykernel is installed outside the interpreter's importable site-packages path.\npython: {}\ninterpreter site-packages: {}{}\nfound ipykernel under:\n{}",
+                    python_path.display(),
+                    purelib.display(),
+                    import_error
+                        .as_ref()
+                        .map(|err| format!("\nimport error: {err}"))
+                        .unwrap_or_default(),
+                    found
+                ),
+            )
+        }
+        IpykernelDiagnostic::InterpreterProbeFailed {
+            python_path,
+            message,
+        } => (
+            KernelErrorReason::DependencyCacheMissingIpykernel,
+            format!(
+                "Could not inspect ipykernel in the prepared {env_source} environment.\npython: {}\nprobe error: {}",
+                python_path.display(),
+                message
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn missing_ipykernel_maps_to_cache_missing_reason_with_probe_context() {
+        let diagnostic = IpykernelDiagnostic::Missing {
+            python_path: PathBuf::from("/tmp/env/bin/python"),
+            purelib: PathBuf::from("/tmp/env/lib/python3.11/site-packages"),
+            import_error: Some("ModuleNotFoundError: No module named ipykernel".to_string()),
+        };
+
+        let (reason, details) = classify_ipykernel_diagnostic(&diagnostic, "conda:inline");
+
+        assert_eq!(reason, KernelErrorReason::DependencyCacheMissingIpykernel);
+        assert!(details.contains("conda:inline"));
+        assert!(details.contains("/tmp/env/bin/python"));
+        assert!(details.contains("ModuleNotFoundError"));
+    }
+
+    #[test]
+    fn sibling_site_packages_candidate_maps_to_abi_mismatch_reason() {
+        let diagnostic = IpykernelDiagnostic::SitePackagesMismatch {
+            python_path: PathBuf::from("/tmp/env/bin/python"),
+            purelib: PathBuf::from("/tmp/env/lib/python3.14t/site-packages"),
+            import_error: None,
+            candidates: vec![PathBuf::from("/tmp/env/lib/python3.14/site-packages")],
+        };
+
+        let (reason, details) = classify_ipykernel_diagnostic(&diagnostic, "conda:inline");
+
+        assert_eq!(reason, KernelErrorReason::IpykernelSitePackagesMismatch);
+        assert!(details.contains("python3.14t"));
+        assert!(details.contains("python3.14/site-packages"));
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -28,6 +28,7 @@ pub mod daemon_telemetry;
 pub mod dx_blob_comm;
 pub mod embedded_plugins;
 pub mod inline_env;
+pub(crate) mod ipykernel_error;
 pub mod jupyter_kernel;
 pub mod kernel_connection;
 pub(crate) mod kernel_ports;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -168,6 +168,15 @@ pub(crate) fn get_inline_conda_channels(snapshot: &NotebookMetadataSnapshot) -> 
     vec!["conda-forge".to_string()]
 }
 
+/// Extract the optional Python version constraint from inline Conda metadata.
+pub(crate) fn get_inline_conda_python(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
+    snapshot
+        .runt
+        .conda
+        .as_ref()
+        .and_then(|conda| conda.python.clone())
+}
+
 /// Extract dependency entries from a pixi.toml or pyproject.toml with [tool.pixi].
 ///
 /// Section-aware: only collects `key = value` lines from `[dependencies]`,
@@ -2363,6 +2372,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
 pub(crate) async fn try_conda_pool_for_inline_deps(
     deps: &[String],
     channels: &[String],
+    python: Option<&str>,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
@@ -2377,6 +2387,11 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             "[notebook-sync] Conda inline deps use non-default channels {:?}, skipping pool reuse",
             channels
         );
+        return Err(());
+    }
+
+    if python.is_some() {
+        debug!("[notebook-sync] Conda inline deps pin Python, skipping pool reuse");
         return Err(());
     }
 
@@ -2412,8 +2427,10 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
             // restart cache-hits. See #2089 / #2083. The claim is
             // best-effort, so install runtime ownership before releasing
             // the lease (see try_uv_pool_for_inline_deps for rationale).
-            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
-                .await;
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(
+                &mut env, deps, channels, None,
+            )
+            .await;
             {
                 let mut ep = room.runtime_agent_env_path.write().await;
                 *ep = Some(env.venv_path.clone());
@@ -2456,7 +2473,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                     // caveat as the Subset arm — install runtime
                     // ownership before releasing.
                     crate::inline_env::claim_pool_env_for_conda_inline_cache(
-                        &mut env, deps, channels,
+                        &mut env, deps, channels, None,
                     )
                     .await;
                     {
@@ -3060,9 +3077,13 @@ pub(crate) async fn auto_launch_kernel(
                 .as_ref()
                 .map(get_inline_conda_channels)
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
+            let python = metadata_snapshot.as_ref().and_then(get_inline_conda_python);
+            let python = python.as_deref();
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
+            if let Some(cached) =
+                crate::inline_env::check_conda_inline_cache(&deps, &channels, python)
+            {
                 info!(
                     "[notebook-sync] Conda inline cache hit at {:?}",
                     cached.python_path
@@ -3079,6 +3100,7 @@ pub(crate) async fn auto_launch_kernel(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
+                    python,
                     &daemon,
                     room,
                     progress_handler.clone(),
@@ -3099,6 +3121,7 @@ pub(crate) async fn auto_launch_kernel(
                         match crate::inline_env::prepare_conda_inline_env(
                             &deps,
                             &channels,
+                            python,
                             progress_handler.clone(),
                         )
                         .await
@@ -3379,11 +3402,17 @@ pub(crate) async fn auto_launch_kernel(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            if !kernel_env::venv_has_ipykernel(&env.python_path) {
+            let diagnostic = kernel_env::diagnose_ipykernel(&env.python_path);
+            if !diagnostic.is_present() {
                 warn!(
-                    "[notebook-sync] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
+                    "[notebook-sync] prepared env at {:?} ({}) cannot import ipykernel: {:?}",
                     env.venv_path,
-                    env_source.as_str()
+                    env_source.as_str(),
+                    diagnostic
+                );
+                let (reason, details) = crate::ipykernel_error::classify_ipykernel_diagnostic(
+                    &diagnostic,
+                    env_source.as_str(),
                 );
                 // Don't delete the env dir here: it's a content-addressed
                 // cache shared with any other notebook using the same
@@ -3396,9 +3425,10 @@ pub(crate) async fn auto_launch_kernel(
                 // error and let the user edit deps to bump the hash.
                 let env_source_label = env_source.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error(
+                    sd.set_lifecycle_with_error_details(
                         &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::MissingIpykernel),
+                        Some(reason),
+                        Some(&details),
                     )?;
                     sd.set_kernel_info("python", "python", &env_source_label)?;
                     Ok(())

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -19,7 +19,7 @@ use crate::notebook_sync_server::{
     acquire_prewarmed_env_with_capture, build_launched_config, captured_env_for_runtime,
     captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
     extract_pixi_toml_deps, format_conda_env_yml_build_details, get_inline_conda_channels,
-    get_inline_conda_deps, get_inline_uv_deps, get_inline_uv_prerelease,
+    get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps, get_inline_uv_prerelease,
     missing_conda_env_yml_decision, project_environment_build_approved,
     promote_inline_deps_to_project, publish_kernel_state_presence, reset_starting_state,
     reset_starting_state_with_outcome, resolve_metadata_snapshot,
@@ -810,9 +810,13 @@ pub(crate) async fn handle(
                 .as_ref()
                 .map(get_inline_conda_channels)
                 .unwrap_or_else(|| vec!["conda-forge".to_string()]);
+            let python = metadata_snapshot.as_ref().and_then(get_inline_conda_python);
+            let python = python.as_deref();
 
             // Fast path: check inline env cache first (instant on hit)
-            if let Some(cached) = crate::inline_env::check_conda_inline_cache(&deps, &channels) {
+            if let Some(cached) =
+                crate::inline_env::check_conda_inline_cache(&deps, &channels, python)
+            {
                 info!(
                     "[notebook-sync] LaunchKernel: Conda inline cache hit at {:?}",
                     cached.python_path
@@ -829,6 +833,7 @@ pub(crate) async fn handle(
                 match try_conda_pool_for_inline_deps(
                     &deps,
                     &channels,
+                    python,
                     daemon,
                     room,
                     launch_progress_handler.clone(),
@@ -849,6 +854,7 @@ pub(crate) async fn handle(
                         match crate::inline_env::prepare_conda_inline_env(
                             &deps,
                             &channels,
+                            python,
                             launch_progress_handler.clone(),
                         )
                         .await
@@ -1146,11 +1152,17 @@ pub(crate) async fn handle(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            if !kernel_env::venv_has_ipykernel(&env.python_path) {
+            let diagnostic = kernel_env::diagnose_ipykernel(&env.python_path);
+            if !diagnostic.is_present() {
                 warn!(
-                    "[launch-kernel] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
+                    "[launch-kernel] prepared env at {:?} ({}) cannot import ipykernel: {:?}",
                     env.venv_path,
-                    parsed_resolved.as_str()
+                    parsed_resolved.as_str(),
+                    diagnostic
+                );
+                let (reason, details) = crate::ipykernel_error::classify_ipykernel_diagnostic(
+                    &diagnostic,
+                    parsed_resolved.as_str(),
                 );
                 // Don't delete the env dir: for inline/pep723 it's a
                 // content-addressed cache shared across notebooks and
@@ -1172,9 +1184,10 @@ pub(crate) async fn handle(
                 reset_starting_state(room, None).await;
                 let env_source_label = parsed_resolved.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error(
+                    sd.set_lifecycle_with_error_details(
                         &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::MissingIpykernel),
+                        Some(reason),
+                        Some(&details),
                     )?;
                     sd.set_kernel_info("python", "python", &env_source_label)?;
                     Ok(())

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -23,7 +23,11 @@ export type KernelActivity = "Unknown" | "Idle" | "Busy";
  * [`KERNEL_ERROR_REASON`] constants instead of bare string literals when
  * gating UI on a specific cause.
  */
-export type KernelErrorReasonKey = "missing_ipykernel" | "conda_env_yml_missing";
+export type KernelErrorReasonKey =
+  | "missing_ipykernel"
+  | "dependency_cache_missing_ipykernel"
+  | "ipykernel_site_packages_mismatch"
+  | "conda_env_yml_missing";
 
 /**
  * Typed error-reason strings. Mirrors `KernelErrorReason::as_str()` on
@@ -32,6 +36,8 @@ export type KernelErrorReasonKey = "missing_ipykernel" | "conda_env_yml_missing"
  */
 export const KERNEL_ERROR_REASON = {
   MISSING_IPYKERNEL: "missing_ipykernel",
+  DEPENDENCY_CACHE_MISSING_IPYKERNEL: "dependency_cache_missing_ipykernel",
+  IPYKERNEL_SITE_PACKAGES_MISMATCH: "ipykernel_site_packages_mismatch",
   /**
    * environment.yml declares a conda env that isn't built on this
    * machine. Daemon sets this instead of silently falling back to a

--- a/python/runtimed/src/runtimed/_constants.py
+++ b/python/runtimed/src/runtimed/_constants.py
@@ -22,7 +22,12 @@ from typing import Final, Literal
 #: Typed error-reason strings on ``kernel.error_reason``. Mirrors
 #: ``KernelErrorReason::as_str()`` in the Rust ``runtime_doc`` crate and
 #: ``KERNEL_ERROR_REASON`` in the TypeScript ``@runtimed`` package.
-KernelErrorReasonKey = Literal["missing_ipykernel", "conda_env_yml_missing"]
+KernelErrorReasonKey = Literal[
+    "missing_ipykernel",
+    "dependency_cache_missing_ipykernel",
+    "ipykernel_site_packages_mismatch",
+    "conda_env_yml_missing",
+]
 
 
 class KERNEL_ERROR_REASON:
@@ -35,6 +40,12 @@ class KERNEL_ERROR_REASON:
     """
 
     MISSING_IPYKERNEL: Final[KernelErrorReasonKey] = "missing_ipykernel"
+    DEPENDENCY_CACHE_MISSING_IPYKERNEL: Final[KernelErrorReasonKey] = (
+        "dependency_cache_missing_ipykernel"
+    )
+    IPYKERNEL_SITE_PACKAGES_MISMATCH: Final[KernelErrorReasonKey] = (
+        "ipykernel_site_packages_mismatch"
+    )
     #: environment.yml declares a conda env that isn't built on this
     #: machine. Daemon sets this instead of silently falling back to a
     #: pool env so the frontend can render a specific "build your env"

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -244,6 +244,20 @@ class TestKernelErrorReasonConstants:
         """``CONDA_ENV_YML_MISSING`` matches the Rust enum's wire string."""
         assert runtimed.KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING == "conda_env_yml_missing"
 
+    def test_dependency_cache_missing_ipykernel_value(self):
+        """``DEPENDENCY_CACHE_MISSING_IPYKERNEL`` matches the Rust enum's wire string."""
+        assert (
+            runtimed.KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL
+            == "dependency_cache_missing_ipykernel"
+        )
+
+    def test_ipykernel_site_packages_mismatch_value(self):
+        """``IPYKERNEL_SITE_PACKAGES_MISMATCH`` matches the Rust enum's wire string."""
+        assert (
+            runtimed.KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH
+            == "ipykernel_site_packages_mismatch"
+        )
+
 
 class TestCreateNotebookValidation:
     """Test create_notebook working_dir validation on NativeAsyncClient."""


### PR DESCRIPTION
## Summary

- add typed rich diagnostics for stale ipykernel caches and Conda site-packages ABI mismatches
- route typed launch failures into the below-toolbar banner with Conda/project context and human status labels
- honor inline Conda Python metadata in cache/build/reuse decisions and default managed Conda solves to GIL Python

## Test Plan

- `cargo test -p kernel-env ipykernel`
- `cargo test -p runtime-doc error_reason`
- `cargo test -p kernel-env managed_specs`
- `cargo test -p kernel-env explicit_free_threaded_pin_does_not_add_gil_selector`
- `cargo test -p kernel-env gil_policy_changes_cache_identity`
- `cargo test -p runtimed ipykernel_error`
- `pnpm test:run apps/notebook/src/lib/__tests__/kernel-status.test.ts apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `cargo xtask lint --fix`

## Notes

- The existing untracked `runt-diagnostics-2026-05-01-084403.tar.gz` is intentionally left out of this PR.
- `uv run pytest python/runtimed/tests/test_session_unit.py -q` did not run to completion in this worktree because `runtimed` was not installed into the newly-created root `.venv`; direct constant-file verification passed.
