### PR TITLE
feat(protocol): gate requests on required notebook heads

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1097,13 +1097,8 @@ function AppContent() {
       executingCellsRef.current.add(cellId);
 
       try {
-        // Flush pending source sync so daemon has latest code before executing.
-        // flushAndWait() guarantees any in-flight debounced flush has landed,
-        // then sends remaining changes and awaits delivery.
-        if (!(await flushSync())) {
-          logger.warn("[App] handleExecuteCell: source sync failed, skipping");
-          return;
-        }
+        const requiredHeads = getHandle()?.get_heads_hex() ?? [];
+        getEngine()?.flush();
 
         // Starting a fresh execution updates the cell's execution_id pointer,
         // and output rendering follows that pointer.
@@ -1118,7 +1113,7 @@ function AppContent() {
           // For startup races (e.g. daemon already auto-starting), still try execute.
           if (!started && pendingKernelStartRef.current) return;
         }
-        const response = await executeCell(cellId);
+        const response = await executeCell(cellId, { required_heads: requiredHeads });
         if (response.result === "error") {
           logger.error("[App] handleExecuteCell: daemon error", response.error);
         } else if (response.result === "no_kernel") {
@@ -1126,7 +1121,7 @@ function AppContent() {
           logger.warn("[App] handleExecuteCell: no kernel, attempting restart");
           const restarted = await tryStartKernel();
           if (restarted) {
-            const retry = await executeCell(cellId);
+            const retry = await executeCell(cellId, { required_heads: requiredHeads });
             if (retry.result === "error") {
               logger.error("[App] handleExecuteCell: daemon error after restart", retry.error);
             } else if (retry.result === "no_kernel") {
@@ -1143,7 +1138,15 @@ function AppContent() {
         }, 150);
       }
     },
-    [sessionReady, flushSync, kernelStatus, tryStartKernel, captureExecuteTrustAction, executeCell],
+    [
+      sessionReady,
+      getHandle,
+      getEngine,
+      kernelStatus,
+      tryStartKernel,
+      captureExecuteTrustAction,
+      executeCell,
+    ],
   );
 
   const handleAddCell = useCallback(
@@ -1192,11 +1195,8 @@ function AppContent() {
     }
     runAllInFlightRef.current = true;
     try {
-      // Flush pending source sync so daemon has latest code
-      if (!(await flushSync())) {
-        logger.warn("[App] handleRunAllCells: source sync failed, skipping");
-        return;
-      }
+      const requiredHeads = getHandle()?.get_heads_hex() ?? [];
+      getEngine()?.flush();
 
       // Start kernel via daemon if not running or awaiting trust
       if (
@@ -1217,7 +1217,7 @@ function AppContent() {
       }
 
       // Daemon reads cell sources from Automerge doc and queues them
-      const response = await daemonRunAllCells();
+      const response = await daemonRunAllCells({ required_heads: requiredHeads });
       if (response.result === "error") {
         logger.error("[App] handleRunAllCells: daemon error", response.error);
       } else if (response.result === "no_kernel") {
@@ -1231,7 +1231,8 @@ function AppContent() {
     kernelStatus,
     tryStartKernel,
     captureRunAllTrustAction,
-    flushSync,
+    getHandle,
+    getEngine,
     daemonRunAllCells,
   ]);
 

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -355,7 +355,15 @@ function AppContent() {
   // NotebookClient for sending kernel commands via transport. The host's
   // transport is the single instance shared with the SyncEngine in
   // useAutomergeNotebook — no more separate connection per consumer.
-  const notebookClient = useMemo(() => new NotebookClient({ transport: host.transport }), [host]);
+  const notebookClient = useMemo(
+    () =>
+      new NotebookClient({
+        transport: host.transport,
+        getRequiredHeads: () => getHandle()?.get_heads_hex() ?? [],
+        flushBeforeRequiredHeadsRequest: () => getEngine()?.flush(),
+      }),
+    [host, getHandle, getEngine],
+  );
 
   // Daemon-owned kernel execution
   const {
@@ -1097,9 +1105,6 @@ function AppContent() {
       executingCellsRef.current.add(cellId);
 
       try {
-        const requiredHeads = getHandle()?.get_heads_hex() ?? [];
-        getEngine()?.flush();
-
         // Starting a fresh execution updates the cell's execution_id pointer,
         // and output rendering follows that pointer.
 
@@ -1113,7 +1118,7 @@ function AppContent() {
           // For startup races (e.g. daemon already auto-starting), still try execute.
           if (!started && pendingKernelStartRef.current) return;
         }
-        const response = await executeCell(cellId, { required_heads: requiredHeads });
+        const response = await executeCell(cellId);
         if (response.result === "error") {
           logger.error("[App] handleExecuteCell: daemon error", response.error);
         } else if (response.result === "no_kernel") {
@@ -1121,7 +1126,7 @@ function AppContent() {
           logger.warn("[App] handleExecuteCell: no kernel, attempting restart");
           const restarted = await tryStartKernel();
           if (restarted) {
-            const retry = await executeCell(cellId, { required_heads: requiredHeads });
+            const retry = await executeCell(cellId);
             if (retry.result === "error") {
               logger.error("[App] handleExecuteCell: daemon error after restart", retry.error);
             } else if (retry.result === "no_kernel") {
@@ -1138,15 +1143,7 @@ function AppContent() {
         }, 150);
       }
     },
-    [
-      sessionReady,
-      getHandle,
-      getEngine,
-      kernelStatus,
-      tryStartKernel,
-      captureExecuteTrustAction,
-      executeCell,
-    ],
+    [sessionReady, kernelStatus, tryStartKernel, captureExecuteTrustAction, executeCell],
   );
 
   const handleAddCell = useCallback(
@@ -1195,9 +1192,6 @@ function AppContent() {
     }
     runAllInFlightRef.current = true;
     try {
-      const requiredHeads = getHandle()?.get_heads_hex() ?? [];
-      getEngine()?.flush();
-
       // Start kernel via daemon if not running or awaiting trust
       if (
         kernelStatus === KERNEL_STATUS.NOT_STARTED ||
@@ -1217,7 +1211,7 @@ function AppContent() {
       }
 
       // Daemon reads cell sources from Automerge doc and queues them
-      const response = await daemonRunAllCells({ required_heads: requiredHeads });
+      const response = await daemonRunAllCells();
       if (response.result === "error") {
         logger.error("[App] handleRunAllCells: daemon error", response.error);
       } else if (response.result === "no_kernel") {
@@ -1226,15 +1220,7 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [
-    sessionReady,
-    kernelStatus,
-    tryStartKernel,
-    captureRunAllTrustAction,
-    getHandle,
-    getEngine,
-    daemonRunAllCells,
-  ]);
+  }, [sessionReady, kernelStatus, tryStartKernel, captureRunAllTrustAction, daemonRunAllCells]);
 
   const handleRestartAndRunAll = useCallback(async () => {
     // The daemon clears visible outputs by moving cells to fresh execution

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -270,7 +270,8 @@ export function useDaemonKernel({
   );
 
   const executeCell = useCallback(
-    (cellId: string) => client.executeCell(cellId) as Promise<NotebookResponse>,
+    (cellId: string, options?: { required_heads?: string[] }) =>
+      client.executeCell(cellId, options) as Promise<NotebookResponse>,
     [client],
   );
 
@@ -302,7 +303,8 @@ export function useDaemonKernel({
   );
 
   const runAllCells = useCallback(
-    () => client.runAllCells() as Promise<NotebookResponse>,
+    (options?: { required_heads?: string[] }) =>
+      client.runAllCells(options) as Promise<NotebookResponse>,
     [client],
   );
 

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -270,8 +270,7 @@ export function useDaemonKernel({
   );
 
   const executeCell = useCallback(
-    (cellId: string, options?: { required_heads?: string[] }) =>
-      client.executeCell(cellId, options) as Promise<NotebookResponse>,
+    (cellId: string) => client.executeCell(cellId) as Promise<NotebookResponse>,
     [client],
   );
 
@@ -303,8 +302,7 @@ export function useDaemonKernel({
   );
 
   const runAllCells = useCallback(
-    (options?: { required_heads?: string[] }) =>
-      client.runAllCells(options) as Promise<NotebookResponse>,
+    () => client.runAllCells() as Promise<NotebookResponse>,
     [client],
   );
 

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -254,6 +254,14 @@ pub enum SaveErrorKind {
 pub struct NotebookRequestEnvelope {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Causal precondition for handling this request.
+    ///
+    /// When present, the daemon must not evaluate the request until its
+    /// notebook document has incorporated every listed Automerge change hash.
+    /// The document may have advanced beyond these heads; this is a
+    /// containment check, not an equality check.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_heads: Vec<String>,
     #[serde(flatten)]
     pub request: NotebookRequest,
 }
@@ -812,16 +820,19 @@ mod tests {
     fn request_envelope_flattens_and_round_trips() {
         let env = NotebookRequestEnvelope {
             id: Some("req-1".into()),
+            required_heads: vec!["a".repeat(64)],
             request: NotebookRequest::ExecuteCell {
                 cell_id: "cell-42".into(),
             },
         };
         let json = serde_json::to_value(&env).expect("serialize");
         assert_eq!(json["id"], "req-1");
+        assert_eq!(json["required_heads"][0], "a".repeat(64));
         assert_eq!(json["action"], "execute_cell");
         assert_eq!(json["cell_id"], "cell-42");
         let parsed: NotebookRequestEnvelope = serde_json::from_value(json).expect("deserialize");
         assert_eq!(parsed.id.as_deref(), Some("req-1"));
+        assert_eq!(parsed.required_heads, vec!["a".repeat(64)]);
         assert!(matches!(
             parsed.request,
             NotebookRequest::ExecuteCell { cell_id } if cell_id == "cell-42"

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -571,6 +571,19 @@ impl DocHandle {
         &self,
         request: NotebookRequest,
     ) -> Result<NotebookResponse, SyncError> {
+        self.send_request_after_heads(request, Vec::new()).await
+    }
+
+    /// Send a request after the daemon has incorporated the required heads.
+    ///
+    /// This is a causal precondition: the daemon may evaluate the request
+    /// against a newer document, but it must first have every listed change in
+    /// its local Automerge history.
+    pub async fn send_request_after_heads(
+        &self,
+        request: NotebookRequest,
+        required_heads: Vec<String>,
+    ) -> Result<NotebookResponse, SyncError> {
         debug!(
             "[doc-handle] send_request: {:?} ({})",
             std::mem::discriminant(&request),
@@ -580,6 +593,7 @@ impl DocHandle {
         self.cmd_tx
             .send(SyncCommand::SendRequest {
                 request,
+                required_heads,
                 reply: reply_tx,
                 broadcast_tx: None,
             })
@@ -604,12 +618,24 @@ impl DocHandle {
         self.cmd_tx
             .send(SyncCommand::SendRequest {
                 request,
+                required_heads: Vec::new(),
                 reply: reply_tx,
                 broadcast_tx: Some(broadcast_tx),
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Get the current document heads as protocol hex strings.
+    pub fn current_heads_hex(&self) -> Result<Vec<String>, SyncError> {
+        let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        Ok(state
+            .doc
+            .get_heads()
+            .into_iter()
+            .map(|head| head.to_string())
+            .collect())
     }
 
     /// Confirm that the daemon has merged our current local heads.

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -37,6 +37,7 @@ pub enum RelayCommand {
     SendRequest {
         id: String,
         request: NotebookRequest,
+        required_heads: Vec<String>,
         reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
         /// Optional broadcast sender for delivering broadcasts during long-running
         /// requests (e.g., LaunchKernel with environment progress updates).
@@ -133,7 +134,7 @@ impl RelayHandle {
         &self,
         request: NotebookRequest,
     ) -> Result<NotebookResponse, SyncError> {
-        self.send_request_inner(request, None).await
+        self.send_request_inner(request, Vec::new(), None).await
     }
 
     /// Send a request with a broadcast channel for real-time progress updates.
@@ -146,12 +147,14 @@ impl RelayHandle {
         request: NotebookRequest,
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     ) -> Result<NotebookResponse, SyncError> {
-        self.send_request_inner(request, Some(broadcast_tx)).await
+        self.send_request_inner(request, Vec::new(), Some(broadcast_tx))
+            .await
     }
 
     async fn send_request_inner(
         &self,
         request: NotebookRequest,
+        required_heads: Vec<String>,
         broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
     ) -> Result<NotebookResponse, SyncError> {
         let timeout = crate::relay_task::request_timeout(&request);
@@ -164,6 +167,7 @@ impl RelayHandle {
             .send(RelayCommand::SendRequest {
                 id: id.clone(),
                 request,
+                required_heads,
                 reply: reply_tx,
                 broadcast_tx,
             })

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -121,6 +121,7 @@ where
                 RelayCommand::SendRequest {
                     id,
                     request,
+                    required_heads,
                     reply,
                     broadcast_tx,
                 } => {
@@ -129,6 +130,7 @@ where
                         &mut pending,
                         id,
                         request,
+                        required_heads,
                         reply,
                         broadcast_tx,
                     )
@@ -196,11 +198,13 @@ async fn handle_send_request<W: AsyncWrite + Unpin>(
     pending: &mut HashMap<String, PendingEntry>,
     id: String,
     request: NotebookRequest,
+    required_heads: Vec<String>,
     reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
     broadcast_tx: Option<tokio::sync::broadcast::Sender<NotebookBroadcast>>,
 ) {
     let envelope = NotebookRequestEnvelope {
         id: Some(id.clone()),
+        required_heads,
         request,
     };
 

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -89,6 +89,7 @@ pub enum SyncCommand {
     /// Send a request to the daemon and wait for a response.
     SendRequest {
         request: NotebookRequest,
+        required_heads: Vec<String>,
         reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
         /// Optional broadcast sender for delivering broadcasts during long-running
         /// requests (e.g., LaunchKernel with environment progress updates).
@@ -407,10 +408,11 @@ impl SyncReactor {
         match cmd {
             SyncCommand::SendRequest {
                 request,
+                required_heads,
                 reply,
                 broadcast_tx,
             } => {
-                self.register_request(writer, request, reply, broadcast_tx)
+                self.register_request(writer, request, required_heads, reply, broadcast_tx)
                     .await;
             }
 
@@ -803,6 +805,7 @@ impl SyncReactor {
         &mut self,
         writer: &mut W,
         request: NotebookRequest,
+        required_heads: Vec<String>,
         reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
         broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
     ) {
@@ -810,6 +813,7 @@ impl SyncReactor {
         let deadline = Instant::now() + crate::relay_task::request_timeout(&request);
         let envelope = NotebookRequestEnvelope {
             id: Some(id.clone()),
+            required_heads,
             request,
         };
 
@@ -1784,6 +1788,7 @@ mod tests {
             let mut reader = connection::FramedReader::spawn(BufReader::new(server_read), 64);
             let mut writer = BufWriter::new(server_write);
             let mut ids = Vec::new();
+            let mut required_heads = Vec::new();
 
             while ids.len() < 2 {
                 let frame = timeout(Duration::from_secs(15), reader.recv())
@@ -1796,8 +1801,13 @@ mod tests {
                 }
                 let envelope: NotebookRequestEnvelope =
                     serde_json::from_slice(&frame.payload).expect("request envelope");
+                required_heads.push(envelope.required_heads);
                 ids.push(envelope.id.expect("request id"));
             }
+            assert!(required_heads.iter().any(Vec::is_empty));
+            assert!(required_heads
+                .iter()
+                .any(|heads| heads == &vec!["b".repeat(64)]));
 
             send_typed_json_frame(
                 &mut writer,
@@ -1839,7 +1849,8 @@ mod tests {
         let (progress_tx, mut progress_rx) = broadcast::channel(8);
         let first =
             handle.send_request_with_broadcast(NotebookRequest::GetDocBytes {}, progress_tx);
-        let second = handle.send_request(NotebookRequest::GetDocBytes {});
+        let second =
+            handle.send_request_after_heads(NotebookRequest::GetDocBytes {}, vec!["b".repeat(64)]);
 
         let (first_response, second_response) = tokio::join!(first, second);
         let first_response = first_response.expect("first response");

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -38,7 +38,7 @@ pub struct ExecutionResult {
 
 /// Execute a cell and wait for completion.
 ///
-/// 1. Calls `confirm_sync()` to ensure the daemon has the latest cell source.
+/// 1. Captures current Automerge heads as a causal precondition.
 /// 2. Sends `ExecuteCell` request.
 /// 3. Polls RuntimeStateDoc until the execution reaches terminal status.
 /// 4. Collects and resolves outputs from the CRDT.
@@ -53,16 +53,22 @@ pub async fn execute_and_wait(
     blob_base_url: &Option<String>,
     blob_store_path: &Option<std::path::PathBuf>,
 ) -> ExecutionResult {
-    // Step 1: Ensure daemon has our latest edits
-    if let Err(e) = handle.confirm_sync().await {
-        warn!("confirm_sync failed before execution: {e}");
-    }
+    // Step 1: Capture the source version this command is meant to observe.
+    let required_heads = match handle.current_heads_hex() {
+        Ok(heads) => heads,
+        Err(e) => {
+            warn!("failed to capture notebook heads before execution: {e}");
+            Vec::new()
+        }
+    };
 
     // Step 2: Submit execution request
     let request = NotebookRequest::ExecuteCell {
         cell_id: cell_id.to_string(),
     };
-    let response = handle.send_request(request).await;
+    let response = handle
+        .send_request_after_heads(request, required_heads)
+        .await;
 
     let execution_id = match response {
         Ok(NotebookResponse::CellQueued { execution_id, .. }) => Some(execution_id),
@@ -182,16 +188,22 @@ pub struct RunAllResult {
 
 /// Queue all cells for execution without waiting for completion.
 ///
-/// 1. Calls `confirm_sync()` to ensure the daemon has the latest cell sources.
+/// 1. Captures current Automerge heads as a causal precondition.
 /// 2. Sends `RunAllCells` request.
 ///
 /// Returns immediately with the queued cell→execution ID mapping.
 pub async fn run_all_and_queue(handle: &DocHandle) -> RunAllResult {
-    if let Err(e) = handle.confirm_sync().await {
-        warn!("confirm_sync failed before run_all_cells: {e}");
-    }
+    let required_heads = match handle.current_heads_hex() {
+        Ok(heads) => heads,
+        Err(e) => {
+            warn!("failed to capture notebook heads before run_all_cells: {e}");
+            Vec::new()
+        }
+    };
 
-    let response = handle.send_request(NotebookRequest::RunAllCells {}).await;
+    let response = handle
+        .send_request_after_heads(NotebookRequest::RunAllCells {}, required_heads)
+        .await;
 
     let cell_execution_ids: HashMap<String, String> = match response {
         Ok(NotebookResponse::AllCellsQueued { queued }) => queued

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -659,11 +659,14 @@ async fn queue_existing_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
             .ok_or_else(|| Error::from_reason("Not connected"))?
             .clone()
     };
-    handle.confirm_sync().await.map_err(to_napi_err)?;
+    let required_heads = handle.current_heads_hex().map_err(to_napi_err)?;
     let response = handle
-        .send_request(NotebookRequest::ExecuteCell {
-            cell_id: cell_id.to_string(),
-        })
+        .send_request_after_heads(
+            NotebookRequest::ExecuteCell {
+                cell_id: cell_id.to_string(),
+            },
+            required_heads,
+        )
         .await
         .map_err(to_napi_err)?;
     match response {

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1351,23 +1351,25 @@ pub(crate) async fn queue_cell(
         }
     }
 
-    let response = {
+    let handle = {
         let st = state.lock().await;
-
-        let handle = st
-            .handle
+        st.handle
             .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        handle.confirm_sync().await.map_err(to_py_err)?;
-
-        handle
-            .send_request(NotebookRequest::ExecuteCell {
-                cell_id: cell_id.to_string(),
-            })
-            .await
-            .map_err(to_py_err)?
+            .ok_or_else(|| to_py_err("Not connected"))?
+            .clone()
     };
+
+    let required_heads = handle.current_heads_hex().map_err(to_py_err)?;
+
+    let response = handle
+        .send_request_after_heads(
+            NotebookRequest::ExecuteCell {
+                cell_id: cell_id.to_string(),
+            },
+            required_heads,
+        )
+        .await
+        .map_err(to_py_err)?;
 
     match response {
         NotebookResponse::CellQueued { execution_id, .. } => {
@@ -1470,10 +1472,10 @@ pub(crate) async fn queue_all_cells(
             .clone()
     };
 
-    handle.confirm_sync().await.map_err(to_py_err)?;
+    let required_heads = handle.current_heads_hex().map_err(to_py_err)?;
 
     let response = handle
-        .send_request(NotebookRequest::RunAllCells {})
+        .send_request_after_heads(NotebookRequest::RunAllCells {}, required_heads)
         .await
         .map_err(to_py_err)?;
 

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use automerge::ChangeHash;
 use tokio::io::AsyncWrite;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -12,6 +13,7 @@ use crate::requests::{handle_notebook_request, request_label};
 pub(super) const PEER_OUTBOUND_QUEUE_CAPACITY: usize = 1024;
 const PEER_REQUEST_QUEUE_CAPACITY: usize = 64;
 const SLOW_PEER_REQUEST: std::time::Duration = std::time::Duration::from_secs(30);
+const REQUIRED_HEADS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 struct OutboundFrame {
     frame_type: NotebookFrameType,
@@ -156,7 +158,10 @@ pub(super) fn spawn_peer_request_worker(
             );
 
             let start = std::time::Instant::now();
-            let response = handle_notebook_request(&room, envelope.request, daemon.clone()).await;
+            let response = match wait_for_required_heads(&room, &envelope.required_heads).await {
+                Ok(()) => handle_notebook_request(&room, envelope.request, daemon.clone()).await,
+                Err(error) => notebook_protocol::protocol::NotebookResponse::Error { error },
+            };
             let elapsed = start.elapsed();
             if elapsed >= SLOW_PEER_REQUEST {
                 let response_kind = std::mem::discriminant(&response);
@@ -194,6 +199,52 @@ pub(super) fn spawn_peer_request_worker(
         Ok(())
     });
     PeerRequestWorker { tx, handle }
+}
+
+async fn wait_for_required_heads(
+    room: &NotebookRoom,
+    required_heads: &[String],
+) -> Result<(), String> {
+    if required_heads.is_empty() {
+        return Ok(());
+    }
+
+    let heads = parse_required_heads(required_heads)?;
+    let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+
+    tokio::time::timeout(REQUIRED_HEADS_TIMEOUT, async {
+        loop {
+            {
+                let mut doc = room.doc.write().await;
+                let has_all_heads = heads
+                    .iter()
+                    .all(|head| doc.doc_mut().get_change_by_hash(head).is_some());
+                if has_all_heads {
+                    return Ok(());
+                }
+            }
+
+            match changed_rx.recv().await {
+                Ok(()) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err("Required notebook heads could not be observed".to_string());
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| "Timed out waiting for required notebook heads".to_string())?
+}
+
+fn parse_required_heads(required_heads: &[String]) -> Result<Vec<ChangeHash>, String> {
+    required_heads
+        .iter()
+        .map(|head| {
+            head.parse::<ChangeHash>()
+                .map_err(|_| "Request contained an invalid required notebook head".to_string())
+        })
+        .collect()
 }
 
 pub(super) fn enqueue_notebook_request(
@@ -273,8 +324,71 @@ pub(super) fn queue_session_status(
 mod tests {
     use super::*;
 
+    use crate::blob_store::BlobStore;
     use crate::protocol::NotebookRequest;
     use tokio::sync::oneshot;
+    use uuid::Uuid;
+
+    fn test_room() -> Arc<NotebookRoom> {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        Arc::new(NotebookRoom::new_fresh(
+            Uuid::new_v4(),
+            None,
+            tmp.path(),
+            blob_store,
+            true,
+        ))
+    }
+
+    #[tokio::test]
+    async fn required_heads_are_satisfied_by_present_change_history() {
+        let room = test_room();
+        let heads = {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "cell-1", "code").expect("add cell");
+            doc.get_heads_hex()
+        };
+
+        wait_for_required_heads(&room, &heads)
+            .await
+            .expect("present heads should satisfy the causal gate");
+    }
+
+    #[tokio::test]
+    async fn required_heads_wait_until_change_history_arrives() {
+        let room = test_room();
+        let mut incoming = {
+            let mut doc = room.doc.write().await;
+            doc.fork_with_actor("test:incoming")
+        };
+        incoming
+            .add_cell(0, "cell-1", "code")
+            .expect("add incoming cell");
+        let heads = incoming.get_heads_hex();
+
+        let wait_room = room.clone();
+        let wait_heads = heads.clone();
+        let waiter =
+            tokio::spawn(async move { wait_for_required_heads(&wait_room, &wait_heads).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(
+            !waiter.is_finished(),
+            "missing heads should keep the causal gate pending"
+        );
+
+        {
+            let mut doc = room.doc.write().await;
+            doc.merge(&mut incoming).expect("merge incoming change");
+        }
+        let _ = room.broadcasts.changed_tx.send(());
+
+        waiter
+            .await
+            .expect("wait task should not panic")
+            .expect("merged heads should satisfy the causal gate");
+    }
 
     #[tokio::test]
     async fn peer_writer_enqueue_does_not_wait_for_socket_drain() {
@@ -324,6 +438,7 @@ mod tests {
         worker
             .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
                 id: Some("first".to_string()),
+                required_heads: Vec::new(),
                 request: NotebookRequest::GetDocBytes {},
             })
             .expect("first request should enqueue");
@@ -331,6 +446,7 @@ mod tests {
         worker
             .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
                 id: Some("second".to_string()),
+                required_heads: Vec::new(),
                 request: NotebookRequest::GetDocBytes {},
             })
             .expect("second request should fill the queue");
@@ -339,6 +455,7 @@ mod tests {
         let err = worker
             .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
                 id: Some("third".to_string()),
+                required_heads: Vec::new(),
                 request: NotebookRequest::GetDocBytes {},
             })
             .expect_err("full queue should reject immediately");
@@ -377,6 +494,7 @@ mod tests {
         request_tx
             .try_send(notebook_protocol::protocol::NotebookRequestEnvelope {
                 id: Some("first".to_string()),
+                required_heads: Vec::new(),
                 request: NotebookRequest::GetDocBytes {},
             })
             .expect("queue should accept first request");
@@ -389,6 +507,7 @@ mod tests {
 
         let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
             id: Some("second".to_string()),
+            required_heads: Vec::new(),
             request: NotebookRequest::GetDocBytes {},
         })
         .unwrap();
@@ -423,6 +542,7 @@ mod tests {
 
         let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
             id: Some("closed".to_string()),
+            required_heads: Vec::new(),
             request: NotebookRequest::GetDocBytes {},
         })
         .unwrap();

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -36,8 +36,8 @@ pub(super) struct PeerRequestWorker {
 
 #[derive(Debug)]
 pub(super) enum RequestEnqueueError {
-    Full(notebook_protocol::protocol::NotebookRequestEnvelope),
-    Closed(notebook_protocol::protocol::NotebookRequestEnvelope),
+    Full(Box<notebook_protocol::protocol::NotebookRequestEnvelope>),
+    Closed(Box<notebook_protocol::protocol::NotebookRequestEnvelope>),
 }
 
 impl Drop for PeerWriterTask {
@@ -103,8 +103,12 @@ impl PeerRequestWorker {
         envelope: notebook_protocol::protocol::NotebookRequestEnvelope,
     ) -> Result<(), RequestEnqueueError> {
         self.tx.try_send(envelope).map_err(|e| match e {
-            mpsc::error::TrySendError::Full(envelope) => RequestEnqueueError::Full(envelope),
-            mpsc::error::TrySendError::Closed(envelope) => RequestEnqueueError::Closed(envelope),
+            mpsc::error::TrySendError::Full(envelope) => {
+                RequestEnqueueError::Full(Box::new(envelope))
+            }
+            mpsc::error::TrySendError::Closed(envelope) => {
+                RequestEnqueueError::Closed(Box::new(envelope))
+            }
         })
     }
 }
@@ -271,14 +275,14 @@ pub(super) fn enqueue_notebook_request(
                     "[notebook-sync] Peer request queue full for {} (peer_id={})",
                     notebook_id, peer_id
                 );
-                queue_request_error(writer, envelope.id, "Peer request queue full")?;
+                queue_request_error(writer, envelope.id.clone(), "Peer request queue full")?;
             }
             RequestEnqueueError::Closed(envelope) => {
                 warn!(
                     "[notebook-sync] Peer request worker stopped for {} (peer_id={})",
                     notebook_id, peer_id
                 );
-                queue_request_error(writer, envelope.id, "Peer request worker stopped")?;
+                queue_request_error(writer, envelope.id.clone(), "Peer request worker stopped")?;
                 anyhow::bail!("peer request worker stopped for {}", notebook_id);
             }
         }

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -19,6 +19,7 @@ import {
   FrameType,
   type FrameListener,
   type NotebookRequest,
+  type NotebookRequestOptions,
   type NotebookResponse,
   type NotebookTransport,
 } from "runtimed";
@@ -113,7 +114,7 @@ export class TauriTransport implements NotebookTransport {
     return unlisten;
   }
 
-  async sendRequest(request: unknown): Promise<unknown> {
+  async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
     const req = request as NotebookRequest;
     const id = crypto.randomUUID();
 
@@ -123,7 +124,12 @@ export class TauriTransport implements NotebookTransport {
     // TS uses `type:` as the discriminator internally, so translate on
     // the way out.
     const { type, ...rest } = req as { type: string } & Record<string, unknown>;
-    const envelope = { id, action: type, ...rest };
+    const envelope = {
+      id,
+      ...(options?.required_heads?.length ? { required_heads: options.required_heads } : {}),
+      action: type,
+      ...rest,
+    };
     const payload = new TextEncoder().encode(JSON.stringify(envelope));
 
     const timeoutMs = requestTimeoutMs(req);

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -22,7 +22,7 @@
  */
 
 import { FrameType } from "./transport";
-import type { NotebookTransport, FrameListener } from "./transport";
+import type { FrameListener, NotebookRequestOptions, NotebookTransport } from "./transport";
 import type { SessionStatus } from "./handle";
 
 // ── Server handle interface ──────────────────────────────────────────
@@ -75,7 +75,8 @@ export class DirectTransport implements NotebookTransport {
    * Handler for `sendRequest` calls. Set this to provide test responses.
    * Defaults to returning `{ result: "ok" }` for all requests.
    */
-  requestHandler: (request: unknown) => Promise<unknown> = () => Promise.resolve({ result: "ok" });
+  requestHandler: (request: unknown, options?: NotebookRequestOptions) => Promise<unknown> = () =>
+    Promise.resolve({ result: "ok" });
 
   constructor(server: ServerHandle) {
     this.server = server;
@@ -117,11 +118,11 @@ export class DirectTransport implements NotebookTransport {
     };
   }
 
-  async sendRequest(request: unknown): Promise<unknown> {
+  async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
     if (!this._connected) {
       throw new Error("DirectTransport: not connected");
     }
-    return this.requestHandler(request);
+    return this.requestHandler(request, options);
   }
 
   disconnect(): void {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -10,7 +10,7 @@ export { SyncEngine } from "./sync-engine";
 export type { SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
 
 // Transport
-export type { NotebookTransport, FrameListener } from "./transport";
+export type { FrameListener, NotebookRequestOptions, NotebookTransport } from "./transport";
 export {
   FrameType,
   sendAutomergeSyncFrame,

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -9,7 +9,7 @@
  */
 
 import type { SyncEngineLogger } from "./sync-engine";
-import type { NotebookTransport } from "./transport";
+import type { NotebookRequestOptions, NotebookTransport } from "./transport";
 import type {
   CommRequestMessage,
   CompletionItem,
@@ -71,8 +71,11 @@ export class NotebookClient {
   }
 
   /** Send a typed request and return the response. */
-  async sendRequest(request: NotebookRequest): Promise<NotebookResponse> {
-    return this.transport.sendRequest(request) as Promise<NotebookResponse>;
+  async sendRequest(
+    request: NotebookRequest,
+    options?: NotebookRequestOptions,
+  ): Promise<NotebookResponse> {
+    return this.transport.sendRequest(request, options) as Promise<NotebookResponse>;
   }
 
   /** Launch a kernel via the daemon. */
@@ -96,13 +99,16 @@ export class NotebookClient {
   }
 
   /** Execute a cell (daemon reads source from synced document). */
-  async executeCell(cellId: string): Promise<NotebookResponse> {
+  async executeCell(cellId: string, options?: NotebookRequestOptions): Promise<NotebookResponse> {
     this.log.debug("[notebook-client] Executing cell:", cellId);
     try {
-      return await this.sendRequest({
-        type: "execute_cell",
-        cell_id: cellId,
-      });
+      return await this.sendRequest(
+        {
+          type: "execute_cell",
+          cell_id: cellId,
+        },
+        options,
+      );
     } catch (e) {
       this.log.error("[notebook-client] Execute failed:", e);
       throw e;
@@ -191,10 +197,10 @@ export class NotebookClient {
   }
 
   /** Run all code cells (daemon reads from synced doc). */
-  async runAllCells(): Promise<NotebookResponse> {
+  async runAllCells(options?: NotebookRequestOptions): Promise<NotebookResponse> {
     this.log.debug("[notebook-client] Running all cells");
     try {
-      return await this.sendRequest({ type: "run_all_cells" });
+      return await this.sendRequest({ type: "run_all_cells" }, options);
     } catch (e) {
       this.log.error("[notebook-client] Run all cells failed:", e);
       throw e;

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -59,15 +59,21 @@ const nullLogger: SyncEngineLogger = {
 export interface NotebookClientOptions {
   transport: NotebookTransport;
   logger?: SyncEngineLogger;
+  getRequiredHeads?: () => string[];
+  flushBeforeRequiredHeadsRequest?: () => void;
 }
 
 export class NotebookClient {
   private readonly transport: NotebookTransport;
   private readonly log: SyncEngineLogger;
+  private readonly getRequiredHeads?: () => string[];
+  private readonly flushBeforeRequiredHeadsRequest?: () => void;
 
   constructor(opts: NotebookClientOptions) {
     this.transport = opts.transport;
     this.log = opts.logger ?? nullLogger;
+    this.getRequiredHeads = opts.getRequiredHeads;
+    this.flushBeforeRequiredHeadsRequest = opts.flushBeforeRequiredHeadsRequest;
   }
 
   /** Send a typed request and return the response. */
@@ -75,7 +81,16 @@ export class NotebookClient {
     request: NotebookRequest,
     options?: NotebookRequestOptions,
   ): Promise<NotebookResponse> {
-    return this.transport.sendRequest(request, options) as Promise<NotebookResponse>;
+    if (options) {
+      return this.transport.sendRequest(request, options) as Promise<NotebookResponse>;
+    }
+    return this.transport.sendRequest(request) as Promise<NotebookResponse>;
+  }
+
+  private requiredHeadsOptions(): NotebookRequestOptions | undefined {
+    const required_heads = this.getRequiredHeads?.() ?? [];
+    this.flushBeforeRequiredHeadsRequest?.();
+    return required_heads.length ? { required_heads } : undefined;
   }
 
   /** Launch a kernel via the daemon. */
@@ -99,7 +114,7 @@ export class NotebookClient {
   }
 
   /** Execute a cell (daemon reads source from synced document). */
-  async executeCell(cellId: string, options?: NotebookRequestOptions): Promise<NotebookResponse> {
+  async executeCell(cellId: string): Promise<NotebookResponse> {
     this.log.debug("[notebook-client] Executing cell:", cellId);
     try {
       return await this.sendRequest(
@@ -107,7 +122,7 @@ export class NotebookClient {
           type: "execute_cell",
           cell_id: cellId,
         },
-        options,
+        this.requiredHeadsOptions(),
       );
     } catch (e) {
       this.log.error("[notebook-client] Execute failed:", e);
@@ -197,10 +212,10 @@ export class NotebookClient {
   }
 
   /** Run all code cells (daemon reads from synced doc). */
-  async runAllCells(options?: NotebookRequestOptions): Promise<NotebookResponse> {
+  async runAllCells(): Promise<NotebookResponse> {
     this.log.debug("[notebook-client] Running all cells");
     try {
-      return await this.sendRequest({ type: "run_all_cells" }, options);
+      return await this.sendRequest({ type: "run_all_cells" }, this.requiredHeadsOptions());
     } catch (e) {
       this.log.error("[notebook-client] Run all cells failed:", e);
       throw e;

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -56,6 +56,11 @@ export function sendPresenceFrame(
 /** Callback for receiving inbound frames from the daemon. */
 export type FrameListener = (payload: number[]) => void;
 
+export interface NotebookRequestOptions {
+  /** Causal precondition: daemon must have these notebook heads before handling. */
+  required_heads?: string[];
+}
+
 /**
  * Pluggable connection layer between SyncEngine and the daemon.
  *
@@ -90,7 +95,7 @@ export interface NotebookTransport {
    * - WebSocketTransport: serializes as frame type 0x01 with correlation ID
    * - DirectTransport: delegates to a configurable handler
    */
-  sendRequest(request: unknown): Promise<unknown>;
+  sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown>;
 
   /** Whether the transport is currently connected. */
   readonly connected: boolean;

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -14,6 +14,28 @@ function stubClient() {
   return { client: new NotebookClient({ transport }), sendRequest };
 }
 
+function stubClientWithHeads(heads: string[]) {
+  const sendRequest = vi.fn().mockResolvedValue({ result: "cell_queued", execution_id: "exec-1" });
+  const flush = vi.fn();
+  const transport = {
+    sendFrame: async () => {},
+    onFrame: () => () => {},
+    sendRequest,
+    connected: true,
+    disconnect: () => {},
+  } satisfies NotebookTransport;
+
+  return {
+    client: new NotebookClient({
+      transport,
+      getRequiredHeads: () => heads,
+      flushBeforeRequiredHeadsRequest: flush,
+    }),
+    flush,
+    sendRequest,
+  };
+}
+
 describe("NotebookClient", () => {
   it("emits unguarded sync_environment requests", async () => {
     const { client, sendRequest } = stubClient();
@@ -65,5 +87,29 @@ describe("NotebookClient", () => {
       type: "clone_as_ephemeral",
       source_notebook_id: "source-1",
     });
+  });
+
+  it("attaches required heads to daemon-managed execute requests", async () => {
+    const { client, flush, sendRequest } = stubClientWithHeads(["head-a"]);
+
+    await client.executeCell("cell-1");
+
+    expect(flush).toHaveBeenCalledOnce();
+    expect(sendRequest).toHaveBeenCalledWith(
+      { type: "execute_cell", cell_id: "cell-1" },
+      { required_heads: ["head-a"] },
+    );
+  });
+
+  it("attaches required heads to daemon-managed run-all requests", async () => {
+    const { client, flush, sendRequest } = stubClientWithHeads(["head-a", "head-b"]);
+
+    await client.runAllCells();
+
+    expect(flush).toHaveBeenCalledOnce();
+    expect(sendRequest).toHaveBeenCalledWith(
+      { type: "run_all_cells" },
+      { required_heads: ["head-a", "head-b"] },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add `required_heads` request-envelope metadata for causal command preconditions
- make the daemon defer request handling until its notebook doc contains every required Automerge change hash
- switch UI, MCP, Python, and Node execute paths from blocking preflight sync waits to "send after these heads" requests

## Verification

- `cargo test -p notebook-protocol request_envelope_flattens_and_round_trips`
- `cargo test -p runtimed required_heads --lib`
- `cargo test -p notebook-sync concurrent_send_request_routes_responses_by_id`
- `cargo check -p notebook-protocol -p notebook-sync -p runt-mcp -p runtimed-node`
- `cargo check -p runtimed -p runtimed-py`
- `cargo check -p runtimed-py -p runtimed-node -p runt-mcp`
- `pnpm --filter notebook-ui build`
- `cargo xtask lint --fix`
