### PR TITLE
docs(skills): add automerge-sync and mcp-session-lifecycle Claude skills

### DIFF
--- a/.claude/skills/automerge-document-model/SKILL.md
+++ b/.claude/skills/automerge-document-model/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: automerge-document-model
+description: >
+  Understand Automerge's internal document model: ops, changes, actors,
+  the OpSet, ChangeGraph, save/load lifecycle, fork/merge semantics, and
+  the AutoCommit wrapper. Use when debugging save/load issues, reasoning
+  about document size, understanding fork/merge at the data structure
+  level, diagnosing #1187-class panics, or evaluating why concurrent
+  sync can corrupt indices.
+---
+
+# Automerge Document Model Internals
+
+Use this skill when working at the level below sync: document structure,
+change application, save/load round-trips, fork/merge, actor management,
+or diagnosing panics in the op application pipeline. Complements
+`automerge-sync` (which covers the sync protocol) with the data model
+that sync operates on.
+
+## The Five Core Types
+
+### OpId — The Universal Identifier
+
+Every operation has an `OpId(counter, actor_index)`. Counter is globally
+monotonic per actor. Actor index is a position in the document's actor
+table (not the ActorId bytes). OpIds are used as:
+
+- Object identifiers (`ObjId` is a newtype over `OpId`)
+- Element identifiers in lists (`ElemId` is a newtype over `OpId`)
+- Operation references for predecessor tracking
+
+The special `ROOT` OpId is `(0, 0)` — the implicit root Map object.
+`HEAD` ElemId is also `(0, 0)` — the sentinel before position 0 in lists.
+
+### ActorId — Peer Identity
+
+A `TinyVec<[u8; 16]>` — 16 bytes inline (UUID-sized), heap-allocated
+if larger. Lexicographic byte ordering is load-bearing: change encoding
+depends on actors being sorted by their byte representation. nteract
+uses UTF-8 encoded labels like `"runtimed"` or `"human:<session-uuid>"`.
+
+**Actor table:** Each document maintains a `Vec<ActorId>` in `OpSet.actors`.
+Ops store only the index (`ActorIdx`) into this table, not the full
+ActorId bytes. This is why actor ordering matters — if two documents
+disagree on which index maps to which actor, ops are misinterpreted.
+
+### Change — A Batch of Operations
+
+```rust
+Change {
+    stored: StoredChange<'static, Verified>,  // columnar-encoded ops
+    compression: CompressionState,             // raw or DEFLATE
+    len: usize,                                // number of ops
+}
+```
+
+Key properties:
+- `actor_id()` — the actor that created this change
+- `seq()` — monotonic sequence number per actor (1, 2, 3, ...)
+- `deps()` — change hashes this change depends on (causal parents)
+- `hash()` — SHA-256 of the change bytes (the `ChangeHash`)
+- `start_op()` — first OpId counter in this change
+- `max_op()` — `start_op + len - 1`
+
+Changes are **causally ordered**: a change can only be applied after
+all changes in its `deps` have been applied. Changes that arrive before
+their deps go into the `ChangeQueue` (pending).
+
+### ChangeGraph — The DAG of History
+
+```rust
+ChangeGraph {
+    edges: Vec<Edge>,                           // child→parent edges
+    hashes: Vec<ChangeHash>,                    // one per node
+    actors: Vec<ActorIdx>,                      // actor of each change
+    parents: Vec<Option<EdgeIdx>>,              // first edge per node
+    seq: Vec<u32>,                              // seq per change
+    max_ops: Vec<u32>,                          // cumulative op count
+    heads: BTreeSet<ChangeHash>,                // current heads
+    nodes_by_hash: HashMap<ChangeHash, NodeIdx>,// hash→node lookup
+    clock_cache: HashMap<NodeIdx, SeqClock>,    // cached vector clocks
+    seq_index: Vec<Vec<NodeIdx>>,               // per-actor change list
+}
+```
+
+This is the core structure for:
+- **Heads:** The `heads` set = changes with no children. This is what
+  sync messages advertise and what `get_heads()` returns.
+- **Causal ordering:** `deps_for_hash()` walks parent edges.
+- **Change lookup:** `has_change()`, `get_hash_for_actor_seq()`.
+- **Clock computation:** Vector clock from any change, cached every
+  16 changes for efficiency.
+
+**nteract usage:** `get_change_by_hash()` is the containment check
+behind `required_heads` — the daemon checks whether each listed hash
+exists in the ChangeGraph before processing a request.
+
+### OpSet — The Materialized Document
+
+```rust
+OpSet {
+    actors: Vec<ActorId>,    // actor table
+    obj_info: ObjIndex,      // object metadata index
+    cols: Columns,           // columnar op storage
+    text_encoding: TextEncoding,
+}
+```
+
+The OpSet stores all applied operations in a columnar format (using
+the `hexane` crate). Operations are stored sorted by `(object, key,
+lamport_timestamp)` for efficient querying. The `ObjIndex` tracks
+which objects exist, their types, and byte ranges in the columnar store.
+
+**This is what save/load round-trips reconstruct.** `save()` serializes
+the OpSet + ChangeGraph into a compact `Document` format. `load()`
+deserializes and rebuilds the OpSet from the stored columns.
+
+## The Automerge Struct
+
+```rust
+Automerge {
+    queue: ChangeQueue,        // pending changes (deps not yet met)
+    change_graph: ChangeGraph, // full history DAG
+    deps: HashSet<ChangeHash>, // current heads (fast access)
+    ops: OpSet,                // materialized operations
+    actor: Actor,              // current actor (Unused or Cached index)
+}
+```
+
+### save() and load()
+
+**save()** produces a single `Document` chunk:
+1. Serializes the OpSet columns (all operations, sorted)
+2. Serializes the ChangeGraph metadata (actors, hashes, deps, seqs)
+3. Optionally DEFLATE-compresses
+4. Appends any orphaned (queued) changes as raw change chunks
+
+**load()** rebuilds from the Document chunk:
+1. Parses the columnar data
+2. Reconstructs the OpSet (actors, columns, object index)
+3. Reconstructs the ChangeGraph (nodes, edges, heads)
+4. Verifies head hashes match (unless `VerificationMode::DontCheck`)
+5. Processes any trailing change chunks via `load_incremental`
+
+**Key insight for nteract:** The save/load round-trip reconstructs a
+fresh OpSet from columnar data. This clears any corrupted in-memory
+indices (like the actor table ordering issue in #1187) because the
+columnar format is the canonical representation. That's why nteract's
+`rebuild_from_save()` works as a recovery mechanism.
+
+### load_incremental()
+
+Adds changes to an existing document:
+1. If document is empty, delegates to `load()` (more efficient)
+2. Parses change chunks from the input
+3. Calls `apply_changes_log_patches()` for causal application
+4. Returns the number of new ops applied
+
+This is what `receive_sync_message` calls internally — sync messages
+carry changes that get applied via `load_incremental`.
+
+### save_after(heads)
+
+Saves only changes *after* the given heads — returns raw change chunks,
+not a Document format. Useful for incremental saves. `save_incremental()`
+(on AutoCommit) uses this with the `save_cursor` to emit only new changes.
+
+## Fork and Merge
+
+### fork()
+
+```rust
+pub fn fork(&self) -> Self {
+    let mut f = self.clone();      // full deep clone
+    f.set_actor(ActorId::random()); // new actor identity
+    f
+}
+```
+
+A fork is a complete clone of the document with a new actor ID. Both
+documents share the same history up to the fork point. Mutations on
+either side create changes with different actors, so they compose
+cleanly on merge (no counter collisions).
+
+**Cost:** O(document size) — the entire OpSet, ChangeGraph, and queue
+are cloned. For large notebooks, this is significant.
+
+### fork_at(heads)
+
+Creates a new document containing only changes up to `heads`:
+1. Walks backward from `heads` through the ChangeGraph collecting hashes
+2. Creates a fresh `Automerge::new()`
+3. Extracts changes for those hashes and applies them
+
+**Much more expensive than fork()** — it doesn't clone; it replays
+changes from scratch. Used for time-travel views. nteract avoids this
+in production paths due to automerge/automerge#1327.
+
+### merge(other)
+
+```rust
+pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ChangeHash>, AutomergeError> {
+    let changes = self.get_changes_added(other);
+    self.apply_changes_log_patches(changes, &mut PatchLog::inactive())?;
+    Ok(self.get_heads())
+}
+```
+
+Merge extracts changes from `other` that `self` doesn't have and applies
+them. After merge, `self` contains all ops from both documents.
+
+**The DuplicateSeqNumber trap:** If two forks share the same ActorId
+(because `fork()` clones the actor and the caller forgot to change it),
+both will produce changes with the same `(actor, seq)` pair. The second
+merge returns `DuplicateSeqNumber`. nteract's `fork_with_actor()` exists
+specifically to prevent this.
+
+## The AutoCommit Wrapper
+
+nteract uses `AutoCommit`, not raw `Automerge`:
+
+```rust
+AutoCommit {
+    doc: Automerge,                              // inner document
+    transaction: Option<(PatchLog, TransactionInner)>,  // open tx
+    patch_log: PatchLog,                         // diff tracking
+    diff_cursor: Vec<ChangeHash>,                // last-diffed heads
+    save_cursor: Vec<ChangeHash>,                // last-saved heads
+    isolation: Option<Vec<ChangeHash>>,          // isolation heads
+}
+```
+
+**Auto-transaction:** Mutations open a transaction implicitly. The
+transaction accumulates ops. Calling any read method, `save()`, `fork()`,
+`merge()`, or `sync()` first calls `ensure_transaction_closed()`, which
+commits the pending transaction and advances the document heads.
+
+**Isolation mode:** `isolate(heads)` limits the visible document to a
+specific point in history. `integrate()` returns to the latest heads.
+Mutations while isolated create changes that depend on the isolation
+heads, not the document tips.
+
+**PatchLog:** Tracks diffs between `diff_cursor` and current heads for
+incremental materialization. `diff_incremental()` returns patches and
+advances the cursor. This is how nteract's WASM side computes
+`CellChangeset` — by diffing the PatchLog after receiving sync frames.
+
+## Why #1187 Panics Happen
+
+The panic occurs in `BatchApply::apply()` during `PatchLog::migrate_actors()`:
+
+1. **Setup:** Two peers sync concurrently. Peer A introduces actor X;
+   Peer B introduces actor Y.
+2. **Actor ordering:** The actor table must be sorted lexicographically.
+   When a new actor is inserted, existing PatchLog entries contain
+   OpIds with actor indices that may shift.
+3. **migrate_actors()** tries to rewrite PatchLog entries to match the
+   new actor ordering. It expects actors to only be appended in sorted
+   order. If concurrent sync messages interleave such that the PatchLog
+   sees actor indices that don't match the OpSet's actor table order,
+   `migrate_actors()` returns `PatchLogMismatch`.
+4. **The unwrap:** `log.migrate_actors(&doc.ops().actors).unwrap()` in
+   `BatchApply::apply()` (line 807) panics on mismatch.
+
+**Why save/load fixes it:** After a save/load round-trip:
+- The OpSet's columnar data re-sorts actors correctly
+- The PatchLog is empty (no pending diffs)
+- The ChangeGraph is rebuilt from column metadata
+- `sync::State::new()` starts a fresh sync handshake
+
+**Why catch_unwind is needed:** The panic happens inside `receive_sync_message`
+→ `load_incremental` → `apply_changes` → `BatchApply::apply`. Since this
+is an automerge bug (not a logic error in nteract), catching and rebuilding
+is the correct workaround until upstream fixes the actor migration logic.
+
+## Document Size Factors
+
+Understanding what makes documents grow:
+
+| Factor | Growth pattern | Impact |
+|--------|---------------|--------|
+| Operations (puts, splices, deletes) | O(total mutations) | Largest factor |
+| Actor table | O(unique peers) | Small per entry, but affects all OpIds |
+| ChangeGraph | O(total changes) | Metadata overhead per change |
+| Tombstones (deletes) | Accumulate forever | Can dominate in heavily-edited text |
+| Change queue | O(out-of-order changes) | Temporary; resolved when deps arrive |
+
+**save() compacts:** The Document format is significantly smaller than
+the in-memory representation because it uses columnar encoding with
+delta and run-length compression.
+
+**Decompaction is not built-in:** Automerge doesn't garbage-collect
+tombstones or squash history. To compact, you'd need to create a new
+document and replay only the current visible state — losing history.
+
+## nteract-Specific Usage Patterns
+
+### Per-Cell O(1) Accessors
+
+nteract's WASM bindings use direct Automerge map lookups:
+`get_cell_source(id)`, `get_cell_type(id)`, etc. These work because
+cells are keyed by ID in an Automerge Map. The OpSet's `ObjIndex`
+provides O(1) object lookup; reading a specific key in a map is
+O(log n) in the key's op history (usually small).
+
+### Dual Documents
+
+Each notebook room has two Automerge documents:
+1. **NotebookDoc** — bidirectional, contains cell content
+2. **RuntimeStateDoc** — daemon-authoritative, contains outputs/state
+
+Each has its own OpSet, ChangeGraph, actor table, and sync::State.
+save/load rebuilds work independently on each.
+
+### fork_and_merge for Synchronous Mutations
+
+```rust
+doc.fork_and_merge(|fork| {
+    fork.update_source("cell-1", "x = 1\n");
+});
+```
+
+Safe for synchronous blocks — actor collision is harmless because
+merge completes before any concurrent fork exists. No unique actor
+needed.
+
+### fork_with_actor for Async Mutations
+
+```rust
+let mut fork = doc.fork_with_actor("runtimed:iopub:kernel-abc");
+// ... async work ...
+fork.set_outputs(cell_id, outputs);
+doc.merge(&mut fork)?;
+```
+
+Required when the fork crosses an `.await` — another fork might exist
+concurrently, and shared actors cause DuplicateSeqNumber on merge.
+
+## Decision Framework
+
+| Situation | Approach |
+|-----------|----------|
+| Need to recover from corrupted indices | `save()` → `load()` round-trip (rebuilds OpSet from columns) |
+| Need to check if peer has specific changes | `change_graph.has_change(&hash)` (O(1) hash lookup) |
+| Need document at earlier point | `fork_at(heads)` — expensive, avoid in hot paths |
+| Need concurrent async mutations | `fork_with_actor()` — unique actor per concurrent fork |
+| Need synchronous batch mutation | `fork_and_merge()` — shared actor is safe |
+| Need to shrink document bytes | `save()` uses columnar + DEFLATE; no history compaction available |
+| Need to understand document size | Count ops, actors, tombstones; save() gives compressed size |
+| Debugging a panic in apply | Check actor table ordering; likely #1187-class bug; catch_unwind + rebuild |
+| Need incremental save for wire | `save_after(heads)` for changes since last sync point |
+
+## Key Source Files
+
+| File | What it teaches |
+|------|----------------|
+| `automerge/src/automerge.rs` | `Automerge` struct, fork/merge/save/load, change application |
+| `automerge/src/autocommit.rs` | `AutoCommit` wrapper, auto-transaction, isolation, PatchLog |
+| `automerge/src/change.rs` | `Change` struct, actor_id/seq/deps/hash accessors |
+| `automerge/src/change_graph.rs` | `ChangeGraph` DAG, heads, clock computation, causal queries |
+| `automerge/src/op_set2/op_set.rs` | `OpSet` columnar storage, actor table, object index |
+| `automerge/src/op_set2/change/batch.rs` | `BatchApply::apply`, actor migration, the #1187 panic site |
+| `automerge/src/patches/patch_log.rs` | `PatchLog`, `migrate_actors` — the function that panics |
+| `automerge/src/types.rs` | `OpId`, `ActorId`, `ObjId`, `ElemId`, `OpType` |
+| `automerge/src/storage/` | Columnar encoding, Document format, change parsing |
+| `notebook-doc/src/lib.rs` | nteract's `NotebookDoc` wrapper: fork/merge/save/load/rebuild |
+| `notebook-sync/src/shared.rs` | `SharedDocState`, `rebuild_state_doc`, dual-doc management |
+| `notebook-sync/src/sync_task.rs` | catch_unwind guards, `rebuild_shared_doc_state` with cell-count guard |

--- a/.claude/skills/automerge-sync/SKILL.md
+++ b/.claude/skills/automerge-sync/SKILL.md
@@ -283,9 +283,13 @@ Don't reset sync state just because local mutations happened. Reset it
 when the *transport* breaks (reconnect, panic recovery). Resetting
 after every mutation would make every sync round a full exchange.
 
-## Confirm Sync Design
+## Causal Ordering: confirm_sync and required_heads
 
-`confirm_sync` verifies the daemon has merged specific local changes:
+Two mechanisms ensure the daemon sees client edits before acting on them:
+
+### confirm_sync (client-side wait)
+
+`confirm_sync` blocks the client until the daemon has merged specific heads:
 
 1. Caller captures current heads via `DocHandle::confirm_sync()`
 2. A `ConfirmSync` command goes to the sync task with target heads
@@ -296,6 +300,39 @@ after every mutation would make every sync round a full exchange.
 
 This is non-blocking -- the frame loop keeps draining while the waiter
 resolves in the background.
+
+### required_heads (daemon-side wait, preferred)
+
+`required_heads` moves the wait to the daemon, eliminating the client-side
+round-trip:
+
+1. Client captures current heads via `DocHandle::current_heads_hex()`
+2. Client sends the request with `required_heads` in the envelope
+3. Daemon's `wait_for_required_heads()` checks if the notebook doc contains
+   all listed change hashes (containment check, not equality)
+4. If not yet present, subscribes to `changed_tx` and polls until all
+   heads arrive or 10s timeout
+5. Only then does the daemon evaluate the request
+
+**Why required_heads is better:**
+- No client-side blocking -- the request is sent immediately
+- The daemon can process other requests while waiting
+- Works correctly even if the sync stream is slow (the request just
+  queues behind the sync convergence)
+- Replaces the old `confirm_sync` → `execute_cell` two-step with a
+  single `execute_cell` request that carries its causal precondition
+
+**Used by:** `execute_cell`, `run_all_cells` (both MCP and frontend).
+Frontend flushes pending sync before capturing heads to minimize the
+daemon-side wait.
+
+### Which to use
+
+| Scenario | Use |
+|----------|-----|
+| Execute / run-all (need source synced) | `required_heads` via `send_request_after_heads` |
+| General "is my edit synced?" check | `confirm_sync` (still available) |
+| Save (daemon reads doc directly) | Neither -- daemon reads its own doc copy |
 
 ## Key Source Files
 
@@ -308,6 +345,9 @@ resolves in the background.
 | `samod/subduction-sans-io/src/engine.rs` | `handle_connection_lost` -- simplest correct reconnection |
 | `crates/notebook-sync/src/sync_task.rs` | Biased select, catch_unwind, rebuild |
 | `crates/notebook-sync/src/shared.rs` | `SharedDocState`, dual sync states |
+| `crates/notebook-sync/src/handle.rs` | `send_request_after_heads`, `current_heads_hex`, `confirm_sync` |
+| `crates/runtimed/src/notebook_sync_server/peer_writer.rs` | `wait_for_required_heads`, daemon-side causal gate |
+| `crates/runt-mcp/src/execution.rs` | MCP execute path using required_heads |
 
 ## Decision Framework
 
@@ -321,3 +361,4 @@ When you need to decide how to handle sync state:
 | Adding a new sync stream | New frame type, new sync::State field, catch_unwind guard |
 | Peer lost all data (empty heads) | Already handled -- receive_sync_message resets sent_hashes |
 | Switching read-only to read-write | set_read_only() handles reset + SyncReset flag |
+| Need daemon to see edits before executing | Use `required_heads` (not confirm_sync) |

--- a/.claude/skills/automerge-sync/SKILL.md
+++ b/.claude/skills/automerge-sync/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: automerge-sync
+description: >
+  Understand and work with Automerge sync protocol internals. Use when
+  debugging sync failures, changing reconnection logic, adding new sync
+  streams, or reasoning about why peers converge (or don't). Covers
+  sync::State lifecycle, bloom filters, in-flight suppression, and the
+  nteract catch_unwind recovery pattern.
+---
+
+# Automerge Sync Internals
+
+Use this skill when working on sync behavior: reconnection, peer state,
+convergence bugs, new frame types, or catch_unwind recovery. This encodes
+knowledge from reading the actual automerge sync implementation, not just
+the docs.
+
+## How Automerge Sync Actually Works
+
+The protocol is a back-and-forth negotiation between two peers over a
+reliable in-order stream. Each peer maintains a `sync::State` per remote
+peer. The loop is:
+
+1. Initiator calls `generate_sync_message()` with an empty `State`
+2. Receiver calls `receive_sync_message()` then `generate_sync_message()`
+3. Repeat until both return `None` (converged)
+
+**Source:** `rust/automerge/src/sync.rs` in `automerge/automerge`
+
+### What's In a Sync Message
+
+```
+Message {
+    heads: Vec<ChangeHash>,        // "here's what I have"
+    need: Vec<ChangeHash>,         // "I'm missing these specific changes"
+    have: Vec<Have>,               // bloom filter of what I have since last_sync
+    changes: ChunkList,            // actual change data to apply
+    flags: Option<MessageFlags>,   // capabilities + transient signals
+    version: MessageVersion,       // V1 or V2
+}
+```
+
+The `Have` struct contains `last_sync` (heads at last successful sync) and a
+`BloomFilter` summarizing changes since then. The bloom filter has 1% false
+positive rate (10 bits/entry, 7 probes). False positives mean "I probably
+have this" -- the sender sends a change only if all peer bloom filters say
+they *don't* have it.
+
+### The `sync::State` Fields
+
+13 fields, but only `shared_heads` survives `encode()`/`decode()`:
+
+| Field | Purpose | Persists? |
+|-------|---------|-----------|
+| `shared_heads` | Hashes both peers agree they share | Yes |
+| `last_sent_heads` | Our heads when we last sent a message | No |
+| `their_heads` | Their most recently advertised heads | No |
+| `their_need` | Specific changes they requested | No |
+| `their_have` | Their bloom filter summaries | No |
+| `sent_hashes` | Changes we've already sent this session | No |
+| `in_flight` | True while awaiting ack (suppresses duplicate sends) | No |
+| `have_responded` | True after we've sent at least one message | No |
+| `their_capabilities` | MessageV2, SyncReset support | No |
+| `read_only` | We ignore their changes | No |
+| `peer_read_only` | They ignore our changes | No |
+| `needs_reset` | Next message gets SyncReset flag | No |
+
+**Critical insight:** `encode()` only serializes `shared_heads`. Everything
+else is session-ephemeral. This means:
+
+- `sync::State::new()` is safe for reconnection -- you lose optimization
+  (resend changes the peer already has) but never lose correctness
+- Persisting encoded sync state is only useful when reconnecting to the
+  *same* peer identity
+- The automerge-repo `beginSync` hack (encode/decode round-trip) exists
+  solely to clear `in_flight` and `sent_hashes` while preserving
+  `shared_heads`
+
+### In-Flight Suppression
+
+`generate_sync_message()` returns `None` when `in_flight` is `true` AND
+`last_sent_heads == our_heads` AND `have_responded` is `true`. This
+prevents duplicate messages while awaiting an ack.
+
+`receive_sync_message()` always sets `in_flight = false` on entry -- any
+incoming message counts as an ack.
+
+**Mistake to avoid:** Don't try to work around `None` returns from
+`generate_sync_message()`. The suppression is correct. If you need to
+force a fresh exchange, reset the sync state.
+
+### How Changes Are Selected
+
+`generate_sync_message()` in `Automerge`:
+
+1. Compute `our_need` = missing deps from their advertised heads
+2. Build a bloom filter from our changes since `shared_heads`
+3. If they have `their_have` + `their_need`, compute which changes to send:
+   - Filter through their bloom filter (send what they probably don't have)
+   - Deduplicate against `sent_hashes`
+   - If sending >1/3 of the doc, send the whole doc as V2 (more efficient)
+4. The `Message.heads` we send becomes their next `their_heads` for us
+
+### How Changes Are Applied
+
+`receive_sync_message_inner()`:
+
+1. Set `in_flight = false` (ack)
+2. Process `MessageFlags` -- discover capabilities, handle SyncReset
+3. If changes present and not read-only, `load_incremental` them
+4. Advance `shared_heads` based on what we both now have
+5. Trim `sent_hashes` to only changes they haven't seen
+6. **Empty heads detection:** If they send `heads: []`, reset
+   `last_sent_heads` and `sent_hashes` to trigger full resync (they lost
+   all data)
+
+### Version Negotiation
+
+V1 is the original format. V2 allows compressed document encoding (faster
+first sync). Backward-compatible: V1 messages append a `MessageFlags`
+section that old implementations ignore. New implementations read the flags
+to discover V2 support. Once discovered, subsequent messages use V2.
+
+## nteract's Sync Architecture
+
+nteract runs two sync streams over one socket connection:
+
+| Stream | Frame | Document | Ownership |
+|--------|-------|----------|-----------|
+| Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional |
+| RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative |
+
+Each stream has its own `sync::State` (`peer_state` and `state_peer_state`).
+They share the same `Arc<Mutex<SharedDocState>>` but operate independently.
+
+### The Sync Task Loop
+
+`sync_task.rs` runs a biased `tokio::select!` with priority:
+
+1. **Frame** (incoming daemon frames) -- highest, keeps socket drained
+2. **Changed** (local mutations) -- generates outbound sync
+3. **Command** (requests, confirm_sync) -- daemon RPC
+4. **Maintenance** (50ms tick) -- watchdog, confirm_sync retries
+
+The mutex is `std::sync::Mutex` (not tokio), never held across `.await`.
+Recovery from mutex poisoning: `unwrap_or_else(|e| e.into_inner())`.
+
+### catch_unwind Recovery Pattern
+
+automerge 0.7 has a known panic in `BatchApply::apply` when the internal
+patch log actor table gets out of order during concurrent sync
+(automerge/automerge#1187). Both sync handlers use the same pattern:
+
+```rust
+// Step 1: catch_unwind around receive_sync_message
+let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+    state.receive_sync_message(msg)
+}));
+match recv_result {
+    Ok(Ok(())) => {}
+    Ok(Err(e)) => { warn!(...); return; }
+    Err(_panic) => {
+        rebuild_shared_doc_state(&mut state);
+        return;
+    }
+}
+
+// Step 2: catch_unwind around generate_sync_message (can also panic)
+match std::panic::catch_unwind(AssertUnwindSafe(|| {
+    state.generate_sync_message().map(|msg| msg.encode())
+})) {
+    Ok(bytes) => bytes,
+    Err(_) => {
+        rebuild_shared_doc_state(&mut state);
+        None
+    }
+}
+```
+
+**Rebuild for notebook doc** (`rebuild_shared_doc_state`):
+1. `save()` the doc to bytes
+2. `AutoCommit::load()` from those bytes (clears corrupted indices)
+3. **Cell-count guard:** if rebuilt doc has fewer cells, skip rebuild
+   (only reset sync state) to prevent silent cell loss
+4. Preserve actor ID
+5. `peer_state = sync::State::new()` to force fresh handshake
+
+**Rebuild for RuntimeStateDoc** (`rebuild_state_doc`):
+1. Round-trip `save()`/`load()` via `rebuild_from_save()`
+2. `state_peer_state = sync::State::new()`
+
+Both follow the principle: **reset transport state, preserve document truth.**
+
+### Why Resetting `sync::State` Works
+
+When you set `peer_state = sync::State::new()`:
+- `shared_heads` becomes `[]` (empty)
+- `in_flight` becomes `false`
+- `have_responded` becomes `false`
+
+This means the next `generate_sync_message()` will:
+- Send our current heads
+- Build a bloom filter from *all* our changes (since shared_heads is empty)
+- The daemon will respond with any changes we're missing
+
+The cost is bandwidth (may resend changes the peer already has), but
+correctness is guaranteed. The bloom filter negotiation quickly converges
+to only sending what's actually missing.
+
+## Reconnection Patterns
+
+### nteract: Fresh State
+
+nteract uses `sync::State::new()` on every reconnection. This is correct
+because:
+- The daemon may have received changes from other peers during disconnect
+- The client may have applied local mutations during disconnect
+- A fresh handshake discovers what's missing from both sides
+- `SharedDocState::try_new()` initializes both `peer_state` and
+  `state_peer_state` as `sync::State::new()`
+
+### automerge-repo: Encode/Decode Round-Trip
+
+automerge-repo's `DocSynchronizer.beginSync()` does:
+```typescript
+const reparsedSyncState = A.decodeSyncState(A.encodeSyncState(syncState))
+```
+
+This preserves `shared_heads` but clears all session-ephemeral fields.
+The comment calls it a "HACK" to prevent infinite loops from failed
+in-flight messages. It's actually using the designed encode/decode contract
+correctly -- `encode()` only serializes what should survive reconnection.
+
+### samod: Remove and Forget
+
+samod's `SubductionEngine.handle_connection_lost()` removes the connection
+and calls `incremental.peer_disconnected(peer_id)`. No sync state is
+preserved. Each new connection starts fresh. This is the simplest correct
+approach.
+
+## Common Mistakes
+
+### 1. Sharing sync::State across peers
+
+Each remote peer needs its own `sync::State`. The state tracks what *that
+specific peer* has told us. Sharing it between peers causes:
+- Duplicate sends (already sent to peer A, but State thinks peer B needs it)
+- Missing sends (peer B never told us their heads, but State has peer A's)
+- In-flight suppression for the wrong peer
+
+### 2. Expecting generate_sync_message to always return something
+
+After local mutations, `generate_sync_message()` may return `None` if
+there's an in-flight unacked message. This is correct behavior.
+
+### 3. Blocking the frame reader
+
+The sync task must keep draining incoming frames. Any command handler that
+blocks waiting for a specific response starves broadcasts, state sync,
+and sync replies. Use waiters/pending-request registration instead.
+
+### 4. Forgetting catch_unwind on new sync handlers
+
+If you add a new Automerge sync stream (e.g., PoolStateSync `0x06`),
+it needs the same catch_unwind + rebuild pattern. Any `receive_sync_message`
+or `generate_sync_message` call on a concurrently-synced document is
+vulnerable to automerge#1187.
+
+### 5. Skipping the cell-count guard
+
+`save()` on a panic-corrupted doc may drop ops, producing fewer cells.
+The guard in `rebuild_shared_doc_state` prevents silent cell loss by
+falling back to sync-state-only reset when the rebuilt doc has fewer cells.
+
+### 6. Holding the mutex across I/O
+
+The lock scope must be a block that drops before any `.await`. Compute
+the ack bytes inside the lock, send them outside it.
+
+### 7. Resetting sync state when you should preserve it
+
+Don't reset sync state just because local mutations happened. Reset it
+when the *transport* breaks (reconnect, panic recovery). Resetting
+after every mutation would make every sync round a full exchange.
+
+## Confirm Sync Design
+
+`confirm_sync` verifies the daemon has merged specific local changes:
+
+1. Caller captures current heads via `DocHandle::confirm_sync()`
+2. A `ConfirmSync` command goes to the sync task with target heads
+3. The sync task registers target heads as a waiter
+4. Normal inbound `AutomergeSync` handling checks waiters after each receive
+5. When `shared_heads` include all target heads, the waiter resolves
+6. Timeout: 10s total, 200ms retry ticks
+
+This is non-blocking -- the frame loop keeps draining while the waiter
+resolves in the background.
+
+## Key Source Files
+
+| File | What to read |
+|------|-------------|
+| `automerge/src/sync.rs` | `generate_sync_message`, `receive_sync_message_inner`, `advance_heads` |
+| `automerge/src/sync/state.rs` | `State` struct, `encode`/`decode`, `set_read_only` |
+| `automerge/src/sync/bloom.rs` | `BloomFilter`, 1% FP rate params |
+| `automerge-repo/.../DocSynchronizer.ts` | Per-peer `#syncStates`, `beginSync` encode/decode hack |
+| `samod/subduction-sans-io/src/engine.rs` | `handle_connection_lost` -- simplest correct reconnection |
+| `crates/notebook-sync/src/sync_task.rs` | Biased select, catch_unwind, rebuild |
+| `crates/notebook-sync/src/shared.rs` | `SharedDocState`, dual sync states |
+
+## Decision Framework
+
+When you need to decide how to handle sync state:
+
+| Situation | Action |
+|-----------|--------|
+| Transport disconnect + reconnect | Reset sync::State (new() or encode/decode round-trip) |
+| automerge panic caught | Rebuild doc (save/load), reset sync::State |
+| Local mutation happened | Do nothing -- next generate_sync_message handles it |
+| Adding a new sync stream | New frame type, new sync::State field, catch_unwind guard |
+| Peer lost all data (empty heads) | Already handled -- receive_sync_message resets sent_hashes |
+| Switching read-only to read-write | set_read_only() handles reset + SyncReset flag |

--- a/.claude/skills/automerge-sync/SKILL.md
+++ b/.claude/skills/automerge-sync/SKILL.md
@@ -123,15 +123,18 @@ to discover V2 support. Once discovered, subsequent messages use V2.
 
 ## nteract's Sync Architecture
 
-nteract runs two sync streams over one socket connection:
+nteract runs three sync streams over one socket connection:
 
-| Stream | Frame | Document | Ownership |
-|--------|-------|----------|-----------|
-| Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional |
-| RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative |
+| Stream | Frame | Document | Ownership | Sync state location |
+|--------|-------|----------|-----------|---------------------|
+| Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional | `notebook-sync::SharedDocState.peer_state` |
+| RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative | `notebook-sync::SharedDocState.state_peer_state` |
+| PoolState | `0x06` PoolStateSync | PoolDoc | Daemon-authoritative | Frontend owns pool-doc sync state; daemon peer loop carries `pool_peer_state` separately |
 
-Each stream has its own `sync::State` (`peer_state` and `state_peer_state`).
-They share the same `Arc<Mutex<SharedDocState>>` but operate independently.
+The notebook and runtime-state streams share the same
+`Arc<Mutex<SharedDocState>>` and each has its own `sync::State` within it.
+PoolStateSync is separate — the frontend manages its sync state directly
+while the daemon carries `pool_peer_state` in the peer loop.
 
 ### The Sync Task Loop
 
@@ -316,15 +319,18 @@ round-trip:
 
 **Why required_heads is better:**
 - No client-side blocking -- the request is sent immediately
-- The daemon can process other requests while waiting
-- Works correctly even if the sync stream is slow (the request just
-  queues behind the sync convergence)
+- The main peer sync loop still drains frames while the wait runs, so
+  the required heads can arrive and other peers are unaffected. However,
+  later requests from the *same* peer remain queued behind the waiting
+  request (it runs inside the per-peer request worker)
 - Replaces the old `confirm_sync` → `execute_cell` two-step with a
   single `execute_cell` request that carries its causal precondition
 
 **Used by:** `execute_cell`, `run_all_cells` (both MCP and frontend).
-Frontend flushes pending sync before capturing heads to minimize the
-daemon-side wait.
+Frontend captures current heads first, then triggers a fire-and-forget
+`flush()` to nudge the sync stream to deliver them. This preserves
+the causal baseline in `required_heads` while minimizing daemon-side
+wait (see #2457 for the ordering rationale).
 
 ### Which to use
 
@@ -332,7 +338,8 @@ daemon-side wait.
 |----------|-----|
 | Execute / run-all (need source synced) | `required_heads` via `send_request_after_heads` |
 | General "is my edit synced?" check | `confirm_sync` (still available) |
-| Save (daemon reads doc directly) | Neither -- daemon reads its own doc copy |
+| Client-initiated save (MCP `save_notebook`) | `confirm_sync` before `SaveNotebook` request -- ensures edits reach daemon |
+| Daemon-internal autosave | Neither -- daemon reads its own doc copy directly |
 
 ## Key Source Files
 

--- a/.claude/skills/execution-pipeline/SKILL.md
+++ b/.claude/skills/execution-pipeline/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: execution-pipeline
+description: >
+  The end-to-end cell execution pipeline from MCP tool call through
+  daemon to kernel and back. Use when debugging execution failures,
+  understanding output timing, investigating why outputs are missing
+  or stale, or modifying the execute/run-all flow. Covers
+  required_heads, CellQueued, RuntimeStateDoc polling, output-sync
+  grace, and output resolution.
+---
+
+# Cell Execution Pipeline
+
+Use this skill when debugging execution-related issues: cells that
+don't execute, outputs that don't appear, execution that times out,
+or MCP tools that return empty results. This traces the full path
+from tool invocation to resolved outputs.
+
+## The Five Stages
+
+### Stage 1: Causal Precondition (required_heads)
+
+Before sending an execute request, the client captures the current
+Automerge heads of the notebook document:
+
+```rust
+let required_heads = handle.current_heads_hex()?;
+```
+
+These heads are attached to the request envelope. The daemon's
+`wait_for_required_heads()` defers processing until all listed change
+hashes exist in its copy of the notebook document (checked via
+`get_change_by_hash` — a ChangeGraph containment check).
+
+**Why this matters:** Without `required_heads`, the daemon might
+execute against stale cell source — the client wrote "x = 1" but the
+daemon hasn't received that sync frame yet, so it executes the old
+"x = 0".
+
+**Timeout:** 10 seconds. If heads don't arrive, the daemon logs a
+warning and processes anyway (graceful degradation).
+
+**Frontend optimization:** Before capturing heads, the frontend calls
+`flushSync()` to push any pending source edits into the sync stream,
+minimizing the daemon-side wait.
+
+### Stage 2: Request Submission
+
+The client sends an `ExecuteCell` or batch `RunAllCells` request:
+
+```rust
+let request = NotebookRequest::ExecuteCell {
+    cell_id: cell_id.to_string(),
+};
+let response = handle.send_request_after_heads(request, required_heads).await;
+```
+
+`send_request_after_heads` wraps the request in a
+`NotebookRequestEnvelope` with the captured heads and sends it through
+the sync task.
+
+### Stage 3: Daemon Queuing
+
+The daemon receives the request, waits for required heads (Stage 1),
+reads the cell source from its synced notebook document, and queues
+execution with the kernel:
+
+1. Daemon reads source from its `NotebookDoc` (the CRDT, not the
+   `.ipynb` file)
+2. Creates a unique `execution_id`
+3. Writes to `RuntimeStateDoc`: execution entry with status `"queued"`,
+   then `"running"` when the kernel starts
+4. Responds with `CellQueued { execution_id, position }` immediately
+5. Forwards code to the kernel via ZMQ `execute_request`
+
+**Key invariant:** The daemon writes `set_execution_done(eid, success)`
+to RuntimeStateDoc ONLY AFTER all output manifests for that execution
+are committed. This ordering guarantee is what makes RuntimeStateDoc
+polling reliable.
+
+### Stage 4: Terminal Wait (RuntimeStateDoc Polling)
+
+The client polls RuntimeStateDoc for execution completion:
+
+```rust
+await_execution_terminal(handle, &execution_id, timeout, None).await
+```
+
+**Phase 1 — Terminal status poll:**
+- Polls every 50ms
+- Checks `executions[eid].status` for `"done"` or `"error"`
+- Also watches for kernel-level failure (`kernel.lifecycle == Error|Shutdown`)
+- Returns `KernelFailed` if the kernel dies while execution is pending
+
+**Phase 2 — Output-sync grace:**
+- After terminal status is reached, the output list might still be
+  empty on the client's replica (sync lag)
+- Polls every 10ms for up to 500ms (the grace period)
+- Exits as soon as outputs appear
+
+**Why RuntimeStateDoc, not broadcasts:** The `ExecutionDone` broadcast
+arrives over a separate channel and the client's Automerge replica may
+not have caught up on the final stream writes. The RuntimeStateDoc is
+authoritative — once status is `"done"`, outputs are guaranteed to be
+in the same document.
+
+### Stage 5: Output Resolution
+
+Outputs are inline manifest Maps in RuntimeStateDoc, containing
+`ContentRef` entries per MIME type:
+
+```rust
+let outputs = output_resolver::resolve_cell_outputs_for_llm(&output_manifests, ctx).await;
+```
+
+Resolution depends on MIME type:
+- **Text MIME** (`text/*`, `application/json`, `image/svg+xml`):
+  Inline string if ≤1KB, or fetch from blob store as UTF-8
+- **Binary MIME** (`image/png`, `audio/*`, etc.):
+  Always blob store. Frontend gets `http://` URL. Python gets raw bytes.
+- **Widget output** (`application/vnd.jupyter.widget-view+json`):
+  References comm state in RuntimeStateDoc
+
+MCP execution paths use **preview mode** — output is truncated for
+LLM consumption. Agents that need full output call
+`get_cell(full_output=true)` separately.
+
+## Execution ID Lifecycle
+
+```
+Client sends ExecuteCell
+  → Daemon returns CellQueued { execution_id: "exec-abc" }
+  → RuntimeStateDoc: executions["exec-abc"] = { status: "queued" }
+  → Kernel starts: executions["exec-abc"].status = "running"
+  → Outputs arrive: executions["exec-abc"].outputs = [manifest1, ...]
+  → Kernel done: executions["exec-abc"] = { status: "done", success: true }
+  → Client reads outputs from executions["exec-abc"].outputs
+```
+
+The `execution_id` is the stable reference for one execution attempt.
+If the same cell is executed twice, each gets a different
+`execution_id`. Agents can pass `execution_id` to `get_cell()` to
+read outputs for a specific execution rather than the cell's current
+outputs.
+
+## Run-All Flow
+
+`run_all_cells` follows the same pipeline but batched:
+
+1. Captures `required_heads` once
+2. Sends `RunAllCells` request with all cell IDs
+3. Daemon returns `AllCellsQueued { cell_execution_ids }` — a map of
+   `cell_id → execution_id` for every queued cell
+4. Client polls each `execution_id` in parallel with a shared deadline
+5. Returns per-cell results
+
+**Timeout:** The shared deadline applies to the entire run, not per-cell.
+If one cell takes 90% of the budget, remaining cells get less time.
+
+## Common Failure Modes
+
+### "Outputs are empty"
+
+1. **Output-sync grace too short:** The execution finished but outputs
+   haven't synced yet. The 500ms grace usually suffices, but very large
+   outputs (big DataFrames, many plots) may need more time.
+2. **execution_id mismatch:** Reading outputs with the wrong
+   `execution_id` or reading the cell's "current" outputs after
+   re-execution replaced them.
+3. **Blob store unreachable:** Binary outputs reference blobs. If the
+   blob HTTP server is down, resolution fails silently.
+
+### "Cell didn't execute"
+
+1. **required_heads timeout:** Daemon waited 10s for heads that never
+   arrived. Check if the sync stream is healthy.
+2. **Kernel not ready:** The kernel isn't started or is in error state.
+   The daemon returns an error response, not `CellQueued`.
+3. **Trust gate:** Untrusted notebooks may block execution pending
+   approval.
+
+### "Execution timed out"
+
+1. **Long-running cell:** The cell genuinely takes longer than the
+   timeout (default varies by caller — MCP uses 120s).
+2. **Kernel hung:** The kernel process is alive but not responding.
+   Check `kernel.lifecycle` in RuntimeStateDoc.
+3. **Sync stall:** Terminal status was written by the daemon but the
+   client's sync stream stopped delivering frames. Check daemon logs
+   for sync errors.
+
+### "Stale outputs from previous execution"
+
+The execution completed but the outputs visible belong to an earlier
+run. This happens when:
+1. Reading cell outputs without using the `execution_id` — the cell's
+   "current" pointer may not have been updated yet
+2. The RuntimeStateDoc sync hasn't delivered the latest writes
+
+Fix: Always use `execution_id` from the `CellQueued` response to
+read outputs for a specific execution.
+
+## Two Document Architecture
+
+Execution spans both Automerge documents in a notebook room:
+
+| Document | What it holds for execution |
+|----------|---------------------------|
+| **NotebookDoc** | Cell source code (what to execute) |
+| **RuntimeStateDoc** | Execution lifecycle, outputs, kernel status |
+
+The `required_heads` gate ensures NotebookDoc is synced before
+execution starts. RuntimeStateDoc polling ensures outputs are
+available before the client reads them. Both sync streams run
+concurrently on the same socket connection.
+
+## Key Source Files
+
+| File | Role |
+|------|------|
+| `crates/runt-mcp/src/execution.rs` | `execute_and_wait`, `run_all_and_wait` — MCP entry points |
+| `crates/notebook-sync/src/execution_wait.rs` | `await_execution_terminal` — shared two-phase polling |
+| `crates/notebook-sync/src/handle.rs` | `send_request_after_heads`, `current_heads_hex` |
+| `crates/runtimed/src/notebook_sync_server/peer_writer.rs` | `wait_for_required_heads` — daemon-side causal gate |
+| `crates/runtimed/src/runtime_agent/` | Kernel management, output routing, `set_execution_done` |
+| `crates/runtime-doc/src/doc.rs` | RuntimeStateDoc schema — executions map, kernel status |
+| `crates/runtimed-client/src/output_resolver.rs` | `resolve_cell_outputs_for_llm` — manifest → Output |
+| `crates/notebook-doc/src/mime.rs` | MIME classification (text vs binary) |
+| `packages/runtimed/src/notebook-client.ts` | Frontend `executeCell` with `getRequiredHeads` callback |

--- a/.claude/skills/mcp-session-lifecycle/SKILL.md
+++ b/.claude/skills/mcp-session-lifecycle/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: mcp-session-lifecycle
+description: >
+  Understand the MCP server session lifecycle: proxy supervision, daemon
+  watch loop, session state machine, rejoin/reconnect races, and room
+  eviction. Use when working on runt-mcp, runt-mcp-proxy, daemon_watch.rs,
+  or any code that reads/writes the session Arc<RwLock<Option<NotebookSession>>>.
+---
+
+# MCP Session Lifecycle
+
+Use this skill when debugging session state, changing reconnection logic,
+working on the proxy, or reasoning about races between background rejoin
+and user-initiated tool calls.
+
+## Three Layers
+
+The MCP server has three layers, each with its own lifecycle:
+
+```
+MCP Client (Claude, etc.)
+    |
+    v
+[runt-mcp-proxy] Process supervision layer
+    |  - Tracks last_notebook_id from tool results
+    |  - Restarts child on crash / daemon upgrade
+    |  - Seeds NTERACT_MCP_REJOIN_NOTEBOOK env var
+    v
+[runt-mcp] Session state layer
+    |  - Arc<RwLock<Option<NotebookSession>>>
+    |  - daemon_watch loop (background rejoin)
+    |  - Tool dispatch (user-initiated session changes)
+    v
+[runtimed] Room lifecycle layer
+    - NotebookRoom per notebook UUID
+    - Peer counting, delayed eviction (30s)
+    - Automerge sync, RuntimeStateDoc
+```
+
+### Proxy Layer (`runt-mcp-proxy`)
+
+The proxy is the outermost shell. It:
+- Spawns the actual `runt mcp` child process
+- Monitors stdout for MCP JSON-RPC and extracts `notebook_id` from
+  `connect_notebook` / `create_notebook` results
+- On child exit: if exit code is `EX_TEMPFAIL` (75), the daemon upgraded
+  and we restart with the new binary; otherwise just restart
+- Seeds `NTERACT_MCP_REJOIN_NOTEBOOK` env var so the child can rejoin
+  the notebook the previous child was attached to
+- Detects binary version changes (compares SHA of new binary path)
+
+### Session State Layer (`runt-mcp`)
+
+This is where most complexity lives. Key types:
+
+```rust
+// The shared session state
+session: Arc<RwLock<Option<NotebookSession>>>
+
+// What's in a session
+struct NotebookSession {
+    handle: DocHandle,        // Automerge sync handle
+    broadcast_rx: Receiver,   // Daemon broadcast channel
+    notebook_id: String,      // UUID
+    notebook_path: Option<String>, // File path (None for untitled)
+}
+```
+
+Two code paths compete for the session write lock:
+
+1. **Tool calls** (`connect_notebook`, `create_notebook`): User-initiated,
+   always win. Take write lock, install new session.
+2. **daemon_watch loop** (`rejoin`): Background auto-rejoin. Must check
+   that no tool call has changed the session during the async window.
+
+### Daemon Room Layer (`runtimed`)
+
+- Rooms are keyed by UUID, never change identity
+- File paths are a secondary index (`PathIndex`)
+- Peer counting: each connection is a peer. When all peers disconnect,
+  a delayed eviction timer starts (default 30s, configurable via
+  `keep_alive_secs`)
+- If no peer reconnects within the eviction window: kernel shuts down,
+  file watcher stops, room removed
+
+## The Watch Loop State Machine
+
+`daemon_watch.rs` runs a classify → act loop on `DaemonEvent`s:
+
+```
+classify(event, initial_target, has_session, was_disconnected, disconnect_target)
+    -> WatchDecision { Exit | RejoinInitial | RejoinContinuation | MarkDisconnected | NoOp }
+```
+
+### State Tracking
+
+| Variable | Purpose |
+|----------|---------|
+| `initial_target` | From `NTERACT_MCP_REJOIN_NOTEBOOK` env var. Cleared once consumed or once a tool call establishes a session. |
+| `was_disconnected` | True after `Disconnected` event. Prevents heartbeat `Connected` events from triggering spurious rejoins. |
+| `disconnect_target` | Stashed notebook_id/path when session cleared on disconnect. Used for rejoin when daemon comes back. |
+
+### Event → Decision Matrix
+
+| Event | initial_target? | has_session? | was_disconnected? | Decision |
+|-------|----------------|-------------|-------------------|----------|
+| `Upgraded` (version change) | any | any | any | Exit(75) |
+| `Upgraded` (same version) | Some(t) | any | any | RejoinInitial(t) |
+| `Upgraded` (same version) | None | true | any | RejoinContinuation |
+| `Connected` | Some(t) | any | any | RejoinInitial(t) |
+| `Connected` | None | true | true | RejoinContinuation |
+| `Connected` | None | true | false | NoOp (heartbeat, not a real reconnect) |
+| `Connected` | None | false | true | RejoinInitial(disconnect_target) |
+| `Disconnected` | any | any | any | MarkDisconnected |
+
+### The Heartbeat Problem (#2088)
+
+`DaemonConnection` emits `Connected` every ~10s as a heartbeat. Without
+`was_disconnected` gating, every heartbeat would trigger a rejoin, creating
+a brief 2-peer spike that resets the room's eviction timer. The fix:
+only rejoin after a real `Disconnected` event.
+
+## The Session-Write Guard
+
+The critical race: rejoin is async (socket connect + initial sync load,
+potentially 120s). During that window, a tool call might establish a
+completely different session. Without a guard, rejoin would overwrite it.
+
+The guard in `rejoin()`:
+```rust
+// After connect + initial load succeed...
+{
+    let guard = session.read().await;
+    if let Some(existing) = guard.as_ref() {
+        if existing.notebook_id != new_notebook_id {
+            info!("Rejoin superseded by active session; dropping");
+            return true;
+        }
+    }
+}
+// Only now install the rejoined session
+*session.write().await = Some(new_session);
+```
+
+**Invariant:** User-initiated session changes always win over background
+rejoin. The guard ensures this by checking the session state *after* the
+async work completes.
+
+## Session Access Pattern
+
+All tool handlers use the `require_handle!` macro:
+
+```rust
+// Read lock → clone DocHandle → drop lock → work
+let handle = {
+    let guard = session.read().await;
+    match guard.as_ref() {
+        Some(s) => s.handle.clone(),
+        None => return no_session_error(...),
+    }
+};
+// handle is now owned; lock is dropped
+handle.with_doc(|doc| { ... });
+```
+
+This prevents lock contention: the read lock is held only for the clone,
+not for the entire tool execution. `DocHandle` is cheaply cloneable
+(`Arc<Mutex<SharedDocState>>`).
+
+## Rejoin: File-Backed vs Ephemeral
+
+| Notebook type | Identified by | Rejoin method | Eviction check |
+|--------------|---------------|---------------|----------------|
+| File-backed | Has file path | `connect_open(path)` | File exists on disk |
+| Ephemeral (untitled) | UUID only | `connect(uuid)` | `list_rooms` check |
+
+**Ephemeral notebooks** get an explicit `list_rooms` check before rejoin.
+If the room was evicted during disconnect, we clear the session
+immediately instead of creating a phantom empty room.
+
+**File-backed notebooks** use `connect_open(path)` which lets the daemon
+reload from disk. The `.automerge` persist files for file-backed rooms
+are deleted, so UUID-only connect would yield an empty document.
+
+## Session Drop Tracking
+
+When a session ends, `last_session_drop` records why:
+
+```rust
+enum SessionDropReason {
+    Evicted,       // Room evicted (all peers left, timer expired)
+    Switched,      // User connected to a different notebook
+    Disconnected,  // Daemon connection lost
+}
+
+struct SessionDropInfo {
+    reason: SessionDropReason,
+    notebook_id: String,
+    notebook_path: Option<String>,
+}
+```
+
+The `no_session_error()` function uses this to give the MCP client
+actionable guidance: "notebook X was evicted, call connect_notebook"
+vs "daemon disconnected, retry in a moment."
+
+## Common Mistakes
+
+### 1. Taking write lock during tool execution
+
+Tool handlers should clone the `DocHandle` under a read lock, then drop
+the lock before doing work. Holding a write lock during async work blocks
+all other tool calls and the rejoin loop.
+
+### 2. Not checking session after async work in rejoin
+
+Any async gap in rejoin (socket connect, initial load) is a window where
+a tool call can change the session. Always re-check before installing.
+
+### 3. Treating Connected events as reconnection signals
+
+`Connected` fires on every heartbeat (~10s). Only rejoin after a real
+`Disconnected` event (`was_disconnected` flag).
+
+### 4. UUID-only connect for file-backed notebooks
+
+File-backed rooms don't have persistent `.automerge` files after the room
+is closed. Use `connect_open(path)` to let the daemon reload from disk.
+
+### 5. Creating phantom rooms on rejoin
+
+If an ephemeral room was evicted, `connect(uuid)` creates a new empty room
+with no cells and no kernel. Check `list_rooms` first.
+
+## Key Source Files
+
+| File | What it owns |
+|------|-------------|
+| `crates/runt-mcp/src/daemon_watch.rs` | `classify()` pure function, `watch()` loop, `rejoin()` |
+| `crates/runt-mcp/src/session.rs` | `NotebookSession`, `SessionDropReason`, `SessionDropInfo` |
+| `crates/runt-mcp/src/lib.rs` | `NteractMcp` server, `require_handle!` pattern |
+| `crates/runt-mcp/src/tools/session.rs` | `connect_notebook`, `create_notebook`, `disconnect_previous_session` |
+| `crates/runt-mcp-proxy/src/proxy.rs` | `McpProxy`, `restart_child()`, `track_session()` |
+| `crates/runtimed/src/notebook_sync_server/` | Room lifecycle, peer counting, eviction |
+
+## North Star: Concurrent MCP Clients
+
+The current architecture assumes a single MCP client per daemon session.
+The north star is supporting multiple concurrent MCP clients against the
+same daemon. Key tension points:
+
+- **Session state is per-process:** Each `runt mcp` process has one
+  `Arc<RwLock<Option<NotebookSession>>>`. Multiple clients would need
+  either multiple processes or per-client session tracking.
+- **Peer identity:** Currently one peer label per MCP process. Multiple
+  clients would need distinct peer identities for presence and
+  conflict resolution.
+- **Tool dispatch:** `require_handle!` assumes one active session. With
+  multiple notebooks open, tools would need notebook_id routing.
+- **Proxy supervision:** The proxy tracks one `last_notebook_id`. Multiple
+  concurrent notebooks would need a session registry.

--- a/.claude/skills/sync-protocol-patterns/SKILL.md
+++ b/.claude/skills/sync-protocol-patterns/SKILL.md
@@ -169,10 +169,16 @@ How each system answers "has the remote peer seen my changes?"
 | nteract `required_heads` | Daemon-side waiter on `get_change_by_hash` | Daemon defers, client free | Per-request |
 
 **Key insight:** All systems converge on the same principle: **track heads
-per peer, notify asynchronously, never block the sync loop.** nteract's
-`required_heads` is a request-scoped specialization of this pattern —
-the daemon defers one specific request until causal preconditions are met,
-while the sync stream continues unblocked.
+per peer, notify asynchronously, never block the sync loop.** But only
+nteract gates *actions* on causal preconditions. automerge-repo's
+`RemoteHeadsSubscriptions` is peer-awareness ("I know where you are"),
+and samod's `RemoteHeads` on every data message is informational with
+staleness filtering (counter <= last_seen → drop) — neither system
+defers request processing until specific heads arrive. nteract's
+`required_heads` is genuinely novel: request-scoped causal gating where
+the daemon defers one specific request until its preconditions are met,
+while the sync stream continues unblocked. This eliminates the
+client-side round-trip that `confirm_sync` required.
 
 ## Connection Lifecycle Patterns
 

--- a/.claude/skills/sync-protocol-patterns/SKILL.md
+++ b/.claude/skills/sync-protocol-patterns/SKILL.md
@@ -198,15 +198,22 @@ reduce the initial sync burst.
 
 ## When Adding a New Sync Stream
 
-If you need to add a new Automerge-synced document to the protocol (like
-PoolStateSync frame `0x06`):
+If you need to add a new Automerge-synced document to the protocol
+(e.g., a hypothetical `AgentCoordinationSync`):
 
 1. **Allocate a frame type** in `notebook-wire`
-2. **Add sync state fields** to `SharedDocState` (doc + peer_state pair)
+2. **Decide sync state ownership.** Two patterns exist:
+   - **SharedDocState pattern** (notebook `0x00`, runtime-state `0x05`):
+     sync state lives in `notebook-sync::SharedDocState` as a doc +
+     peer_state pair managed by `sync_task.rs`
+   - **Separate ownership** (pool-state `0x06`): frontend owns its
+     sync state directly; daemon carries `pool_peer_state` in the peer
+     loop. Choose this when sync-task's biased select isn't the right
+     priority model for the new stream
 3. **Add catch_unwind guards** for both receive and generate paths
 4. **Add a rebuild function** following the save→load→reset pattern
-5. **Update the biased select loop** — decide priority relative to
-   existing streams
+5. **Update the biased select loop** (SharedDocState pattern) or the
+   relevant owner's frame handler (separate ownership)
 6. **Consider subscription scope** — does every peer need this stream,
    or only specific consumers?
 7. **Test with concurrent mutation** — the automerge#1187 panic only

--- a/.claude/skills/sync-protocol-patterns/SKILL.md
+++ b/.claude/skills/sync-protocol-patterns/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: sync-protocol-patterns
+description: >
+  Design patterns for sync protocols learned from automerge-repo and samod.
+  Use when designing new protocol features, adding sync streams, changing
+  causal ordering, or evaluating how upstream patterns could improve nteract.
+  Complements automerge-sync (which covers the raw automerge sync protocol)
+  with higher-level architectural patterns.
+---
+
+# Sync Protocol Patterns
+
+Use this skill when designing protocol features, not just fixing bugs.
+It distills architectural patterns from three production sync systems
+and maps them to nteract's design decisions.
+
+## Three Architectures Compared
+
+### automerge-repo: Document-Centric, Transport-Agnostic
+
+**Architecture:** `Repo` owns document lifecycle. `DocHandle` is the
+mutation/event surface. `DocSynchronizer` manages per-peer sync. Network
+adapters are pluggable message transports.
+
+**Key pattern — Remote Heads Subscriptions:**
+
+automerge-repo tracks *where* each peer's heads are, not just *that*
+they changed. `RemoteHeadsSubscriptions` is a pub/sub system where:
+
+- Each peer has a `StorageId` (stable identity across reconnections)
+- Peers subscribe to specific `StorageId`s to track their heads
+- When a peer's heads change, all subscribers are notified
+- `handleImmediateRemoteHeadsChanged()` handles directly-connected peers
+- `handleRemoteHeads()` handles transitively-relayed updates
+
+This enables "I know peer X has seen my changes" without a blocking
+round-trip — the answer arrives as a notification, not a response.
+
+**nteract parallel:** This is what `required_heads` achieves for execute
+requests. The daemon knows the client's heads from the sync stream and
+can defer handling until the heads arrive. A future enhancement could
+make this more general: the daemon could proactively notify clients when
+it has processed specific heads, enabling fire-and-forget causal ordering.
+
+**Key pattern — Document State Machine:**
+
+DocHandle has an XState machine: `idle → loading → requesting → ready |
+unavailable | unloaded | deleted`. Documents aren't immediately usable —
+they must be loaded from storage or fetched from peers first.
+
+nteract's DocHandle is simpler: always "ready" once constructed. This
+works because nteract always connects to one known daemon (not a mesh of
+peers), so the initial sync is a single handshake, not a discovery
+protocol. If nteract ever needs offline-first or peer-to-peer sync, the
+state machine pattern becomes necessary.
+
+### samod/subduction: Sans-IO, Signed, Metadata-First
+
+**Architecture:** `SubductionEngine` is a pure sans-IO state machine:
+`handle(Input<C>) -> EngineOutput<C>`. No threads, no async, no IO.
+The caller executes IO and feeds results back.
+
+**Key pattern — Sans-IO State Machine:**
+
+The engine accepts typed input events and returns output actions:
+
+```rust
+pub enum Input<C> {
+    NewConnection { id: C, outgoing: bool, ... },
+    ReceivedBytes { id: C, bytes: Vec<u8>, ... },
+    ConnectionLost { id: C },
+    SigningComplete { op_id: OpId, signature: ... },
+    StorageComplete { op_id: OpId, result: ... },
+    FindDocument { sed_id: ... },
+    NewLocalChanges { sed_id: ..., changes: ... },
+}
+
+pub struct EngineOutput<C> {
+    pub send: Vec<(C, Vec<u8>)>,
+    pub storage_ops: Vec<IssuedOp>,
+    pub sign_requests: Vec<SignRequest>,
+    pub data_for_docs: Vec<(SedimentreeId, Vec<Vec<u8>>)>,
+    pub search_status: Vec<(SedimentreeId, SearchStatus)>,
+}
+```
+
+**Why this matters for nteract:** nteract's sync task is async Rust with
+a biased `select!` loop. This works but makes testing harder — you need
+real tokio runtimes and mock IO. A sans-IO core would let you test
+protocol logic with pure function calls. Worth considering for any new
+complex protocol state (e.g., multi-peer coordination, pool sync).
+
+**Key pattern — Two-Phase Sync (Batch + Incremental):**
+
+samod separates sync into two phases:
+
+1. **Batch sync** (initial): Fingerprint-based reconciliation in 1.5
+   round trips. The requestor sends a compact fingerprint summary; the
+   responder computes the diff and sends missing data.
+2. **Incremental sync** (steady-state): Subscription-based push. After
+   batch sync establishes a baseline, peers subscribe to receive live
+   updates as commits/fragments arrive.
+
+The `IncrementalSync` type ties together:
+- `SubscriptionTracker`: which peers watch which documents
+- `PeerCounter`: per-peer monotonic send counters
+- `RemoteHeadsTracker`: filters stale updates via counters
+
+**nteract parallel:** nteract's initial sync handshake (automerge bloom
+filter exchange) is the batch phase. The subsequent `AutomergeSync`
+frame stream is the incremental phase. But nteract doesn't have the
+subscription/counter infrastructure — if it ever needs to sync across
+multiple daemon instances or support peer-to-peer, samod's model shows
+how to layer incrementality on top.
+
+**Key pattern — Storage Coordinator:**
+
+`StorageCoordinator` manages multi-step async IO operations without
+async/await. It:
+- Issues `KvOp`s with `OpId` tracking
+- Handles multi-phase operations (load commit → load blob → assemble)
+- Maps sub-task completions to parent operations
+- Returns `StorageComplete` when all constituent tasks finish
+
+This is the same pattern as nteract's `confirm_sync` waiters and
+`required_heads` — tracking pending async work and resolving when
+conditions are met — but generalized to arbitrary multi-step operations.
+
+**Key pattern — Per-Peer Monotonic Counters:**
+
+Every incremental message carries a per-peer counter. Receivers filter
+stale/out-of-order messages: if `incoming_counter <= last_seen`, drop it.
+Counters are cleared on disconnect and restart from 1 on reconnect.
+
+nteract doesn't currently need this (single daemon, ordered TCP stream),
+but it would be essential for:
+- Multiple daemon replicas
+- WebSocket transport with potential reordering
+- Multi-peer sync where messages may arrive out of causal order
+
+### nteract: Socket-Based, CRDT-Centric
+
+**Architecture:** Direct Unix socket connection. Length-prefixed typed
+frames. Two CRDT sync streams (notebook + runtime state) on one
+connection. Daemon as authoritative server, clients as syncing peers.
+
+**Where nteract is ahead:**
+- `required_heads` is a clean causal ordering primitive that neither
+  automerge-repo nor samod has in exactly this form
+- The catch_unwind + rebuild pattern handles automerge bugs gracefully
+- Per-cell O(1) WASM accessors avoid full-doc materialization
+
+**Where nteract could learn from upstream:**
+- automerge-repo's document state machine for handling offline/loading
+  states more gracefully
+- samod's sans-IO pattern for testable protocol logic
+- samod's subscription tracker for future multi-peer scenarios
+
+## Heads Tracking Across Ecosystems
+
+How each system answers "has the remote peer seen my changes?"
+
+| System | Mechanism | Blocking? | Granularity |
+|--------|-----------|-----------|-------------|
+| automerge (raw) | `shared_heads` in sync::State | No — updated on each message exchange | Per-peer |
+| automerge-repo | `RemoteHeadsSubscriptions` with StorageId tracking | No — notification-based | Per-storage-peer |
+| samod | `RemoteHeads` with monotonic per-peer counters | No — carried on every data message | Per-peer per-document |
+| nteract `confirm_sync` | Client-side waiter on `shared_heads` | Client blocks, daemon free | Per-request |
+| nteract `required_heads` | Daemon-side waiter on `get_change_by_hash` | Daemon defers, client free | Per-request |
+
+**Key insight:** All systems converge on the same principle: **track heads
+per peer, notify asynchronously, never block the sync loop.** nteract's
+`required_heads` is a request-scoped specialization of this pattern —
+the daemon defers one specific request until causal preconditions are met,
+while the sync stream continues unblocked.
+
+## Connection Lifecycle Patterns
+
+How each system handles disconnect → reconnect:
+
+| System | On Disconnect | On Reconnect | State Preserved |
+|--------|--------------|-------------|-----------------|
+| automerge-repo | `endSync(peerId)` — removes from active list, keeps sync state | `beginSync` — encode/decode to clear in-flight, preserves shared_heads | Sync state (for same peer) |
+| samod | `handle_connection_lost` — remove connection, call `peer_disconnected` | New connection → fresh handshake + batch sync | Nothing — clean slate |
+| nteract | `MarkDisconnected` → clear session → stash target | `rejoin()` → new `sync::State::new()` + full handshake | Session identity (notebook_id/path) but not sync state |
+
+**Design space:** nteract currently takes the "clean slate" approach for
+sync state (like samod) but preserves session identity (like automerge-repo
+preserves sync state). If latency on reconnect becomes a problem, the
+automerge-repo approach (preserve `shared_heads` via encode/decode) could
+reduce the initial sync burst.
+
+## When Adding a New Sync Stream
+
+If you need to add a new Automerge-synced document to the protocol (like
+PoolStateSync frame `0x06`):
+
+1. **Allocate a frame type** in `notebook-wire`
+2. **Add sync state fields** to `SharedDocState` (doc + peer_state pair)
+3. **Add catch_unwind guards** for both receive and generate paths
+4. **Add a rebuild function** following the save→load→reset pattern
+5. **Update the biased select loop** — decide priority relative to
+   existing streams
+6. **Consider subscription scope** — does every peer need this stream,
+   or only specific consumers?
+7. **Test with concurrent mutation** — the automerge#1187 panic only
+   manifests under concurrent sync, so single-peer tests miss it
+
+## Design Decision Checklist
+
+When making protocol design decisions:
+
+| Question | Pattern to apply |
+|----------|-----------------|
+| "Should this block the client or the daemon?" | Prefer daemon-side waits (required_heads pattern) |
+| "How do I know the remote has my changes?" | Track heads per peer, don't block the sync loop |
+| "Should I add a new frame type?" | Only if it's a separate Automerge doc or needs distinct priority |
+| "How do I handle disconnection?" | Reset transport state, preserve document truth |
+| "Should protocol logic be async?" | Consider sans-IO for testability (samod pattern) |
+| "How do I order operations causally?" | Attach heads to requests, let the receiver defer |
+| "Should state survive reconnection?" | Only shared_heads; all other sync state is session-ephemeral |
+
+## Key Upstream Source Files
+
+| File | What it teaches |
+|------|----------------|
+| `automerge-repo/src/RemoteHeadsSubscriptions.ts` | Pub/sub heads tracking across peers |
+| `automerge-repo/src/DocHandle.ts` | Document state machine (idle → ready) |
+| `automerge-repo/src/synchronizer/DocSynchronizer.ts` | Per-peer sync state management |
+| `automerge-repo/src/network/messages.ts` | Message taxonomy (sync, request, ephemeral, remote-heads-changed) |
+| `samod/subduction-sans-io/src/engine.rs` | Sans-IO protocol engine pattern |
+| `samod/subduction-sans-io/src/incremental.rs` | Subscription + counter-based live sync |
+| `samod/subduction-sans-io/src/batch_sync.rs` | Fingerprint-based batch reconciliation |
+| `samod/subduction-sans-io/src/storage_coord.rs` | Multi-step async IO without async/await |
+| `samod/subduction-sans-io/src/messages.rs` | Binary wire format with schema+size+tag envelope |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 This is a map. Subsystem details live in `contributing/`, auto-loaded rules live in `.claude/rules/`, and operational recipes live in `.claude/skills/` and `.codex/skills/`. Run `cargo xtask help` for build commands.
 
+Claude-specific skills live in `.claude/skills/`. Use when the task matches:
+- `automerge-sync` for sync protocol internals, reconnection, peer state lifecycle, in-flight suppression, catch_unwind recovery, and convergence debugging
+- `mcp-session-lifecycle` for MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, and room eviction
+
 Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
 - `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification
 - `nteract-python-bindings` for `maturin develop`, venv selection, and MCP server work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This is a map. Subsystem details live in `contributing/`, auto-loaded rules live
 Claude-specific skills live in `.claude/skills/`. Use when the task matches:
 - `automerge-sync` for sync protocol internals, reconnection, peer state lifecycle, in-flight suppression, catch_unwind recovery, and convergence debugging
 - `mcp-session-lifecycle` for MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, and room eviction
+- `sync-protocol-patterns` for higher-level protocol design: comparing automerge-repo/samod/nteract architectures, adding new sync streams, heads tracking patterns, and connection lifecycle decisions
 
 Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
 - `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Claude-specific skills live in `.claude/skills/`. Use when the task matches:
 - `automerge-sync` for sync protocol internals, reconnection, peer state lifecycle, in-flight suppression, catch_unwind recovery, and convergence debugging
 - `mcp-session-lifecycle` for MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, and room eviction
 - `sync-protocol-patterns` for higher-level protocol design: comparing automerge-repo/samod/nteract architectures, adding new sync streams, heads tracking patterns, and connection lifecycle decisions
+- `automerge-document-model` for Automerge internals: OpSet, ChangeGraph, actor tables, save/load lifecycle, fork/merge semantics, #1187 panic root cause, and document size reasoning
 
 Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
 - `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Claude-specific skills live in `.claude/skills/`. Use when the task matches:
 - `mcp-session-lifecycle` for MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, and room eviction
 - `sync-protocol-patterns` for higher-level protocol design: comparing automerge-repo/samod/nteract architectures, adding new sync streams, heads tracking patterns, and connection lifecycle decisions
 - `automerge-document-model` for Automerge internals: OpSet, ChangeGraph, actor tables, save/load lifecycle, fork/merge semantics, #1187 panic root cause, and document size reasoning
+- `execution-pipeline` for end-to-end cell execution: required_heads → ExecuteCell → CellQueued → RuntimeStateDoc polling → output-sync grace → output resolution. Use when debugging missing outputs, execution timeouts, or stale results
 
 Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
 - `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification


### PR DESCRIPTION
## Summary

- Adds two new `.claude/skills/` entries built from deep reading of upstream automerge (`automerge/automerge`), automerge-repo (`automerge/automerge-repo`), and samod (`alexjg/samod` subduction branch) source code.
- **`automerge-sync`**: `sync::State` field-by-field semantics (all 13 fields, persistence contract), bloom filter negotiation, in-flight suppression, message version negotiation, reconnection patterns from three upstream repos, and the nteract catch_unwind + cell-count guard recovery pattern.
- **`mcp-session-lifecycle`**: Three-layer proxy/MCP/daemon architecture, the watch loop classify/act state machine with full event-decision matrix, session-write guard race, heartbeat vs real disconnect (#2088), file-backed vs ephemeral rejoin strategies, and the concurrent MCP north-star note.
- Updates `AGENTS.md` with a Claude-specific skills discovery section.

## Test plan

- [ ] Skills are markdown-only; no code changes
- [ ] Verify `cargo xtask lint --fix` passes (confirmed clean)
- [ ] Verify AGENTS.md references are accurate