### PR TITLE
fix(notebook): pulse isolated renderer layout after output changes

### DIFF
--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -198,6 +198,36 @@ type MessageHandler = (type: string, payload: unknown) => void;
 
 let messageHandler: MessageHandler | null = null;
 
+const LAYOUT_PULSE_DELAYS_MS = [0, 160, 600];
+let layoutPulseTimers: number[] = [];
+
+function pulseRendererLayout(): void {
+  window.dispatchEvent(new Event("resize"));
+  window.dispatchEvent(new Event("scroll"));
+  document.dispatchEvent(new Event("scroll", { bubbles: true }));
+  document.body?.dispatchEvent(new Event("scroll", { bubbles: true }));
+  window.parent.postMessage(
+    {
+      type: "resize",
+      payload: { height: document.body.scrollHeight },
+    },
+    "*",
+  );
+}
+
+function scheduleRendererLayoutPulses(): void {
+  for (const timer of layoutPulseTimers) {
+    window.clearTimeout(timer);
+  }
+  layoutPulseTimers = [];
+  for (const delay of LAYOUT_PULSE_DELAYS_MS) {
+    const timer = window.setTimeout(() => {
+      requestAnimationFrame(pulseRendererLayout);
+    }, delay);
+    layoutPulseTimers.push(timer);
+  }
+}
+
 function setupMessageListener() {
   // Create JSON-RPC transport — handles nteract/* methods from the host
   rpcTransport = new JsonRpcTransport(window.parent, window.parent);
@@ -297,6 +327,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
       }
 
@@ -324,6 +355,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
       }
 
@@ -338,6 +370,7 @@ function IsolatedRendererApp() {
             "*",
           );
         });
+        scheduleRendererLayoutPulses();
         break;
 
       case "theme": {

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -204,8 +204,8 @@ let layoutPulseTimers: number[] = [];
 function pulseRendererLayout(): void {
   window.dispatchEvent(new Event("resize"));
   window.dispatchEvent(new Event("scroll"));
-  document.dispatchEvent(new Event("scroll", { bubbles: true }));
-  document.body?.dispatchEvent(new Event("scroll", { bubbles: true }));
+  document.dispatchEvent(new Event("scroll"));
+  document.body?.dispatchEvent(new Event("scroll"));
   window.parent.postMessage(
     {
       type: "resize",


### PR DESCRIPTION
## Summary

- Backport only the isolated renderer layout-pulse portion from #2442.
- Schedule a few delayed resize/scroll pulses after render, batch render, and clear so virtualized outputs get a settling window in macOS WebView.
- Leave the focused-cell resnap/editor-registry changes out of this branch.

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-bridge.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/reload-detection.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
