### PR TITLE
feat(runtimed): expose tokio runtime metrics via daemon status

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2141,6 +2141,11 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
             } else {
                 None
             };
+            let runtime_metrics = if running {
+                client.runtime_metrics().await.ok()
+            } else {
+                None
+            };
             let is_dev = runt_workspace::is_dev_mode();
 
             // Get socket path from daemon info or default
@@ -2182,6 +2187,7 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                         .and_then(|i| i.blob_port.map(|p| format!("http://127.0.0.1:{}", p))),
                     "worktree_hash": runt_workspace::get_workspace_path()
                         .map(|p| runt_workspace::worktree_hash(&p)),
+                    "runtime_metrics": runtime_metrics,
                 });
                 println!("{}", serde_json::to_string_pretty(&output)?);
             } else {

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -239,6 +239,54 @@ impl PoolClient {
         }
     }
 
+    /// Query tokio runtime metrics (worker utilization, task counts).
+    ///
+    /// Returns the raw metrics snapshot as a JSON value. Daemons that
+    /// predate this request return `Err(DaemonError("Unknown request"))`.
+    pub async fn runtime_metrics(&self) -> Result<serde_json::Value, ClientError> {
+        let response = self.send_request(Request::GetRuntimeMetrics).await?;
+        match response {
+            Response::RuntimeMetrics {
+                num_workers,
+                num_alive_tasks,
+                global_queue_depth,
+                worker_busy_us,
+                worker_park_count,
+                uptime_us,
+            } => {
+                let uptime_us_f = uptime_us as f64;
+                let workers: Vec<serde_json::Value> = (0..num_workers)
+                    .map(|i| {
+                        let busy = worker_busy_us.get(i).copied().unwrap_or(0);
+                        let parks = worker_park_count.get(i).copied().unwrap_or(0);
+                        let utilization = if uptime_us_f > 0.0 {
+                            (busy as f64 / uptime_us_f * 100.0).min(100.0)
+                        } else {
+                            0.0
+                        };
+                        serde_json::json!({
+                            "busy_us": busy,
+                            "park_count": parks,
+                            "utilization_pct": (utilization * 100.0).round() / 100.0,
+                        })
+                    })
+                    .collect();
+
+                Ok(serde_json::json!({
+                    "num_workers": num_workers,
+                    "num_alive_tasks": num_alive_tasks,
+                    "global_queue_depth": global_queue_depth,
+                    "uptime_us": uptime_us,
+                    "workers": workers,
+                }))
+            }
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError(
+                "Unexpected response".to_string(),
+            )),
+        }
+    }
+
     /// Request an environment from the pool.
     ///
     /// Returns `Ok(Some(env))` if an environment was available,

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -69,6 +69,12 @@ pub enum Request {
     /// or is forcibly killed. Clients should prefer this request and
     /// fall back to `Ping` if they only need the version.
     GetDaemonInfo,
+
+    /// Get tokio runtime metrics (worker utilization, task counts, queue
+    /// depths). Used by `runt daemon status --json` and diagnostic tools
+    /// to measure whether the daemon's async runtime is spreading work
+    /// across cores under load.
+    GetRuntimeMetrics,
 }
 
 /// Responses from the daemon to clients.
@@ -177,6 +183,29 @@ pub enum Response {
 
     /// Environment paths currently in use by running kernels.
     ActiveEnvPaths { paths: Vec<PathBuf> },
+
+    /// Tokio runtime metrics snapshot.
+    ///
+    /// Returned from `Request::GetRuntimeMetrics`. Carries per-worker
+    /// busy durations, task counts, and queue depths so tooling can
+    /// compute utilization without `tokio_unstable`.
+    RuntimeMetrics {
+        /// Number of tokio worker threads.
+        num_workers: usize,
+        /// Number of currently alive (spawned but not yet completed) tasks.
+        num_alive_tasks: usize,
+        /// Tasks waiting in the global (injection) queue.
+        global_queue_depth: usize,
+        /// Per-worker cumulative busy duration in microseconds.
+        /// Index corresponds to worker index 0..num_workers.
+        worker_busy_us: Vec<u64>,
+        /// Per-worker park (idle) count. High park counts relative to
+        /// poll counts indicate an underloaded worker.
+        worker_park_count: Vec<u64>,
+        /// Wall-clock microseconds since daemon start — divide
+        /// `worker_busy_us[i]` by this to get per-worker utilization.
+        uptime_us: u64,
+    },
 }
 
 /// Kernel info for a notebook room.
@@ -317,6 +346,44 @@ mod tests {
             roundtrip_request(&Request::FlushPool),
             Request::FlushPool
         ));
+    }
+
+    #[test]
+    fn test_request_get_runtime_metrics() {
+        assert!(matches!(
+            roundtrip_request(&Request::GetRuntimeMetrics),
+            Request::GetRuntimeMetrics
+        ));
+    }
+
+    #[test]
+    fn test_response_runtime_metrics() {
+        let resp = Response::RuntimeMetrics {
+            num_workers: 4,
+            num_alive_tasks: 42,
+            global_queue_depth: 3,
+            worker_busy_us: vec![100_000, 200_000, 150_000, 50_000],
+            worker_park_count: vec![10, 20, 15, 5],
+            uptime_us: 1_000_000,
+        };
+        match roundtrip_response(&resp) {
+            Response::RuntimeMetrics {
+                num_workers,
+                num_alive_tasks,
+                global_queue_depth,
+                worker_busy_us,
+                worker_park_count,
+                uptime_us,
+            } => {
+                assert_eq!(num_workers, 4);
+                assert_eq!(num_alive_tasks, 42);
+                assert_eq!(global_queue_depth, 3);
+                assert_eq!(worker_busy_us, vec![100_000, 200_000, 150_000, 50_000]);
+                assert_eq!(worker_park_count, vec![10, 20, 15, 5]);
+                assert_eq!(uptime_us, 1_000_000);
+            }
+            _ => panic!("unexpected response type"),
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1356,6 +1356,38 @@ impl Daemon {
         }
     }
 
+    /// Snapshot tokio runtime metrics for diagnostics.
+    ///
+    /// Uses only stable APIs (`worker_total_busy_duration`,
+    /// `worker_park_count`, `num_alive_tasks`, `global_queue_depth`).
+    /// Per-worker steal/poll counts require `tokio_unstable` and are
+    /// omitted to avoid a build-time cfg flag.
+    fn build_runtime_metrics(&self) -> Response {
+        let metrics = tokio::runtime::Handle::current().metrics();
+        let n = metrics.num_workers();
+
+        let uptime = chrono::Utc::now()
+            .signed_duration_since(self.started_at)
+            .to_std()
+            .unwrap_or_default();
+
+        let mut worker_busy_us = Vec::with_capacity(n);
+        let mut worker_park_count = Vec::with_capacity(n);
+        for i in 0..n {
+            worker_busy_us.push(metrics.worker_total_busy_duration(i).as_micros() as u64);
+            worker_park_count.push(metrics.worker_park_count(i));
+        }
+
+        Response::RuntimeMetrics {
+            num_workers: n,
+            num_alive_tasks: metrics.num_alive_tasks(),
+            global_queue_depth: metrics.global_queue_depth(),
+            worker_busy_us,
+            worker_park_count,
+            uptime_us: uptime.as_micros() as u64,
+        }
+    }
+
     /// Get the room eviction delay.
     ///
     /// Returns the eviction delay duration.
@@ -3202,6 +3234,8 @@ impl Daemon {
             },
 
             Request::GetDaemonInfo => self.build_daemon_info().await,
+
+            Request::GetRuntimeMetrics => self.build_runtime_metrics(),
 
             Request::Shutdown => {
                 self.trigger_shutdown().await;


### PR DESCRIPTION
## Summary

- Add `GetRuntimeMetrics` request/response to the pool IPC protocol
- Daemon snapshots tokio `RuntimeMetrics` (stable API, no `tokio_unstable` needed): per-worker busy duration, park count, alive tasks, global queue depth
- Client computes per-worker utilization percentage from `busy_us / uptime_us`
- `runt daemon status --json` includes a new `runtime_metrics` section with worker-level detail

This lets us measure whether the daemon's async runtime is spreading work across cores under concurrent load — directly feeding batch concurrency scaling decisions.

### Example output (in `daemon status --json`)

```json
"runtime_metrics": {
  "num_workers": 8,
  "num_alive_tasks": 42,
  "global_queue_depth": 0,
  "uptime_us": 3600000000,
  "workers": [
    { "busy_us": 180000000, "park_count": 1200, "utilization_pct": 5.0 },
    { "busy_us": 360000000, "park_count": 800, "utilization_pct": 10.0 },
    ...
  ]
}
```

## Test plan

- [x] Protocol roundtrip tests for `GetRuntimeMetrics` request and `RuntimeMetrics` response
- [x] All 191 `runtimed-client` tests pass
- [x] `cargo xtask lint --fix` clean
- [ ] Manual: `runt-nightly daemon status --json | jq .runtime_metrics` on nightly install