### PR TITLE
docs(npm): polish package publishing metadata

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with trusted publishing support
         run: npm install -g npm@latest
@@ -87,6 +88,7 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with trusted publishing support
         run: npm install -g npm@latest
@@ -119,6 +121,7 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with trusted publishing support
         run: npm install -g npm@latest

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -1,0 +1,85 @@
+# @runtimed/node
+
+Node.js bindings for the nteract `runtimed` daemon. This package lets Node,
+Bun, and other CommonJS-compatible runtimes create notebooks, run Python cells,
+queue executions, read outputs, save notebooks, and manage notebook dependencies
+through the same local daemon used by nteract desktop.
+
+## Install
+
+```bash
+npm install @runtimed/node
+```
+
+`@runtimed/node` ships a small JavaScript wrapper plus TypeScript declarations.
+The native binding is installed through an optional platform package such as
+`@runtimed/node-darwin-arm64` or `@runtimed/node-linux-x64-gnu`.
+
+## Basic Usage
+
+```js
+const { createNotebook, defaultSocketPath } = require("@runtimed/node");
+
+async function main() {
+  const session = await createNotebook({
+    runtime: "python",
+    workingDir: process.cwd(),
+  });
+
+  try {
+    console.log("daemon socket:", defaultSocketPath());
+
+    const result = await session.runCell("sum(range(10))");
+    console.log(result.status);
+    console.log(result.outputs);
+
+    await session.saveNotebook();
+  } finally {
+    await session.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+```
+
+## API Surface
+
+- `defaultSocketPath()` returns the socket path for the current nteract channel
+  or the `RUNTIMED_SOCKET_PATH` override.
+- `socketPathForChannel("stable" | "nightly")` returns a channel-specific
+  daemon socket path.
+- `createNotebook(options)` creates a notebook and starts a runtime.
+- `openNotebook(notebookId, options)` connects to an existing notebook.
+- `getExecutionResult(executionId, options)` reads a result by execution ID.
+- `Session.runCell(source, options)` creates, runs, and waits for a cell.
+- `Session.queueCell(source, options)` queues a cell and returns IDs.
+- `Session.waitForExecution(executionId, options)` waits for queued work.
+- `Session.addUvDependency(spec)` records a UV dependency for the notebook.
+- `Session.syncEnvironment()` installs recorded notebook dependencies.
+- `Session.saveNotebook(path?)` saves the notebook.
+- `Session.close()` releases the daemon connection.
+
+## Daemon Requirements
+
+The package talks to a local `runtimed` daemon over its Unix socket. In a
+development checkout, run the per-worktree daemon before using the bindings:
+
+```bash
+cargo xtask dev-daemon
+```
+
+Published nteract desktop builds manage their own daemon. Set
+`RUNTIMED_SOCKET_PATH` when you need to connect to a specific daemon instance.
+
+## Platform Packages
+
+The platform packages are implementation details and should normally be
+installed through `@runtimed/node`:
+
+- `@runtimed/node-darwin-arm64`
+- `@runtimed/node-linux-x64-gnu`
+
+They contain only the compiled native `.node` binary for their target platform.

--- a/packages/runtimed-node/npm/darwin-arm64/README.md
+++ b/packages/runtimed-node/npm/darwin-arm64/README.md
@@ -1,0 +1,11 @@
+# @runtimed/node-darwin-arm64
+
+Native macOS arm64 binding for `@runtimed/node`.
+
+This package contains the compiled N-API `.node` binary used by
+`@runtimed/node` on Apple Silicon Macs. Install `@runtimed/node` directly unless
+you are debugging or publishing the platform package itself.
+
+```bash
+npm install @runtimed/node
+```

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runtimed/node-darwin-arm64",
   "version": "0.0.1",
-  "description": "macOS arm64 native binding for @runtimed/node",
+  "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",
   "license": "BSD-3-Clause",
@@ -10,6 +10,19 @@
     "url": "git+https://github.com/nteract/desktop.git",
     "directory": "packages/runtimed-node/npm/darwin-arm64"
   },
+  "homepage": "https://github.com/nteract/desktop/tree/main/packages/runtimed-node#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/desktop/issues"
+  },
+  "keywords": [
+    "nteract",
+    "runtimed",
+    "notebook",
+    "native",
+    "napi-rs",
+    "darwin",
+    "arm64"
+  ],
   "os": [
     "darwin"
   ],
@@ -17,6 +30,7 @@
     "arm64"
   ],
   "files": [
+    "README.md",
     "runtimed-node.darwin-arm64.node"
   ],
   "scripts": {

--- a/packages/runtimed-node/npm/linux-x64-gnu/README.md
+++ b/packages/runtimed-node/npm/linux-x64-gnu/README.md
@@ -1,0 +1,11 @@
+# @runtimed/node-linux-x64-gnu
+
+Native Linux x64 GNU binding for `@runtimed/node`.
+
+This package contains the compiled N-API `.node` binary used by
+`@runtimed/node` on glibc-based Linux x64 systems. Install `@runtimed/node`
+directly unless you are debugging or publishing the platform package itself.
+
+```bash
+npm install @runtimed/node
+```

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
   "version": "0.0.1",
-  "description": "Linux x64 GNU native binding for @runtimed/node",
+  "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",
   "license": "BSD-3-Clause",
@@ -10,6 +10,20 @@
     "url": "git+https://github.com/nteract/desktop.git",
     "directory": "packages/runtimed-node/npm/linux-x64-gnu"
   },
+  "homepage": "https://github.com/nteract/desktop/tree/main/packages/runtimed-node#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/desktop/issues"
+  },
+  "keywords": [
+    "nteract",
+    "runtimed",
+    "notebook",
+    "native",
+    "napi-rs",
+    "linux",
+    "x64",
+    "glibc"
+  ],
   "os": [
     "linux"
   ],
@@ -20,6 +34,7 @@
     "glibc"
   ],
   "files": [
+    "README.md",
     "runtimed-node.linux-x64-gnu.node"
   ],
   "scripts": {

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runtimed/node",
   "version": "0.0.1",
-  "description": "Node.js bindings for the runtimed daemon client (napi-rs).",
+  "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",
   "repository": {
@@ -9,6 +9,19 @@
     "url": "git+https://github.com/nteract/desktop.git",
     "directory": "packages/runtimed-node"
   },
+  "homepage": "https://github.com/nteract/desktop/tree/main/packages/runtimed-node#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/desktop/issues"
+  },
+  "keywords": [
+    "nteract",
+    "runtimed",
+    "notebook",
+    "jupyter",
+    "python",
+    "kernel",
+    "napi-rs"
+  ],
   "main": "./src/index.cjs",
   "types": "./src/index.d.ts",
   "exports": {
@@ -19,6 +32,7 @@
     }
   },
   "files": [
+    "README.md",
     "src/index.cjs",
     "src/index.d.ts",
     "src/binding.cjs",

--- a/plugins/nteract/pi/README.md
+++ b/plugins/nteract/pi/README.md
@@ -1,21 +1,25 @@
 # @nteract/pi
 
-Pi extensions for nteract.
+Pi extensions for running Python through the local nteract `runtimed` daemon.
+The package provides a persistent notebook-backed REPL for coding agents and
+terminal workflows that need stateful Python execution.
 
 ## Extensions
 
-- `extensions/repl.ts` registers a persistent `python` tool backed by the local
-  nteract `runtimed` daemon through `@runtimed/node`.
-- It also registers `python_add_dependencies`, `python_save_notebook`, and
-  `/python-reset`.
+- `extensions/repl.ts` registers a persistent `python` tool backed by
+  `@runtimed/node`.
+- `python_add_dependencies` records notebook UV dependencies.
+- `python_save_notebook` saves the backing notebook.
+- `/python-reset` starts a fresh notebook session.
 
 ## Install
-
-Once published:
 
 ```bash
 pi install npm:@nteract/pi@next
 ```
+
+Use the `next` tag for prerelease builds until the package is promoted to the
+default npm tag.
 
 ## Local Use
 

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nteract/pi",
   "version": "0.0.1",
-  "description": "nteract extensions for Pi",
+  "description": "Pi extensions that run Python through the local nteract runtimed daemon.",
   "type": "module",
   "license": "BSD-3-Clause",
   "repository": {
@@ -9,12 +9,19 @@
     "url": "git+https://github.com/nteract/desktop.git",
     "directory": "plugins/nteract/pi"
   },
+  "homepage": "https://github.com/nteract/desktop/tree/main/plugins/nteract/pi#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/desktop/issues"
+  },
   "keywords": [
     "pi-package",
     "nteract",
+    "runtimed",
     "notebook",
     "python",
-    "repl"
+    "repl",
+    "jupyter",
+    "agent"
   ],
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

- Add npm-facing READMEs for `@runtimed/node` and its native platform packages.
- Improve npm package descriptions, keywords, homepage, and issue metadata for the runtimed Node bindings and `@nteract/pi`.
- Pin the npm registry in the manual `publish-npm.yml` workflow for trusted-publishing runs.

## Verification

- `node -e "for (const f of ['packages/runtimed-node/package.json','packages/runtimed-node/npm/darwin-arm64/package.json','packages/runtimed-node/npm/linux-x64-gnu/package.json','plugins/nteract/pi/package.json']) JSON.parse(require('node:fs').readFileSync(f,'utf8')); console.log('package json ok')"`
- `pnpm --dir plugins/nteract/pi pack:dry-run`
- `pnpm --dir packages/runtimed-node build`
- `pnpm --dir packages/runtimed-node pack:dry-run`
- `pnpm --dir packages/runtimed-node assemble:platform -- --expected-target darwin-arm64`
- `pnpm --dir packages/runtimed-node/npm/darwin-arm64 pack:dry-run`
- `git diff --check`

Linux native package dry-run is covered by the Linux CI matrix because the local checkout can only assemble the macOS arm64 native package.
