### PR TITLE
perf(xtask): skip volatile wasm rebuild when notebook --attach

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -448,10 +448,15 @@ fn cmd_notebook(notebook: Option<&str>, attach: bool) {
     require_pnpm();
     require_tauri();
 
-    // Vite's isolated-renderer plugin reads the gitignored renderer-plugin
-    // outputs as virtual modules; missing files become empty strings and
-    // every plugin renders blank. Build them once on fresh clones.
-    ensure_build_artifacts();
+    // In --attach mode Tauri points at an already-running Vite dev server.
+    // That Vite process owns the renderer-plugin virtual modules and the
+    // runtimed-wasm bindings; our rebuilds here would just duplicate work
+    // it's already watching for. Skip the force-rebuild cost in that case.
+    // Without --attach, Tauri boots its own Vite, and we still need fresh
+    // artifacts before the TS compile fires.
+    if !attach {
+        ensure_build_artifacts();
+    }
 
     // Always use dev mode to prevent the Tauri app from auto-installing
     // the dev binary as the system daemon sidecar — that would clobber


### PR DESCRIPTION
`cargo xtask notebook --attach` points Tauri at an already-running Vite dev server (spawned by `cargo xtask vite` or nteract-dev `up vite=true`). That Vite process owns the isolated-renderer virtual modules and the runtimed-wasm bindings end-to-end: it watches the Rust sources, rebuilds wasm-pack outputs on change, and HMRs the TS side. Rebuilding them again in xtask before the attach just duplicates work Vite will redo itself. 6-10s on a warm tree, more on sift-wasm because of the parquet chain.

The stale-binding footgun this was added to catch (merged in #2464) still applies to `cargo xtask build` and bare `cargo xtask notebook` - the force-rebuild closes the window wherever xtask is the only thing running wasm-pack. `--attach` is the one path where another process owns the window.

Context on why this is a real papercut: the author's standing flow is `cargo xtask dev-daemon` in one terminal and `cargo xtask notebook --attach` (against a separately-run Vite) in another, because `cargo xtask dev` and bare `cargo xtask notebook` aren't trustworthy. Every `notebook --attach` restart paid the force-rebuild tax for nothing.

Related future DX work (not in this PR): see #2222 for `show_notebook` + `--attach` coexistence, and a potential `cargo xtask up` / `down` that wraps the same supervisor logic `nteract-dev` uses so the two-terminal dance can collapse to one.
