### PR TITLE
feat(runtime-agent): surface hot-sync env-progress via RuntimeStateDoc

### DIFF
--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -122,6 +122,13 @@ pub async fn run_runtime_agent(
     let mut seen_execution_ids = HashSet::new();
     let mut cmd_rx: Option<mpsc::Receiver<QueueCommand>> = None;
 
+    // Async responses from spawned tasks (currently: SyncEnvironment).
+    // Keeping these off the request handler's await frees the main loop to
+    // forward state_changed_rx frames while `sync_dependencies` runs, so the
+    // progress banner updates live instead of collapsing to one final write.
+    let (async_response_tx, mut async_response_rx) =
+        mpsc::channel::<notebook_protocol::protocol::RuntimeAgentResponseEnvelope>(4);
+
     info!("[runtime-agent] Infrastructure ready, entering main loop");
 
     // -- 4. Main event loop -------------------------------------------------
@@ -164,6 +171,39 @@ pub async fn run_runtime_agent(
                                         } else {
                                             warn!("[runtime-agent] Interrupt requested but no kernel running");
                                         }
+                                        continue;
+                                    }
+
+                                    // SyncEnvironment runs `uv`/`conda` install, which can take
+                                    // seconds. Handling it inline would starve the
+                                    // state_changed_rx arm, so the coordinator wouldn't see
+                                    // Installing/Solving/Download events until the install
+                                    // finished. Snapshot the launched config and spawn.
+                                    if let RuntimeAgentRequest::SyncEnvironment(env_kind) =
+                                        &envelope.request
+                                    {
+                                        let snapshot = kernel
+                                            .as_ref()
+                                            .map(|k| (k.env_source().to_string(), k.launched_config().clone()));
+                                        let env_kind = env_kind.clone();
+                                        let id = envelope.id.clone();
+                                        let state_for_task = ctx.state.clone();
+                                        let tx = async_response_tx.clone();
+                                        tokio::spawn(async move {
+                                            let response = run_sync_environment(
+                                                env_kind,
+                                                snapshot,
+                                                state_for_task,
+                                            )
+                                            .await;
+                                            let envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
+                                                id,
+                                                response,
+                                            };
+                                            if tx.send(envelope).await.is_err() {
+                                                warn!("[runtime-agent] SyncEnvironment response channel closed before send");
+                                            }
+                                        });
                                         continue;
                                     }
 
@@ -403,6 +443,25 @@ pub async fn run_runtime_agent(
                     ).await {
                         warn!("[runtime-agent] Failed to send RuntimeStateSync: {}", e);
                         break;
+                    }
+                }
+            }
+
+            // Responses from long-running spawned tasks (SyncEnvironment).
+            Some(envelope) = async_response_rx.recv() => {
+                match serde_json::to_vec(&envelope) {
+                    Ok(json) => {
+                        if let Err(e) = send_typed_frame(
+                            &mut writer,
+                            NotebookFrameType::Response,
+                            &json,
+                        ).await {
+                            warn!("[runtime-agent] Failed to send async response: {}", e);
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        warn!("[runtime-agent] Failed to serialize async response: {}", e);
                     }
                 }
             }
@@ -823,138 +882,148 @@ async fn handle_runtime_agent_request(
             }
         }
 
-        RuntimeAgentRequest::SyncEnvironment(env_kind) => {
-            info!(
-                "[runtime-agent] SyncEnvironment: installing {:?}",
-                env_kind.packages()
-            );
+        RuntimeAgentRequest::SyncEnvironment(_) => {
+            // The main select loop intercepts SyncEnvironment and spawns
+            // `run_sync_environment` so it doesn't block state sync. This
+            // arm is unreachable in practice, but keeps the match exhaustive.
+            (
+                RuntimeAgentResponse::Error {
+                    error: "SyncEnvironment must be dispatched through run_sync_environment"
+                        .to_string(),
+                },
+                None,
+            )
+        }
+    }
+}
 
-            if let Some(ref kernel_ref) = kernel {
-                let es = kernel_ref.env_source().to_string();
+/// Run a hot-sync install outside the main select loop.
+///
+/// The caller snapshots the kernel's `(env_source, launched_config)` before
+/// spawning so we don't borrow the kernel across the install. Progress phases
+/// flow through [`RuntimeDocProgressHandler`] into the runtime-agent's
+/// RuntimeStateDoc, which the main loop forwards to the coordinator live.
+async fn run_sync_environment(
+    env_kind: notebook_protocol::protocol::EnvKind,
+    kernel_snapshot: Option<(String, notebook_protocol::protocol::LaunchedEnvConfig)>,
+    state: RuntimeStateHandle,
+) -> RuntimeAgentResponse {
+    info!(
+        "[runtime-agent] SyncEnvironment: installing {:?}",
+        env_kind.packages()
+    );
 
-                // Deno doesn't support hot-sync — requires kernel restart
-                if es == "deno" {
-                    return (
-                        RuntimeAgentResponse::Error {
-                            error: "Hot-sync not supported for Deno environments. Kernel restart required.".to_string(),
+    let Some((es, launched)) = kernel_snapshot else {
+        return RuntimeAgentResponse::Error {
+            error: "No kernel running".to_string(),
+        };
+    };
+
+    // Deno doesn't support hot-sync — requires kernel restart.
+    if es == "deno" {
+        return RuntimeAgentResponse::Error {
+            error: "Hot-sync not supported for Deno environments. Kernel restart required."
+                .to_string(),
+        };
+    }
+
+    let Some(venv_path) = launched.venv_path.clone() else {
+        return RuntimeAgentResponse::Error {
+            error: "No venv path available".to_string(),
+        };
+    };
+    let Some(python_path) = launched.python_path.clone() else {
+        return RuntimeAgentResponse::Error {
+            error: "No python path available".to_string(),
+        };
+    };
+
+    let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
+        crate::inline_env::RuntimeDocProgressHandler::new(state.clone()),
+    );
+
+    match env_kind {
+        notebook_protocol::protocol::EnvKind::Uv { packages } => {
+            let uv_env = kernel_env::uv::UvEnvironment {
+                venv_path: venv_path.clone(),
+                python_path: python_path.clone(),
+            };
+            match kernel_env::uv::sync_dependencies(&uv_env, &packages, handler.clone()).await {
+                Ok(()) => {
+                    // Terminal Ready phase so the frontend banner clears.
+                    // `sync_dependencies` emits InstallComplete, which is not a
+                    // terminal state for `projectEnvProgress`; Ready is.
+                    handler.on_progress(
+                        "uv",
+                        kernel_env::EnvProgressPhase::Ready {
+                            env_path: venv_path.to_string_lossy().into_owned(),
+                            python_path: python_path.to_string_lossy().into_owned(),
                         },
-                        None,
                     );
-                }
-
-                // Get venv and python paths from the kernel's launched config
-                let launched = kernel_ref.launched_config();
-                let venv_path = match &launched.venv_path {
-                    Some(p) => p.clone(),
-                    None => {
-                        return (
-                            RuntimeAgentResponse::Error {
-                                error: "No venv path available".to_string(),
-                            },
-                            None,
-                        );
-                    }
-                };
-                let python_path = match &launched.python_path {
-                    Some(p) => p.clone(),
-                    None => {
-                        return (
-                            RuntimeAgentResponse::Error {
-                                error: "No python path available".to_string(),
-                            },
-                            None,
-                        );
-                    }
-                };
-
-                match env_kind {
-                    notebook_protocol::protocol::EnvKind::Uv { packages } => {
-                        let uv_env = kernel_env::uv::UvEnvironment {
-                            venv_path,
-                            python_path,
-                        };
-
-                        // Write progress phases into the runtime-agent's local
-                        // RuntimeStateDoc. The coordinator sync loop forwards them to the
-                        // room's authoritative doc, so the frontend banner tracks hot-sync
-                        // the same way it tracks auto-launch.
-                        let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
-                            std::sync::Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
-                                ctx.state.clone(),
-                            ));
-                        match kernel_env::uv::sync_dependencies(&uv_env, &packages, handler).await {
-                            Ok(()) => (
-                                RuntimeAgentResponse::EnvironmentSynced {
-                                    synced_packages: packages,
-                                },
-                                None,
-                            ),
-                            Err(e) => {
-                                error!(
-                                    "[runtime-agent] Failed to sync UV packages {:?}: {}",
-                                    packages, e
-                                );
-                                (
-                                    RuntimeAgentResponse::Error {
-                                        error: format!("Failed to install packages: {}", e),
-                                    },
-                                    None,
-                                )
-                            }
-                        }
-                    }
-                    notebook_protocol::protocol::EnvKind::Conda { packages, channels } => {
-                        let conda_env = kernel_env::conda::CondaEnvironment {
-                            env_path: venv_path,
-                            python_path,
-                        };
-
-                        let conda_deps = kernel_env::conda::CondaDependencies {
-                            dependencies: packages.clone(),
-                            channels: if channels.is_empty() {
-                                vec!["conda-forge".to_string()]
-                            } else {
-                                channels
-                            },
-                            python: None,
-                            env_id: None,
-                        };
-
-                        let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
-                            std::sync::Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
-                                ctx.state.clone(),
-                            ));
-                        match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps, handler)
-                            .await
-                        {
-                            Ok(()) => (
-                                RuntimeAgentResponse::EnvironmentSynced {
-                                    synced_packages: packages,
-                                },
-                                None,
-                            ),
-                            Err(e) => {
-                                error!(
-                                    "[runtime-agent] Failed to sync Conda packages {:?} with channels {:?}: {}",
-                                    packages, conda_deps.channels, e
-                                );
-                                (
-                                    RuntimeAgentResponse::Error {
-                                        error: format!("Failed to install packages: {}", e),
-                                    },
-                                    None,
-                                )
-                            }
-                        }
+                    RuntimeAgentResponse::EnvironmentSynced {
+                        synced_packages: packages,
                     }
                 }
-            } else {
-                (
-                    RuntimeAgentResponse::Error {
-                        error: "No kernel running".to_string(),
-                    },
-                    None,
-                )
+                Err(e) => {
+                    error!(
+                        "[runtime-agent] Failed to sync UV packages {:?}: {}",
+                        packages, e
+                    );
+                    let msg = format!("Failed to install packages: {}", e);
+                    handler.on_progress(
+                        "uv",
+                        kernel_env::EnvProgressPhase::Error {
+                            message: msg.clone(),
+                        },
+                    );
+                    RuntimeAgentResponse::Error { error: msg }
+                }
+            }
+        }
+        notebook_protocol::protocol::EnvKind::Conda { packages, channels } => {
+            let conda_env = kernel_env::conda::CondaEnvironment {
+                env_path: venv_path.clone(),
+                python_path: python_path.clone(),
+            };
+            let conda_deps = kernel_env::conda::CondaDependencies {
+                dependencies: packages.clone(),
+                channels: if channels.is_empty() {
+                    vec!["conda-forge".to_string()]
+                } else {
+                    channels
+                },
+                python: None,
+                env_id: None,
+            };
+            match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps, handler.clone())
+                .await
+            {
+                Ok(()) => {
+                    handler.on_progress(
+                        "conda",
+                        kernel_env::EnvProgressPhase::Ready {
+                            env_path: venv_path.to_string_lossy().into_owned(),
+                            python_path: python_path.to_string_lossy().into_owned(),
+                        },
+                    );
+                    RuntimeAgentResponse::EnvironmentSynced {
+                        synced_packages: packages,
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "[runtime-agent] Failed to sync Conda packages {:?} with channels {:?}: {}",
+                        packages, conda_deps.channels, e
+                    );
+                    let msg = format!("Failed to install packages: {}", e);
+                    handler.on_progress(
+                        "conda",
+                        kernel_env::EnvProgressPhase::Error {
+                            message: msg.clone(),
+                        },
+                    );
+                    RuntimeAgentResponse::Error { error: msg }
+                }
             }
         }
     }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -266,40 +266,37 @@ pub async fn run_runtime_agent(
                                     // handler treats it as best-effort, but it still bumps
                                     // the generation so the sync task will skip terminal
                                     // Ready/Error writes after the kernel is gone.
-                                    if matches!(
-                                        envelope.request,
+                                    let is_launch_or_restart = matches!(
+                                        &envelope.request,
                                         RuntimeAgentRequest::LaunchKernel { .. }
                                             | RuntimeAgentRequest::RestartKernel { .. }
-                                    ) {
-                                        if inflight_sync.is_some() {
-                                            if let Err(e) = send_runtime_agent_response(
-                                                &mut writer,
-                                                envelope.id.clone(),
-                                                RuntimeAgentResponse::Error {
-                                                    error: "Environment sync in progress; retry after it completes"
-                                                        .to_string(),
-                                                },
-                                            )
-                                            .await
-                                            {
-                                                warn!(
-                                                    "[runtime-agent] Failed to send lifecycle busy response: {}",
-                                                    e
-                                                );
-                                                break;
-                                            }
-                                            continue;
+                                    );
+                                    if is_launch_or_restart && inflight_sync.is_some() {
+                                        if let Err(e) = send_runtime_agent_response(
+                                            &mut writer,
+                                            envelope.id.clone(),
+                                            RuntimeAgentResponse::Error {
+                                                error: "Environment sync in progress; retry after it completes"
+                                                    .to_string(),
+                                            },
+                                        )
+                                        .await
+                                        {
+                                            warn!(
+                                                "[runtime-agent] Failed to send lifecycle busy response: {}",
+                                                e
+                                            );
+                                            break;
                                         }
+                                        continue;
                                     }
 
-                                    if matches!(envelope.request, RuntimeAgentRequest::ShutdownKernel) {
-                                        sync_generation
-                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                                    } else if matches!(
-                                        envelope.request,
-                                        RuntimeAgentRequest::LaunchKernel { .. }
-                                            | RuntimeAgentRequest::RestartKernel { .. }
-                                    ) {
+                                    if is_launch_or_restart
+                                        || matches!(
+                                            &envelope.request,
+                                            RuntimeAgentRequest::ShutdownKernel
+                                        )
+                                    {
                                         sync_generation
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                     }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -874,11 +874,14 @@ async fn handle_runtime_agent_request(
                             python_path,
                         };
 
-                        // Runtime-agent hot-sync path has no progress channel back to
-                        // the coordinator yet. Route to logs only; follow-up can thread
-                        // this through the agent's sync connection.
+                        // Write progress phases into the runtime-agent's local
+                        // RuntimeStateDoc. The coordinator sync loop forwards them to the
+                        // room's authoritative doc, so the frontend banner tracks hot-sync
+                        // the same way it tracks auto-launch.
                         let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
-                            std::sync::Arc::new(kernel_env::LogHandler);
+                            std::sync::Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
+                                ctx.state.clone(),
+                            ));
                         match kernel_env::uv::sync_dependencies(&uv_env, &packages, handler).await {
                             Ok(()) => (
                                 RuntimeAgentResponse::EnvironmentSynced {
@@ -918,7 +921,9 @@ async fn handle_runtime_agent_request(
                         };
 
                         let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
-                            std::sync::Arc::new(kernel_env::LogHandler);
+                            std::sync::Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
+                                ctx.state.clone(),
+                            ));
                         match kernel_env::conda::sync_dependencies(&conda_env, &conda_deps, handler)
                             .await
                         {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -129,10 +129,11 @@ pub async fn run_runtime_agent(
     let (async_response_tx, mut async_response_rx) =
         mpsc::channel::<notebook_protocol::protocol::RuntimeAgentResponseEnvelope>(4);
 
-    // In-flight env-sync task. A new SyncEnvironment aborts any prior task,
-    // and each kernel lifecycle transition (LaunchKernel, ShutdownKernel,
-    // RestartKernel) bumps `sync_generation` so stale tasks don't write
-    // terminal env-progress or EnvironmentSynced against a newer kernel.
+    // In-flight env-sync task. Only one SyncEnvironment may run at a time;
+    // overlapping env mutations race on the same prefix. Launch/restart is
+    // rejected while a sync is active for the same reason. Shutdown is allowed,
+    // but it invalidates the sync generation so terminal progress does not
+    // claim the now-shutdown kernel is ready.
     //
     // The atomic is shared between the main loop (which bumps it) and each
     // spawned task (which compares its captured generation before emitting
@@ -191,16 +192,31 @@ pub async fn run_runtime_agent(
                                     // Installing/Solving/Download events until the install
                                     // finished. Snapshot the launched config and spawn.
                                     //
-                                    // Cancel any in-flight sync: the coordinator only expects
-                                    // one active install at a time, and overlapping tasks
-                                    // would race on the same env prefix. Bump the generation
-                                    // so the aborted task's pending writes (and any stale
-                                    // state events already in flight) are ignored.
+                                    // Reject overlapping syncs rather than aborting the task:
+                                    // tokio::process children keep running when their waiting
+                                    // future is dropped, so aborting would not stop the uv
+                                    // install that is mutating the environment prefix.
                                     if let RuntimeAgentRequest::SyncEnvironment(env_kind) =
                                         &envelope.request
                                     {
-                                        if let Some(prev) = inflight_sync.take() {
-                                            prev.abort();
+                                        if inflight_sync.is_some() {
+                                            if let Err(e) = send_runtime_agent_response(
+                                                &mut writer,
+                                                envelope.id.clone(),
+                                                RuntimeAgentResponse::Error {
+                                                    error: "Environment sync already in progress"
+                                                        .to_string(),
+                                                },
+                                            )
+                                            .await
+                                            {
+                                                warn!(
+                                                    "[runtime-agent] Failed to send busy SyncEnvironment response: {}",
+                                                    e
+                                                );
+                                                break;
+                                            }
+                                            continue;
                                         }
                                         let generation = sync_generation
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
@@ -224,38 +240,66 @@ pub async fn run_runtime_agent(
                                                 gen_ref,
                                             )
                                             .await;
-                                            // If the task was superseded, the envelope is
-                                            // dropped so we don't correlate a stale response
-                                            // to the coordinator's newest request id.
-                                            if let Some(response) = response {
-                                                let envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
-                                                    id,
-                                                    response,
-                                                };
-                                                if tx.send(envelope).await.is_err() {
-                                                    warn!(
-                                                        "[runtime-agent] SyncEnvironment response channel closed before send",
-                                                    );
+                                            let response = response.unwrap_or_else(|| {
+                                                RuntimeAgentResponse::Error {
+                                                    error: "Environment sync was superseded"
+                                                        .to_string(),
                                                 }
+                                            });
+                                            let envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
+                                                id,
+                                                response,
+                                            };
+                                            if tx.send(envelope).await.is_err() {
+                                                warn!(
+                                                    "[runtime-agent] SyncEnvironment response channel closed before send",
+                                                );
                                             }
                                         });
                                         inflight_sync = Some(handle);
                                         continue;
                                     }
 
-                                    // Kernel lifecycle transitions invalidate any in-flight
-                                    // env sync: a stale task that finishes after the kernel
-                                    // is gone or swapped would otherwise write Ready/Error
-                                    // into RuntimeStateDoc for the wrong generation.
+                                    // Launch/restart would race against the active prefix
+                                    // mutation, so reject it until the sync task sends its
+                                    // response. Shutdown is allowed because the daemon-side
+                                    // handler treats it as best-effort, but it still bumps
+                                    // the generation so the sync task will skip terminal
+                                    // Ready/Error writes after the kernel is gone.
                                     if matches!(
                                         envelope.request,
                                         RuntimeAgentRequest::LaunchKernel { .. }
                                             | RuntimeAgentRequest::RestartKernel { .. }
-                                            | RuntimeAgentRequest::ShutdownKernel
                                     ) {
-                                        if let Some(prev) = inflight_sync.take() {
-                                            prev.abort();
+                                        if inflight_sync.is_some() {
+                                            if let Err(e) = send_runtime_agent_response(
+                                                &mut writer,
+                                                envelope.id.clone(),
+                                                RuntimeAgentResponse::Error {
+                                                    error: "Environment sync in progress; retry after it completes"
+                                                        .to_string(),
+                                                },
+                                            )
+                                            .await
+                                            {
+                                                warn!(
+                                                    "[runtime-agent] Failed to send lifecycle busy response: {}",
+                                                    e
+                                                );
+                                                break;
+                                            }
+                                            continue;
                                         }
+                                    }
+
+                                    if matches!(envelope.request, RuntimeAgentRequest::ShutdownKernel) {
+                                        sync_generation
+                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                                    } else if matches!(
+                                        envelope.request,
+                                        RuntimeAgentRequest::LaunchKernel { .. }
+                                            | RuntimeAgentRequest::RestartKernel { .. }
+                                    ) {
                                         sync_generation
                                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                     }
@@ -279,12 +323,7 @@ pub async fn run_runtime_agent(
 
                                     // Only send response for queries (not commands)
                                     if !is_command {
-                                        let resp_envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
-                                            id,
-                                            response,
-                                        };
-                                        let json = serde_json::to_vec(&resp_envelope)?;
-                                        send_typed_frame(&mut writer, NotebookFrameType::Response, &json).await?;
+                                        send_runtime_agent_response(&mut writer, id, response).await?;
                                     }
                                 }
                             }
@@ -502,20 +541,10 @@ pub async fn run_runtime_agent(
 
             // Responses from long-running spawned tasks (SyncEnvironment).
             Some(envelope) = async_response_rx.recv() => {
-                match serde_json::to_vec(&envelope) {
-                    Ok(json) => {
-                        if let Err(e) = send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::Response,
-                            &json,
-                        ).await {
-                            warn!("[runtime-agent] Failed to send async response: {}", e);
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        warn!("[runtime-agent] Failed to serialize async response: {}", e);
-                    }
+                inflight_sync = None;
+                if let Err(e) = send_runtime_agent_response_envelope(&mut writer, envelope).await {
+                    warn!("[runtime-agent] Failed to send async response: {}", e);
+                    break;
                 }
             }
         }
@@ -540,6 +569,27 @@ type AgentWriter = tokio::io::WriteHalf<tokio::net::UnixStream>;
 type AgentReader = tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
 #[cfg(windows)]
 type AgentWriter = tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
+
+async fn send_runtime_agent_response(
+    writer: &mut AgentWriter,
+    id: String,
+    response: RuntimeAgentResponse,
+) -> anyhow::Result<()> {
+    send_runtime_agent_response_envelope(
+        writer,
+        notebook_protocol::protocol::RuntimeAgentResponseEnvelope { id, response },
+    )
+    .await
+}
+
+async fn send_runtime_agent_response_envelope(
+    writer: &mut AgentWriter,
+    envelope: notebook_protocol::protocol::RuntimeAgentResponseEnvelope,
+) -> anyhow::Result<()> {
+    let json = serde_json::to_vec(&envelope)?;
+    send_typed_frame(writer, NotebookFrameType::Response, &json).await?;
+    Ok(())
+}
 
 /// Open a stream to the daemon socket and perform the RuntimeAgent
 /// handshake. Extracted from the main startup path so the reconnect

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -129,6 +129,17 @@ pub async fn run_runtime_agent(
     let (async_response_tx, mut async_response_rx) =
         mpsc::channel::<notebook_protocol::protocol::RuntimeAgentResponseEnvelope>(4);
 
+    // In-flight env-sync task. A new SyncEnvironment aborts any prior task,
+    // and each kernel lifecycle transition (LaunchKernel, ShutdownKernel,
+    // RestartKernel) bumps `sync_generation` so stale tasks don't write
+    // terminal env-progress or EnvironmentSynced against a newer kernel.
+    //
+    // The atomic is shared between the main loop (which bumps it) and each
+    // spawned task (which compares its captured generation before emitting
+    // terminal events). u64 wraparound is a non-issue in practice.
+    let sync_generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let mut inflight_sync: Option<tokio::task::JoinHandle<()>> = None;
+
     info!("[runtime-agent] Infrastructure ready, entering main loop");
 
     // -- 4. Main event loop -------------------------------------------------
@@ -179,32 +190,74 @@ pub async fn run_runtime_agent(
                                     // state_changed_rx arm, so the coordinator wouldn't see
                                     // Installing/Solving/Download events until the install
                                     // finished. Snapshot the launched config and spawn.
+                                    //
+                                    // Cancel any in-flight sync: the coordinator only expects
+                                    // one active install at a time, and overlapping tasks
+                                    // would race on the same env prefix. Bump the generation
+                                    // so the aborted task's pending writes (and any stale
+                                    // state events already in flight) are ignored.
                                     if let RuntimeAgentRequest::SyncEnvironment(env_kind) =
                                         &envelope.request
                                     {
-                                        let snapshot = kernel
-                                            .as_ref()
-                                            .map(|k| (k.env_source().to_string(), k.launched_config().clone()));
+                                        if let Some(prev) = inflight_sync.take() {
+                                            prev.abort();
+                                        }
+                                        let generation = sync_generation
+                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                                            .wrapping_add(1);
+
+                                        let snapshot = kernel.as_ref().map(|k| {
+                                            (k.env_source().to_string(), k.launched_config().clone())
+                                        });
                                         let env_kind = env_kind.clone();
                                         let id = envelope.id.clone();
                                         let state_for_task = ctx.state.clone();
                                         let tx = async_response_tx.clone();
-                                        tokio::spawn(async move {
+                                        let gen_ref = sync_generation.clone();
+
+                                        let handle = tokio::spawn(async move {
                                             let response = run_sync_environment(
                                                 env_kind,
                                                 snapshot,
                                                 state_for_task,
+                                                generation,
+                                                gen_ref,
                                             )
                                             .await;
-                                            let envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
-                                                id,
-                                                response,
-                                            };
-                                            if tx.send(envelope).await.is_err() {
-                                                warn!("[runtime-agent] SyncEnvironment response channel closed before send");
+                                            // If the task was superseded, the envelope is
+                                            // dropped so we don't correlate a stale response
+                                            // to the coordinator's newest request id.
+                                            if let Some(response) = response {
+                                                let envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
+                                                    id,
+                                                    response,
+                                                };
+                                                if tx.send(envelope).await.is_err() {
+                                                    warn!(
+                                                        "[runtime-agent] SyncEnvironment response channel closed before send",
+                                                    );
+                                                }
                                             }
                                         });
+                                        inflight_sync = Some(handle);
                                         continue;
+                                    }
+
+                                    // Kernel lifecycle transitions invalidate any in-flight
+                                    // env sync: a stale task that finishes after the kernel
+                                    // is gone or swapped would otherwise write Ready/Error
+                                    // into RuntimeStateDoc for the wrong generation.
+                                    if matches!(
+                                        envelope.request,
+                                        RuntimeAgentRequest::LaunchKernel { .. }
+                                            | RuntimeAgentRequest::RestartKernel { .. }
+                                            | RuntimeAgentRequest::ShutdownKernel
+                                    ) {
+                                        if let Some(prev) = inflight_sync.take() {
+                                            prev.abort();
+                                        }
+                                        sync_generation
+                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                                     }
 
                                     let is_command = envelope.request.is_command();
@@ -903,39 +956,51 @@ async fn handle_runtime_agent_request(
 /// spawning so we don't borrow the kernel across the install. Progress phases
 /// flow through [`RuntimeDocProgressHandler`] into the runtime-agent's
 /// RuntimeStateDoc, which the main loop forwards to the coordinator live.
+///
+/// `generation` is the sync generation this task owns; `current_generation`
+/// is a shared atomic bumped by the main loop on kernel lifecycle transitions
+/// and on any newer SyncEnvironment request. Returning `None` signals the task
+/// was superseded: the caller drops the response so a stale id doesn't
+/// correlate to the coordinator's latest request, and the final Ready/Error
+/// is skipped so we don't clobber a fresher `env.progress` write.
 async fn run_sync_environment(
     env_kind: notebook_protocol::protocol::EnvKind,
     kernel_snapshot: Option<(String, notebook_protocol::protocol::LaunchedEnvConfig)>,
     state: RuntimeStateHandle,
-) -> RuntimeAgentResponse {
+    generation: u64,
+    current_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
+) -> Option<RuntimeAgentResponse> {
     info!(
-        "[runtime-agent] SyncEnvironment: installing {:?}",
+        "[runtime-agent] SyncEnvironment[gen={}]: installing {:?}",
+        generation,
         env_kind.packages()
     );
 
+    let is_current = || current_generation.load(std::sync::atomic::Ordering::SeqCst) == generation;
+
     let Some((es, launched)) = kernel_snapshot else {
-        return RuntimeAgentResponse::Error {
+        return Some(RuntimeAgentResponse::Error {
             error: "No kernel running".to_string(),
-        };
+        });
     };
 
     // Deno doesn't support hot-sync — requires kernel restart.
     if es == "deno" {
-        return RuntimeAgentResponse::Error {
+        return Some(RuntimeAgentResponse::Error {
             error: "Hot-sync not supported for Deno environments. Kernel restart required."
                 .to_string(),
-        };
+        });
     }
 
     let Some(venv_path) = launched.venv_path.clone() else {
-        return RuntimeAgentResponse::Error {
+        return Some(RuntimeAgentResponse::Error {
             error: "No venv path available".to_string(),
-        };
+        });
     };
     let Some(python_path) = launched.python_path.clone() else {
-        return RuntimeAgentResponse::Error {
+        return Some(RuntimeAgentResponse::Error {
             error: "No python path available".to_string(),
-        };
+        });
     };
 
     let handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
@@ -950,6 +1015,13 @@ async fn run_sync_environment(
             };
             match kernel_env::uv::sync_dependencies(&uv_env, &packages, handler.clone()).await {
                 Ok(()) => {
+                    if !is_current() {
+                        debug!(
+                            "[runtime-agent] SyncEnvironment[gen={}] superseded before Ready",
+                            generation
+                        );
+                        return None;
+                    }
                     // Terminal Ready phase so the frontend banner clears.
                     // `sync_dependencies` emits InstallComplete, which is not a
                     // terminal state for `projectEnvProgress`; Ready is.
@@ -960,15 +1032,18 @@ async fn run_sync_environment(
                             python_path: python_path.to_string_lossy().into_owned(),
                         },
                     );
-                    RuntimeAgentResponse::EnvironmentSynced {
+                    Some(RuntimeAgentResponse::EnvironmentSynced {
                         synced_packages: packages,
-                    }
+                    })
                 }
                 Err(e) => {
                     error!(
                         "[runtime-agent] Failed to sync UV packages {:?}: {}",
                         packages, e
                     );
+                    if !is_current() {
+                        return None;
+                    }
                     let msg = format!("Failed to install packages: {}", e);
                     handler.on_progress(
                         "uv",
@@ -976,7 +1051,7 @@ async fn run_sync_environment(
                             message: msg.clone(),
                         },
                     );
-                    RuntimeAgentResponse::Error { error: msg }
+                    Some(RuntimeAgentResponse::Error { error: msg })
                 }
             }
         }
@@ -999,6 +1074,13 @@ async fn run_sync_environment(
                 .await
             {
                 Ok(()) => {
+                    if !is_current() {
+                        debug!(
+                            "[runtime-agent] SyncEnvironment[gen={}] superseded before Ready",
+                            generation
+                        );
+                        return None;
+                    }
                     handler.on_progress(
                         "conda",
                         kernel_env::EnvProgressPhase::Ready {
@@ -1006,15 +1088,18 @@ async fn run_sync_environment(
                             python_path: python_path.to_string_lossy().into_owned(),
                         },
                     );
-                    RuntimeAgentResponse::EnvironmentSynced {
+                    Some(RuntimeAgentResponse::EnvironmentSynced {
                         synced_packages: packages,
-                    }
+                    })
                 }
                 Err(e) => {
                     error!(
                         "[runtime-agent] Failed to sync Conda packages {:?} with channels {:?}: {}",
                         packages, conda_deps.channels, e
                     );
+                    if !is_current() {
+                        return None;
+                    }
                     let msg = format!("Failed to install packages: {}", e);
                     handler.on_progress(
                         "conda",
@@ -1022,7 +1107,7 @@ async fn run_sync_environment(
                             message: msg.clone(),
                         },
                     );
-                    RuntimeAgentResponse::Error { error: msg }
+                    Some(RuntimeAgentResponse::Error { error: msg })
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #2465. Surfaces hot-sync env-progress in the frontend banner by routing `SyncEnvironment` through `RuntimeDocProgressHandler` instead of a `LogHandler` stub.

The previous PR flagged this as follow-up because the runtime-agent was thought to have "no progress channel back to the coordinator." It actually does: the agent owns a local `RuntimeStateDoc` that syncs to the coordinator via the `state_changed_rx` loop at `runtime_agent.rs:391`. Every `set_env_progress()` write wakes that loop and ships a `RuntimeStateSync` frame, so progress lands in the room's authoritative doc and the frontend projects it just like auto-launch does.

## Change

Two call sites in `handle_runtime_agent_request` for `SyncEnvironment`, one UV and one conda. Replace:

```rust
let handler = Arc::new(kernel_env::LogHandler);
```

with:

```rust
let handler = Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
    ctx.state.clone(),
));
```

The handler already logs every phase via its internal `LogHandler`, so daemon logs keep the same shape; the new behavior is the CRDT write.

## Verification

Live hot-sync in the UI, kernel backend `uv:prewarmed`, added `humanize` via `manage_dependencies(add=[...], apply=sync)`:

```
18:46:35  SyncEnvironment: installing [..., humanize]
18:46:35  Syncing 7 dependencies to .../envs/3d52d98feb794f92
18:46:35  [uv] Installing 7 packages...         <- Installing phase
18:46:36  [uv] Resolved from local cache        <- OfflineHit phase
18:46:36  [uv] Installation complete in 942ms   <- InstallComplete (terminal)
```

Each `[uv] ...` line is the handler firing both its internal `LogHandler` and the CRDT write on the same call.

## Test plan

- [x] `cargo xtask lint` passes.
- [x] `cargo xtask clippy` passes.
- [x] Manual: UV hot-sync via `manage_dependencies(apply="sync")` shows Installing / OfflineHit / InstallComplete in the frontend banner (previously silent).
- [ ] Manual: conda hot-sync shows the same phases.
