### PR TITLE
feat(runt): expose bootstrap_dx in config set CLI

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -479,6 +479,7 @@ const VALID_CONFIG_KEYS: &[&str] = &[
     "uv_pool_size",
     "conda_pool_size",
     "pixi_pool_size",
+    "bootstrap_dx",
 ];
 
 /// Daemon management commands (replaces Pool + runtimed service commands)


### PR DESCRIPTION
## Summary
- Adds `bootstrap_dx` to the `VALID_CONFIG_KEYS` allowlist in the `runt config set` command
- Enables `runt-nightly config set bootstrap_dx true/false` for toggling the dx/repr-llm kernel bootstrap

## Context
`bootstrap_dx` was already readable via `config list` and persisted in the settings doc, but the CLI's `config set` command rejected it with "Unknown setting" because the key wasn't in the hardcoded allowlist.

Needed so we can toggle it per-gremlin-run to test repr-llm output paths (`text/llm+plain` MIME type).

### What `bootstrap_dx` controls
When `true`, the daemon:
1. Launches kernels via `python -m nteract_kernel_launcher` instead of `ipykernel_launcher`
2. The launcher registers custom display formatters that produce `text/llm+plain` MIME output for DataFrames
3. Vendors `nteract-kernel-launcher` + `dx` packages into kernel environments
4. Injects `PYTHONPATH` pointing to the launcher cache for pool/cache-hit envs

## Test plan
- [x] `cargo build -p runt` clean
- [x] `cargo xtask lint --fix` clean
- [ ] CI green