### PR TITLE
chore(runtimed-node): align platform packages to 0.1.0 and fix bump coverage

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,6 +42,8 @@ jobs:
             runner: macos-latest
           - target: linux-x64-gnu
             runner: ubuntu-latest
+          - target: win32-x64-msvc
+            runner: windows-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -204,6 +204,26 @@ const TARGETS: &[Target] = &[
         format: Format::Json,
         matches: 1,
     },
+    Target {
+        path: "packages/runtimed-node/npm/darwin-arm64/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/runtimed-node/npm/linux-x64-gnu/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/runtimed-node/npm/win32-x64-msvc/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "plugins/nteract/pi/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
     // Python packages
     Target {
         path: "python/nteract/pyproject.toml",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/README.md
+++ b/packages/runtimed-node/npm/win32-x64-msvc/README.md
@@ -1,0 +1,11 @@
+# @runtimed/node-win32-x64-msvc
+
+Native Windows x64 MSVC binding for `@runtimed/node`.
+
+This package contains the compiled N-API `.node` binary used by
+`@runtimed/node` on Windows x64 systems. Install `@runtimed/node` directly
+unless you are debugging or publishing the platform package itself.
+
+```bash
+npm install @runtimed/node
+```

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@runtimed/node-darwin-arm64",
+  "name": "@runtimed/node-win32-x64-msvc",
   "version": "0.1.0",
-  "description": "macOS arm64 native N-API binding for @runtimed/node.",
+  "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
-  "main": "./runtimed-node.darwin-arm64.node",
+  "main": "./runtimed-node.win32-x64-msvc.node",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nteract/desktop.git",
-    "directory": "packages/runtimed-node/npm/darwin-arm64"
+    "directory": "packages/runtimed-node/npm/win32-x64-msvc"
   },
   "homepage": "https://github.com/nteract/desktop/tree/main/packages/runtimed-node#readme",
   "bugs": {
@@ -20,21 +20,22 @@
     "notebook",
     "native",
     "napi-rs",
-    "darwin",
-    "arm64"
+    "win32",
+    "x64",
+    "msvc"
   ],
   "os": [
-    "darwin"
+    "win32"
   ],
   "cpu": [
-    "arm64"
+    "x64"
   ],
   "files": [
     "README.md",
-    "runtimed-node.darwin-arm64.node"
+    "runtimed-node.win32-x64-msvc.node"
   ],
   "scripts": {
-    "prepack": "node -e \"const fs = require('node:fs'); if (!fs.existsSync('runtimed-node.darwin-arm64.node')) { console.error('Run pnpm --dir packages/runtimed-node assemble:platform before packing @runtimed/node-darwin-arm64.'); process.exit(1); }\"",
+    "prepack": "node -e \"const fs = require('node:fs'); if (!fs.existsSync('runtimed-node.win32-x64-msvc.node')) { console.error('Run pnpm --dir packages/runtimed-node assemble:platform before packing @runtimed/node-win32-x64-msvc.'); process.exit(1); }\"",
     "pack:dry-run": "pnpm pack --dry-run"
   },
   "publishConfig": {

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -42,7 +42,8 @@
     "binaryName": "runtimed-node",
     "targets": [
       "aarch64-apple-darwin",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-pc-windows-msvc"
     ]
   },
   "scripts": {
@@ -56,7 +57,8 @@
   },
   "optionalDependencies": {
     "@runtimed/node-darwin-arm64": "workspace:*",
-    "@runtimed/node-linux-x64-gnu": "workspace:*"
+    "@runtimed/node-linux-x64-gnu": "workspace:*",
+    "@runtimed/node-win32-x64-msvc": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -41,6 +41,7 @@
   "napi": {
     "binaryName": "runtimed-node",
     "targets": [
+      "aarch64-apple-darwin",
       "x86_64-unknown-linux-gnu"
     ]
   },

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pi extensions that run Python through the local nteract runtimed daemon.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
       '@runtimed/node-linux-x64-gnu':
         specifier: workspace:*
         version: link:npm/linux-x64-gnu
+      '@runtimed/node-win32-x64-msvc':
+        specifier: workspace:*
+        version: link:npm/win32-x64-msvc
 
   packages/runtimed-node/npm/darwin-arm64: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,8 @@ importers:
 
   packages/runtimed-node/npm/linux-x64-gnu: {}
 
+  packages/runtimed-node/npm/win32-x64-msvc: {}
+
   packages/sift:
     dependencies:
       '@chenglou/pretext':


### PR DESCRIPTION
The 2.4 bump missed the `@runtimed/node` platform packages, `@nteract/pi`, and the bump TARGETS — so the wrapper moved to 0.1.0 while everything around it stayed at 0.0.1.

Changes:

- Bump `@runtimed/node-darwin-arm64`, `@runtimed/node-linux-x64-gnu`, and `@nteract/pi` to 0.1.0
- Add all of those (plus the new win32 package) to `TARGETS` in `bump.rs` so they stay in lockstep
- Add a `@runtimed/node-win32-x64-msvc` platform package. 0.1.0 is already bootstrapped on npm from a local winlab4 build; this PR wires it into `optionalDependencies` and the `publish-npm.yml` matrix
- Fix the stale `napi.targets` list on the wrapper

After merge, trigger `publish-npm.yml` with `tag: latest` to ship `@runtimed/node@0.1.0`, the three natives, and `@nteract/pi@0.1.0`.

_PR submitted by @rgbkrk's agent Quill, via Zed_