### PR TITLE
chore: bump patch versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ]
 }

--- a/.claude/plugins/nteract/.claude-plugin/plugin.json
+++ b/.claude/plugins/nteract/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nteract",
   "description": "Open, run, and edit nteract notebooks from Claude Code",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "automerge",
  "serde_json",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4187,7 +4187,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "libc",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "automerge",
  "automunge",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "automerge",
  "log",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -6969,7 +6969,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -7005,7 +7005,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "hex",
@@ -7020,7 +7020,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7033,7 +7033,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "automerge",
  "automunge",
@@ -7046,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7110,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -7138,7 +7138,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7162,7 +7162,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "kernel-env",
  "log",
@@ -7181,7 +7181,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -7900,7 +7900,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11105,7 +11105,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.4.0"
+version = "2.4.1"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.4.0"
+version = "2.4.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.4.0"
+version = "2.4.1"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license = "BSD-3-Clause"
 repository = "https://github.com/nteract/desktop"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.4.0"
+version = "2.4.1"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository = "https://github.com/nteract/desktop"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pi extensions that run Python through the local nteract runtimed daemon.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.1.0"
+version = "2.1.1"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.3.0"
+version = "0.3.1"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.4.0"
+version = "2.4.1"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.1.0"
+version = "0.1.1"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.4.0"
+version = "2.4.1"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Patch bump across the versioned artifact set via `cargo xtask bump patch`. 48 version fields across 47 files, `Cargo.lock` regenerated.

Covers all of `packages/`, including the `@runtimed/node-{darwin-arm64,linux-x64-gnu,win32-x64-msvc}` ABI variants. The Windows binding never got published at 0.1.0 (chicken-and-egg for OIDC trusted publishing, see [publish-npm run 25243690351](https://github.com/nteract/desktop/actions/runs/25243690351)), so this gives us a clean 0.1.1 for the first real Windows publish.

Branch-only bump; no releasing here.

## Version tiers

| Tier | Old | New |
|------|-----|-----|
| App / daemon / runt / Python top-line | 2.4.0 | 2.4.1 |
| `dx` | 2.1.0 | 2.1.1 |
| Protocol / doc / sync / runt-mcp / wasm / trust / workspace / kernel-\* / nteract-kernel-launcher | 0.3.0 | 0.3.1 |
| Frontend, node bindings, proxy, sift-wasm, nteract-mcp, automunge, runtime-doc, xtask, plugin manifests | 0.2.0 | 0.2.1 |
| `@runtimed/node` + platform packages, `@nteract/sift`, `@nteract/pi`, `prewarm` | 0.1.0 | 0.1.1 |

## Test plan

- [ ] CI green
