### PR TITLE
fix(widgets): coerce ipywidgets Image/Video width+height to CSS pixels

### DIFF
--- a/src/components/widgets/__tests__/css-length.test.ts
+++ b/src/components/widgets/__tests__/css-length.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the ipywidgets length coercion used by ImageWidget and VideoWidget.
+ *
+ * Regression guard: `ipywidgets.Image(width=64)` arrives as the bare string
+ * "64" (because `width` is a `CUnicode` trait), which is not a valid CSS
+ * length. Without coercion, browsers silently fall back to the image's
+ * intrinsic size — e.g. a 1x1 PNG renders invisible.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import { toCssLength } from "../css-length";
+
+describe("toCssLength", () => {
+  it("returns undefined for null / undefined / empty", () => {
+    expect(toCssLength(null)).toBeUndefined();
+    expect(toCssLength(undefined)).toBeUndefined();
+    expect(toCssLength("")).toBeUndefined();
+    expect(toCssLength("   ")).toBeUndefined();
+  });
+
+  it("coerces bare integer strings to pixels (ipywidgets CUnicode case)", () => {
+    expect(toCssLength("64")).toBe("64px");
+    expect(toCssLength("0")).toBe("0px");
+    expect(toCssLength("  128  ")).toBe("128px");
+  });
+
+  it("coerces bare numeric values to pixels", () => {
+    expect(toCssLength(64)).toBe("64px");
+    expect(toCssLength(0)).toBe("0px");
+  });
+
+  it("accepts floating point values", () => {
+    expect(toCssLength("64.5")).toBe("64.5px");
+    expect(toCssLength(64.5)).toBe("64.5px");
+  });
+
+  it("preserves already-qualified CSS lengths verbatim", () => {
+    expect(toCssLength("64px")).toBe("64px");
+    expect(toCssLength("50%")).toBe("50%");
+    expect(toCssLength("10rem")).toBe("10rem");
+    expect(toCssLength("auto")).toBe("auto");
+    expect(toCssLength("fit-content")).toBe("fit-content");
+    expect(toCssLength("calc(100% - 20px)")).toBe("calc(100% - 20px)");
+  });
+
+  it("rejects non-finite numeric input", () => {
+    expect(toCssLength(Number.NaN)).toBeUndefined();
+    expect(toCssLength(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+});

--- a/src/components/widgets/__tests__/layout-utils.test.ts
+++ b/src/components/widgets/__tests__/layout-utils.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for Layout model → CSS extraction, focused on the length-coercion
+ * path shared with `toCssLength`. `ipywidgets.Layout` declares every sizing
+ * trait as `CUnicode`, so `Layout(width=64)` arrives as `"64"` and would
+ * collapse the widget to its intrinsic size without coercion.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import {
+  extractChildGridStyles,
+  extractContainerGridStyles,
+  extractGeneralStyles,
+} from "../layout-utils";
+
+describe("extractGeneralStyles length coercion", () => {
+  it("coerces bare numeric width/height strings to pixels", () => {
+    const style = extractGeneralStyles({ width: "64", height: "64" });
+    expect(style.width).toBe("64px");
+    expect(style.height).toBe("64px");
+  });
+
+  it("coerces numeric width/height values to pixels", () => {
+    const style = extractGeneralStyles({ width: 128, height: 96 });
+    expect(style.width).toBe("128px");
+    expect(style.height).toBe("96px");
+  });
+
+  it("preserves already-qualified lengths verbatim", () => {
+    const style = extractGeneralStyles({
+      width: "50%",
+      height: "10rem",
+      min_width: "64px",
+      max_width: "calc(100% - 20px)",
+    });
+    expect(style.width).toBe("50%");
+    expect(style.height).toBe("10rem");
+    expect(style.minWidth).toBe("64px");
+    expect(style.maxWidth).toBe("calc(100% - 20px)");
+  });
+
+  it("coerces min/max width and height", () => {
+    const style = extractGeneralStyles({
+      min_width: "10",
+      max_width: "200",
+      min_height: "20",
+      max_height: "300",
+    });
+    expect(style.minWidth).toBe("10px");
+    expect(style.maxWidth).toBe("200px");
+    expect(style.minHeight).toBe("20px");
+    expect(style.maxHeight).toBe("300px");
+  });
+
+  it("skips empty and null length values", () => {
+    const style = extractGeneralStyles({
+      width: "",
+      height: null as unknown as string,
+      min_width: undefined as unknown as string,
+    });
+    expect(style.width).toBeUndefined();
+    expect(style.height).toBeUndefined();
+    expect(style.minWidth).toBeUndefined();
+  });
+
+  it("leaves non-length string properties untouched", () => {
+    const style = extractGeneralStyles({
+      display: "flex",
+      overflow: "hidden",
+      margin: "10px",
+      width: "64",
+    });
+    expect(style.display).toBe("flex");
+    expect(style.overflow).toBe("hidden");
+    expect(style.margin).toBe("10px");
+    expect(style.width).toBe("64px");
+  });
+});
+
+describe("extractContainerGridStyles", () => {
+  it("extracts grid container properties in camelCase", () => {
+    const style = extractContainerGridStyles({
+      grid_template_columns: "1fr 2fr",
+      grid_gap: "8px",
+    });
+    expect(style.gridTemplateColumns).toBe("1fr 2fr");
+    expect(style.gridGap).toBe("8px");
+  });
+});
+
+describe("extractChildGridStyles", () => {
+  it("extracts grid child placement in camelCase", () => {
+    const style = extractChildGridStyles({
+      grid_area: "header",
+      grid_row: "1 / 3",
+    });
+    expect(style.gridArea).toBe("header");
+    expect(style.gridRow).toBe("1 / 3");
+  });
+});

--- a/src/components/widgets/controls/image-widget.tsx
+++ b/src/components/widgets/controls/image-widget.tsx
@@ -7,14 +7,15 @@
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { buildMediaSrc } from "../buffer-utils";
+import { toCssLength } from "../css-length";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 
 export function ImageWidget({ modelId, className }: WidgetComponentProps) {
   const value = useWidgetModelValue<string | ArrayBuffer | DataView>(modelId, "value");
   const format = useWidgetModelValue<string>(modelId, "format") ?? "png";
-  const width = useWidgetModelValue<string>(modelId, "width") ?? "";
-  const height = useWidgetModelValue<string>(modelId, "height") ?? "";
+  const width = useWidgetModelValue<string | number>(modelId, "width");
+  const height = useWidgetModelValue<string | number>(modelId, "height");
   const description = useWidgetModelValue<string>(modelId, "description");
 
   const src = buildMediaSrc(value, "image", format);
@@ -23,10 +24,17 @@ export function ImageWidget({ modelId, className }: WidgetComponentProps) {
     return null;
   }
 
-  // Build style object for width/height
+  // ipywidgets Image declares width/height as CUnicode, so `Image(width=64)`
+  // arrives as the bare string "64" — not a valid CSS length. The canonical
+  // ipywidgets JS sets these as HTML attributes (where bare numerics are
+  // pixels); we apply the same coercion so the image has real size instead
+  // of falling back to its 1x1 intrinsic dimensions.
+  const cssWidth = toCssLength(width);
+  const cssHeight = toCssLength(height);
+
   const style: React.CSSProperties = {};
-  if (width) style.width = width;
-  if (height) style.height = height;
+  if (cssWidth) style.width = cssWidth;
+  if (cssHeight) style.height = cssHeight;
 
   return (
     <div

--- a/src/components/widgets/controls/video-widget.tsx
+++ b/src/components/widgets/controls/video-widget.tsx
@@ -8,14 +8,15 @@ import { useMemo } from "react";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { buildMediaSrc } from "../buffer-utils";
+import { toCssLength } from "../css-length";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 
 export function VideoWidget({ modelId, className }: WidgetComponentProps) {
   const value = useWidgetModelValue<string | ArrayBuffer | DataView>(modelId, "value");
   const format = useWidgetModelValue<string>(modelId, "format") ?? "mp4";
-  const width = useWidgetModelValue<string>(modelId, "width") ?? "";
-  const height = useWidgetModelValue<string>(modelId, "height") ?? "";
+  const width = useWidgetModelValue<string | number>(modelId, "width");
+  const height = useWidgetModelValue<string | number>(modelId, "height");
   const autoplay = useWidgetModelValue<boolean>(modelId, "autoplay") ?? true;
   const loop = useWidgetModelValue<boolean>(modelId, "loop") ?? true;
   const controls = useWidgetModelValue<boolean>(modelId, "controls") ?? true;
@@ -27,9 +28,12 @@ export function VideoWidget({ modelId, className }: WidgetComponentProps) {
     return null;
   }
 
+  const cssWidth = toCssLength(width);
+  const cssHeight = toCssLength(height);
+
   const style: React.CSSProperties = {};
-  if (width) style.width = width;
-  if (height) style.height = height;
+  if (cssWidth) style.width = cssWidth;
+  if (cssHeight) style.height = cssHeight;
 
   return (
     <div

--- a/src/components/widgets/controls/video-widget.tsx
+++ b/src/components/widgets/controls/video-widget.tsx
@@ -24,7 +24,7 @@ export function VideoWidget({ modelId, className }: WidgetComponentProps) {
 
   const src = useMemo(() => buildMediaSrc(value, "video", format), [value, format]);
 
-  if (!value) {
+  if (!src) {
     return null;
   }
 

--- a/src/components/widgets/css-length.ts
+++ b/src/components/widgets/css-length.ts
@@ -1,0 +1,27 @@
+/**
+ * Coerce a widget length value (from Python's `CUnicode` or `Int`) into a
+ * valid CSS length.
+ *
+ * ipywidgets' `Image`, `Video`, etc. expose `width`/`height` as `CUnicode`.
+ * `Image(width=64)` arrives as the bare string "64", which is not a valid
+ * CSS length and causes browsers to fall back to the element's intrinsic
+ * size — e.g. a 1x1 pixel for a 1x1 PNG. The canonical ipywidgets JS sets
+ * the value as an HTML attribute (where bare numerics are interpreted as
+ * pixels), so we do the same when building the React style prop.
+ *
+ * Already-unit-qualified strings (`"50%"`, `"64px"`, `"10rem"`) pass
+ * through unchanged.
+ */
+export function toCssLength(value: string | number | null | undefined): string | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? `${value}px` : undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  // Bare numeric (integer or float) → pixels.
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return `${trimmed}px`;
+  }
+  return trimmed;
+}

--- a/src/components/widgets/layout-utils.ts
+++ b/src/components/widgets/layout-utils.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { toCssLength } from "./css-length";
 
 /**
  * Utilities for converting ipywidgets Layout model properties to CSS.
@@ -6,6 +7,21 @@ import type { CSSProperties } from "react";
  * ipywidgets uses snake_case for CSS properties (e.g., grid_template_columns),
  * which need to be converted to camelCase for React's style prop.
  */
+
+/**
+ * Layout properties whose values are lengths. Bare numerics coming from
+ * Python (`Layout(width=64)` → `"64"`) need the same unit coercion we apply
+ * to `ipywidgets.Image.width`; without it the browser rejects the value and
+ * the widget collapses to its intrinsic size.
+ */
+const LENGTH_PROPERTIES = new Set([
+  "width",
+  "height",
+  "min_width",
+  "max_width",
+  "min_height",
+  "max_height",
+]);
 
 /**
  * Map of ipywidgets Layout model property names to React CSS property names.
@@ -126,6 +142,14 @@ export function layoutStateToCSS(
     if (value === null || value === undefined || value === "") continue;
     // Apply filter if provided
     if (propertyFilter && !propertyFilter.has(key)) continue;
+
+    if (LENGTH_PROPERTIES.has(key)) {
+      const coerced = toCssLength(value as string | number | null | undefined);
+      if (coerced === undefined) continue;
+      style[toReactCSSProperty(key)] = coerced;
+      continue;
+    }
+
     // Only include string values (CSS values)
     if (typeof value !== "string") continue;
 


### PR DESCRIPTION
ipywidgets declares `Image.width`, `Image.height`, and every `Layout` sizing trait as `CUnicode`, so `Image(width=64)` and `Layout(width=64)` both arrive in the frontend as the bare string `"64"`. Browsers reject that as a CSS length and fall back to the element's intrinsic size — 1×1 for a 1×1 PNG, which renders invisible. The `ipywidgets.Image` blank-square that survived #2474 was this, not the binary-buffer pipeline.

The canonical ipywidgets JS sets width/height as HTML attributes, where bare numerics are pixels. The new `toCssLength` helper does the same coercion when building the React `style` prop. Already-qualified lengths (`"50%"`, `"10rem"`, `"calc(100% - 20px)"`) pass through unchanged.

Consumers:

- `ImageWidget` and `VideoWidget` (direct `width`/`height` traitlets) route through `toCssLength` and share the same `!src` early-return.
- `layoutStateToCSS` applies the same coercion to the sizing keys (`width`, `height`, `min_width`, `max_width`, `min_height`, `max_height`), so anything wrapped in a `Layout` gets the same treatment instead of silently dropping non-string values.

## Behavioral coverage

| Input                       | Before        | After         |
|-----------------------------|---------------|---------------|
| `width=64` (int)            | invisible 1×1 | 64px          |
| `width="64"`                | invisible 1×1 | 64px          |
| `width="64.5"`              | invisible 1×1 | 64.5px        |
| `width="50%"`               | 50%           | 50%           |
| `width="10rem"`             | 10rem         | 10rem         |
| `width="calc(100% - 20px)"` | calc(...)     | calc(...)     |
| `width=""` / `None`         | no style      | no style      |
| `Layout(width=64)`          | skipped       | 64px          |

## Verification

- Hand-run: red/green/blue 16×16 PIL PNGs inside `ipywidgets.Image(width=64, height=64)` render 64×64 with the correct color.
- Unit: `css-length.test.ts` (6 cases) + `layout-utils.test.ts` (8 cases) cover numeric/string/qualified/empty/non-finite inputs across both entry points.
- `cargo xtask lint --fix`: clean.

## Test plan

- [x] `pnpm test run src/components/widgets/__tests__/css-length.test.ts src/components/widgets/__tests__/layout-utils.test.ts`
- [x] Manual: real PIL-generated PNGs render at the requested dimensions in the correct color
- [x] `cargo xtask lint --fix` clean

## Followups

- Kill the outbound `sendMessage` fallback in `anywidget-view.tsx save_changes` and `use-comm-router.ts sendUpdate` (handoff task 2).
- Investigate HMR "Importing a module script failed" errors that fire whenever the isolated-renderer plugin rebuilds — the iframe's sandboxed origin can't satisfy Vite's module-HMR flow, so every edit under `src/components/widgets/**` prints a run of errors before the full-reload lands.
