### PR TITLE
refactor(widgets): drop outbound comm_msg(update) fallback

### DIFF
--- a/src/components/widgets/__tests__/afm-model-proxy.test.ts
+++ b/src/components/widgets/__tests__/afm-model-proxy.test.ts
@@ -10,15 +10,16 @@ function makeProxy(state: Record<string, unknown>) {
   const store = createWidgetStore();
   const commId = "test-comm";
   store.createModel(commId, state);
-  const sendMessage = vi.fn();
+  const sendUpdate = vi.fn();
+  const sendCustom = vi.fn();
   const model = store.getModel(commId)!;
   const proxy = createAFMModelProxy(
     model,
     store,
-    sendMessage,
+    { sendUpdate, sendCustom },
     () => store.getModel(commId)?.state ?? {},
   );
-  return { proxy, store, sendMessage };
+  return { proxy, store, sendUpdate, sendCustom };
 }
 
 describe("createAFMModelProxy", () => {
@@ -89,9 +90,43 @@ describe("createAFMModelProxy", () => {
 
   describe("set + save_changes", () => {
     it("buffers changes until save_changes is called", () => {
-      const { proxy, sendMessage } = makeProxy({ value: 0 });
+      const { proxy, sendUpdate } = makeProxy({ value: 0 });
       proxy.set("value", 42);
-      expect(sendMessage).not.toHaveBeenCalled();
+      expect(sendUpdate).not.toHaveBeenCalled();
+    });
+
+    it("routes save_changes through sendUpdate as a plain state patch", () => {
+      const { proxy, sendUpdate } = makeProxy({ value: 0, other: "a" });
+      proxy.set("value", 42);
+      proxy.set("other", "b");
+      proxy.save_changes();
+      expect(sendUpdate).toHaveBeenCalledTimes(1);
+      expect(sendUpdate).toHaveBeenCalledWith("test-comm", { value: 42, other: "b" });
+    });
+
+    it("is a no-op when there are no pending changes", () => {
+      const { proxy, sendUpdate } = makeProxy({ value: 0 });
+      proxy.save_changes();
+      expect(sendUpdate).not.toHaveBeenCalled();
+    });
+
+    it("clears pending changes after save", () => {
+      const { proxy, sendUpdate } = makeProxy({ value: 0 });
+      proxy.set("value", 1);
+      proxy.save_changes();
+      proxy.save_changes();
+      expect(sendUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("send", () => {
+    it("routes custom messages through sendCustom with buffers", () => {
+      const { proxy, sendCustom, sendUpdate } = makeProxy({ value: 0 });
+      const buf = new ArrayBuffer(4);
+      proxy.send({ type: "ping" }, undefined, [buf]);
+      expect(sendCustom).toHaveBeenCalledTimes(1);
+      expect(sendCustom).toHaveBeenCalledWith("test-comm", { type: "ping" }, [buf]);
+      expect(sendUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -8,9 +8,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { getCrdtCommWriter } from "./crdt-comm-writer";
 import {
-  type SendMessage,
   useWidgetModel,
   useWidgetStoreRequired,
   type WidgetModel,
@@ -203,43 +201,32 @@ export function injectCSS(modelId: string, css: string): InjectedCSS {
   };
 }
 
-// === Message Headers ===
-
-/**
- * Session ID for all outgoing messages.
- * Must be stable across messages for the kernel to track the session.
- */
-const SESSION_ID = crypto.randomUUID();
-
-/**
- * Create a complete Jupyter message header with all fields.
- * All fields are required for compatibility with strongly-typed backends (Rust, Go).
- */
-function createHeader(msgType: string, username: string = "frontend") {
-  return {
-    msg_id: crypto.randomUUID(),
-    msg_type: msgType,
-    username,
-    session: SESSION_ID,
-    date: new Date().toISOString(),
-    version: "5.3",
-  };
-}
-
 // === AFM Model Proxy ===
 
 type EventCallback = (...args: unknown[]) => void;
 
 /**
+ * Outbound helpers the AFM proxy uses to reach the kernel. `sendUpdate`
+ * goes through `WidgetUpdateManager` → CRDT; `sendCustom` goes through the
+ * daemon shell channel as a Jupyter `comm_msg(method: "custom")`.
+ */
+export interface AFMProxyOutbound {
+  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+}
+
+/**
  * Create an AFM-compatible model proxy that wraps the widget store.
  *
- * The proxy buffers local changes until save_changes() is called,
- * at which point it sends a comm_msg to the kernel.
+ * The proxy buffers local changes until `save_changes()` is called. State
+ * patches flow through `outbound.sendUpdate` (CRDT via update manager);
+ * custom messages go through `outbound.sendCustom` (shell channel). The
+ * proxy never builds Jupyter comm frames itself.
  */
 export function createAFMModelProxy(
   model: WidgetModel,
   store: WidgetStore,
-  sendMessage: SendMessage,
+  outbound: AFMProxyOutbound,
   getCurrentState: () => Record<string, unknown>,
 ): AnyWidgetModel {
   // Buffer for local changes (set but not yet saved)
@@ -286,34 +273,13 @@ export function createAFMModelProxy(
 
       const patch = { ...pendingChanges };
 
-      // Try CRDT path first (writes directly to RuntimeStateDoc,
-      // no SendComm round-trip). Falls back to SendComm if CRDT
-      // writer isn't available yet.
-      const writer = getCrdtCommWriter();
-      if (writer) {
-        writer(model.id, patch);
-        // Optimistically update the WidgetStore for instant feedback
-        store.updateModel(model.id, patch);
-      } else {
-        // Fallback: Send comm_msg with update method to kernel
-        sendMessage({
-          header: createHeader("comm_msg"),
-          parent_header: null,
-          metadata: {},
-          content: {
-            comm_id: model.id,
-            data: {
-              method: "update",
-              state: patch,
-              buffer_paths: [],
-            },
-          },
-          buffers: [],
-          channel: "shell",
-        });
-      }
+      // Route through the context's sendUpdate. In the parent window this
+      // hits WidgetUpdateManager → debounced CRDT write with optimistic
+      // store update + echo suppression. In the iframe it posts a bridge
+      // notification to the parent which then takes the same path. Either
+      // way, no hand-built comm_msg frame and no shell-channel fallback.
+      outbound.sendUpdate(model.id, patch);
 
-      // Clear pending changes after sending
       for (const key of Object.keys(pendingChanges)) {
         delete pendingChanges[key];
       }
@@ -403,24 +369,9 @@ export function createAFMModelProxy(
       _callbacks?: Record<string, unknown>,
       buffers?: ArrayBuffer[],
     ): void {
-      // Send custom message to kernel
-      // Full Jupyter protocol message format for strongly-typed backends
-      // Note: ipywidgets expects content to be nested in data.content, not spread
-      sendMessage({
-        header: createHeader("comm_msg"),
-        parent_header: null,
-        metadata: {},
-        content: {
-          comm_id: model.id,
-          data: {
-            method: "custom",
-            content: content, // Wrap content properly for ipywidgets protocol
-            buffer_paths: [],
-          },
-        },
-        buffers: buffers ?? [],
-        channel: "shell",
-      });
+      // Custom messages are ephemeral events (ipycanvas draw commands,
+      // quak row requests, button-click side effects). Always shell.
+      outbound.sendCustom(model.id, content, buffers);
     },
 
     widget_manager: {
@@ -429,11 +380,10 @@ export function createAFMModelProxy(
         if (!refModel) {
           throw new Error(`Model not found: ${modelId}`);
         }
-        // Create a proxy for the referenced model
         return createAFMModelProxy(
           refModel,
           store,
-          sendMessage,
+          outbound,
           () => store.getModel(modelId)?.state ?? {},
         );
       },
@@ -462,17 +412,17 @@ interface AnyWidgetViewProps {
  */
 export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { store, sendMessage } = useWidgetStoreRequired();
+  const { store, sendUpdate, sendCustom } = useWidgetStoreRequired();
   const [error, setError] = useState<Error | null>(null);
 
   // Refs for values that need to be fresh but shouldn't trigger effect re-runs
   const storeRef = useRef(store);
-  const sendMessageRef = useRef(sendMessage);
+  const outboundRef = useRef<AFMProxyOutbound>({ sendUpdate, sendCustom });
 
   // Keep refs up to date without triggering the main effect
   useEffect(() => {
     storeRef.current = store;
-    sendMessageRef.current = sendMessage;
+    outboundRef.current = { sendUpdate, sendCustom };
   });
 
   // Use reactive model hook - triggers re-render when model changes
@@ -551,7 +501,16 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
           if (isCancelled) return;
         }
 
-        // Create the AFM model proxy using refs for stable references
+        // Create the AFM model proxy using refs for stable references.
+        // `outboundRef` returns a stable wrapper so callbacks captured inside
+        // the widget (event listeners, timers) always see the current
+        // sendUpdate/sendCustom without triggering this effect to re-run.
+        const outboundProxy: AFMProxyOutbound = {
+          sendUpdate: (commId, state, buffers) =>
+            outboundRef.current.sendUpdate(commId, state, buffers),
+          sendCustom: (commId, content, buffers) =>
+            outboundRef.current.sendCustom(commId, content, buffers),
+        };
         const modelProxy = createAFMModelProxy(
           {
             id: stableModelId,
@@ -560,7 +519,7 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
             modelModule: "",
           } as WidgetModel,
           storeRef.current,
-          sendMessageRef.current,
+          outboundProxy,
           getCurrentState,
         );
 

--- a/src/components/widgets/crdt-comm-writer.ts
+++ b/src/components/widgets/crdt-comm-writer.ts
@@ -1,9 +1,11 @@
 /**
  * Module-level CRDT comm writer for widget state updates.
  *
- * Set by the notebook app when the WASM handle is available.
- * Read by anywidget-view.tsx to write state directly to RuntimeStateDoc
- * instead of going through SendComm request/response.
+ * `WidgetUpdateManager` is instantiated at module load (before the WASM
+ * handle exists), so it can't capture the writer in its constructor. The
+ * notebook app installs the writer via `setCrdtCommWriter` once the handle
+ * is ready; the manager reads it back via `getCrdtCommWriter` on each
+ * debounced flush. If the writer is still null, the manager re-queues.
  */
 
 type CrdtCommWriter = (commId: string, patch: Record<string, unknown>) => void;

--- a/src/components/widgets/use-comm-router.ts
+++ b/src/components/widgets/use-comm-router.ts
@@ -4,11 +4,14 @@
  * Widget interactions (slider drags, button clicks, `model.send()` calls)
  * travel frontend → kernel through two channels:
  *
- * - State updates (method: "update") prefer the CRDT path — the store
- *   writes directly into `RuntimeStateDoc.comms[commId].state` and the
- *   daemon forwards to the kernel.
- * - Custom messages (method: "custom") and fallback updates still use the
- *   daemon shell channel, wrapped in a Jupyter comm_msg frame.
+ * - State updates (method: "update") go to `WidgetUpdateManager`, which
+ *   writes a debounced delta into `RuntimeStateDoc.comms[commId].state`;
+ *   the daemon diffs and forwards to the kernel. If the CRDT writer
+ *   isn't installed yet, the manager re-queues the flush — no shell-
+ *   channel fallback.
+ * - Custom messages (method: "custom") and `comm_close` still use the
+ *   daemon shell channel, wrapped in a Jupyter comm_msg frame, because
+ *   they're ephemeral events rather than CRDT state.
  *
  * Inbound state arrives via `SyncEngine.commChanges$` (see `App.tsx`);
  * there's no Jupyter-protocol inbound path in this file.
@@ -18,7 +21,6 @@
  */
 
 import { useCallback, useEffect, useRef } from "react";
-import { getCrdtCommWriter } from "./crdt-comm-writer";
 import type { WidgetStore } from "./widget-store";
 import type { WidgetUpdateManager } from "./widget-update-manager";
 
@@ -60,14 +62,14 @@ interface OutgoingJupyterCommMessage {
 export type SendMessage = (msg: OutgoingJupyterCommMessage) => void;
 
 export interface UseCommRouterOptions {
-  /** Function to send messages to the kernel */
+  /** Function to send messages to the kernel (used for custom messages and comm_close). */
   sendMessage: SendMessage;
   /** Widget store instance */
   store: WidgetStore;
   /** Optional username for message headers (default: "frontend") */
   username?: string;
-  /** Optional update manager for debounced CRDT writes + echo suppression. */
-  updateManager?: WidgetUpdateManager;
+  /** Debounced CRDT writer for outbound state updates. */
+  updateManager: WidgetUpdateManager;
 }
 
 export interface UseCommRouterReturn {
@@ -90,29 +92,6 @@ function createHeader(msgType: string, username: string): JupyterMessageHeader {
     session: SESSION_ID,
     date: new Date().toISOString(),
     version: "5.3",
-  };
-}
-
-function createUpdateMessage(
-  commId: string,
-  state: Record<string, unknown>,
-  buffers: ArrayBuffer[] | undefined,
-  username: string,
-): OutgoingJupyterCommMessage {
-  return {
-    header: createHeader("comm_msg", username),
-    parent_header: null,
-    metadata: {},
-    content: {
-      comm_id: commId,
-      data: {
-        method: "update",
-        state,
-        buffer_paths: [],
-      },
-    },
-    buffers: buffers ?? [],
-    channel: "shell",
   };
 }
 
@@ -155,9 +134,10 @@ function createCloseMessage(commId: string, username: string): OutgoingJupyterCo
 /**
  * Hook exposing outbound comm helpers.
  *
- * `sendUpdate` prefers the CRDT writer when no binary buffers are involved;
- * the fallback path is the daemon shell channel. `sendCustom` and
- * `closeComm` always go through the shell channel.
+ * `sendUpdate` always routes through `WidgetUpdateManager` — the manager
+ * applies the patch to the store immediately for optimistic UI and then
+ * debounces the CRDT write. `sendCustom` and `closeComm` go through the
+ * shell channel because they're ephemeral events, not CRDT state.
  */
 export function useCommRouter({
   sendMessage,
@@ -179,19 +159,7 @@ export function useCommRouter({
 
   const sendUpdate = useCallback(
     (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => {
-      const manager = managerRef.current;
-      if (manager) {
-        manager.updateAndPersist(commId, state, buffers);
-        return;
-      }
-      // Fallback for contexts without a manager (iframe outbound bridge).
-      storeRef.current.updateModel(commId, state);
-      const writer = getCrdtCommWriter();
-      if (writer && !buffers?.length) {
-        writer(commId, state);
-      } else {
-        sendMessageRef.current(createUpdateMessage(commId, state, buffers, usernameRef.current));
-      }
+      managerRef.current.updateAndPersist(commId, state, buffers);
     },
     [],
   );

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -33,13 +33,11 @@ import {
 
 interface WidgetStoreContextValue {
   store: WidgetStore;
-  /** Raw send function (prefer sendUpdate/sendCustom for specific cases) */
-  sendMessage: SendMessage;
-  /** Send a state update to the kernel */
+  /** Send a state update to the kernel. Routed through WidgetUpdateManager. */
   sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
-  /** Send a custom message to the kernel */
+  /** Send a custom message (method: "custom") via the daemon shell channel. */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
-  /** Close a comm channel */
+  /** Close a comm channel via the daemon shell channel. */
   closeComm: (commId: string) => void;
 }
 
@@ -52,10 +50,10 @@ export const WidgetStoreContext = createContext<WidgetStoreContextValue | null>(
 
 interface WidgetStoreProviderProps {
   children: ReactNode;
-  /** Function to send messages back to the kernel (for widget interactions) */
+  /** Function to send messages back to the kernel (for custom messages and comm_close) */
   sendMessage?: SendMessage;
-  /** Optional update manager for debounced CRDT writes + echo suppression. */
-  updateManager?: import("./widget-update-manager").WidgetUpdateManager;
+  /** Debounced CRDT writer for outbound state updates. */
+  updateManager: import("./widget-update-manager").WidgetUpdateManager;
 }
 
 /**
@@ -93,12 +91,11 @@ export function WidgetStoreProvider({
   const value = useMemo(
     () => ({
       store,
-      sendMessage,
       sendUpdate,
       sendCustom,
       closeComm,
     }),
-    [store, sendMessage, sendUpdate, sendCustom, closeComm],
+    [store, sendUpdate, sendCustom, closeComm],
   );
 
   return <WidgetStoreContext.Provider value={value}>{children}</WidgetStoreContext.Provider>;

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -106,34 +106,11 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
   );
 
   // Value for main WidgetStoreContext (so existing widget components work).
-  // sendMessage parses outgoing Jupyter comm frames and dispatches to the
-  // bridge — inbound messages arrive via postMessage / the bridge client.
+  // Built-in widgets and the AFM model proxy read sendUpdate/sendCustom/
+  // closeComm directly; the bridge client relays each to the parent window.
   const mainContextValue = useMemo(
     () => ({
       store: client.store,
-      sendMessage: (msg: {
-        content: {
-          comm_id?: string;
-          data?: {
-            method?: string;
-            state?: Record<string, unknown>;
-            content?: Record<string, unknown>;
-          };
-        };
-        buffers?: ArrayBuffer[];
-      }) => {
-        const commId = msg.content?.comm_id;
-        const method = msg.content?.data?.method;
-        const buffers = msg.buffers;
-
-        if (!commId) return;
-
-        if (method === "update" && msg.content?.data?.state) {
-          client.sendUpdate(commId, msg.content.data.state, buffers);
-        } else if (method === "custom" && msg.content?.data?.content) {
-          client.sendCustom(commId, msg.content.data.content, buffers);
-        }
-      },
       sendUpdate: client.sendUpdate,
       sendCustom: client.sendCustom,
       closeComm: client.closeComm,


### PR DESCRIPTION
Follow-up to #2474. Widget state updates already run through `WidgetUpdateManager` → debounced CRDT write; the two remaining `sendMessage(comm_msg(update))` fallbacks were legacy scaffolding. This PR removes them and tightens the types.

## The two dead branches

**`useCommRouter.sendUpdate`** (`src/components/widgets/use-comm-router.ts`). When called with an `updateManager`, the hook routed through the manager and returned early. The "no manager" branch then built a Jupyter `comm_msg(update)` and pushed it to the daemon shell channel. Only one caller exists (`WidgetStoreProvider` in `App.tsx`), and it always supplies the manager. `updateManager` is now required.

**`anywidget-view.save_changes`** (`src/components/widgets/anywidget-view.tsx`). `AnyWidgetView` renders exclusively inside the iframe (widget-view+json isn't in `MAIN_DOM_SAFE_TYPES`), and `setCrdtCommWriter` only fires from the main app — so `getCrdtCommWriter()` in the iframe is always null. The "fallback" was the one-and-only path. It built a full Jupyter frame which the iframe provider then parsed right back apart to call `client.sendUpdate`. The proxy now just calls `ctx.sendUpdate(commId, patch)`; the iframe's bridge is authoritative either way.

`model.send()` (custom events) still routes through `ctx.sendCustom` → shell channel, same as before — handoff marked custom messages out of scope.

## Shape changes

- `useCommRouter`: `updateManager` moved from optional to required. `createUpdateMessage` deleted.
- `createAFMModelProxy`: takes `outbound: { sendUpdate, sendCustom }` instead of a raw `sendMessage: SendMessage`. The proxy stops hand-rolling Jupyter frames and the internal `createHeader` / `SESSION_ID` are gone.
- `WidgetStoreContextValue`: `sendMessage` field dropped from the consumer surface. `WidgetStoreProvider` still accepts `sendMessage` as a prop (feeds `useCommRouter` for `sendCustom`/`closeComm`).
- `IframeWidgetStoreProvider`: the Jupyter-frame-parsing `sendMessage` relay is gone; `WidgetStoreContext` now exposes `client.sendUpdate`/`sendCustom`/`closeComm` directly.
- `crdt-comm-writer.ts`: updated docstring to reflect that `WidgetUpdateManager` is now the only consumer.

## Test plan

- [x] `pnpm test run` — 1180 passed, 3 skipped.
- [x] `cargo xtask lint --fix` — clean.
- [x] New coverage in `afm-model-proxy.test.ts`: `save_changes` calls `sendUpdate`, clears pending, is a no-op with no pending changes; `send` routes buffers through `sendCustom`.
- [ ] Manual: ipywidgets slider drag + button click + `ipywidgets.Image` still render in the desktop app (author did not run the GUI — flagging for reviewer).

## Followups untouched

- HMR "Importing a module script failed" errors on iframe renderer rebuilds (task 8 in the brainstorm).
- `SendMessage` / `JupyterMessageHeader` type re-exports from `widget-store-context.tsx` are now unused outside their declaration — left in place to keep this diff scoped to the fallback removal.
