### PR TITLE
fix(kernel-env): detect Python version mismatch in conda:env_yml envs, guard user-managed envs

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1144,7 +1144,7 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
 ///
 /// This is cheaper than spawning `python --version` and works even when the
 /// environment's Python is broken or missing from PATH.
-fn detect_installed_python_version(env_path: &std::path::Path) -> Option<String> {
+pub fn detect_installed_python_version(env_path: &std::path::Path) -> Option<String> {
     let meta_dir = env_path.join("conda-meta");
     let entries = std::fs::read_dir(&meta_dir).ok()?;
     for entry in entries.flatten() {
@@ -1189,6 +1189,56 @@ fn has_freethreading_package(env_path: &std::path::Path) -> bool {
         }
     }
     false
+}
+
+/// Check whether the installed Python version in a conda env matches the
+/// requested constraint from environment.yaml (e.g. `"3.12"`).
+///
+/// Compares major.minor only — a constraint of `"3.12"` matches installed
+/// `"3.12.7"` but not `"3.14.4"`. Returns `true` if the constraint is
+/// satisfied or if either version can't be determined (fail-open to avoid
+/// unnecessary rebuilds). Returns `false` when the installed major.minor
+/// clearly doesn't match the constraint.
+///
+/// Used by the `conda:env_yml` launch path to detect when an existing named
+/// env has a different Python version than what environment.yaml requests,
+/// triggering a rebuild instead of syncing into the wrong Python.
+pub fn installed_python_matches_constraint(env_path: &std::path::Path, requested: &str) -> bool {
+    let installed = match detect_installed_python_version(env_path) {
+        Some(v) => v,
+        None => return true, // Can't detect → fail-open
+    };
+
+    // Extract major.minor from installed (e.g. "3.14.4" → "3.14")
+    let installed_parts: Vec<&str> = installed.split('.').collect();
+    let installed_mm = if installed_parts.len() >= 2 {
+        format!("{}.{}", installed_parts[0], installed_parts[1])
+    } else {
+        return true; // Unusual format → fail-open
+    };
+
+    // Extract major.minor from the constraint. The constraint may be
+    // "3.12", "3.12.7", ">=3.12", etc. Strip common prefixes and take
+    // the first version-like token.
+    let cleaned = requested
+        .trim_start_matches(">=")
+        .trim_start_matches("<=")
+        .trim_start_matches("==")
+        .trim_start_matches('=')
+        .trim_start_matches('>')
+        .trim_start_matches('<');
+    let first = cleaned.split(',').next().unwrap_or(cleaned);
+    let first = first.trim_end_matches(".*");
+    let req_parts: Vec<&str> = first.split('.').collect();
+    let requested_mm = if req_parts.len() >= 2 {
+        format!("{}.{}", req_parts[0], req_parts[1])
+    } else if !req_parts.is_empty() && !req_parts[0].is_empty() {
+        req_parts[0].to_string()
+    } else {
+        return true; // Can't parse → fail-open
+    };
+
+    installed_mm == requested_mm
 }
 
 /// Find the site-packages directory inside a venv/env.
@@ -1491,5 +1541,36 @@ mod tests {
     fn has_freethreading_package_false_when_no_conda_meta() {
         let dir = tempfile::tempdir().unwrap();
         assert!(!has_freethreading_package(dir.path()));
+    }
+
+    #[test]
+    fn python_constraint_matches_same_major_minor() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.12.7-h2b28147_0.json"), "{}").unwrap();
+
+        assert!(installed_python_matches_constraint(dir.path(), "3.12"));
+        assert!(installed_python_matches_constraint(dir.path(), "3.12.7"));
+        assert!(installed_python_matches_constraint(dir.path(), ">=3.12"));
+        assert!(installed_python_matches_constraint(dir.path(), "==3.12"));
+    }
+
+    #[test]
+    fn python_constraint_rejects_different_major_minor() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.14.4-h2b28147_0.json"), "{}").unwrap();
+
+        assert!(!installed_python_matches_constraint(dir.path(), "3.12"));
+        assert!(!installed_python_matches_constraint(dir.path(), "3.13"));
+    }
+
+    #[test]
+    fn python_constraint_fails_open_when_no_env() {
+        let dir = tempfile::tempdir().unwrap();
+        // No conda-meta → can't detect → returns true (fail-open)
+        assert!(installed_python_matches_constraint(dir.path(), "3.12"));
     }
 }

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -468,7 +468,7 @@ async fn install_conda_env(
 
     if let Some(ref py) = deps.python {
         specs.push(MatchSpec::from_str(
-            &format!("python={}", py),
+            &format_python_spec(py),
             match_spec_options,
         )?);
     } else {
@@ -1105,13 +1105,27 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Format a Python version constraint as a conda MatchSpec string.
+///
+/// Bare versions (`"3.11"`, `"3.11.*"`) get `python=` prepended.
+/// Operator-prefixed constraints (`">=3.9"`, `">=3.9,<4"`) get `python`
+/// prepended without an extra `=`, producing e.g. `"python>=3.9,<4"`.
+fn format_python_spec(constraint: &str) -> String {
+    let first = constraint.as_bytes().first().copied().unwrap_or(b'0');
+    if first == b'>' || first == b'<' || first == b'=' || first == b'!' || first == b'~' {
+        format!("python{}", constraint)
+    } else {
+        format!("python={}", constraint)
+    }
+}
+
 /// Build the list of spec strings that `install_conda_env` would produce,
 /// for matching against a lock file.
 fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
     let mut specs = Vec::new();
 
     if let Some(ref py) = deps.python {
-        specs.push(format!("python={}", py));
+        specs.push(format_python_spec(py));
     } else {
         specs.push("python>=3.13".to_string());
     }
@@ -1226,30 +1240,47 @@ pub fn installed_python_matches_constraint(env_path: &std::path::Path, requested
         return true; // Unusual format → fail-open
     };
 
+    // Split by comma and check every clause. A compound constraint like
+    // ">=3.9,<3.13" must satisfy ALL parts. Each clause is parsed
+    // independently for its operator and version.
+    for clause in requested.split(',') {
+        let clause = clause.trim();
+        if clause.is_empty() {
+            continue;
+        }
+        if !check_single_clause((inst_major, inst_minor), clause) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Check a single version constraint clause (e.g. `">=3.9"`, `"3.12.*"`,
+/// `"<4"`) against an installed (major, minor) pair. Returns `true` when
+/// the clause is satisfied or unparseable (fail-open).
+fn check_single_clause(inst: (u32, u32), clause: &str) -> bool {
     // Detect the operator from the constraint prefix, then extract the
     // version number. Conda environment.yaml uses single `=` for pins
     // (equivalent to `==` in pip).
-    let (op, version_str) = if let Some(rest) = requested.strip_prefix(">=") {
+    let (op, version_str) = if let Some(rest) = clause.strip_prefix(">=") {
         (">=", rest)
-    } else if let Some(rest) = requested.strip_prefix("<=") {
+    } else if let Some(rest) = clause.strip_prefix("<=") {
         ("<=", rest)
-    } else if let Some(rest) = requested.strip_prefix("==") {
+    } else if let Some(rest) = clause.strip_prefix("==") {
         ("==", rest)
-    } else if let Some(rest) = requested.strip_prefix('>') {
+    } else if let Some(rest) = clause.strip_prefix('>') {
         (">", rest)
-    } else if let Some(rest) = requested.strip_prefix('<') {
+    } else if let Some(rest) = clause.strip_prefix('<') {
         ("<", rest)
-    } else if let Some(rest) = requested.strip_prefix('=') {
+    } else if let Some(rest) = clause.strip_prefix('=') {
         ("==", rest)
     } else {
         // Bare version like "3.12" — treat as exact pin
-        ("==", requested)
+        ("==", clause)
     };
 
-    // Take the first comma-separated segment (handles ">=3.9,<3.13").
-    let first = version_str.split(',').next().unwrap_or(version_str);
-    let first = first.trim_end_matches(".*");
-    let req_parts: Vec<&str> = first.split('.').collect();
+    let trimmed = version_str.trim_end_matches(".*");
+    let req_parts: Vec<&str> = trimmed.split('.').collect();
 
     let (req_major, req_minor) = if req_parts.len() >= 2 {
         match (req_parts[0].parse::<u32>(), req_parts[1].parse::<u32>()) {
@@ -1257,17 +1288,26 @@ pub fn installed_python_matches_constraint(env_path: &std::path::Path, requested
             _ => return true, // Can't parse → fail-open
         }
     } else if !req_parts.is_empty() && !req_parts[0].is_empty() {
-        // Major-only constraint like "3" or "3.*" — any minor is fine
-        // as long as major matches.
+        // Major-only constraint like "3" or "<4" — compare major only.
+        // For ordering operators we treat the version as (major, 0) so
+        // that `<4` means `< 4.0`, which accepts any Python 3.x.
         match req_parts[0].parse::<u32>() {
-            Ok(major) => return inst_major == major,
+            Ok(major) => {
+                return match op {
+                    ">=" => inst.0 >= major,
+                    ">" => inst.0 > major,
+                    "<=" => inst.0 <= major,
+                    "<" => inst.0 < major,
+                    // "==" and bare: exact major match, any minor
+                    _ => inst.0 == major,
+                };
+            }
             Err(_) => return true, // Can't parse → fail-open
         }
     } else {
         return true; // Can't parse → fail-open
     };
 
-    let inst = (inst_major, inst_minor);
     let req = (req_major, req_minor);
 
     match op {
@@ -1648,13 +1688,13 @@ mod tests {
     }
 
     #[test]
-    fn python_constraint_comma_range_first_segment() {
+    fn python_constraint_comma_range_both_clauses() {
         let dir = tempfile::tempdir().unwrap();
         let meta = dir.path().join("conda-meta");
         std::fs::create_dir_all(&meta).unwrap();
         std::fs::write(meta.join("python-3.11.0-h2b28147_0.json"), "{}").unwrap();
 
-        // ">=3.9,<3.13" → only checks first segment (>=3.9), 3.11 >= 3.9 → true
+        // ">=3.9,<3.13" → 3.11 >= 3.9 AND 3.11 < 3.13 → true
         assert!(installed_python_matches_constraint(
             dir.path(),
             ">=3.9,<3.13"
@@ -1662,9 +1702,48 @@ mod tests {
     }
 
     #[test]
+    fn python_constraint_upper_bound_enforced() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.14.0-h2b28147_0.json"), "{}").unwrap();
+
+        // ">=3.9,<3.13" → 3.14 >= 3.9 but 3.14 NOT < 3.13 → false
+        assert!(!installed_python_matches_constraint(
+            dir.path(),
+            ">=3.9,<3.13"
+        ));
+    }
+
+    #[test]
+    fn python_constraint_major_only_lt() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.11.0-h2b28147_0.json"), "{}").unwrap();
+
+        // ">=3.9,<4" → 3.11 >= 3.9 AND 3 < 4 → true
+        assert!(installed_python_matches_constraint(dir.path(), ">=3.9,<4"));
+    }
+
+    #[test]
     fn python_constraint_fails_open_when_no_env() {
         let dir = tempfile::tempdir().unwrap();
         // No conda-meta → can't detect → returns true (fail-open)
         assert!(installed_python_matches_constraint(dir.path(), "3.12"));
+    }
+
+    #[test]
+    fn format_python_spec_bare_version() {
+        assert_eq!(format_python_spec("3.11"), "python=3.11");
+        assert_eq!(format_python_spec("3.11.*"), "python=3.11.*");
+    }
+
+    #[test]
+    fn format_python_spec_operator_prefixed() {
+        assert_eq!(format_python_spec(">=3.9"), "python>=3.9");
+        assert_eq!(format_python_spec(">=3.9,<4"), "python>=3.9,<4");
+        assert_eq!(format_python_spec("==3.12"), "python==3.12");
+        assert_eq!(format_python_spec("<4"), "python<4");
     }
 }

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1229,18 +1229,18 @@ pub fn installed_python_matches_constraint(env_path: &std::path::Path, requested
     // Detect the operator from the constraint prefix, then extract the
     // version number. Conda environment.yaml uses single `=` for pins
     // (equivalent to `==` in pip).
-    let (op, version_str) = if requested.starts_with(">=") {
-        (">=", &requested[2..])
-    } else if requested.starts_with("<=") {
-        ("<=", &requested[2..])
-    } else if requested.starts_with("==") {
-        ("==", &requested[2..])
-    } else if requested.starts_with('>') {
-        (">", &requested[1..])
-    } else if requested.starts_with('<') {
-        ("<", &requested[1..])
-    } else if requested.starts_with('=') {
-        ("==", &requested[1..])
+    let (op, version_str) = if let Some(rest) = requested.strip_prefix(">=") {
+        (">=", rest)
+    } else if let Some(rest) = requested.strip_prefix("<=") {
+        ("<=", rest)
+    } else if let Some(rest) = requested.strip_prefix("==") {
+        ("==", rest)
+    } else if let Some(rest) = requested.strip_prefix('>') {
+        (">", rest)
+    } else if let Some(rest) = requested.strip_prefix('<') {
+        ("<", rest)
+    } else if let Some(rest) = requested.strip_prefix('=') {
+        ("==", rest)
     } else {
         // Bare version like "3.12" — treat as exact pin
         ("==", requested)

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1192,13 +1192,16 @@ fn has_freethreading_package(env_path: &std::path::Path) -> bool {
 }
 
 /// Check whether the installed Python version in a conda env matches the
-/// requested constraint from environment.yaml (e.g. `"3.12"`).
+/// requested constraint from environment.yaml (e.g. `"3.12"`, `">=3.9"`).
 ///
-/// Compares major.minor only — a constraint of `"3.12"` matches installed
-/// `"3.12.7"` but not `"3.14.4"`. Returns `true` if the constraint is
-/// satisfied or if either version can't be determined (fail-open to avoid
-/// unnecessary rebuilds). Returns `false` when the installed major.minor
-/// clearly doesn't match the constraint.
+/// Handles exact pins (`python=3.12`, `python==3.12`), range constraints
+/// (`python>=3.9`, `python>=3.9,<3.13`), major-only (`python=3`), and
+/// wildcard (`python=3.*`). Compares on major.minor, using the operator
+/// semantics from the original constraint string.
+///
+/// Returns `true` if the constraint is satisfied or if either version can't
+/// be determined (fail-open to avoid unnecessary rebuilds). Returns `false`
+/// only when the installed version clearly violates the constraint.
 ///
 /// Used by the `conda:env_yml` launch path to detect when an existing named
 /// env has a different Python version than what environment.yaml requests,
@@ -1209,36 +1212,72 @@ pub fn installed_python_matches_constraint(env_path: &std::path::Path, requested
         None => return true, // Can't detect → fail-open
     };
 
-    // Extract major.minor from installed (e.g. "3.14.4" → "3.14")
+    // Parse installed major.minor as (u32, u32).
     let installed_parts: Vec<&str> = installed.split('.').collect();
-    let installed_mm = if installed_parts.len() >= 2 {
-        format!("{}.{}", installed_parts[0], installed_parts[1])
+    let (inst_major, inst_minor) = if installed_parts.len() >= 2 {
+        match (
+            installed_parts[0].parse::<u32>(),
+            installed_parts[1].parse::<u32>(),
+        ) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => return true, // Unusual format → fail-open
+        }
     } else {
         return true; // Unusual format → fail-open
     };
 
-    // Extract major.minor from the constraint. The constraint may be
-    // "3.12", "3.12.7", ">=3.12", etc. Strip common prefixes and take
-    // the first version-like token.
-    let cleaned = requested
-        .trim_start_matches(">=")
-        .trim_start_matches("<=")
-        .trim_start_matches("==")
-        .trim_start_matches('=')
-        .trim_start_matches('>')
-        .trim_start_matches('<');
-    let first = cleaned.split(',').next().unwrap_or(cleaned);
+    // Detect the operator from the constraint prefix, then extract the
+    // version number. Conda environment.yaml uses single `=` for pins
+    // (equivalent to `==` in pip).
+    let (op, version_str) = if requested.starts_with(">=") {
+        (">=", &requested[2..])
+    } else if requested.starts_with("<=") {
+        ("<=", &requested[2..])
+    } else if requested.starts_with("==") {
+        ("==", &requested[2..])
+    } else if requested.starts_with('>') {
+        (">", &requested[1..])
+    } else if requested.starts_with('<') {
+        ("<", &requested[1..])
+    } else if requested.starts_with('=') {
+        ("==", &requested[1..])
+    } else {
+        // Bare version like "3.12" — treat as exact pin
+        ("==", requested)
+    };
+
+    // Take the first comma-separated segment (handles ">=3.9,<3.13").
+    let first = version_str.split(',').next().unwrap_or(version_str);
     let first = first.trim_end_matches(".*");
     let req_parts: Vec<&str> = first.split('.').collect();
-    let requested_mm = if req_parts.len() >= 2 {
-        format!("{}.{}", req_parts[0], req_parts[1])
+
+    let (req_major, req_minor) = if req_parts.len() >= 2 {
+        match (req_parts[0].parse::<u32>(), req_parts[1].parse::<u32>()) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => return true, // Can't parse → fail-open
+        }
     } else if !req_parts.is_empty() && !req_parts[0].is_empty() {
-        req_parts[0].to_string()
+        // Major-only constraint like "3" or "3.*" — any minor is fine
+        // as long as major matches.
+        match req_parts[0].parse::<u32>() {
+            Ok(major) => return inst_major == major,
+            Err(_) => return true, // Can't parse → fail-open
+        }
     } else {
         return true; // Can't parse → fail-open
     };
 
-    installed_mm == requested_mm
+    let inst = (inst_major, inst_minor);
+    let req = (req_major, req_minor);
+
+    match op {
+        ">=" => inst >= req,
+        "<=" => inst <= req,
+        ">" => inst > req,
+        "<" => inst < req,
+        // "==" and bare versions: exact major.minor match
+        _ => inst == req,
+    }
 }
 
 /// Find the site-packages directory inside a venv/env.
@@ -1565,6 +1604,61 @@ mod tests {
 
         assert!(!installed_python_matches_constraint(dir.path(), "3.12"));
         assert!(!installed_python_matches_constraint(dir.path(), "3.13"));
+    }
+
+    #[test]
+    fn python_constraint_range_ge_accepts_higher() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.12.4-h2b28147_0.json"), "{}").unwrap();
+
+        // 3.12 >= 3.9 → true
+        assert!(installed_python_matches_constraint(dir.path(), ">=3.9"));
+        // 3.12 >= 3.12 → true
+        assert!(installed_python_matches_constraint(dir.path(), ">=3.12"));
+        // 3.12 >= 3.13 → false
+        assert!(!installed_python_matches_constraint(dir.path(), ">=3.13"));
+    }
+
+    #[test]
+    fn python_constraint_range_lt_rejects_higher() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.12.4-h2b28147_0.json"), "{}").unwrap();
+
+        // 3.12 < 3.13 → true
+        assert!(installed_python_matches_constraint(dir.path(), "<3.13"));
+        // 3.12 < 3.12 → false
+        assert!(!installed_python_matches_constraint(dir.path(), "<3.12"));
+    }
+
+    #[test]
+    fn python_constraint_major_only_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.12.4-h2b28147_0.json"), "{}").unwrap();
+
+        // Major-only: "3" or "3.*" → any 3.x is fine
+        assert!(installed_python_matches_constraint(dir.path(), "3"));
+        assert!(installed_python_matches_constraint(dir.path(), "3.*"));
+        assert!(!installed_python_matches_constraint(dir.path(), "2"));
+    }
+
+    #[test]
+    fn python_constraint_comma_range_first_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("python-3.11.0-h2b28147_0.json"), "{}").unwrap();
+
+        // ">=3.9,<3.13" → only checks first segment (>=3.9), 3.11 >= 3.9 → true
+        assert!(installed_python_matches_constraint(
+            dir.path(),
+            ">=3.9,<3.13"
+        ));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3262,7 +3262,50 @@ pub(crate) async fn auto_launch_kernel(
         };
 
         let python_path = crate::project_file::conda_python_path(&conda_prefix);
-        if python_path.exists() {
+
+        // Check for Python version mismatch: if environment.yaml
+        // requests e.g. python=3.12 but the existing env has 3.14,
+        // remove the env so it gets recreated with the correct
+        // version. Without this, sync_dependencies pins the
+        // installed version and ignores the yaml constraint.
+        let python_version_ok = if python_path.exists() {
+            if let Some(ref requested) = env_config.python {
+                let matches = kernel_env::conda::installed_python_matches_constraint(
+                    &conda_prefix,
+                    requested,
+                );
+                if !matches {
+                    let installed =
+                        kernel_env::conda::detect_installed_python_version(&conda_prefix)
+                            .unwrap_or_else(|| "unknown".to_string());
+                    warn!(
+                        "[notebook-sync] conda:env_yml Python mismatch: \
+                         environment.yaml requests python={} but env has {}; \
+                         rebuilding env",
+                        requested, installed
+                    );
+                    if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                        warn!(
+                            "[notebook-sync] Failed to remove mismatched env {:?}: {}",
+                            conda_prefix, e
+                        );
+                    }
+                    false
+                } else {
+                    true
+                }
+            } else {
+                true // No python constraint → any version is fine
+            }
+        } else {
+            false // No existing env
+        };
+
+        // Re-check python_path after potential env removal
+        let python_path = crate::project_file::conda_python_path(&conda_prefix);
+
+        if python_path.exists() && python_version_ok {
+            // Existing env with correct Python — sync deps into it
             let conda_env = kernel_env::CondaEnvironment {
                 env_path: conda_prefix.clone(),
                 python_path: python_path.clone(),

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3202,11 +3202,18 @@ pub(crate) async fn auto_launch_kernel(
             }
         };
 
-        let conda_prefix = if let Some(ref prefix) = env_config.prefix {
-            prefix.clone()
+        // Track whether the env is daemon-owned (safe to auto-rebuild)
+        // vs. user-managed (prefix: field or pre-existing named env).
+        let (conda_prefix, is_daemon_owned_env) = if let Some(ref prefix) = env_config.prefix {
+            (prefix.clone(), false) // User-specified path — never auto-delete
         } else if let Some(ref name) = env_config.name {
-            crate::project_file::find_named_conda_env(name)
-                .unwrap_or_else(|| crate::project_file::default_conda_envs_dir().join(name))
+            match crate::project_file::find_named_conda_env(name) {
+                Some(found) => (found, false), // Pre-existing user env — never auto-delete
+                None => (
+                    crate::project_file::default_conda_envs_dir().join(name),
+                    true,
+                ),
+            }
         } else {
             let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
             let conda_deps_tmp = kernel_env::CondaDependencies {
@@ -3215,7 +3222,10 @@ pub(crate) async fn auto_launch_kernel(
                 python: env_config.python.clone(),
                 env_id: None,
             };
-            cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
+            (
+                cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp)),
+                true,
+            )
         };
 
         let mut all_deps = env_config.dependencies.clone();
@@ -3265,9 +3275,10 @@ pub(crate) async fn auto_launch_kernel(
 
         // Check for Python version mismatch: if environment.yaml
         // requests e.g. python=3.12 but the existing env has 3.14,
-        // remove the env so it gets recreated with the correct
-        // version. Without this, sync_dependencies pins the
-        // installed version and ignores the yaml constraint.
+        // the env needs rebuilding. Only auto-rebuild daemon-owned
+        // envs (cache/hash paths). For user-managed envs (prefix:
+        // field or pre-existing named env), surface an error so the
+        // user can rebuild manually.
         let python_version_ok = if python_path.exists() {
             if let Some(ref requested) = env_config.python {
                 let matches = kernel_env::conda::installed_python_matches_constraint(
@@ -3278,19 +3289,44 @@ pub(crate) async fn auto_launch_kernel(
                     let installed =
                         kernel_env::conda::detect_installed_python_version(&conda_prefix)
                             .unwrap_or_else(|| "unknown".to_string());
-                    warn!(
-                        "[notebook-sync] conda:env_yml Python mismatch: \
-                         environment.yaml requests python={} but env has {}; \
-                         rebuilding env",
-                        requested, installed
-                    );
-                    if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                    if is_daemon_owned_env {
                         warn!(
-                            "[notebook-sync] Failed to remove mismatched env {:?}: {}",
-                            conda_prefix, e
+                            "[notebook-sync] conda:env_yml Python mismatch: \
+                             environment.yaml requests python={} but env has {}; \
+                             rebuilding daemon-owned env",
+                            requested, installed
                         );
+                        if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                            warn!(
+                                "[notebook-sync] Failed to remove mismatched env {:?}: {}",
+                                conda_prefix, e
+                            );
+                        }
+                        false
+                    } else {
+                        let details = format!(
+                            "Conda env {:?} has Python {} but environment.yml requests \
+                             python={}. This is a user-managed env — rebuild it manually \
+                             with: conda env remove -n {} && conda env create -f environment.yml",
+                            conda_prefix,
+                            installed,
+                            requested,
+                            env_config.name.as_deref().unwrap_or("<env>"),
+                        );
+                        warn!("[notebook-sync] {}", details);
+                        if let Err(e) = room.state.with_doc(|sd| {
+                            sd.set_lifecycle_with_error_details(
+                                &RuntimeLifecycle::Error,
+                                None,
+                                Some(&details),
+                            )?;
+                            sd.clear_env_progress()?;
+                            Ok(())
+                        }) {
+                            warn!("[runtime-state] {}", e);
+                        }
+                        return;
                     }
-                    false
                 } else {
                     true
                 }

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -780,7 +780,8 @@ mod tests {
         };
         assert_eq!(project_file.kind, ProjectFileKind::EnvironmentYml);
         assert!(parsed.dependencies.iter().any(|d| d == "numpy"));
-        assert_eq!(parsed.requires_python.as_deref(), Some("3.11"));
+        // rattler normalizes `python=3.11` → `"3.11.*"`
+        assert_eq!(parsed.requires_python.as_deref(), Some("3.11.*"));
         let ProjectFileExtras::EnvironmentYml { channels, pip } = parsed.extras else {
             panic!("expected EnvironmentYml extras");
         };

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -329,24 +329,13 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
         };
 
         if name == "python" {
-            // Extract major.minor version from the version spec
+            // Preserve the full version spec string so downstream
+            // constraint checks can apply correct operator semantics
+            // (e.g. ">=3.9,<4" stays as ">=3.9,<4", not stripped to "3.9").
             if let Some(ref version_spec) = spec.version {
                 let v = version_spec.to_string();
-                // Parse first version bound (e.g. ">=3.9,<4" → "3.9")
-                let cleaned = v
-                    .trim_start_matches(">=")
-                    .trim_start_matches("<=")
-                    .trim_start_matches("==")
-                    .trim_start_matches('=')
-                    .trim_start_matches('>')
-                    .trim_start_matches('<');
-                let first = cleaned.split(',').next().unwrap_or(cleaned);
-                let first = first.trim_end_matches(".*");
-                let parts: Vec<&str> = first.split('.').collect();
-                if parts.len() >= 2 {
-                    python = Some(format!("{}.{}", parts[0], parts[1]));
-                } else if !parts.is_empty() && !parts[0].is_empty() {
-                    python = Some(parts[0].to_string());
+                if !v.is_empty() {
+                    python = Some(v);
                 }
             }
         } else if !name.is_empty() {
@@ -543,7 +532,8 @@ mod tests {
         assert_eq!(config.channels, vec!["conda-forge"]);
         // rattler normalizes conda `=` pin: numpy=1.24 → numpy 1.24.*
         assert_eq!(config.dependencies, vec!["numpy 1.24.*", "pandas"]);
-        assert_eq!(config.python, Some("3.11".to_string()));
+        // rattler normalizes conda `=` pin: python=3.11 → 3.11.*
+        assert_eq!(config.python, Some("3.11.*".to_string()));
     }
 
     #[test]
@@ -560,7 +550,7 @@ mod tests {
         let content = "name: test\ndependencies:\n  - numpy\n  - pip:\n    - requests\n    - flask\n  - scipy\n  - matplotlib\n  - python=3.11\n";
         let config = parse_environment_yml_content(content).unwrap();
         assert_eq!(config.dependencies, vec!["numpy", "scipy", "matplotlib"]);
-        assert_eq!(config.python, Some("3.11".to_string()));
+        assert_eq!(config.python, Some("3.11.*".to_string()));
     }
 
     #[test]
@@ -575,7 +565,8 @@ mod tests {
     fn test_parse_env_yml_python_version_extraction() {
         let content = "dependencies:\n  - python>=3.9,<4\n  - numpy\n";
         let config = parse_environment_yml_content(content).unwrap();
-        assert_eq!(config.python, Some("3.9".to_string()));
+        // Range constraints preserved: >=3.9,<4 stays as-is
+        assert_eq!(config.python, Some(">=3.9,<4".to_string()));
         assert_eq!(config.dependencies, vec!["numpy"]);
     }
 

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -926,15 +926,22 @@ pub(crate) async fn handle(
 
                     // Resolve the conda prefix: prefix: → direct path,
                     // name: → search standard dirs, create if not found.
-                    let conda_prefix = if let Some(ref prefix) = env_config.prefix {
-                        // Explicit prefix: path from environment.yml
-                        prefix.clone()
+                    // Track whether the env is daemon-owned (safe to
+                    // auto-rebuild) vs. user-managed (prefix: field or
+                    // pre-existing named env).
+                    let (conda_prefix, is_daemon_owned_env) = if let Some(ref prefix) =
+                        env_config.prefix
+                    {
+                        // Explicit prefix: path from environment.yml — user-managed
+                        (prefix.clone(), false)
                     } else if let Some(ref name) = env_config.name {
-                        // Named env — search for existing, or determine creation path
-                        crate::project_file::find_named_conda_env(name).unwrap_or_else(|| {
-                            // Will create at default location
-                            crate::project_file::default_conda_envs_dir().join(name)
-                        })
+                        match crate::project_file::find_named_conda_env(name) {
+                            Some(found) => (found, false), // Pre-existing user env
+                            None => (
+                                crate::project_file::default_conda_envs_dir().join(name),
+                                true,
+                            ),
+                        }
                     } else {
                         // No name or prefix — use a hash-based env in cache
                         let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
@@ -944,7 +951,10 @@ pub(crate) async fn handle(
                             python: env_config.python.clone(),
                             env_id: None,
                         };
-                        cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
+                        (
+                            cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp)),
+                            true,
+                        )
                     };
 
                     // Merge env.yml deps with any CRDT notebook deps (additive)
@@ -999,9 +1009,9 @@ pub(crate) async fn handle(
 
                     // Check for Python version mismatch: if environment.yaml
                     // requests e.g. python=3.12 but the existing env has 3.14,
-                    // remove the env so it gets recreated with the correct
-                    // version. Without this, sync_dependencies pins the
-                    // installed version and ignores the yaml constraint.
+                    // the env needs rebuilding. Only auto-rebuild daemon-owned
+                    // envs (cache/hash paths). For user-managed envs (prefix:
+                    // field or pre-existing named env), surface an error.
                     let python_version_ok = if python_path.exists() {
                         if let Some(ref requested) = env_config.python {
                             let matches = kernel_env::conda::installed_python_matches_constraint(
@@ -1013,19 +1023,42 @@ pub(crate) async fn handle(
                                     &conda_prefix,
                                 )
                                 .unwrap_or_else(|| "unknown".to_string());
-                                warn!(
-                                    "[notebook-sync] conda:env_yml Python mismatch: \
-                                     environment.yaml requests python={} but env has {}; \
-                                     rebuilding env",
-                                    requested, installed
-                                );
-                                if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                                if is_daemon_owned_env {
                                     warn!(
-                                        "[notebook-sync] Failed to remove mismatched env {:?}: {}",
-                                        conda_prefix, e
+                                        "[notebook-sync] conda:env_yml Python mismatch: \
+                                         environment.yaml requests python={} but env has {}; \
+                                         rebuilding daemon-owned env",
+                                        requested, installed
                                     );
+                                    if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                                        warn!(
+                                            "[notebook-sync] Failed to remove mismatched env {:?}: {}",
+                                            conda_prefix, e
+                                        );
+                                    }
+                                    false
+                                } else {
+                                    let details = format!(
+                                        "Conda env {:?} has Python {} but environment.yml \
+                                         requests python={}. This is a user-managed env — \
+                                         rebuild it manually with: conda env remove -n {} \
+                                         && conda env create -f environment.yml",
+                                        conda_prefix,
+                                        installed,
+                                        requested,
+                                        env_config.name.as_deref().unwrap_or("<env>"),
+                                    );
+                                    reset_starting_state_with_outcome(
+                                        room,
+                                        None,
+                                        ResetOutcome::Error {
+                                            reason: None,
+                                            details: &details,
+                                        },
+                                    )
+                                    .await;
+                                    return NotebookResponse::Error { error: details };
                                 }
-                                false
                             } else {
                                 true
                             }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -997,8 +997,49 @@ pub(crate) async fn handle(
 
                     let python_path = crate::project_file::conda_python_path(&conda_prefix);
 
-                    if python_path.exists() {
-                        // Existing env — sync deps into it
+                    // Check for Python version mismatch: if environment.yaml
+                    // requests e.g. python=3.12 but the existing env has 3.14,
+                    // remove the env so it gets recreated with the correct
+                    // version. Without this, sync_dependencies pins the
+                    // installed version and ignores the yaml constraint.
+                    let python_version_ok = if python_path.exists() {
+                        if let Some(ref requested) = env_config.python {
+                            let matches = kernel_env::conda::installed_python_matches_constraint(
+                                &conda_prefix,
+                                requested,
+                            );
+                            if !matches {
+                                let installed = kernel_env::conda::detect_installed_python_version(
+                                    &conda_prefix,
+                                )
+                                .unwrap_or_else(|| "unknown".to_string());
+                                warn!(
+                                    "[notebook-sync] conda:env_yml Python mismatch: \
+                                     environment.yaml requests python={} but env has {}; \
+                                     rebuilding env",
+                                    requested, installed
+                                );
+                                if let Err(e) = tokio::fs::remove_dir_all(&conda_prefix).await {
+                                    warn!(
+                                        "[notebook-sync] Failed to remove mismatched env {:?}: {}",
+                                        conda_prefix, e
+                                    );
+                                }
+                                false
+                            } else {
+                                true
+                            }
+                        } else {
+                            true // No python constraint → any version is fine
+                        }
+                    } else {
+                        false // No existing env
+                    };
+
+                    let python_path = crate::project_file::conda_python_path(&conda_prefix);
+
+                    if python_path.exists() && python_version_ok {
+                        // Existing env with correct Python — sync deps into it
                         let conda_env = kernel_env::CondaEnvironment {
                             env_path: conda_prefix.clone(),
                             python_path: python_path.clone(),


### PR DESCRIPTION
## Summary

- When `environment.yml` requests e.g. `python=3.12` but a cached conda env already has Python 3.14, `sync_dependencies` would pin the installed version and silently ignore the yaml constraint
- Adds `installed_python_matches_constraint()` to `kernel-env` that compares installed vs requested major.minor
- Both `conda:env_yml` code paths (`launch_kernel.rs` + `metadata.rs`) now check for version mismatch before syncing
- **Guards user-managed envs:** only daemon-owned cache envs are auto-rebuilt on mismatch; user-managed envs (from `prefix:` field or pre-existing named envs) surface an error with a remediation command instead of being silently deleted

## Details

**Root cause:** `sync_dependencies` correctly pins the installed Python version for dependency resolution, but the `conda:env_yml` path calls it even when the existing env has a different Python than requested. The installed 3.14 gets pinned, the yaml's `python=3.12` is silently ignored.

**Version mismatch detection:** before entering the "existing env → sync deps" branch, check `installed_python_matches_constraint()`. If major.minor doesn't match, the env needs rebuilding. Fail-open: if either version can't be determined, returns `true` to avoid unnecessary rebuilds.

**Daemon-owned vs user-managed:** tracks `is_daemon_owned_env` based on how the conda prefix was resolved:

| Source | Owned by | On mismatch |
|--------|----------|-------------|
| `prefix:` field | User | Surface error with remediation command |
| `name:` found by `find_named_conda_env` | User | Surface error with remediation command |
| `name:` fallback to `default_conda_envs_dir` | Daemon | Auto-rebuild (remove + recreate) |
| Hash-based cache path (no name/prefix) | Daemon | Auto-rebuild |

## Test plan

- [x] 3 unit tests: constraint match, mismatch, fail-open (`cargo test -p kernel-env -- python_constraint`)
- [x] `cargo check -p runtimed -p kernel-env` clean
- [x] `cargo xtask lint --fix` clean
- [ ] CI green
- [ ] `codex review --base main` clean