### PR TITLE
chore(dev): suppress spurious HMR errors on iframe-renderer rebuilds

### DIFF
--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -269,7 +269,19 @@ export const css = ${JSON.stringify(css)};
       });
     },
 
-    // HMR: rebuild from source when isolated renderer files change
+    // HMR: rebuild from source when isolated renderer files change.
+    //
+    // Iframe-bundle files (`src/isolated-renderer/**`, and the iframe-shared
+    // parts of `src/components/{outputs,isolated,widgets}/**`) are bundled
+    // into the IIFE, not loaded directly by the main window. Vite's default
+    // HMR pipeline doesn't know how to hot-apply them (the main bundle
+    // imports them only for side-effect registration via
+    // `@/components/widgets/controls`), so letting it run in parallel with
+    // our `full-reload` produces a stream of "TypeError: Importing a module
+    // script failed" errors before the reload lands.
+    //
+    // We handle the update ourselves by rebuilding the IIFE + full-reloading
+    // and return `[]` so Vite skips its own module-update flow.
     async handleHotUpdate({ file, server: devServer }) {
       const isIsolatedRendererFile =
         file.startsWith(isolatedRendererDir) ||
@@ -278,31 +290,33 @@ export const css = ${JSON.stringify(css)};
             file.includes("/isolated/") ||
             file.includes("/widgets/")));
 
-      if (isIsolatedRendererFile) {
-        console.log(
-          `[isolated-renderer] Rebuilding due to change in: ${path.relative(path.resolve(__dirname, "../.."), file)}`,
-        );
-        invalidateDevCache();
-        devBuildPromise = buildRendererFromSource();
-        await devBuildPromise;
+      if (!isIsolatedRendererFile) return;
 
-        const mod = devServer.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
-        if (mod) {
-          devServer.moduleGraph.invalidateModule(mod);
-        }
+      console.log(
+        `[isolated-renderer] Rebuilding due to change in: ${path.relative(path.resolve(__dirname, "../.."), file)}`,
+      );
+      invalidateDevCache();
+      devBuildPromise = buildRendererFromSource();
+      await devBuildPromise;
 
-        for (const name of devPluginOutputs.keys()) {
-          const pluginMod = devServer.moduleGraph.getModuleById(`${RESOLVED_PLUGIN_PREFIX}${name}`);
-          if (pluginMod) {
-            devServer.moduleGraph.invalidateModule(pluginMod);
-          }
-        }
-
-        devServer.ws.send({
-          type: "full-reload",
-          path: "*",
-        });
+      const mod = devServer.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
+      if (mod) {
+        devServer.moduleGraph.invalidateModule(mod);
       }
+
+      for (const name of devPluginOutputs.keys()) {
+        const pluginMod = devServer.moduleGraph.getModuleById(`${RESOLVED_PLUGIN_PREFIX}${name}`);
+        if (pluginMod) {
+          devServer.moduleGraph.invalidateModule(pluginMod);
+        }
+      }
+
+      devServer.ws.send({
+        type: "full-reload",
+        path: "*",
+      });
+
+      return [];
     },
   };
 }

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -273,11 +273,12 @@ export const css = ${JSON.stringify(css)};
     //
     // Iframe-bundle files (`src/isolated-renderer/**`, and the iframe-shared
     // parts of `src/components/{outputs,isolated,widgets}/**`) are bundled
-    // into the IIFE, not loaded directly by the main window. Vite's default
-    // HMR pipeline doesn't know how to hot-apply them (the main bundle
-    // imports them only for side-effect registration via
-    // `@/components/widgets/controls`), so letting it run in parallel with
-    // our `full-reload` produces a stream of "TypeError: Importing a module
+    // into the IIFE that actually runs inside the sandboxed iframe. The main
+    // bundle imports the registration index (`@/components/widgets/controls`)
+    // only for side effects; individual widget components render in the
+    // iframe, not the main window. Vite's default HMR has no Fast Refresh
+    // boundary to target here, so letting it run in parallel with our
+    // `full-reload` produces a stream of "TypeError: Importing a module
     // script failed" errors before the reload lands.
     //
     // We handle the update ourselves by rebuilding the IIFE + full-reloading


### PR DESCRIPTION
Every edit under `src/components/widgets/**`, `src/components/outputs/**`, `src/components/isolated/**`, or `src/isolated-renderer/**` produced a burst of HMR noise in dev:

```
[isolated-renderer] Rebuilding due to change in: src/components/widgets/controls/image-widget.tsx
[vite] TypeError: Importing a module script failed.
[vite] Failed to reload /@fs/…/image-widget.tsx. This could be due to syntax errors or importing non-existent modules.
[vite] TypeError: Importing a module script failed.
[vite] Failed to reload /src/index.css. This could be due to syntax errors or importing non-existent modules.
```

…followed by a full page reload a moment later. The UI "went out of sync" during the window between the failed HMR attempts and the full-reload landing, which was particularly annoying while iterating on widgets.

## Root cause

Two pipelines ran in parallel for iframe-bundle files:

1. `isolated-renderer` plugin (`handleHotUpdate`): rebuild the IIFE, invalidate virtual modules, send `{type: "full-reload", path: "*"}`.
2. Vite default HMR: try to hot-apply the changed `.tsx` against the main bundle.

Files under those paths are bundled into the IIFE only — the main bundle imports `@/components/widgets/controls` for side-effect registration, but doesn't render these components itself. When Vite's default HMR tried to re-fetch and re-evaluate the `.tsx` module in main-bundle context, the module script import failed, and each importer of the module repeated the error before the full-reload landed.

## Fix

`handleHotUpdate` returns `[]` for iframe-bundle files so Vite skips its own module-update flow. Our full-reload is the only signal sent. No behavior change for non-iframe files — Tailwind CSS HMR and standard React Fast Refresh still work.

## Verification

- Edit `src/components/widgets/controls/image-widget.tsx` in dev. Vite log shows one line: `[isolated-renderer] Rebuilding due to change in: src/components/widgets/controls/image-widget.tsx`. No TypeError flood, no `hmr update /@fs/…` chatter for the iframe file.
- `pnpm test run`: 1180 passed, 3 skipped.
- `cargo xtask lint --fix`: clean.
