### PR TITLE
fix(runtimed): release daemon singleton lock on drop

### DIFF
--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -5,6 +5,8 @@
 //! lives in `runtimed_client::singleton` and is re-exported via `pub use runtimed_client::*`.
 
 use std::fs::{File, OpenOptions};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
 use chrono::Utc;
@@ -192,6 +194,14 @@ impl DaemonLock {
 
 impl Drop for DaemonLock {
     fn drop(&mut self) {
+        // Release the advisory lock explicitly before returning from Drop.
+        // Relying only on File's field drop is usually enough, but macOS CI has
+        // observed an immediate re-acquire in the same process racing the close.
+        #[cfg(unix)]
+        unsafe {
+            libc::flock(self._lock_file.as_raw_fd(), libc::LOCK_UN);
+        }
+
         // Clean up info file when daemon exits
         if self.info_path.exists() {
             std::fs::remove_file(&self.info_path).ok();


### PR DESCRIPTION
## Summary
- explicitly unlock the Unix daemon singleton flock during `Drop`
- avoids immediate same-process re-acquire races observed on macOS CI

## Verification
- `cargo test -p runtimed singleton::tests::drop_releases_lock_and_removes_info -- --nocapture`
- `cargo test -p runtimed notebook_sync_server::tests::test_new_fresh_untitled_trust_from_doc -- --nocapture`
- `cargo test -p runtimed --lib`
- `cargo xtask lint --fix`

Draft until CI confirms the macOS main failure is fixed.
