### PR TITLE
fix(mcp): 4 gremlin-discovered MCP surface fixes

### DIFF
--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -775,6 +775,127 @@ pub fn validate_package_specifier(spec: &str) -> Result<(), String> {
              Package names may only contain letters, digits, hyphens, underscores, and dots"
         ));
     }
+    validate_version_operators(spec, &name)?;
+    Ok(())
+}
+
+/// Reject obviously invalid version operators in a specifier.
+///
+/// PEP 508 operators: `==`, `!=`, `<=`, `>=`, `<`, `>`, `~=`, `===`.
+/// Conda MatchSpec operators: same minus `===`.
+///
+/// This catches mangled specifiers like `pandas>>>999` or `numpy=!2.0`
+/// that would be silently recorded in the CRDT and only fail (confusingly)
+/// at install time. Not a full PEP 508 parser — just enough to reject
+/// operator sequences that no package manager would accept.
+///
+/// # Examples
+///
+/// ```
+/// use notebook_doc::metadata::validate_version_operators;
+/// assert!(validate_version_operators("pandas>=2.0", "pandas").is_ok());
+/// assert!(validate_version_operators("numpy==1.24", "numpy").is_ok());
+/// assert!(validate_version_operators("scipy~=1.11", "scipy").is_ok());
+/// assert!(validate_version_operators("foo===1.0", "foo").is_ok());
+/// assert!(validate_version_operators("pandas>>>999", "pandas").is_err());
+/// assert!(validate_version_operators("numpy=!2.0", "numpy").is_err());
+/// assert!(validate_version_operators("pandas", "pandas").is_ok());
+/// assert!(validate_version_operators("requests[security]>=2.0", "requests").is_ok());
+/// ```
+pub fn validate_version_operators(spec: &str, name: &str) -> Result<(), String> {
+    // Strip leading name (case-insensitive match since extract_package_name lowercases).
+    let spec_trimmed = spec.trim();
+    let after_name = if let Some(rest) = spec_trimmed.get(..name.len()).and_then(|prefix| {
+        if prefix.eq_ignore_ascii_case(name) {
+            spec_trimmed.get(name.len()..)
+        } else {
+            None
+        }
+    }) {
+        rest
+    } else {
+        // Name doesn't match at start — might have channel prefix.
+        // Skip to first version operator character.
+        let first_op = spec_trimmed.find(&['>', '<', '=', '!', '~'][..]);
+        match first_op {
+            Some(i) => &spec_trimmed[i..],
+            None => return Ok(()), // no version constraint
+        }
+    };
+
+    // Skip past extras brackets `[...]` and whitespace.
+    let after_extras = if let Some(bracket_start) = after_name.find('[') {
+        let bracket_end = after_name[bracket_start..].find(']');
+        match bracket_end {
+            Some(end) => after_name[bracket_start + end + 1..].trim_start(),
+            None => after_name, // unmatched bracket, caught elsewhere
+        }
+    } else {
+        after_name.trim_start()
+    };
+
+    if after_extras.is_empty() {
+        return Ok(()); // bare package name, no version constraint
+    }
+
+    // Check that version clauses use valid operators. Comma-separated
+    // clauses are checked individually (e.g., ">=1.0,<2.0").
+    for clause in after_extras.split(',') {
+        let clause = clause.trim();
+        if clause.is_empty() {
+            continue;
+        }
+        // Allow environment markers (;python_version>="3.8") — stop
+        // validating once we hit a semicolon.
+        if clause.starts_with(';') {
+            break;
+        }
+        // Allow URL specifiers (@ https://...).
+        if clause.starts_with('@') {
+            break;
+        }
+        // Allow bare version (no operator) — conda supports `numpy 1.24.*`.
+        if clause
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit() || c == '*')
+        {
+            continue;
+        }
+        // Non-operator start — could be env markers, path extras, etc.
+        if !clause
+            .chars()
+            .next()
+            .is_some_and(|c| matches!(c, '>' | '<' | '=' | '!' | '~'))
+        {
+            continue;
+        }
+
+        // Extract the operator prefix: consume all leading operator chars,
+        // then verify the prefix is a recognized operator.
+        let op_len = clause
+            .chars()
+            .take_while(|c| matches!(c, '>' | '<' | '=' | '!' | '~'))
+            .count();
+        let op = &clause[..op_len];
+        match op {
+            "===" | "~=" | "==" | "!=" | ">=" | "<=" | ">" | "<"
+            // Conda accepts single `=` as a glob operator (`python=3.12`
+            // means `python==3.12.*`). Not valid PEP 508, but UV would
+            // reject it at install time — our job is catching garbage
+            // operators, not full spec validation.
+            | "=" => {
+                // Valid operator — ok.
+            }
+            _ => {
+                return Err(format!(
+                    "invalid version specifier in '{spec}': '{op}' is not a \
+                     recognized operator (>=, <=, ==, !=, ~=, ===, >, <)"
+                ));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1119,6 +1240,24 @@ mod tests {
         assert!(validate_package_specifier("[\"pandas\"").is_err());
         assert!(validate_package_specifier("\"numpy\"").is_err());
         assert!(validate_package_specifier("\"seaborn\"]").is_err());
+    }
+
+    #[test]
+    fn test_validate_package_specifier_bad_version_operators() {
+        // Triple > is not a valid operator
+        assert!(validate_package_specifier("pandas>>>999").is_err());
+        // =! is not valid (should be !=)
+        assert!(validate_package_specifier("numpy=!2.0").is_err());
+        // >>= is not valid
+        assert!(validate_package_specifier("scipy>>=1.0").is_err());
+        // <<<< is not valid
+        assert!(validate_package_specifier("foo<<<<1.0").is_err());
+        // Valid operators should still pass
+        assert!(validate_package_specifier("pandas>=2.0,<3.0").is_ok());
+        assert!(validate_package_specifier("numpy~=1.24").is_ok());
+        assert!(validate_package_specifier("foo===1.0.0").is_ok());
+        // Conda-style single = should pass (for interop)
+        assert!(validate_package_specifier("python=3.12").is_ok());
     }
 
     // ── validate_conda_package_specifier ───────────────────────

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -73,6 +73,12 @@ pub struct AddDependencyParams {
 pub struct RemoveDependencyParams {
     /// Package to remove.
     pub package: String,
+    /// Action after removing: "none" (just record, default) or "restart"
+    /// (restart kernel so the package is actually uninstalled).
+    /// Hot-uninstall ("sync") is not supported — removals always require
+    /// a kernel restart to take effect.
+    #[serde(default)]
+    pub after: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -691,14 +697,33 @@ pub async fn manage_dependencies(
 }
 
 /// Remove a package dependency. Auto-detects the notebook's package manager.
+///
+/// Supports `after: "restart"` to restart the kernel so the package is
+/// actually uninstalled from the running environment. Without `after`,
+/// the response includes `needs_restart: true` when the dep was present.
 pub async fn remove_dependency(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     let package = arg_str(request, "package")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
+    let after = arg_str(request, "after").unwrap_or("none");
 
-    let handle = require_handle!(server);
+    // "sync" is not meaningful for removals — the daemon's SyncEnvironment
+    // rejects removes and signals needs_restart. Map it to "restart" so the
+    // caller gets the right outcome without a confusing intermediate error.
+    let after = if after == "sync" { "restart" } else { after };
+
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                drop(guard);
+                return super::no_session_error(server).await;
+            }
+        }
+    };
 
     let manager = detect_package_manager(&handle);
 
@@ -713,12 +738,24 @@ pub async fn remove_dependency(
 
     let deps = get_deps_for_manager(&handle, &manager);
 
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "dependencies": deps,
         "removed": package,
         "was_present": removed,
         "package_manager": manager.as_str(),
     });
+
+    if after == "restart" && removed {
+        apply_dependency_changes(&handle, &notebook_id, "restart", &mut result).await;
+        if let Some(apply) = result.as_object_mut().and_then(|obj| obj.remove("apply")) {
+            result["restart"] = apply;
+        }
+    } else if removed {
+        // The dep was removed from metadata but the running environment
+        // still has the package installed. Signal the caller.
+        result["needs_restart"] = serde_json::json!(true);
+    }
+
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -998,20 +998,6 @@ pub async fn show_notebook(
     };
     let is_ephemeral = room.ephemeral;
 
-    if !has_display() {
-        let mut result = serde_json::json!({
-            "notebook_id": target,
-            "opened": false,
-            "reason": "No display available (headless environment). The notebook is running in the daemon and accessible via MCP tools."
-        });
-        if is_ephemeral {
-            result["note"] = serde_json::json!(
-                "This notebook is ephemeral. Use save_notebook(path) to persist."
-            );
-        }
-        return tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default());
-    }
-
     // Resolve the on-disk path: prefer room path (authoritative), then session
     // path, then fall back to the target string if it looks like a file path.
     let resolved_path = room
@@ -1019,6 +1005,23 @@ pub async fn show_notebook(
         .as_deref()
         .or(session_path.as_deref())
         .filter(|p| std::path::Path::new(p).is_absolute());
+
+    if !has_display() {
+        let mut result = serde_json::json!({
+            "notebook_id": target,
+            "opened": false,
+            "reason": "No display available (headless environment). The notebook is running in the daemon and accessible via MCP tools."
+        });
+        if let Some(path) = resolved_path {
+            result["path"] = serde_json::json!(path);
+        }
+        if is_ephemeral {
+            result["note"] = serde_json::json!(
+                "This notebook is ephemeral. Use save_notebook(path) to persist."
+            );
+        }
+        return tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default());
+    }
 
     if let Some(path) = resolved_path {
         runt_workspace::open_notebook_app(Some(std::path::Path::new(path)), &[])
@@ -1032,6 +1035,12 @@ pub async fn show_notebook(
     }
 
     let mut result = serde_json::json!({ "notebook_id": target, "opened": true });
+    // Include path in the response so callers can see where the notebook lives.
+    if let Some(path) = room.notebook_path.as_deref() {
+        result["path"] = serde_json::json!(path);
+    } else if let Some(path) = session_path.as_deref() {
+        result["path"] = serde_json::json!(path);
+    }
     if is_ephemeral {
         result["warning"] =
             serde_json::json!("This notebook is ephemeral. Save it from the app to keep it.");

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -248,11 +248,19 @@ fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::V
                     serde_json::json!(state.env.prewarmed_packages),
                 );
             }
-            // Error surface (#2157): when the kernel is in an error
-            // state, MCP clients get both the typed reason (stable
-            // for programmatic handling) and the human-readable
-            // details (for surfacing to the user).
-            if matches!(state.kernel.lifecycle, runtime_doc::RuntimeLifecycle::Error) {
+            // Error surface (#2157): when the kernel is in an error or
+            // decision-pending state, MCP clients get both the typed
+            // reason (stable for programmatic handling) and the
+            // human-readable details (for surfacing to the user).
+            // AwaitingEnvBuild carries CondaEnvYmlMissing + details
+            // about which env to create — without this, MCP clients
+            // only see kernel_status "awaiting_env_build" with no
+            // explanation of what's wrong or what action to take.
+            if matches!(
+                state.kernel.lifecycle,
+                runtime_doc::RuntimeLifecycle::Error
+                    | runtime_doc::RuntimeLifecycle::AwaitingEnvBuild
+            ) {
                 if let Some(reason) = state
                     .kernel
                     .error_reason
@@ -1083,6 +1091,39 @@ mod tests {
         assert!(
             uuid::Uuid::parse_str(&notebook_id).is_ok(),
             "notebook_id in save response must be a valid UUID"
+        );
+    }
+
+    /// Lifecycle states that carry error_reason/error_details must be
+    /// surfaced to MCP clients. Verify the predicate covers both Error
+    /// and AwaitingEnvBuild (the two states that write error details).
+    #[test]
+    fn error_surface_covers_awaiting_env_build() {
+        use runtime_doc::RuntimeLifecycle;
+        let should_surface = |lc: &RuntimeLifecycle| -> bool {
+            matches!(
+                lc,
+                RuntimeLifecycle::Error | RuntimeLifecycle::AwaitingEnvBuild
+            )
+        };
+
+        assert!(
+            should_surface(&RuntimeLifecycle::Error),
+            "Error must surface error details"
+        );
+        assert!(
+            should_surface(&RuntimeLifecycle::AwaitingEnvBuild),
+            "AwaitingEnvBuild must surface error details"
+        );
+        assert!(
+            !should_surface(&RuntimeLifecycle::NotStarted),
+            "NotStarted must not surface error details"
+        );
+        assert!(
+            !should_surface(&RuntimeLifecycle::Running(
+                runtime_doc::KernelActivity::Idle
+            )),
+            "Running(Idle) must not surface error details"
         );
     }
 }


### PR DESCRIPTION
## Summary

Four MCP surface fixes discovered by the gremlin test suite:

1. **Surface error_reason/error_details for AwaitingEnvBuild lifecycle** — When an `environment.yml` references a nonexistent conda env, the daemon correctly writes `CondaEnvYmlMissing` reason and human-readable details to RuntimeStateDoc. But `read_runtime_info()` only surfaced these fields for the `Error` lifecycle, so MCP clients saw `kernel_status: "awaiting_env_build"` with no explanation. Widened the predicate to also include `AwaitingEnvBuild`.

2. **Add `after` parameter to `remove_dependency`** — `remove_dependency` only updated CRDT metadata without signaling that the running environment still had the package installed. Now supports `after: "restart"` to restart the kernel so the removal takes effect, and returns `needs_restart: true` when the dep was removed but the caller didn't request a restart.

3. **Reject invalid version operators in dep specifiers** — `add_dependency("pandas>>>999")` was silently accepted because validation only checked the package name, never the version operator. Added `validate_version_operators()` that extracts operator prefixes and rejects sequences no package manager would accept (`>>>`, `=!`, `>>=`, etc.). Accepts conda's single `=` glob operator for interop.

4. **Include path in `show_notebook` response** — After saving, `show_notebook` only returned `notebook_id` and `opened` status. Now includes the resolved on-disk path (from daemon room or session) in both headless and display response branches.

## Context

Found by gremlin suite scenarios: `conda-env-yml-fallback` (#1), `conda-lifecycle` (#2), `tool-resilience` (#3), `show-notebook-title` (#4).

## Test plan

- [x] `cargo test -p runt-mcp` — 117 tests pass
- [x] `cargo test -p notebook-doc` — 300 tests pass including 7 doctests
- [x] `cargo xtask lint --fix` — clean
- [x] CI