### PR TITLE
refactor(mcp): batch dependency edits into a single CRDT transaction

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -661,8 +661,15 @@ impl NotebookDoc {
         F: FnOnce(&mut metadata::NotebookMetadataSnapshot) -> T,
     {
         let mut snapshot = self.get_metadata_snapshot().unwrap_or_default();
+        let before = snapshot.clone();
         let result = f(&mut snapshot);
-        self.set_metadata_snapshot(&snapshot)?;
+        // Skip the write when the closure didn't actually mutate anything.
+        // This avoids unnecessary Automerge ops, sync notifications, and
+        // dirty/autosave work for no-op paths (e.g. removing a package
+        // that isn't present, or manage_dependencies with empty edits).
+        if snapshot != before {
+            self.set_metadata_snapshot(&snapshot)?;
+        }
         Ok(result)
     }
 
@@ -5172,5 +5179,50 @@ mod tests {
             .with_metadata(|snap| snap.uv_dependencies().len())
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_with_metadata_noop_skips_write() {
+        use automerge::ReadDoc;
+
+        let mut doc = NotebookDoc::new("nb-noop");
+        doc.add_uv_dependency("numpy").unwrap();
+
+        // Capture heads after the initial write
+        let heads_before = doc.doc.get_heads();
+
+        // No-op closure: read deps but don't mutate
+        let deps = doc
+            .with_metadata(|snap| snap.uv_dependencies().to_vec())
+            .unwrap();
+        assert_eq!(deps, vec!["numpy"]);
+
+        // Heads should be unchanged — no write happened
+        let heads_after = doc.doc.get_heads();
+        assert_eq!(
+            heads_before, heads_after,
+            "with_metadata should skip set_metadata_snapshot when the closure doesn't mutate"
+        );
+    }
+
+    #[test]
+    fn test_with_metadata_noop_remove_absent_skips_write() {
+        use automerge::ReadDoc;
+
+        let mut doc = NotebookDoc::new("nb-noop-remove");
+        doc.add_uv_dependency("numpy").unwrap();
+        let heads_before = doc.doc.get_heads();
+
+        // Removing a package that isn't present — should be a no-op
+        doc.with_metadata(|snap| {
+            snap.remove_uv_dependency("nonexistent-pkg");
+        })
+        .unwrap();
+
+        let heads_after = doc.doc.get_heads();
+        assert_eq!(
+            heads_before, heads_after,
+            "removing an absent package should not produce Automerge ops"
+        );
     }
 }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -5183,8 +5183,6 @@ mod tests {
 
     #[test]
     fn test_with_metadata_noop_skips_write() {
-        use automerge::ReadDoc;
-
         let mut doc = NotebookDoc::new("nb-noop");
         doc.add_uv_dependency("numpy").unwrap();
 
@@ -5207,8 +5205,6 @@ mod tests {
 
     #[test]
     fn test_with_metadata_noop_remove_absent_skips_write() {
-        use automerge::ReadDoc;
-
         let mut doc = NotebookDoc::new("nb-noop-remove");
         doc.add_uv_dependency("numpy").unwrap();
         let heads_before = doc.doc.get_heads();

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -637,6 +637,35 @@ impl NotebookDoc {
         )
     }
 
+    // ── Batch metadata mutation ───────────────────────────────────
+
+    /// Read the metadata snapshot, apply mutations via a closure, and write
+    /// it back in a single Automerge transaction.
+    ///
+    /// This is the preferred way to apply multiple metadata changes (especially
+    /// dependency adds/removes) — one `get_metadata_snapshot` read, N in-memory
+    /// mutations, one `set_metadata_snapshot` write. Each individual convenience
+    /// method (e.g. `add_uv_dependency`) does a full read-mutate-write cycle,
+    /// so batching N changes through `with_metadata` produces O(1) Automerge
+    /// ops instead of O(N).
+    ///
+    /// ```ignore
+    /// doc.with_metadata(|snap| {
+    ///     snap.add_uv_dependency("numpy>=1.24");
+    ///     snap.add_uv_dependency("pandas>=2.0");
+    ///     snap.remove_uv_dependency("scipy");
+    /// })?;
+    /// ```
+    pub fn with_metadata<F, T>(&mut self, f: F) -> Result<T, AutomergeError>
+    where
+        F: FnOnce(&mut metadata::NotebookMetadataSnapshot) -> T,
+    {
+        let mut snapshot = self.get_metadata_snapshot().unwrap_or_default();
+        let result = f(&mut snapshot);
+        self.set_metadata_snapshot(&snapshot)?;
+        Ok(result)
+    }
+
     // ── UV dependency convenience methods ─────────────────────────
 
     /// Add a UV dependency, deduplicating by package name (case-insensitive).
@@ -5081,5 +5110,67 @@ mod tests {
         let round_tripped = crate::get_metadata_snapshot_from_doc(doc.doc())
             .expect("free function should surface extras");
         assert!(round_tripped.extras.contains_key("jupytext"));
+    }
+
+    #[test]
+    fn test_with_metadata_batch_adds() {
+        let mut doc = NotebookDoc::new("nb-with-meta-batch");
+
+        doc.with_metadata(|snap| {
+            snap.add_uv_dependency("numpy>=1.24");
+            snap.add_uv_dependency("pandas>=2.0");
+            snap.add_uv_dependency("scipy");
+        })
+        .unwrap();
+
+        let deps = doc
+            .get_metadata_snapshot()
+            .unwrap()
+            .uv_dependencies()
+            .to_vec();
+        assert_eq!(deps, vec!["numpy>=1.24", "pandas>=2.0", "scipy"]);
+    }
+
+    #[test]
+    fn test_with_metadata_batch_add_and_remove() {
+        let mut doc = NotebookDoc::new("nb-with-meta-mixed");
+
+        // Start with some deps
+        doc.with_metadata(|snap| {
+            snap.add_uv_dependency("numpy");
+            snap.add_uv_dependency("pandas");
+            snap.add_uv_dependency("scipy");
+        })
+        .unwrap();
+
+        // Batch: add one, remove two, upgrade one
+        let removed = doc
+            .with_metadata(|snap| {
+                snap.add_uv_dependency("polars>=0.20");
+                snap.add_uv_dependency("numpy>=2.0"); // upgrade
+                let r1 = snap.remove_uv_dependency("scipy");
+                let r2 = snap.remove_uv_dependency("nonexistent");
+                (r1, r2)
+            })
+            .unwrap();
+
+        assert_eq!(removed, (true, false));
+        let deps = doc
+            .get_metadata_snapshot()
+            .unwrap()
+            .uv_dependencies()
+            .to_vec();
+        assert_eq!(deps, vec!["pandas", "polars>=0.20", "numpy>=2.0"]);
+    }
+
+    #[test]
+    fn test_with_metadata_returns_closure_value() {
+        let mut doc = NotebookDoc::new("nb-with-meta-ret");
+        doc.add_uv_dependency("numpy").unwrap();
+
+        let count = doc
+            .with_metadata(|snap| snap.uv_dependencies().len())
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -352,6 +352,30 @@ impl DocHandle {
         self.with_notebook_doc(|nd| nd.set_metadata_snapshot(snapshot))
     }
 
+    /// Read the metadata snapshot, apply mutations via a closure, and write
+    /// it back in a single lock/snapshot/sync cycle.
+    ///
+    /// Prefer this over calling individual convenience methods (e.g.
+    /// `add_uv_dependency` + `remove_uv_dependency`) in a loop — each of
+    /// those acquires the lock, reads the full snapshot, writes it back,
+    /// publishes a snapshot, and notifies the sync task. `with_metadata`
+    /// does all of that exactly once regardless of how many mutations the
+    /// closure applies.
+    ///
+    /// ```ignore
+    /// let removed = handle.with_metadata(|snap| {
+    ///     snap.add_uv_dependency("numpy>=1.24");
+    ///     snap.add_uv_dependency("pandas>=2.0");
+    ///     snap.remove_uv_dependency("scipy")
+    /// })?;
+    /// ```
+    pub fn with_metadata<F, T>(&self, f: F) -> Result<T, SyncError>
+    where
+        F: FnOnce(&mut notebook_doc::metadata::NotebookMetadataSnapshot) -> T,
+    {
+        self.with_notebook_doc(|nd| nd.with_metadata(f))
+    }
+
     /// Set cell metadata from a JSON value. Returns true if cell found.
     pub fn set_cell_metadata(
         &self,

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -262,12 +262,20 @@ fn apply_dep_edits(
 ) -> Result<(Vec<String>, Vec<String>), String> {
     use notebook_protocol::connection::PackageManager;
 
+    // Short-circuit: nothing to do → skip the CRDT lock entirely.
+    if add.is_empty() && remove.is_empty() {
+        return Ok((vec![], vec![]));
+    }
+
     // Phase 1: validate all specifiers before touching the CRDT
     for package in add {
         validate_specifier_for_manager(package, manager)?;
     }
 
     // Phase 2: single lock + single snapshot read/write
+    // with_metadata compares before/after and skips the write when the
+    // closure didn't actually mutate anything (e.g. removing a package
+    // that isn't present, or adding one that's already there).
     handle
         .with_metadata(|snap| {
             // Adds

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -226,42 +226,84 @@ pub(crate) fn detect_package_manager(
     PackageManager::Uv
 }
 
-/// Add a dependency using the appropriate package manager, return error string on failure.
+/// Validate a package specifier for the given package manager.
 ///
-/// `Unknown` package managers fall back to Uv (same default as
-/// `detect_package_manager`) — consistent with the historical behavior.
-pub(crate) fn add_dep_for_manager(
-    handle: &notebook_sync::handle::DocHandle,
+/// Pure validation — no CRDT access. Call this for each package before
+/// applying any mutations so invalid specifiers never reach the document.
+fn validate_specifier_for_manager(
     package: &str,
     manager: &notebook_protocol::connection::PackageManager,
 ) -> Result<(), String> {
     use notebook_protocol::connection::PackageManager;
     match manager {
-        PackageManager::Conda => {
-            // Reject PEP 508 extras (`pkg[extra]`) before they land in
-            // the doc — conda matchspecs crash rattler with `invalid
-            // bracket` and take the kernel with them. See #2119.
-            notebook_doc::metadata::validate_conda_package_specifier(package)?;
-            handle
-                .add_conda_dependency(package)
-                .map_err(|e| format!("Failed to add conda dependency: {e}"))
-        }
-        PackageManager::Pixi => {
-            notebook_doc::metadata::validate_conda_package_specifier(package)?;
-            handle
-                .add_pixi_dependency(package)
-                .map_err(|e| format!("Failed to add pixi dependency: {e}"))
+        PackageManager::Conda | PackageManager::Pixi => {
+            notebook_doc::metadata::validate_conda_package_specifier(package)
         }
         PackageManager::Uv | PackageManager::Unknown(_) => {
-            notebook_doc::metadata::validate_package_specifier(package)?;
-            handle
-                .add_uv_dependency(package)
-                .map_err(|e| format!("Failed to add uv dependency: {e}"))
+            notebook_doc::metadata::validate_package_specifier(package)
         }
     }
 }
 
-/// Remove a dependency using the appropriate package manager.
+/// Apply dependency adds and removes in a single atomic CRDT transaction.
+///
+/// Validates all specifiers first, then acquires the doc lock once, applies
+/// all mutations to the in-memory snapshot, and writes back once. This
+/// produces O(1) Automerge ops and sync notifications regardless of how
+/// many packages are added/removed.
+///
+/// Returns `(removed, not_found)` — packages that were present and removed
+/// vs. packages that were requested for removal but not found.
+fn apply_dep_edits(
+    handle: &notebook_sync::handle::DocHandle,
+    add: &[String],
+    remove: &[String],
+    manager: &notebook_protocol::connection::PackageManager,
+) -> Result<(Vec<String>, Vec<String>), String> {
+    use notebook_protocol::connection::PackageManager;
+
+    // Phase 1: validate all specifiers before touching the CRDT
+    for package in add {
+        validate_specifier_for_manager(package, manager)?;
+    }
+
+    // Phase 2: single lock + single snapshot read/write
+    handle
+        .with_metadata(|snap| {
+            // Adds
+            for package in add {
+                match manager {
+                    PackageManager::Conda => snap.add_conda_dependency(package),
+                    PackageManager::Pixi => snap.add_pixi_dependency(package),
+                    PackageManager::Uv | PackageManager::Unknown(_) => {
+                        snap.add_uv_dependency(package)
+                    }
+                }
+            }
+
+            // Removes
+            let mut removed = Vec::new();
+            let mut not_found = Vec::new();
+            for package in remove {
+                let was_present = match manager {
+                    PackageManager::Conda => snap.remove_conda_dependency(package),
+                    PackageManager::Pixi => snap.remove_pixi_dependency(package),
+                    PackageManager::Uv | PackageManager::Unknown(_) => {
+                        snap.remove_uv_dependency(package)
+                    }
+                };
+                if was_present {
+                    removed.push(package.clone());
+                } else {
+                    not_found.push(package.clone());
+                }
+            }
+            (removed, not_found)
+        })
+        .map_err(|e| format!("Failed to apply dependency edits: {e}"))
+}
+
+/// Remove a single dependency using the appropriate package manager.
 ///
 /// `Unknown` package managers fall back to Uv (same default as `add`).
 fn remove_dep_for_manager(
@@ -269,18 +311,8 @@ fn remove_dep_for_manager(
     package: &str,
     manager: &notebook_protocol::connection::PackageManager,
 ) -> Result<bool, String> {
-    use notebook_protocol::connection::PackageManager;
-    match manager {
-        PackageManager::Conda => handle
-            .remove_conda_dependency(package)
-            .map_err(|e| format!("Failed to remove conda dependency: {e}")),
-        PackageManager::Pixi => handle
-            .remove_pixi_dependency(package)
-            .map_err(|e| format!("Failed to remove pixi dependency: {e}")),
-        PackageManager::Uv | PackageManager::Unknown(_) => handle
-            .remove_uv_dependency(package)
-            .map_err(|e| format!("Failed to remove uv dependency: {e}")),
-    }
+    let (removed, _) = apply_dep_edits(handle, &[], &[package.to_string()], manager)?;
+    Ok(!removed.is_empty())
 }
 
 fn dependency_fingerprint_for_handle(handle: &DocHandle) -> Option<String> {
@@ -534,10 +566,9 @@ pub async fn add_dependency(
 
     let manager = detect_package_manager(&handle);
 
-    for package in &packages {
-        if let Err(e) = add_dep_for_manager(&handle, package, &manager) {
-            return tool_error(&e);
-        }
+    // Validate + apply all packages in a single CRDT transaction
+    if let Err(e) = apply_dep_edits(&handle, &packages, &[], &manager) {
+        return tool_error(&e);
     }
     // For the response, use the first package as `package` for backward compat
     let package = packages.first().map(|s| s.as_str()).unwrap_or(raw_package);
@@ -620,21 +651,13 @@ pub async fn manage_dependencies(
 
     let before = dependency_state_json(&handle, &manager);
 
-    for package in &params.add {
-        if let Err(e) = add_dep_for_manager(&handle, package, &manager) {
-            return tool_error(&e);
-        }
-    }
-
-    let mut removed = Vec::new();
-    let mut not_found = Vec::new();
-    for package in &params.remove {
-        match remove_dep_for_manager(&handle, package, &manager) {
-            Ok(true) => removed.push(package.clone()),
-            Ok(false) => not_found.push(package.clone()),
-            Err(e) => return tool_error(&e),
-        }
-    }
+    // Validate all specifiers and apply adds/removes in a single CRDT
+    // transaction — one lock, one snapshot read/write, one sync notification.
+    let (removed, not_found) = match apply_dep_edits(&handle, &params.add, &params.remove, &manager)
+    {
+        Ok(result) => result,
+        Err(e) => return tool_error(&e),
+    };
 
     let mut trust_approved = false;
     let approved_fingerprint = if params.trust {


### PR DESCRIPTION
## Summary

- Add `NotebookDoc::with_metadata()` / `DocHandle::with_metadata()` — read the metadata snapshot once, apply N mutations via closure, write back once
- Refactor `manage_dependencies` and `add_dependency` MCP tools to validate all specifiers upfront, then apply all adds/removes in a single `with_metadata()` call
- Eliminates partial CRDT writes when validation fails mid-batch (e.g. `["numpy", "pandas>>>999", "scipy"]` used to leave `numpy` in the doc before erroring on `pandas>>>999`)

### Before

Each `add_uv_dependency()` on DocHandle:
1. Acquires the doc lock
2. Reads the full metadata snapshot from Automerge
3. Mutates one Vec entry
4. Writes the entire metadata tree back via `update_json_at_key`
5. Publishes a snapshot
6. Notifies the sync task

Adding 5 deps = 5× that cycle. With concurrent peers, the positional Automerge list ops from each intermediate state are conflict magnets.

### After

1. Validate all specifiers (pure, no CRDT access)
2. One `with_metadata()` call: one lock, one snapshot read, N in-memory Vec mutations, one `set_metadata_snapshot` write, one sync notify

O(1) Automerge ops and sync notifications regardless of batch size.

## Test plan

- [x] `cargo test -p notebook-doc -- with_metadata` — 3 new tests (batch adds, mixed add/remove, closure return value)
- [x] `cargo test -p runt-mcp` — 117 existing tests pass
- [x] `cargo test -p notebook-sync` — pass
- [x] `cargo xtask lint --fix` — clean
- [x] `cargo check -p runtimed-wasm -p runtimed-node -p runtimed-py` — downstream crates unaffected