### PR TITLE
fix(runtimed): surface conda env build failures instead of silent not_started

### DIFF
--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -222,6 +222,10 @@ pub enum KernelErrorReason {
     /// to do (`conda env create -f environment.yml`). Accompanying
     /// `error_details` carries the env name.
     CondaEnvYmlMissing,
+    /// An approved environment.yml build was attempted but failed (e.g.,
+    /// channel unreachable, dependency solve error). `error_details`
+    /// carries the rattler/conda error message.
+    CondaEnvBuildFailed,
 }
 
 impl KernelErrorReason {
@@ -231,6 +235,7 @@ impl KernelErrorReason {
             Self::DependencyCacheMissingIpykernel => "dependency_cache_missing_ipykernel",
             Self::IpykernelSitePackagesMismatch => "ipykernel_site_packages_mismatch",
             Self::CondaEnvYmlMissing => "conda_env_yml_missing",
+            Self::CondaEnvBuildFailed => "conda_env_build_failed",
         }
     }
 
@@ -240,6 +245,7 @@ impl KernelErrorReason {
             "dependency_cache_missing_ipykernel" => Some(Self::DependencyCacheMissingIpykernel),
             "ipykernel_site_packages_mismatch" => Some(Self::IpykernelSitePackagesMismatch),
             "conda_env_yml_missing" => Some(Self::CondaEnvYmlMissing),
+            "conda_env_build_failed" => Some(Self::CondaEnvBuildFailed),
             _ => None,
         }
     }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3310,7 +3310,9 @@ pub(crate) async fn auto_launch_kernel(
                         &RuntimeLifecycle::Error,
                         Some(KernelErrorReason::CondaEnvBuildFailed),
                         Some(&details),
-                    )
+                    )?;
+                    sd.clear_env_progress()?;
+                    Ok(())
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -3362,7 +3364,9 @@ pub(crate) async fn auto_launch_kernel(
                             &RuntimeLifecycle::Error,
                             Some(KernelErrorReason::CondaEnvBuildFailed),
                             Some(&details),
-                        )
+                        )?;
+                        sd.clear_env_progress()?;
+                        Ok(())
                     }) {
                         warn!("[runtime-state] {}", e);
                     }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3303,11 +3303,17 @@ pub(crate) async fn auto_launch_kernel(
                 .parent()
                 .unwrap_or_else(|| std::path::Path::new("/tmp"));
             if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                error!(
-                    "[notebook-sync] Failed to create conda envs directory {:?}: {}",
-                    parent, e
-                );
-                reset_starting_state(room, None).await;
+                let details = format!("Failed to create conda envs directory {:?}: {}", parent, e);
+                error!("[notebook-sync] {}", details);
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::CondaEnvBuildFailed),
+                        Some(&details),
+                    )
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
                 return;
             }
 
@@ -3346,11 +3352,20 @@ pub(crate) async fn auto_launch_kernel(
                     )
                 }
                 Err(e) => {
-                    error!(
-                        "[notebook-sync] Failed to create conda env '{}' from environment.yml: {}",
+                    let details = format!(
+                        "Failed to create conda env '{}' from environment.yml: {}",
                         env_name_display, e
                     );
-                    reset_starting_state(room, None).await;
+                    error!("[notebook-sync] {}", details);
+                    if let Err(e) = room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::Error,
+                            Some(KernelErrorReason::CondaEnvBuildFailed),
+                            Some(&details),
+                        )
+                    }) {
+                        warn!("[runtime-state] {}", e);
+                    }
                     return;
                 }
             }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1042,13 +1042,22 @@ pub(crate) async fn handle(
                             .parent()
                             .unwrap_or_else(|| std::path::Path::new("/tmp"));
                         if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                            reset_starting_state(room, None).await;
-                            return NotebookResponse::Error {
-                                error: format!(
-                                    "Failed to create conda envs directory {:?}: {}",
-                                    parent, e
-                                ),
-                            };
+                            let details = format!(
+                                "Failed to create conda envs directory {:?}: {}",
+                                parent, e
+                            );
+                            reset_starting_state_with_outcome(
+                                room,
+                                None,
+                                ResetOutcome::Error {
+                                    reason: Some(
+                                        runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
+                                    ),
+                                    details: &details,
+                                },
+                            )
+                            .await;
+                            return NotebookResponse::Error { error: details };
                         }
                         match kernel_env::conda::prepare_environment_in(
                             &conda_deps,
@@ -1087,13 +1096,22 @@ pub(crate) async fn handle(
                                 )
                             }
                             Err(e) => {
-                                reset_starting_state(room, None).await;
-                                return NotebookResponse::Error {
-                                    error: format!(
-                                        "Failed to create conda env '{}' from environment.yml: {}",
-                                        env_name_display, e
-                                    ),
-                                };
+                                let details = format!(
+                                    "Failed to create conda env '{}' from environment.yml: {}",
+                                    env_name_display, e
+                                );
+                                reset_starting_state_with_outcome(
+                                    room,
+                                    None,
+                                    ResetOutcome::Error {
+                                        reason: Some(
+                                            runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
+                                        ),
+                                        details: &details,
+                                    },
+                                )
+                                .await;
+                                return NotebookResponse::Error { error: details };
                             }
                         }
                     }

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -27,7 +27,8 @@ export type KernelErrorReasonKey =
   | "missing_ipykernel"
   | "dependency_cache_missing_ipykernel"
   | "ipykernel_site_packages_mismatch"
-  | "conda_env_yml_missing";
+  | "conda_env_yml_missing"
+  | "conda_env_build_failed";
 
 /**
  * Typed error-reason strings. Mirrors `KernelErrorReason::as_str()` on
@@ -46,6 +47,12 @@ export const KERNEL_ERROR_REASON = {
    * remediation command.
    */
   CONDA_ENV_YML_MISSING: "conda_env_yml_missing",
+  /**
+   * An approved environment.yml build was attempted but failed (e.g.,
+   * channel unreachable, dependency solve error). `kernel.error_details`
+   * carries the rattler/conda error message.
+   */
+  CONDA_ENV_BUILD_FAILED: "conda_env_build_failed",
 } as const satisfies Record<string, KernelErrorReasonKey>;
 
 /**

--- a/python/runtimed/src/runtimed/_constants.py
+++ b/python/runtimed/src/runtimed/_constants.py
@@ -27,6 +27,7 @@ KernelErrorReasonKey = Literal[
     "dependency_cache_missing_ipykernel",
     "ipykernel_site_packages_mismatch",
     "conda_env_yml_missing",
+    "conda_env_build_failed",
 ]
 
 
@@ -52,6 +53,10 @@ class KERNEL_ERROR_REASON:
     #: banner and MCP tools can report the miss. ``kernel.error_details``
     #: carries the declared env name and remediation command.
     CONDA_ENV_YML_MISSING: Final[KernelErrorReasonKey] = "conda_env_yml_missing"
+    #: An approved environment.yml build was attempted but failed (e.g.,
+    #: channel unreachable, dependency solve error). ``kernel.error_details``
+    #: carries the rattler/conda error message.
+    CONDA_ENV_BUILD_FAILED: Final[KernelErrorReasonKey] = "conda_env_build_failed"
 
 
 # ── Kernel status strings (legacy `kernel.status` vocabulary) ───────


### PR DESCRIPTION
## Summary

When `environment.yml` references a named conda env that doesn't exist and the
deps happen to be in `trusted_packages` (auto-approved), the daemon attempts to
create the env via rattler. If the build fails (channel unreachable, dep solve
error, etc.), the daemon called `reset_starting_state(room, None)` which
silently reset lifecycle to `NotStarted` — the user saw a permanently stuck
kernel with no indication of what went wrong.

- Add `KernelErrorReason::CondaEnvBuildFailed` variant + TypeScript mirror
- Replace silent `reset_starting_state` with
  `set_lifecycle_with_error_details(Error, CondaEnvBuildFailed, details)` in
  both `auto_launch_kernel` and the explicit `LaunchKernel` handler
- The existing generic `KernelLaunchErrorBanner` picks up the new reason and
  displays the rattler error with a Retry button

Found by `conda-env-yml-fallback` gremlin (nightly-tester batch).

## Test plan

- [x] `cargo test -p runtime-doc` — error reason round-trips
- [x] `cargo test -p runtimed --lib` — 627 passed
- [x] `cargo xtask lint --fix` — clean
- [x] Manual repro: `create_notebook(package_manager="conda", working_dir="/tmp/test-issue-2157")` with `environment.yml` naming `nonexistent-conda-env-xyzzy-2157` — daemon now logs the error and writes `Error` lifecycle with `CondaEnvBuildFailed` reason instead of silently resetting to `NotStarted`