### PR TITLE
ci(release): publish Linux install script asset

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1379,6 +1379,8 @@ jobs:
             -e "s/^DEFAULT_TAG=\"\"$/DEFAULT_TAG=\"v${{ needs.compute-version.outputs.version }}\"/" \
             scripts/install-linux-release > release-assets/install-linux-release
           chmod 0755 release-assets/install-linux-release
+          grep -Fqx "DEFAULT_CHANNEL=\"${CHANNEL}\"" release-assets/install-linux-release
+          grep -Fqx "DEFAULT_TAG=\"v${{ needs.compute-version.outputs.version }}\"" release-assets/install-linux-release
           # Notebook installers
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.dmg" release-assets/
           cp "notebook-macos-x64/nteract-${CHANNEL}-darwin-x64.dmg" release-assets/

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1374,7 +1374,10 @@ jobs:
           cp executables/nteract-mcp-linux-x64 "release-assets/${MCP_NAME}-linux-x64"
           cp executables/runt-darwin-arm64 "release-assets/${CLI_NAME}-darwin-arm64"
           cp executables/runt-darwin-x64 "release-assets/${CLI_NAME}-darwin-x64"
-          cp scripts/install-linux-release release-assets/install-linux-release
+          sed \
+            -e "s/^DEFAULT_CHANNEL=\"stable\"$/DEFAULT_CHANNEL=\"${CHANNEL}\"/" \
+            -e "s/^DEFAULT_TAG=\"\"$/DEFAULT_TAG=\"v${{ needs.compute-version.outputs.version }}\"/" \
+            scripts/install-linux-release > release-assets/install-linux-release
           chmod 0755 release-assets/install-linux-release
           # Notebook installers
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.dmg" release-assets/

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1554,7 +1554,7 @@ jobs:
             echo "For Linux shell installs, download \`install-linux-release\` from this release or run:"
             echo ''
             echo '```bash'
-            echo 'curl -fsSL https://sh.nteract.io | sh'
+            echo 'curl -fsSL https://sh.nteract.io | bash'
             echo '```'
             echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1374,6 +1374,8 @@ jobs:
           cp executables/nteract-mcp-linux-x64 "release-assets/${MCP_NAME}-linux-x64"
           cp executables/runt-darwin-arm64 "release-assets/${CLI_NAME}-darwin-arm64"
           cp executables/runt-darwin-x64 "release-assets/${CLI_NAME}-darwin-x64"
+          cp scripts/install-linux-release release-assets/install-linux-release
+          chmod 0755 release-assets/install-linux-release
           # Notebook installers
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.dmg" release-assets/
           cp "notebook-macos-x64/nteract-${CHANNEL}-darwin-x64.dmg" release-assets/
@@ -1417,6 +1419,7 @@ jobs:
           require_file "release-assets/nteract-${CHANNEL}-darwin-x64.app.tar.gz"
           require_file "release-assets/nteract-${CHANNEL}-linux-x64.AppImage"
           require_file "release-assets/nteract-${CHANNEL}-windows-x64.exe"
+          require_file "release-assets/install-linux-release"
           require_sig "release-assets/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig"
           require_sig "release-assets/nteract-${CHANNEL}-darwin-x64.app.tar.gz.sig"
           require_sig "release-assets/nteract-${CHANNEL}-linux-x64.AppImage.sig"
@@ -1543,6 +1546,12 @@ jobs:
             echo ''
             echo "macOS and Windows builds are signed. macOS builds are also notarized. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
             echo ''
+            echo "For Linux shell installs, download \`install-linux-release\` from this release or run:"
+            echo ''
+            echo '```bash'
+            echo 'curl -fsSL https://sh.nteract.io | sh'
+            echo '```'
+            echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
             echo "## ${CLI_NAME} (CLI)"
@@ -1585,6 +1594,7 @@ jobs:
             ./release-assets/nteract-mcp*-linux-x64
             ./release-assets/runt*-darwin-arm64
             ./release-assets/runt*-darwin-x64
+            ./release-assets/install-linux-release
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage.sig
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-arm64.dmg

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,12 +25,19 @@ Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-rel
 | macOS ARM64 (Apple Silicon) | `nteract-{channel}-darwin-arm64.dmg` |
 | Windows x64 | `nteract-{channel}-windows-x64.exe` |
 | Linux x64 | `nteract-{channel}-linux-x64.AppImage` |
+| Linux installer script | `install-linux-release` |
 | CLI (macOS ARM64) | `runt-darwin-arm64` |
 | CLI (Linux x64) | `runt-linux-x64` |
 
 macOS builds are signed and notarized. Windows builds are not code signed. Linux
 desktop releases publish AppImage only; DEB/RPM/APT installs are not currently
 supported because `runtimed` is a per-user daemon.
+
+Linux users can also install the released AppImage with:
+
+```bash
+curl -fsSL https://sh.nteract.io | sh
+```
 
 ### Crate publishing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,7 +36,7 @@ supported because `runtimed` is a per-user daemon.
 Linux users can also install the released AppImage with:
 
 ```bash
-curl -fsSL https://sh.nteract.io | sh
+curl -fsSL https://sh.nteract.io | bash
 ```
 
 ### Crate publishing

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -73,7 +73,9 @@ case "$(uname -m)" in
 esac
 
 REPO="nteract/desktop"
-CHANNEL="stable"
+DEFAULT_CHANNEL="stable"
+DEFAULT_TAG=""
+CHANNEL="$DEFAULT_CHANNEL"
 TAG=""
 FROM_DIR=""
 NO_START=0
@@ -128,6 +130,10 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -z "$TAG" && -z "$FROM_DIR" && "$CHANNEL" == "$DEFAULT_CHANNEL" && -n "$DEFAULT_TAG" ]]; then
+  TAG="$DEFAULT_TAG"
+fi
 
 if [[ -n "$TAG" && -n "$FROM_DIR" ]]; then
   echo "Use either --tag or --from-dir, not both." >&2

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -2,7 +2,7 @@
 # Install a published nteract Linux release for the current user.
 #
 # Intended future entrypoint:
-#   curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | sh
+#   curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash
 #
 # Installs the AppImage plus runt/runtimed/nteract-mcp sidecars into a durable
 # per-user directory, links commands into ~/.local/bin, repairs/installs the


### PR DESCRIPTION
## Summary

- publish `scripts/install-linux-release` as a GitHub release asset named `install-linux-release`
- require the installer asset during release asset validation
- bake the release channel and tag into the published installer asset
- document the shell installer in generated release notes and `RELEASING.md`

## Verification

- `bash -n scripts/install-linux-release`
- `git diff --check`
- `actionlint .github/workflows/release-common.yml`
- `cargo xtask lint --fix`
- Claude Bedrock Opus review: clear after follow-up fixes
