### PR TITLE
refactor(sync): share notebook presence helpers

### DIFF
--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -55,6 +55,7 @@ pub mod connect;
 pub mod error;
 pub mod execution_wait;
 pub mod handle;
+pub mod presence;
 pub mod relay;
 pub mod relay_task;
 mod shared;

--- a/crates/notebook-sync/src/presence.rs
+++ b/crates/notebook-sync/src/presence.rs
@@ -1,0 +1,110 @@
+//! Shared best-effort presence helpers for notebook clients.
+//!
+//! These helpers centralize the common pattern used by MCP, Python, and Node
+//! bindings: encode a labeled presence update and send it through `DocHandle`.
+//! Presence is UX-only, so all send helpers deliberately swallow errors after
+//! logging at debug level.
+
+use notebook_doc::presence::{self, CursorPosition};
+
+use crate::handle::DocHandle;
+
+/// Get the Automerge actor label from the handle, or `None` when unavailable.
+pub fn actor_label(handle: &DocHandle) -> Option<String> {
+    handle.get_actor_id().ok().filter(|s| !s.is_empty())
+}
+
+/// Announce this peer immediately after connecting to a notebook.
+///
+/// Without this, the peer may be invisible in collaborator UI until it performs
+/// an operation that emits cursor/focus presence.
+pub async fn announce(handle: &DocHandle, peer_label: Option<&str>) {
+    let actor = actor_label(handle);
+    let encoded = if let Some(cell_id) = handle.first_cell_id() {
+        presence::encode_focus_update_labeled("local", peer_label, actor.as_deref(), &cell_id)
+    } else {
+        presence::encode_custom_update_labeled("local", peer_label, actor.as_deref(), &[])
+    };
+    send_encoded(handle, encoded, "announce").await;
+}
+
+/// Emit a cursor position in a cell.
+pub async fn emit_cursor(
+    handle: &DocHandle,
+    cell_id: &str,
+    line: u32,
+    column: u32,
+    peer_label: Option<&str>,
+) {
+    let actor = actor_label(handle);
+    let encoded = presence::encode_cursor_update_labeled(
+        "local",
+        peer_label,
+        actor.as_deref(),
+        &CursorPosition {
+            cell_id: cell_id.to_string(),
+            line,
+            column,
+        },
+    );
+    send_encoded(handle, encoded, "emit_cursor").await;
+}
+
+/// Emit a cursor at the end of a source string.
+pub async fn emit_cursor_at_end(
+    handle: &DocHandle,
+    cell_id: &str,
+    source: &str,
+    peer_label: Option<&str>,
+) {
+    let (line, column) = offset_to_line_col(source, source.len());
+    emit_cursor(handle, cell_id, line, column, peer_label).await;
+}
+
+/// Emit cell focus without a specific cursor position.
+pub async fn emit_focus(handle: &DocHandle, cell_id: &str, peer_label: Option<&str>) {
+    let actor = actor_label(handle);
+    let encoded =
+        presence::encode_focus_update_labeled("local", peer_label, actor.as_deref(), cell_id);
+    send_encoded(handle, encoded, "emit_focus").await;
+}
+
+/// Convert a character offset in source to (line, column), both 0-based.
+///
+/// Column is counted in Unicode scalar values after the last newline, matching
+/// the existing Python and MCP behavior.
+pub fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    let before = &source[..offset.min(source.len())];
+    let line = before.chars().filter(|&c| c == '\n').count() as u32;
+    let after_last_newline = match before.rfind('\n') {
+        Some(pos) => &before[pos + 1..],
+        None => before,
+    };
+    let column = after_last_newline.chars().count() as u32;
+    (line, column)
+}
+
+async fn send_encoded(
+    handle: &DocHandle,
+    encoded: Result<Vec<u8>, notebook_doc::presence::PresenceError>,
+    context: &str,
+) {
+    match encoded {
+        Ok(data) => {
+            let _ = handle.send_presence(data).await;
+        }
+        Err(e) => log::debug!("{context}: failed to encode presence: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::offset_to_line_col;
+
+    #[test]
+    fn offset_to_line_col_counts_unicode_columns() {
+        assert_eq!(offset_to_line_col("abc", 3), (0, 3));
+        assert_eq!(offset_to_line_col("a\nbc", 4), (1, 2));
+        assert_eq!(offset_to_line_col("α\nβγ", "α\nβ".len()), (1, 1));
+    }
+}

--- a/crates/notebook-sync/src/presence.rs
+++ b/crates/notebook-sync/src/presence.rs
@@ -4,12 +4,21 @@
 //! bindings: encode a labeled presence update and send it through `DocHandle`.
 //! Presence is UX-only, so all send helpers deliberately swallow errors after
 //! logging at debug level.
+//!
+//! Actor labels are intentionally read from `DocHandle` rather than from each
+//! binding's side-car session state. The handle owns the Automerge actor used
+//! for document writes, so deriving presence provenance from it keeps generated
+//! actor labels visible consistently across Python, Node, and MCP clients.
 
 use notebook_doc::presence::{self, CursorPosition};
 
 use crate::handle::DocHandle;
 
 /// Get the Automerge actor label from the handle, or `None` when unavailable.
+///
+/// This is the canonical actor label for presence provenance. Some bindings
+/// keep an optional requested actor label in session state, but the handle is
+/// where the effective generated actor label lives.
 pub fn actor_label(handle: &DocHandle) -> Option<String> {
     handle.get_actor_id().ok().filter(|s| !s.is_empty())
 }

--- a/crates/runt-mcp/src/presence.rs
+++ b/crates/runt-mcp/src/presence.rs
@@ -1,21 +1,12 @@
 //! Presence helpers for the MCP server.
 //!
-//! Emits cursor positions and cell focus to the daemon so peers
-//! (the notebook app) see where the agent is working. All presence
-//! is best-effort — errors are silently ignored.
+//! Thin wrappers over `notebook_sync::presence` so MCP-specific call sites keep
+//! their existing names while shared encoding/sending logic lives with
+//! `DocHandle`.
 
-use notebook_doc::presence::{self, CursorPosition};
 use notebook_sync::handle::DocHandle;
 
-/// Get the actor label from the handle, or empty string on error.
-fn actor_label(handle: &DocHandle) -> Option<String> {
-    handle.get_actor_id().ok().filter(|s| !s.is_empty())
-}
-
 /// Emit a cursor position (line, column in a cell).
-///
-/// Shows a blinking cursor in the notebook app at the specified position.
-/// `peer_label` is the MCP client's display name (e.g. "Claude Code").
 pub async fn emit_cursor(
     handle: &DocHandle,
     cell_id: &str,
@@ -23,74 +14,20 @@ pub async fn emit_cursor(
     column: u32,
     peer_label: &str,
 ) {
-    let actor = actor_label(handle);
-    match presence::encode_cursor_update_labeled(
-        "local",
-        Some(peer_label),
-        actor.as_deref(),
-        &CursorPosition {
-            cell_id: cell_id.to_string(),
-            line,
-            column,
-        },
-    ) {
-        Ok(data) => {
-            let _ = handle.send_presence(data).await;
-        }
-        Err(e) => tracing::debug!("emit_cursor: failed to encode: {}", e),
-    }
+    notebook_sync::presence::emit_cursor(handle, cell_id, line, column, Some(peer_label)).await;
 }
 
 /// Emit a cell focus (agent is working on this cell, no specific cursor).
-///
-/// Shows a presence dot on the cell without a blinking cursor.
-/// `peer_label` is the MCP client's display name (e.g. "Claude Code").
 pub async fn emit_focus(handle: &DocHandle, cell_id: &str, peer_label: &str) {
-    let actor = actor_label(handle);
-    match presence::encode_focus_update_labeled(
-        "local",
-        Some(peer_label),
-        actor.as_deref(),
-        cell_id,
-    ) {
-        Ok(data) => {
-            let _ = handle.send_presence(data).await;
-        }
-        Err(e) => tracing::debug!("emit_focus: failed to encode: {}", e),
-    }
+    notebook_sync::presence::emit_focus(handle, cell_id, Some(peer_label)).await;
 }
 
 /// Announce presence immediately after connecting to a notebook.
-///
-/// Without this, the peer is invisible in the presence UI until it performs
-/// an action that emits presence (e.g. editing a cell).
 pub async fn announce(handle: &DocHandle, peer_label: &str) {
-    let actor = actor_label(handle);
-    let encoded = if let Some(cell_id) = handle.first_cell_id() {
-        presence::encode_focus_update_labeled("local", Some(peer_label), actor.as_deref(), &cell_id)
-    } else {
-        presence::encode_custom_update_labeled("local", Some(peer_label), actor.as_deref(), &[])
-    };
-    match encoded {
-        Ok(data) => {
-            let _ = handle.send_presence(data).await;
-        }
-        Err(e) => tracing::debug!("announce: failed to encode: {}", e),
-    }
+    notebook_sync::presence::announce(handle, Some(peer_label)).await;
 }
 
-/// Convert a character offset in source to (line, column) — both 0-based.
-/// Column is counted in Unicode code points (not bytes).
-///
-/// Matches the Python `offset_to_line_col()` implementation.
+/// Convert a character offset in source to (line, column), both 0-based.
 pub fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let before = &source[..offset.min(source.len())];
-    let line = before.chars().filter(|&c| c == '\n').count() as u32;
-    // Count characters (not bytes) after the last newline
-    let after_last_newline = match before.rfind('\n') {
-        Some(pos) => &before[pos + 1..],
-        None => before,
-    };
-    let col = after_last_newline.chars().count() as u32;
-    (line, col)
+    notebook_sync::presence::offset_to_line_col(source, offset)
 }

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -595,7 +595,8 @@ impl Session {
         handle
             .add_cell_with_source(&cell_id, &cell_type, opts.after_cell_id.as_deref(), &source)
             .map_err(to_napi_err)?;
-        emit_cursor_presence(&handle, &cell_id, &source, &peer_label).await;
+        notebook_sync::presence::emit_cursor_at_end(&handle, &cell_id, &source, Some(&peer_label))
+            .await;
         Ok(cell_id)
     }
 
@@ -613,7 +614,13 @@ impl Session {
                 .update_source(&cell_id, &source)
                 .map_err(to_napi_err)?;
             if found {
-                emit_cursor_presence(&handle, &cell_id, &source, &peer_label).await;
+                notebook_sync::presence::emit_cursor_at_end(
+                    &handle,
+                    &cell_id,
+                    &source,
+                    Some(&peer_label),
+                )
+                .await;
             }
         }
         if let Some(cell_type) = cell_type {
@@ -630,7 +637,7 @@ impl Session {
         let (handle, peer_label) = session_handle_and_label(&self.state).await?;
         let deleted = handle.delete_cell(&cell_id).map_err(to_napi_err)?;
         if deleted {
-            announce_presence(&handle, &peer_label).await;
+            notebook_sync::presence::announce(&handle, Some(&peer_label)).await;
         }
         Ok(deleted)
     }
@@ -649,7 +656,7 @@ impl Session {
             .move_cell(&cell_id, after_cell_id.as_deref())
             .map_err(to_napi_err)?;
         let peer_label = session_peer_label(&self.state).await;
-        emit_focus_presence(&handle, &cell_id, &peer_label).await;
+        notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
         Ok(position)
     }
 
@@ -665,7 +672,7 @@ impl Session {
         ensure_kernel_started(&self.state).await?;
         let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
         if let Ok((handle, peer_label)) = session_handle_and_label(&self.state).await {
-            emit_focus_presence(&handle, &cell_id, &peer_label).await;
+            notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
         }
 
         let result = tokio::time::timeout(timeout, async {
@@ -916,7 +923,11 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
         peer_label: actor_label.clone(),
     };
 
-    announce_presence(state.handle.as_ref().expect("handle set"), &actor_label).await;
+    notebook_sync::presence::announce(
+        state.handle.as_ref().expect("handle set"),
+        Some(&actor_label),
+    )
+    .await;
 
     Ok(Session {
         notebook_id,
@@ -1000,7 +1011,11 @@ pub async fn open_notebook_path(
         peer_label: actor_label.clone(),
     };
 
-    announce_presence(state.handle.as_ref().expect("handle set"), &actor_label).await;
+    notebook_sync::presence::announce(
+        state.handle.as_ref().expect("handle set"),
+        Some(&actor_label),
+    )
+    .await;
 
     Ok(Session {
         notebook_id,
@@ -1046,7 +1061,11 @@ pub async fn open_notebook(
         peer_label: actor_label.clone(),
     };
 
-    announce_presence(state.handle.as_ref().expect("handle set"), &actor_label).await;
+    notebook_sync::presence::announce(
+        state.handle.as_ref().expect("handle set"),
+        Some(&actor_label),
+    )
+    .await;
 
     Ok(Session {
         notebook_id,
@@ -1142,73 +1161,6 @@ async fn session_handle_and_label(state: &Arc<Mutex<SessionState>>) -> Result<(D
 async fn session_peer_label(state: &Arc<Mutex<SessionState>>) -> String {
     let st = state.lock().await;
     st.peer_label.clone()
-}
-
-fn actor_label(handle: &DocHandle) -> Option<String> {
-    handle.get_actor_id().ok().filter(|s| !s.is_empty())
-}
-
-async fn announce_presence(handle: &DocHandle, peer_label: &str) {
-    let actor = actor_label(handle);
-    let encoded = if let Some(cell_id) = handle.first_cell_id() {
-        notebook_doc::presence::encode_focus_update_labeled(
-            "local",
-            Some(peer_label),
-            actor.as_deref(),
-            &cell_id,
-        )
-    } else {
-        notebook_doc::presence::encode_custom_update_labeled(
-            "local",
-            Some(peer_label),
-            actor.as_deref(),
-            &[],
-        )
-    };
-    if let Ok(data) = encoded {
-        let _ = handle.send_presence(data).await;
-    }
-}
-
-async fn emit_focus_presence(handle: &DocHandle, cell_id: &str, peer_label: &str) {
-    let actor = actor_label(handle);
-    if let Ok(data) = notebook_doc::presence::encode_focus_update_labeled(
-        "local",
-        Some(peer_label),
-        actor.as_deref(),
-        cell_id,
-    ) {
-        let _ = handle.send_presence(data).await;
-    }
-}
-
-async fn emit_cursor_presence(handle: &DocHandle, cell_id: &str, source: &str, peer_label: &str) {
-    let actor = actor_label(handle);
-    let (line, column) = offset_to_line_col(source, source.len());
-    let position = notebook_doc::presence::CursorPosition {
-        cell_id: cell_id.to_string(),
-        line,
-        column,
-    };
-    if let Ok(data) = notebook_doc::presence::encode_cursor_update_labeled(
-        "local",
-        Some(peer_label),
-        actor.as_deref(),
-        &position,
-    ) {
-        let _ = handle.send_presence(data).await;
-    }
-}
-
-fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let before = &source[..offset.min(source.len())];
-    let line = before.chars().filter(|&c| c == '\n').count() as u32;
-    let after_last_newline = match before.rfind('\n') {
-        Some(pos) => &before[pos + 1..],
-        None => before,
-    };
-    let column = after_last_newline.chars().count() as u32;
-    (line, column)
 }
 
 fn peer_label_or_description(peer_label: Option<String>, description: Option<String>) -> String {
@@ -1408,7 +1360,7 @@ async fn add_source_cell(
     handle
         .add_cell_with_source(&cell_id, cell_type, None, source)
         .map_err(to_napi_err)?;
-    emit_cursor_presence(&handle, &cell_id, source, &peer_label).await;
+    notebook_sync::presence::emit_cursor_at_end(&handle, &cell_id, source, Some(&peer_label)).await;
     Ok(cell_id)
 }
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -248,26 +248,7 @@ pub(crate) async fn announce_presence(state: &SessionState) {
         Some(h) => h,
         None => return,
     };
-    let peer_label = state.peer_label.as_deref();
-    let actor_label = state.actor_label.as_deref();
-    let first_cell_id = handle.first_cell_id();
-
-    let encoded = if let Some(cell_id) = first_cell_id {
-        notebook_doc::presence::encode_focus_update_labeled(
-            "local",
-            peer_label,
-            actor_label,
-            &cell_id,
-        )
-    } else {
-        notebook_doc::presence::encode_custom_update_labeled("local", peer_label, actor_label, &[])
-    };
-    match encoded {
-        Ok(data) => {
-            let _ = handle.send_presence(data).await;
-        }
-        Err(e) => log::debug!("announce_presence: failed to encode: {}", e),
-    }
+    notebook_sync::presence::announce(handle, state.peer_label.as_deref()).await;
 }
 
 /// Populate `kernel_started`, `kernel_type`, and `env_source` from the
@@ -1646,25 +1627,13 @@ async fn emit_cursor_presence_internal(
     line: u32,
     column: u32,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Clone what we need and drop the lock before await to avoid contention
-    let (data, handle) = {
+    let (handle, peer_label) = {
         let st = state.lock().await;
-        let peer_label = st.peer_label.clone();
-        let actor_label = st.actor_label.clone();
-        let data = notebook_doc::presence::encode_cursor_update_labeled(
-            "local",
-            peer_label.as_deref(),
-            actor_label.as_deref(),
-            &notebook_doc::presence::CursorPosition {
-                cell_id: cell_id.to_string(),
-                line,
-                column,
-            },
-        )?;
         let handle = st.handle.clone().ok_or("Not connected")?;
-        (data, handle)
+        (handle, st.peer_label.clone())
     };
-    handle.send_presence(data).await?;
+    notebook_sync::presence::emit_cursor(&handle, cell_id, line, column, peer_label.as_deref())
+        .await;
     Ok(())
 }
 
@@ -1677,20 +1646,12 @@ async fn emit_focus_presence_internal(
     state: &Arc<Mutex<SessionState>>,
     cell_id: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let (data, handle) = {
+    let (handle, peer_label) = {
         let st = state.lock().await;
-        let peer_label = st.peer_label.clone();
-        let actor_label = st.actor_label.clone();
-        let data = notebook_doc::presence::encode_focus_update_labeled(
-            "local",
-            peer_label.as_deref(),
-            actor_label.as_deref(),
-            cell_id,
-        )?;
         let handle = st.handle.clone().ok_or("Not connected")?;
-        (data, handle)
+        (handle, st.peer_label.clone())
     };
-    handle.send_presence(data).await?;
+    notebook_sync::presence::emit_focus(&handle, cell_id, peer_label.as_deref()).await;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add shared best-effort presence helpers to notebook-sync alongside DocHandle
- update runt-mcp and runtimed-node to use the shared announce/cursor/focus helpers
- update runtimed-py best-effort announce/cursor/focus paths to use the same helpers
- intentionally normalize presence actor provenance through `DocHandle`, so Python now emits the effective/generated Automerge actor label just like Node and MCP

## Verification
- cargo check -p notebook-sync -p runt-mcp -p runtimed-node -p runtimed-py
- cargo xtask lint --fix

This follows up on the @runtimed/node API expansion review note about duplicated presence helpers across runtimed-py, runt-mcp, and runtimed-node.
