### PR TITLE
Add promote mode and release type dropdown to npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -63,19 +63,19 @@ jobs:
         run: |
           # Get the source tag based on release_type
           SOURCE_TAG="${{ inputs.release_type == 'stable' && 'next' || 'latest' }}"
-          VERSION=$(npm view @nteract/pi@${SOURCE_TAG} version)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
+          VERSION=$(npm view "@nteract/pi@${SOURCE_TAG}" version)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Promote packages to ${{ env.NPM_TAG }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Promoting version $VERSION from ${{ steps.version.outputs.source_tag }} to ${{ env.NPM_TAG }}"
-          npm dist-tag add @nteract/pi@$VERSION ${{ env.NPM_TAG }}
-          npm dist-tag add @runtimed/node@$VERSION ${{ env.NPM_TAG }}
-          npm dist-tag add @runtimed/node-darwin-arm64@$VERSION ${{ env.NPM_TAG }}
-          npm dist-tag add @runtimed/node-linux-x64-gnu@$VERSION ${{ env.NPM_TAG }}
-          npm dist-tag add @runtimed/node-win32-x64-msvc@$VERSION ${{ env.NPM_TAG }}
+          npm dist-tag add "@nteract/pi@$VERSION" "${{ env.NPM_TAG }}"
+          npm dist-tag add "@runtimed/node@$VERSION" "${{ env.NPM_TAG }}"
+          npm dist-tag add "@runtimed/node-darwin-arm64@$VERSION" "${{ env.NPM_TAG }}"
+          npm dist-tag add "@runtimed/node-linux-x64-gnu@$VERSION" "${{ env.NPM_TAG }}"
+          npm dist-tag add "@runtimed/node-win32-x64-msvc@$VERSION" "${{ env.NPM_TAG }}"
 
   native:
     name: Native package (${{ matrix.target }})

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,19 +16,25 @@ name: Publish npm packages
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: npm dist-tag to publish under
-        default: next
+      release_type:
+        description: Release type
+        default: nightly
         required: true
-        type: string
+        type: choice
+        options:
+          - stable
+          - nightly
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: npm-publish-${{ inputs.tag }}
+  group: npm-publish-${{ inputs.release_type }}
   cancel-in-progress: false
+
+env:
+  NPM_TAG: ${{ inputs.release_type == 'stable' && 'latest' || 'next' }}
 
 jobs:
   native:
@@ -75,7 +81,7 @@ jobs:
         run: pnpm --dir packages/runtimed-node/npm/${{ matrix.target }} pack:dry-run
 
       - name: Publish platform package
-        run: npm publish packages/runtimed-node/npm/${{ matrix.target }} --tag "${{ inputs.tag }}" --access public --provenance
+        run: npm publish packages/runtimed-node/npm/${{ matrix.target }} --tag "${{ env.NPM_TAG }}" --access public --provenance
 
   wrapper:
     name: Wrapper package
@@ -112,7 +118,7 @@ jobs:
         run: pnpm --dir packages/runtimed-node pack --pack-destination "$RUNNER_TEMP"
 
       - name: Publish wrapper package
-        run: npm publish "$RUNNER_TEMP"/runtimed-node-*.tgz --tag "${{ inputs.tag }}" --access public --provenance
+        run: npm publish "$RUNNER_TEMP"/runtimed-node-*.tgz --tag "${{ env.NPM_TAG }}" --access public --provenance
 
   pi:
     name: Pi package
@@ -144,4 +150,4 @@ jobs:
         run: pnpm --dir plugins/nteract/pi pack --pack-destination "$RUNNER_TEMP"
 
       - name: Publish Pi package
-        run: npm publish "$RUNNER_TEMP"/nteract-pi-*.tgz --tag "${{ inputs.tag }}" --access public --provenance
+        run: npm publish "$RUNNER_TEMP"/nteract-pi-*.tgz --tag "${{ env.NPM_TAG }}" --access public --provenance

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,6 +24,14 @@ on:
         options:
           - stable
           - nightly
+      mode:
+        description: Action to perform
+        default: publish
+        required: true
+        type: choice
+        options:
+          - publish
+          - promote
 
 permissions:
   contents: read
@@ -37,8 +45,41 @@ env:
   NPM_TAG: ${{ inputs.release_type == 'stable' && 'latest' || 'next' }}
 
 jobs:
+  promote:
+    name: Promote dist-tags
+    if: inputs.mode == 'promote'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use npm with trusted publishing support
+        run: npm install -g npm@latest
+
+      - name: Fetch latest version from current tag
+        id: version
+        run: |
+          # Get the source tag based on release_type
+          SOURCE_TAG="${{ inputs.release_type == 'stable' && 'next' || 'latest' }}"
+          VERSION=$(npm view @nteract/pi@${SOURCE_TAG} version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "source_tag=$SOURCE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Promote packages to ${{ env.NPM_TAG }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Promoting version $VERSION from ${{ steps.version.outputs.source_tag }} to ${{ env.NPM_TAG }}"
+          npm dist-tag add @nteract/pi@$VERSION ${{ env.NPM_TAG }}
+          npm dist-tag add @runtimed/node@$VERSION ${{ env.NPM_TAG }}
+          npm dist-tag add @runtimed/node-darwin-arm64@$VERSION ${{ env.NPM_TAG }}
+          npm dist-tag add @runtimed/node-linux-x64-gnu@$VERSION ${{ env.NPM_TAG }}
+          npm dist-tag add @runtimed/node-win32-x64-msvc@$VERSION ${{ env.NPM_TAG }}
+
   native:
     name: Native package (${{ matrix.target }})
+    if: inputs.mode == 'publish'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -85,6 +126,7 @@ jobs:
 
   wrapper:
     name: Wrapper package
+    if: inputs.mode == 'publish'
     needs: [native]
     runs-on: ubuntu-latest
     steps:
@@ -122,6 +164,7 @@ jobs:
 
   pi:
     name: Pi package
+    if: inputs.mode == 'publish'
     needs: [wrapper]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add promote mode and release type dropdown to npm publish workflow

Replace the free-form `tag` input with a `release_type` choice dropdown and add a `mode` dropdown to either publish new versions or promote existing ones:

**Release type** (determines dist-tag):
- **stable** → `latest` dist-tag
- **nightly** → `next` dist-tag

**Mode** (determines action):
- **publish** — build and publish new package versions (existing behavior)
- **promote** — update dist-tags on existing packages without republishing

The promote mode solves the problem where packages were published with the `next` tag but needed to be moved to `latest`. Instead of republishing (which npm rejects for identical versions), the workflow can now fetch the current version from the opposite tag and run `npm dist-tag add` for all packages.

## Changes
- Convert `inputs.tag` (string) to `inputs.release_type` (choice: stable/nightly)
- Add `inputs.mode` (choice: publish/promote)
- Set `NPM_TAG` env var based on release_type selection
- Add `promote` job that fetches current version and updates dist-tags
- Add `if: inputs.mode == 'publish'` condition to all existing jobs
- Quote shell variables to fix shellcheck linting
