### PR TITLE
docs(pi): update install instructions to use latest tag

### DIFF
--- a/plugins/nteract/pi/README.md
+++ b/plugins/nteract/pi/README.md
@@ -20,11 +20,8 @@ terminal workflows that need stateful Python execution.
 ## Install
 
 ```bash
-pi install npm:@nteract/pi@next
+pi install npm:@nteract/pi
 ```
-
-Use the `next` tag for prerelease builds until the package is promoted to the
-default npm tag.
 
 ## Local Use
 


### PR DESCRIPTION
## Summary

Updates `@nteract/pi` README install instructions to use the default npm tag now that 0.1.2 is published on `latest`, and improves the npm package listing with a better description and author field.

## Changes

- Remove `@next` tag from install command
- Drop prerelease note
- Rewrite package description to highlight key value props: persistent REPL, stateful execution, hot dependency sync, zero cold starts
- Add author field (npm may display nteract org avatar as package icon)
