### PR TITLE
fix(interrupt): remove coordinator-side sweep to fix create_cell(and_run) race

### DIFF
--- a/crates/runtimed/src/requests/interrupt_execution.rs
+++ b/crates/runtimed/src/requests/interrupt_execution.rs
@@ -1,31 +1,19 @@
 //! `NotebookRequest::InterruptExecution` handler.
 
-use tracing::warn;
-
 use crate::notebook_sync_server::{send_runtime_agent_command, NotebookRoom};
 use crate::protocol::NotebookResponse;
 
 pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
     let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
     if has_runtime_agent {
-        // Mark all in-flight executions as failed on the coordinator's copy
-        // of RuntimeStateDoc BEFORE sending the interrupt to the runtime
-        // agent.  This catches execution entries created by a concurrent
-        // ExecuteCell that haven't synced to the runtime agent yet — without
-        // this, those entries stay "queued" forever because the runtime
-        // agent's local queue doesn't know about them when it clears.
-        if let Err(e) = room.state.with_doc(|sd| {
-            sd.mark_inflight_executions_failed()?;
-            Ok(())
-        }) {
-            warn!(
-                "[interrupt] Failed to mark inflight executions on coordinator: {}",
-                e
-            );
-        }
-
-        // Fire-and-forget: the agent handles the SIGINT signal and updates
-        // its local queue / RuntimeStateDoc copy.
+        // Do NOT mark executions as failed here on the coordinator side.
+        // A concurrent ExecuteCell may have just queued an entry that should
+        // run normally after the interrupt completes.  The runtime agent's
+        // interrupt handler calls mark_inflight_executions_failed() on its
+        // own CRDT copy, which only catches entries that have already synced
+        // to the agent (i.e. entries that were genuinely in-flight).  Entries
+        // created concurrently arrive in a later sync frame and get picked
+        // up by get_queued_executions() for normal execution.
         match send_runtime_agent_command(
             room,
             notebook_protocol::protocol::RuntimeAgentRequest::InterruptExecution,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -166,9 +166,9 @@ pub async fn run_runtime_agent(
                                             let cleared = kernel_state.clear_queue();
                                             // Write cleared entries AND sweep any CRDT-synced
                                             // executions that haven't reached the local queue yet.
-                                            // The coordinator does this too, but belt-and-suspenders
-                                            // catches entries that arrived via sync after the
-                                            // coordinator's sweep.
+                                            // Only the agent does this sweep — the coordinator
+                                            // intentionally does NOT, so that concurrently-queued
+                                            // entries survive to execute after the interrupt.
                                             if let Err(e) = state.with_doc(|sd| {
                                                 for entry in &cleared {
                                                     sd.set_execution_done(&entry.execution_id, false)?;
@@ -878,6 +878,7 @@ async fn handle_runtime_agent_request(
                     Ok(()) => {
                         let cleared = state.clear_queue();
                         // Write cleared entries AND sweep CRDT-synced executions
+                        // that haven't reached the local queue yet.
                         if let Err(e) = ctx.state.with_doc(|sd| {
                             for entry in &cleared {
                                 sd.set_execution_done(&entry.execution_id, false)?;


### PR DESCRIPTION
## Summary

- `create_cell(and_run=True)` + `interrupt_kernel` fired in the same MCP turn results in the new cell showing `✗ error` with no output or error text. The cell never reaches the kernel.
- Root cause: PR #2495 added `mark_inflight_executions_failed()` on the coordinator side of the interrupt handler. This sweeps ALL "queued"/"running" entries — including entries created by a concurrent `ExecuteCell` that should run normally after the interrupt completes.
- Fix: remove the coordinator-side sweep. The runtime agent's interrupt handler already calls `mark_inflight_executions_failed()` on its own CRDT copy, which only catches entries that have synced to the agent (genuinely in-flight). Entries created concurrently arrive in a later sync frame and get picked up by `get_queued_executions()` for normal execution.

## The race (before this fix)

```
Time ──────────────────────────────────────────────────────►

MCP layer:     create_cell(and_run=True)   interrupt_kernel
                     │                          │
Coordinator:   ExecuteCell handler        InterruptExecution handler
                     │                          │
                create_execution_with_source    mark_inflight_executions_failed()
                (status: "queued")              (marks ALL queued → "error")
                     │                          │
                     └── entry marked "error" before kernel sees it
                         cell shows ✗ error, no output
```

## Why the agent-side sweep is sufficient

The runtime agent processes frames in a single-threaded `select!` loop:
1. Interrupt arrives → agent clears local queue + `mark_inflight_executions_failed()` on agent's CRDT
2. Only entries already synced to the agent are caught (genuinely in-flight)
3. New entries from concurrent `ExecuteCell` arrive in LATER sync frames
4. `get_queued_executions()` discovers them → they execute normally after interrupt

## Test plan

- [x] `cargo test -p runtimed --lib runtime_agent::tests` — 4 tests pass
- [x] `cargo test -p runtimed` — 36/37 pass (1 pre-existing failure on main: `test_untrusted_launch_and_sync_environment_are_daemon_rejected`)
- [x] `cargo xtask lint --fix` clean
- [x] CI — all checks pass
- [ ] Gremlin replay: breaker gremlin Test 1 (interrupt + create_cell in same turn)

## Codex review

- Round 1: Updated stale comments in both interrupt handler paths (fast-path + slow-path) that referenced "coordinator does this too" — the coordinator no longer calls `mark_inflight_executions_failed()`.