### PR TITLE
docs(interrupt): reframe comments per rgbkrk review

### DIFF
--- a/crates/runtimed/src/requests/interrupt_execution.rs
+++ b/crates/runtimed/src/requests/interrupt_execution.rs
@@ -7,13 +7,13 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
     let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
     if has_runtime_agent {
         // Do NOT mark executions as failed here on the coordinator side.
-        // A concurrent ExecuteCell may have just queued an entry that should
-        // run normally after the interrupt completes.  The runtime agent's
+        // The coordinator's CRDT copy may contain entries from a concurrent
+        // ExecuteCell whose final state should be determined by the runtime
+        // agent, not pre-empted by a blanket sweep.  The runtime agent's
         // interrupt handler calls mark_inflight_executions_failed() on its
-        // own CRDT copy, which only catches entries that have already synced
-        // to the agent (i.e. entries that were genuinely in-flight).  Entries
-        // created concurrently arrive in a later sync frame and get picked
-        // up by get_queued_executions() for normal execution.
+        // own CRDT copy — only entries that have actually synced to the
+        // agent are affected, so final state is correct regardless of
+        // timing between ExecuteCell and InterruptExecution.
         match send_runtime_agent_command(
             room,
             notebook_protocol::protocol::RuntimeAgentRequest::InterruptExecution,

--- a/crates/runtimed/src/requests/interrupt_execution.rs
+++ b/crates/runtimed/src/requests/interrupt_execution.rs
@@ -11,7 +11,7 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         // ExecuteCell whose final state should be determined by the runtime
         // agent, not pre-empted by a blanket sweep.  The runtime agent's
         // interrupt handler calls mark_inflight_executions_failed() on its
-        // own CRDT copy — only entries that have actually synced to the
+        // own CRDT copy - only entries that have actually synced to the
         // agent are affected, so final state is correct regardless of
         // timing between ExecuteCell and InterruptExecution.
         match send_runtime_agent_command(

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -167,8 +167,8 @@ pub async fn run_runtime_agent(
                                             // Write cleared entries AND sweep any CRDT-synced
                                             // executions that haven't reached the local queue yet.
                                             // Only the agent does this sweep — the coordinator
-                                            // intentionally does NOT, so that concurrently-queued
-                                            // entries survive to execute after the interrupt.
+                                            // intentionally does NOT, so that final state is
+                                            // determined by the agent regardless of timing.
                                             if let Err(e) = state.with_doc(|sd| {
                                                 for entry in &cleared {
                                                     sd.set_execution_done(&entry.execution_id, false)?;

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -166,7 +166,7 @@ pub async fn run_runtime_agent(
                                             let cleared = kernel_state.clear_queue();
                                             // Write cleared entries AND sweep any CRDT-synced
                                             // executions that haven't reached the local queue yet.
-                                            // Only the agent does this sweep — the coordinator
+                                            // Only the agent does this sweep - the coordinator
                                             // intentionally does NOT, so that final state is
                                             // determined by the agent regardless of timing.
                                             if let Err(e) = state.with_doc(|sd| {


### PR DESCRIPTION
## Summary

Follow-up to #2501 — rgbkrk's review comment didn't land because the PR was merged before the fix was pushed.

Reframes interrupt handler comments from "entries survive to execute" to "final state is correct regardless of timing" per rgbkrk's feedback:

> "It's not necessarily that we want them to survive to execute but that we want correct state at the end."

Comment-only change, no behavior change.

## Codex review

- N/A (comment-only, no code change)