### PR TITLE
feat(env): install default data packages in pools

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -213,6 +213,8 @@ export default function App() {
     setDefaultCondaPackages,
     defaultPixiPackages,
     setDefaultPixiPackages,
+    installDefaultDataPackages,
+    setInstallDefaultDataPackages,
     keepAliveSecs,
     setKeepAliveSecs,
     featureFlags,
@@ -402,6 +404,22 @@ export default function App() {
                 </span>
               </div>
             )}
+
+            <span className="text-sm text-muted-foreground whitespace-nowrap self-center text-right">
+              Data Stack
+            </span>
+            <div className="flex items-center justify-between gap-3 min-h-8">
+              <div className="space-y-0.5">
+                <span className="text-sm text-foreground">Default data packages</span>
+                <p className="text-[10px] text-muted-foreground/70">
+                  pandas, polars, matplotlib, plotly, altair
+                </p>
+              </div>
+              <Switch
+                checked={installDefaultDataPackages}
+                onCheckedChange={setInstallDefaultDataPackages}
+              />
+            </div>
 
             {/* Packages */}
             {defaultPythonEnv === "uv" && (

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -345,7 +345,7 @@ async fn install_pixi_env(
 }
 
 /// Warm up a pixi environment by running Python to trigger .pyc compilation.
-pub async fn warmup_environment(env: &PixiEnvironment) -> Result<()> {
+pub async fn warmup_environment(env: &PixiEnvironment, extra_modules: &[String]) -> Result<()> {
     let warmup_start = Instant::now();
     info!(
         "[prewarm] Warming up pixi environment at {:?}",
@@ -353,7 +353,8 @@ pub async fn warmup_environment(env: &PixiEnvironment) -> Result<()> {
     );
 
     let site_packages = find_site_packages(&env.venv_path);
-    let warmup_script = crate::warmup::build_warmup_command(&[], true, site_packages.as_deref());
+    let warmup_script =
+        crate::warmup::build_warmup_command(extra_modules, true, site_packages.as_deref());
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -105,6 +105,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("pixi_pool_size")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(defaults.pixi_pool_size),
+        install_default_data_packages: json
+            .get("install_default_data_packages")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.install_default_data_packages),
         bootstrap_dx: json
             .get("bootstrap_dx")
             .and_then(|v| v.as_bool())
@@ -165,6 +169,7 @@ mod tests {
         assert_eq!(settings.default_python_env, PythonEnvType::Uv);
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
+        assert!(settings.install_default_data_packages);
     }
 
     #[test]
@@ -184,6 +189,7 @@ mod tests {
             uv_pool_size: 4,
             conda_pool_size: 5,
             pixi_pool_size: 6,
+            install_default_data_packages: true,
             bootstrap_dx: false,
             ..SyncedSettings::default()
         };
@@ -375,6 +381,7 @@ mod tests {
             uv_pool_size: defaults.uv_pool_size,
             conda_pool_size: defaults.conda_pool_size,
             pixi_pool_size: defaults.pixi_pool_size,
+            install_default_data_packages: defaults.install_default_data_packages,
             bootstrap_dx: defaults.bootstrap_dx,
             ..defaults
         };

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -12,6 +12,7 @@
 //!   theme: "system"
 //!   default_runtime: "python"
 //!   default_python_env: "uv"
+//!   install_default_data_packages: true
 //!   uv/                           ← nested Map
 //!     default_packages: List[…]   ← List of Str
 //!   conda/                        ← nested Map
@@ -272,6 +273,14 @@ pub struct SyncedSettings {
     #[serde(default = "default_pixi_pool_size")]
     pub pixi_pool_size: u64,
 
+    /// Install the curated data-science package set in prewarmed pool environments.
+    ///
+    /// When true, UV/Conda/Pixi pools include pandas, polars, matplotlib,
+    /// plotly, and altair in addition to the managed notebook runtime. Project
+    /// notebooks with explicit dependencies are unaffected.
+    #[serde(default = "default_install_default_data_packages")]
+    pub install_default_data_packages: bool,
+
     /// Enable the nteract data-experience kernel bootstrap (nteract/dx).
     /// When true, the daemon installs `nteract-kernel-launcher` and `dx` into
     /// UV kernel environments, launches kernels via `nteract_kernel_launcher`,
@@ -339,6 +348,7 @@ impl Default for SyncedSettings {
             uv_pool_size: pool_sizes.uv_pool_size,
             conda_pool_size: pool_sizes.conda_pool_size,
             pixi_pool_size: pool_sizes.pixi_pool_size,
+            install_default_data_packages: true,
             bootstrap_dx: false,
             install_id: String::new(),
             telemetry_enabled: true,
@@ -365,6 +375,9 @@ fn default_conda_pool_size() -> u64 {
 }
 fn default_pixi_pool_size() -> u64 {
     DEFAULT_PIXI_POOL_SIZE
+}
+fn default_install_default_data_packages() -> bool {
+    true
 }
 
 /// Backfill `telemetry_consent_recorded` for installations that completed
@@ -466,6 +479,11 @@ impl SettingsDoc {
 
         // nteract/dx kernel bootstrap (opt-in)
         let _ = doc.put(automerge::ROOT, "bootstrap_dx", defaults.bootstrap_dx);
+        let _ = doc.put(
+            automerge::ROOT,
+            "install_default_data_packages",
+            defaults.install_default_data_packages,
+        );
 
         // Telemetry defaults (install_id left empty until first heartbeat)
         let _ = doc.put(automerge::ROOT, "install_id", "");
@@ -578,6 +596,12 @@ impl SettingsDoc {
         // bootstrap_dx: boolean
         if let Some(enabled) = json.get("bootstrap_dx").and_then(|v| v.as_bool()) {
             settings.put_bool("bootstrap_dx", enabled);
+        }
+        if let Some(enabled) = json
+            .get("install_default_data_packages")
+            .and_then(|v| v.as_bool())
+        {
+            settings.put_bool("install_default_data_packages", enabled);
         }
 
         // Telemetry fields
@@ -1013,6 +1037,9 @@ impl SettingsDoc {
             pixi_pool_size: self
                 .get_u64("pixi_pool_size")
                 .unwrap_or(pool_sizes.pixi_pool_size),
+            install_default_data_packages: self
+                .get_bool("install_default_data_packages")
+                .unwrap_or(defaults.install_default_data_packages),
             bootstrap_dx: self
                 .get_bool("bootstrap_dx")
                 .unwrap_or(defaults.bootstrap_dx),
@@ -1166,6 +1193,20 @@ impl SettingsDoc {
                 changed = true;
             }
         }
+        if let Some(enabled) = json
+            .get("install_default_data_packages")
+            .and_then(|v| v.as_bool())
+        {
+            let current = self.get_bool("install_default_data_packages");
+            if current != Some(enabled) {
+                info!(
+                    "[settings] apply_json_changes: install_default_data_packages changed {:?} -> {}",
+                    current, enabled
+                );
+                self.put_bool("install_default_data_packages", enabled);
+                changed = true;
+            }
+        }
 
         // Telemetry fields
         if let Some(id) = json.get("install_id").and_then(|v| v.as_str()) {
@@ -1285,6 +1326,7 @@ mod tests {
         assert_eq!(settings.pixi_pool_size, DEFAULT_POOL_SIZE);
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
+        assert!(settings.install_default_data_packages);
     }
 
     #[test]
@@ -1333,6 +1375,18 @@ mod tests {
             "default_python_env": "conda"
         })));
         assert_eq!(doc.get_all().uv_pool_size, DEFAULT_SELECTED_POOL_SIZE);
+    }
+
+    #[test]
+    fn test_install_default_data_packages_can_be_disabled_from_json() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "install_default_data_packages": false
+        })));
+
+        assert_eq!(doc.get_bool("install_default_data_packages"), Some(false));
+        assert!(!doc.get_all().install_default_data_packages);
     }
 
     #[test]
@@ -1687,6 +1741,7 @@ mod tests {
         assert!(schema_str.contains("theme"));
         assert!(schema_str.contains("default_runtime"));
         assert!(schema_str.contains("default_python_env"));
+        assert!(schema_str.contains("install_default_data_packages"));
         // Should have known values as examples for editor autocomplete
         assert!(schema_str.contains("python"));
         assert!(schema_str.contains("deno"));

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -454,6 +454,8 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         uv_pool_size: get_u64("uv_pool_size").unwrap_or(pool_sizes.uv_pool_size),
         conda_pool_size: get_u64("conda_pool_size").unwrap_or(pool_sizes.conda_pool_size),
         pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(pool_sizes.pixi_pool_size),
+        install_default_data_packages: get_bool("install_default_data_packages")
+            .unwrap_or(defaults.install_default_data_packages),
         bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
         install_id: get_str("install_id").unwrap_or_default(),
         telemetry_enabled: get_bool("telemetry_enabled").unwrap_or(true),

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1078,6 +1078,10 @@ impl AsyncSession {
                 )?;
                 dict.set_item("keep_alive_secs", settings.keep_alive_secs)?;
                 dict.set_item("onboarding_completed", settings.onboarding_completed)?;
+                dict.set_item(
+                    "install_default_data_packages",
+                    settings.install_default_data_packages,
+                )?;
 
                 let uv_dict = PyDict::new(py);
                 uv_dict.set_item("default_packages", &settings.uv.default_packages)?;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2028,7 +2028,7 @@ impl Daemon {
                 #[cfg(not(target_os = "windows"))]
                 let python_path = env_path.join("bin").join("python");
 
-                if python_path.exists() {
+                if python_path.exists() && env_path.join(".warmed").exists() {
                     let hash_matches =
                         pool_package_hash_matches(&env_path, EnvType::Uv, &uv_prewarmed).await;
                     let mut pool = self.uv_pool.lock().await;
@@ -6947,6 +6947,30 @@ mod tests {
         assert_eq!(retired, 0);
         assert!(pool.available.is_empty());
         assert!(pool.retired_paths.is_empty());
+    }
+
+    #[test]
+    fn test_data_package_toggle_retires_previous_pool_entries() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut pool = Pool::new(3, 3600);
+
+        let packages_with_data_stack = uv_prewarmed_packages(&[], true);
+        let packages_without_data_stack = uv_prewarmed_packages(&[], false);
+        assert_ne!(
+            packages_with_data_stack, packages_without_data_stack,
+            "the data-stack toggle must affect the expected pool package set"
+        );
+
+        let mut env = create_test_env(&temp_dir, "runtimed-uv-data-stack");
+        let env_root = pool_env_root(&env.venv_path);
+        env.prewarmed_packages = packages_with_data_stack;
+        pool.add(env);
+
+        let retired = pool.retire_mismatched_packages(&packages_without_data_stack);
+
+        assert_eq!(retired, 1);
+        assert!(pool.available.is_empty());
+        assert!(pool.retired_paths.contains(&env_root));
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -405,6 +405,8 @@ fn spawn_env_deletions(paths: Vec<PathBuf>) {
 struct Pool {
     /// Available environments ready for use.
     available: VecDeque<PoolEntry>,
+    /// Stale-but-usable environments that can bridge a cold pool rebuild.
+    retired_available: VecDeque<PoolEntry>,
     /// Pool-root paths that were found on disk but whose package marker does
     /// not match the current expected package set. Keep these tracked so
     /// orphan GC does not delete a potentially working env while replacement
@@ -429,6 +431,7 @@ struct Pool {
 const MIN_WARM_BASES: usize = 2;
 const POOL_PACKAGE_HASH_FILE: &str = ".runt-pool-packages.sha256";
 const POOL_PACKAGE_HASH_VERSION: &str = "v1";
+const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plotly", "altair"];
 
 fn has_package_named(packages: &[String], name: &str) -> bool {
     packages
@@ -440,9 +443,20 @@ fn has_package_named(packages: &[String], name: &str) -> bool {
         .any(|pkg| pkg == name)
 }
 
-fn extend_default_packages(packages: &mut Vec<String>, extra: &[String]) {
+fn extend_default_packages(
+    packages: &mut Vec<String>,
+    extra: &[String],
+    install_default_data_packages: bool,
+) {
     for pkg in extra {
         packages.push(pkg.clone());
+    }
+    if install_default_data_packages {
+        for pkg in DEFAULT_DATA_PACKAGES {
+            if !has_package_named(packages, pkg) {
+                packages.push((*pkg).to_string());
+            }
+        }
     }
     if !has_package_named(packages, "nbformat") {
         packages.push("nbformat".to_string());
@@ -452,7 +466,7 @@ fn extend_default_packages(packages: &mut Vec<String>, extra: &[String]) {
     }
 }
 
-fn uv_prewarmed_packages(extra: &[String]) -> Vec<String> {
+fn uv_prewarmed_packages(extra: &[String], install_default_data_packages: bool) -> Vec<String> {
     // The launcher package is vendored post-creation. pyarrow and nbformat are
     // part of the managed notebook runtime so rich display formatters work by
     // default; user defaults can still override either package by name.
@@ -462,27 +476,27 @@ fn uv_prewarmed_packages(extra: &[String]) -> Vec<String> {
         "anywidget".to_string(),
         "uv".to_string(),
     ];
-    extend_default_packages(&mut packages, extra);
+    extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
 }
 
-fn conda_prewarmed_packages(extra: &[String]) -> Vec<String> {
+fn conda_prewarmed_packages(extra: &[String], install_default_data_packages: bool) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
     ];
-    extend_default_packages(&mut packages, extra);
+    extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
 }
 
-fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
+fn pixi_prewarmed_packages(extra: &[String], install_default_data_packages: bool) -> Vec<String> {
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
     ];
-    extend_default_packages(&mut packages, extra);
+    extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
 }
 
@@ -554,6 +568,7 @@ impl Pool {
     fn new(target: usize, max_age_secs: u64) -> Self {
         Self {
             available: VecDeque::new(),
+            retired_available: VecDeque::new(),
             retired_paths: std::collections::HashSet::new(),
             warming: 0,
             warming_paths: std::collections::HashSet::new(),
@@ -635,6 +650,7 @@ impl Pool {
             } else {
                 self.retired_paths
                     .insert(pool_env_root(&entry.env.venv_path));
+                self.retired_available.push_back(entry);
                 retired += 1;
             }
         }
@@ -668,6 +684,27 @@ impl Pool {
 
         let mut all_paths = stale_paths;
         all_paths.extend(invalid_paths);
+        while let Some(entry) = self.retired_available.pop_front() {
+            let root = pool_env_root(&entry.env.venv_path);
+            if entry.env.venv_path.exists()
+                && entry.env.python_path.exists()
+                && entry.env.venv_path.join(".warmed").exists()
+            {
+                info!(
+                    "[runtimed] Pool empty; falling back to retired environment {:?}",
+                    entry.env.venv_path
+                );
+                self.retired_paths.remove(&root);
+                self.leased_paths.insert(root);
+                return (Some(entry.env), all_paths);
+            }
+            warn!(
+                "[runtimed] Skipping retired env with missing path or warmup marker: {:?}",
+                entry.env.venv_path
+            );
+            self.retired_paths.remove(&root);
+            all_paths.push(entry.env.venv_path);
+        }
         (None, all_paths)
     }
 
@@ -687,10 +724,12 @@ impl Pool {
         let mut retired = Vec::new();
         if let Some(path) = self.retired_paths.iter().next().cloned() {
             self.retired_paths.remove(&path);
+            self.remove_retired_available(&path);
             retired.push(path);
         }
 
         if self.available.len() >= self.target {
+            self.retired_available.clear();
             retired.extend(self.retired_paths.drain());
         }
         retired
@@ -698,22 +737,39 @@ impl Pool {
 
     fn retired_paths_if_available_at_target(&mut self) -> Vec<PathBuf> {
         if self.available.len() >= self.target {
+            self.retired_available.clear();
             self.retired_paths.drain().collect()
         } else {
             Vec::new()
         }
     }
 
+    #[cfg(test)]
     fn retire_path(&mut self, path: PathBuf) {
         self.retired_paths.insert(pool_env_root(&path));
     }
 
-    fn retire_path_if_fallback_needed(&mut self, path: PathBuf) -> bool {
+    fn retire_env_if_fallback_needed(&mut self, env: PooledEnv) -> bool {
         if self.available.len() + self.retired_paths.len() + self.warming < self.target {
-            self.retire_path(path);
+            self.retired_paths.insert(pool_env_root(&env.venv_path));
+            self.retired_available.push_back(PoolEntry {
+                env,
+                created_at: Instant::now(),
+            });
             true
         } else {
             false
+        }
+    }
+
+    fn remove_retired_available(&mut self, path: &Path) {
+        let root = pool_env_root(path);
+        if let Some(index) = self
+            .retired_available
+            .iter()
+            .position(|entry| pool_env_root(&entry.env.venv_path) == root)
+        {
+            self.retired_available.remove(index);
         }
     }
 
@@ -1116,7 +1172,10 @@ impl Daemon {
     pub async fn uv_pool_packages(&self) -> Vec<String> {
         let settings = self.settings.read().await;
         let synced = settings.get_all();
-        uv_prewarmed_packages(&synced.uv.default_packages)
+        uv_prewarmed_packages(
+            &synced.uv.default_packages,
+            synced.install_default_data_packages,
+        )
     }
 
     /// Snapshot the user's feature-flag settings.
@@ -1207,7 +1266,10 @@ impl Daemon {
     pub async fn conda_pool_packages(&self) -> Vec<String> {
         let settings = self.settings.read().await;
         let synced = settings.get_all();
-        conda_prewarmed_packages(&synced.conda.default_packages)
+        conda_prewarmed_packages(
+            &synced.conda.default_packages,
+            synced.install_default_data_packages,
+        )
     }
 
     /// Create a new daemon with the given configuration.
@@ -1933,9 +1995,18 @@ impl Daemon {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
 
-            let uv_pkgs = uv_prewarmed_packages(&synced.uv.default_packages);
-            let conda_pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
-            let pixi_pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
+            let uv_pkgs = uv_prewarmed_packages(
+                &synced.uv.default_packages,
+                synced.install_default_data_packages,
+            );
+            let conda_pkgs = conda_prewarmed_packages(
+                &synced.conda.default_packages,
+                synced.install_default_data_packages,
+            );
+            let pixi_pkgs = pixi_prewarmed_packages(
+                &synced.pixi.default_packages,
+                synced.install_default_data_packages,
+            );
 
             (uv_pkgs, conda_pkgs, pixi_pkgs)
         };
@@ -1962,7 +2033,13 @@ impl Daemon {
                         pool_package_hash_matches(&env_path, EnvType::Uv, &uv_prewarmed).await;
                     let mut pool = self.uv_pool.lock().await;
                     if !hash_matches {
-                        if pool.retire_path_if_fallback_needed(env_path.clone()) {
+                        let env = PooledEnv {
+                            env_type: EnvType::Uv,
+                            venv_path: env_path.clone(),
+                            python_path,
+                            prewarmed_packages: vec![],
+                        };
+                        if pool.retire_env_if_fallback_needed(env) {
                             retired_found += 1;
                         } else {
                             orphans.push(env_path);
@@ -2005,7 +2082,13 @@ impl Daemon {
                             .await;
                     let mut pool = self.conda_pool.lock().await;
                     if !hash_matches {
-                        if pool.retire_path_if_fallback_needed(env_path.clone()) {
+                        let env = PooledEnv {
+                            env_type: EnvType::Conda,
+                            venv_path: env_path.clone(),
+                            python_path,
+                            prewarmed_packages: vec![],
+                        };
+                        if pool.retire_env_if_fallback_needed(env) {
                             retired_found += 1;
                         } else {
                             orphans.push(env_path);
@@ -2046,7 +2129,13 @@ impl Daemon {
                         pool_package_hash_matches(&env_path, EnvType::Pixi, &pixi_prewarmed).await;
                     let mut pool = self.pixi_pool.lock().await;
                     if !hash_matches {
-                        if pool.retire_path_if_fallback_needed(env_path.clone()) {
+                        let env = PooledEnv {
+                            env_type: EnvType::Pixi,
+                            venv_path,
+                            python_path,
+                            prewarmed_packages: vec![],
+                        };
+                        if pool.retire_env_if_fallback_needed(env) {
                             retired_found += 1;
                         } else {
                             orphans.push(env_path);
@@ -4091,7 +4180,10 @@ impl Daemon {
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let pkgs = uv_prewarmed_packages(&synced.uv.default_packages);
+                let pkgs = uv_prewarmed_packages(
+                    &synced.uv.default_packages,
+                    synced.install_default_data_packages,
+                );
                 (target, pkgs)
             };
 
@@ -4198,7 +4290,10 @@ impl Daemon {
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let pkgs = conda_prewarmed_packages(&synced.conda.default_packages);
+                let pkgs = conda_prewarmed_packages(
+                    &synced.conda.default_packages,
+                    synced.install_default_data_packages,
+                );
                 (target, pkgs)
             };
 
@@ -4312,7 +4407,10 @@ impl Daemon {
                         .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
-                let pkgs = pixi_prewarmed_packages(&synced.pixi.default_packages);
+                let pkgs = pixi_prewarmed_packages(
+                    &synced.pixi.default_packages,
+                    synced.install_default_data_packages,
+                );
                 (target, pkgs)
             };
 
@@ -4463,10 +4561,13 @@ impl Daemon {
         };
 
         // Read default conda packages from synced settings
-        let extra_conda_packages = {
+        let (extra_conda_packages, install_default_data_packages) = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            synced.conda.default_packages
+            (
+                synced.conda.default_packages,
+                synced.install_default_data_packages,
+            )
         };
 
         if !extra_conda_packages.is_empty() {
@@ -4477,7 +4578,8 @@ impl Daemon {
         }
 
         // Build specs: python + notebook essentials + user-configured defaults
-        let conda_install_packages = conda_prewarmed_packages(&extra_conda_packages);
+        let conda_install_packages =
+            conda_prewarmed_packages(&extra_conda_packages, install_default_data_packages);
 
         let match_spec_options = ParseMatchSpecOptions::strict();
         let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
@@ -4692,7 +4794,7 @@ impl Daemon {
 
         // Run warmup script
         let warmup_outcome = self
-            .warmup_conda_env(&python_path, &env_path, &extra_conda_packages)
+            .warmup_conda_env(&python_path, &env_path, &conda_install_packages)
             .await;
 
         match warmup_outcome {
@@ -4856,13 +4958,14 @@ impl Daemon {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
             let pixi_defaults = synced.pixi.default_packages;
+            let install_default_data_packages = synced.install_default_data_packages;
             if !pixi_defaults.is_empty() {
                 info!(
                     "[runtimed] Including default pixi packages: {:?}",
                     pixi_defaults
                 );
             }
-            pixi_prewarmed_packages(&pixi_defaults)
+            pixi_prewarmed_packages(&pixi_defaults, install_default_data_packages)
         };
         let prewarmed_packages = packages.clone();
 
@@ -4878,7 +4981,9 @@ impl Daemon {
         {
             Ok(env) => {
                 // Warm up the environment (.pyc compilation)
-                if let Err(e) = kernel_env::pixi::warmup_environment(&env).await {
+                if let Err(e) =
+                    kernel_env::pixi::warmup_environment(&env, &prewarmed_packages).await
+                {
                     warn!("[runtimed] Pixi warmup failed (non-fatal): {}", e);
                 }
 
@@ -5099,16 +5204,17 @@ impl Daemon {
         }
 
         // Read default uv packages from synced settings
-        let user_default_packages = {
+        let (user_default_packages, install_default_data_packages) = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
             let configured = synced.uv.default_packages;
             if !configured.is_empty() {
                 info!("[runtimed] Including default uv packages: {:?}", configured);
             }
-            configured
+            (configured, synced.install_default_data_packages)
         };
-        let install_packages = uv_prewarmed_packages(&user_default_packages);
+        let install_packages =
+            uv_prewarmed_packages(&user_default_packages, install_default_data_packages);
 
         // Install packages (180 second timeout per attempt). Try uv's cache
         // first so offline users with cached wheels do not take the network
@@ -5258,7 +5364,7 @@ impl Daemon {
             })
         };
         let warmup_script = kernel_env::warmup::build_warmup_command(
-            &user_default_packages,
+            &install_packages,
             false,
             site_packages.as_deref(),
         );
@@ -5360,17 +5466,34 @@ mod tests {
 
     #[test]
     fn test_uv_prewarmed_packages_include_required_display_deps() {
-        let packages = uv_prewarmed_packages(&[]);
+        let packages = uv_prewarmed_packages(&[], true);
+        assert!(packages.iter().any(|pkg| pkg == "nbformat"));
+        assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+        for pkg in DEFAULT_DATA_PACKAGES {
+            assert!(packages.iter().any(|candidate| candidate == pkg));
+        }
+    }
+
+    #[test]
+    fn test_prewarmed_packages_can_disable_default_data_packages() {
+        let packages = uv_prewarmed_packages(&[], false);
+        for pkg in DEFAULT_DATA_PACKAGES {
+            assert!(!packages.iter().any(|candidate| candidate == pkg));
+        }
         assert!(packages.iter().any(|pkg| pkg == "nbformat"));
         assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
     }
 
     #[test]
     fn test_prewarmed_packages_do_not_duplicate_overrides() {
-        let packages = conda_prewarmed_packages(&[
-            "nbformat==5.10.4".to_string(),
-            "conda-forge::pyarrow>=15".to_string(),
-        ]);
+        let packages = conda_prewarmed_packages(
+            &[
+                "nbformat==5.10.4".to_string(),
+                "conda-forge::pyarrow>=15".to_string(),
+                "pandas==2.2.3".to_string(),
+            ],
+            true,
+        );
         let pyarrow_count = packages
             .iter()
             .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
@@ -5381,16 +5504,24 @@ mod tests {
             .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
             .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "nbformat")
             .count();
+        let pandas_count = packages
+            .iter()
+            .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
+            .filter(|pkg| crate::inline_env::normalize_package_name(pkg) == "pandas")
+            .count();
         assert_eq!(pyarrow_count, 1);
         assert_eq!(nbformat_count, 1);
+        assert_eq!(pandas_count, 1);
         assert!(!packages.iter().any(|pkg| pkg == "pyarrow>=14"));
         assert!(!packages.iter().any(|pkg| pkg == "nbformat"));
     }
 
     #[test]
     fn test_conda_prewarmed_packages_does_not_duplicate_direct_ref_pyarrow() {
-        let packages =
-            conda_prewarmed_packages(&["pyarrow@https://example.invalid/pyarrow.whl".to_string()]);
+        let packages = conda_prewarmed_packages(
+            &["pyarrow@https://example.invalid/pyarrow.whl".to_string()],
+            true,
+        );
         let pyarrow_count = packages
             .iter()
             .filter_map(|pkg| crate::inline_env::extract_conda_package_name(pkg))
@@ -5498,6 +5629,7 @@ mod tests {
         assert_eq!(pool.target, 3);
         assert_eq!(pool.max_age_secs, 3600);
         assert_eq!(pool.available.len(), 0);
+        assert!(pool.retired_available.is_empty());
         assert_eq!(pool.warming, 0);
         assert!(pool.leased_paths.is_empty());
         assert!(pool.retired_paths.is_empty());
@@ -5561,6 +5693,29 @@ mod tests {
         assert!(tracked.contains(&pool_env_root(&leased_env.venv_path)));
         assert!(tracked.contains(&warming));
         assert!(tracked.contains(&retired));
+    }
+
+    #[test]
+    fn test_pool_take_falls_back_to_retired_env_when_available_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut pool = Pool::new(2, 3600);
+
+        let mut env = create_test_env(&temp_dir, "runtimed-uv-retired");
+        env.prewarmed_packages = vec!["ipykernel".into()];
+        let root = pool_env_root(&env.venv_path);
+        pool.add(env.clone());
+
+        let expected = vec!["ipykernel".to_string(), "pandas".to_string()];
+        assert_eq!(pool.retire_mismatched_packages(&expected), 1);
+        assert!(pool.available.is_empty());
+        assert!(pool.retired_paths.contains(&root));
+
+        let (taken, stale) = pool.take();
+        assert!(stale.is_empty());
+        assert_eq!(taken.unwrap().venv_path, env.venv_path);
+        assert!(pool.retired_paths.is_empty());
+        assert!(pool.retired_available.is_empty());
+        assert!(pool.leased_paths.contains(&root));
     }
 
     /// Build a minimal `DaemonConfig` for in-process tests. Pool sizes
@@ -6939,7 +7094,7 @@ mod tests {
             ..lease_test_config(&temp_dir)
         };
         std::fs::create_dir_all(&config.cache_dir).unwrap();
-        let expected = uv_prewarmed_packages(&[]);
+        let expected = uv_prewarmed_packages(&[], true);
         let env = create_test_env_in(&config.cache_dir, "runtimed-uv-matching");
         write_pool_package_hash(&env.venv_path, EnvType::Uv, &expected)
             .await
@@ -6967,7 +7122,7 @@ mod tests {
         std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
         std::fs::write(&python_path, "").unwrap();
         std::fs::write(venv_path.join(".warmed"), "").unwrap();
-        let expected = pixi_prewarmed_packages(&[]);
+        let expected = pixi_prewarmed_packages(&[], true);
         write_pool_package_hash(&project_dir, EnvType::Pixi, &expected)
             .await
             .unwrap();

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -353,17 +353,20 @@ async fn main() -> anyhow::Result<()> {
                 ),
             };
 
-            run_daemon(
-                socket,
-                cache_dir,
-                blob_store_dir,
+            let config = DaemonConfig {
+                socket_path: socket.unwrap_or_else(runtimed::default_socket_path),
+                cache_dir: cache_dir.unwrap_or_else(runtimed::default_cache_dir),
+                blob_store_dir: blob_store_dir.unwrap_or_else(runtimed::default_blob_store_dir),
+                execution_store_dir: runtimed::default_execution_store_dir(),
                 uv_pool_size,
                 conda_pool_size,
                 pixi_pool_size,
-                settings_doc,
-                settings_json,
-            )
-            .await
+                settings_doc_path: settings_doc,
+                settings_json_path: settings_json,
+                ..Default::default()
+            };
+
+            run_daemon(config).await
         }
         Some(Commands::Install { binary }) => install_service(binary),
         // Deprecated commands - still work but print warnings
@@ -426,30 +429,8 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-async fn run_daemon(
-    socket: Option<PathBuf>,
-    cache_dir: Option<PathBuf>,
-    blob_store_dir: Option<PathBuf>,
-    uv_pool_size: usize,
-    conda_pool_size: usize,
-    pixi_pool_size: usize,
-    settings_doc: Option<PathBuf>,
-    settings_json: Option<PathBuf>,
-) -> anyhow::Result<()> {
+async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     info!("runtimed starting...");
-
-    let config = DaemonConfig {
-        socket_path: socket.unwrap_or_else(runtimed::default_socket_path),
-        cache_dir: cache_dir.unwrap_or_else(runtimed::default_cache_dir),
-        blob_store_dir: blob_store_dir.unwrap_or_else(runtimed::default_blob_store_dir),
-        execution_store_dir: runtimed::default_execution_store_dir(),
-        uv_pool_size,
-        conda_pool_size,
-        pixi_pool_size,
-        settings_doc_path: settings_doc,
-        settings_json_path: settings_json,
-        ..Default::default()
-    };
 
     info!("Configuration:");
     info!("  Socket: {:?}", config.socket_path);

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -83,6 +83,14 @@ enum Commands {
             default_value_t = runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize
         )]
         pixi_pool_size: usize,
+
+        /// Override persisted settings doc path.
+        #[arg(long, hide = true)]
+        settings_doc: Option<PathBuf>,
+
+        /// Override persisted settings JSON mirror path.
+        #[arg(long, hide = true)]
+        settings_json: Option<PathBuf>,
     },
 
     /// Install daemon as a system service
@@ -304,32 +312,46 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         None | Some(Commands::Run { .. }) => {
             // Extract run args from command or use defaults
-            let (socket, cache_dir, blob_store_dir, uv_pool_size, conda_pool_size, pixi_pool_size) =
-                match cli.command {
-                    Some(Commands::Run {
-                        socket,
-                        cache_dir,
-                        blob_store_dir,
-                        uv_pool_size,
-                        conda_pool_size,
-                        pixi_pool_size,
-                    }) => (
-                        socket,
-                        cache_dir,
-                        blob_store_dir,
-                        uv_pool_size,
-                        conda_pool_size,
-                        pixi_pool_size,
-                    ),
-                    _ => (
-                        None,
-                        None,
-                        None,
-                        runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
-                        runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
-                        runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
-                    ),
-                };
+            let (
+                socket,
+                cache_dir,
+                blob_store_dir,
+                uv_pool_size,
+                conda_pool_size,
+                pixi_pool_size,
+                settings_doc,
+                settings_json,
+            ) = match cli.command {
+                Some(Commands::Run {
+                    socket,
+                    cache_dir,
+                    blob_store_dir,
+                    uv_pool_size,
+                    conda_pool_size,
+                    pixi_pool_size,
+                    settings_doc,
+                    settings_json,
+                }) => (
+                    socket,
+                    cache_dir,
+                    blob_store_dir,
+                    uv_pool_size,
+                    conda_pool_size,
+                    pixi_pool_size,
+                    settings_doc,
+                    settings_json,
+                ),
+                _ => (
+                    None,
+                    None,
+                    None,
+                    runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
+                    runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
+                    runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
+                    None,
+                    None,
+                ),
+            };
 
             run_daemon(
                 socket,
@@ -338,6 +360,8 @@ async fn main() -> anyhow::Result<()> {
                 uv_pool_size,
                 conda_pool_size,
                 pixi_pool_size,
+                settings_doc,
+                settings_json,
             )
             .await
         }
@@ -409,6 +433,8 @@ async fn run_daemon(
     uv_pool_size: usize,
     conda_pool_size: usize,
     pixi_pool_size: usize,
+    settings_doc: Option<PathBuf>,
+    settings_json: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     info!("runtimed starting...");
 
@@ -420,6 +446,8 @@ async fn run_daemon(
         uv_pool_size,
         conda_pool_size,
         pixi_pool_size,
+        settings_doc_path: settings_doc,
+        settings_json_path: settings_json,
         ..Default::default()
     };
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -84,11 +84,7 @@ enum Commands {
         )]
         pixi_pool_size: usize,
 
-        /// Override persisted settings doc path.
-        #[arg(long, hide = true)]
-        settings_doc: Option<PathBuf>,
-
-        /// Override persisted settings JSON mirror path.
+        /// Override canonical settings JSON path.
         #[arg(long, hide = true)]
         settings_json: Option<PathBuf>,
     },
@@ -319,7 +315,6 @@ async fn main() -> anyhow::Result<()> {
                 uv_pool_size,
                 conda_pool_size,
                 pixi_pool_size,
-                settings_doc,
                 settings_json,
             ) = match cli.command {
                 Some(Commands::Run {
@@ -329,7 +324,6 @@ async fn main() -> anyhow::Result<()> {
                     uv_pool_size,
                     conda_pool_size,
                     pixi_pool_size,
-                    settings_doc,
                     settings_json,
                 }) => (
                     socket,
@@ -338,7 +332,6 @@ async fn main() -> anyhow::Result<()> {
                     uv_pool_size,
                     conda_pool_size,
                     pixi_pool_size,
-                    settings_doc,
                     settings_json,
                 ),
                 _ => (
@@ -348,7 +341,6 @@ async fn main() -> anyhow::Result<()> {
                     runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
                     runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
                     runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
-                    None,
                     None,
                 ),
             };
@@ -361,7 +353,6 @@ async fn main() -> anyhow::Result<()> {
                 uv_pool_size,
                 conda_pool_size,
                 pixi_pool_size,
-                settings_doc_path: settings_doc,
                 settings_json_path: settings_json,
                 ..Default::default()
             };

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -463,7 +463,7 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
     )
     .unwrap();
 
-    let synced = tokio::time::timeout(Duration::from_secs(5), sync_client.recv_changes())
+    let synced = tokio::time::timeout(Duration::from_secs(15), sync_client.recv_changes())
         .await
         .expect("settings client should receive the external JSON edit")
         .expect("settings sync connection should stay open");

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,6 +9,7 @@ nteract Desktop settings control default behavior for new notebooks, appearance,
 | Theme | light, dark, system | system | `settings.json` + live Automerge sync |
 | Default runtime | python, deno | python | `settings.json` + live Automerge sync |
 | Default Python env | uv, conda | uv | `settings.json` + live Automerge sync |
+| Install default data packages | boolean | true | `settings.json` + live Automerge sync |
 | Default uv packages | list of strings | (empty) | `settings.json` + live Automerge sync |
 | Default conda packages | list of strings | (empty) | `settings.json` + live Automerge sync |
 | Keep alive secs | integer | 30 | `settings.json` + live Automerge sync |
@@ -35,6 +36,7 @@ ROOT/
   theme: "system"
   default_runtime: "python"
   default_python_env: "uv"
+  install_default_data_packages: true
   keep_alive_secs: 30
   onboarding_completed: false
   uv/                                         ← nested Map
@@ -64,6 +66,7 @@ Example:
   "theme": "system",
   "default_runtime": "python",
   "default_python_env": "uv",
+  "install_default_data_packages": true,
   "uv": {
     "default_packages": ["numpy", "pandas", "matplotlib"]
   },
@@ -122,17 +125,23 @@ If the notebook directory contains a `pyproject.toml` or `environment.yml`, the 
 
 ## Default Packages
 
-Controls which packages are pre-installed in prewarmed environments. These packages are available immediately when you open a new notebook, without needing to add them as inline dependencies.
+Controls which extra packages are pre-installed in prewarmed environments. These packages are available immediately when you open a new notebook, without needing to add them as inline dependencies.
 
-Since uv and conda have different package ecosystems, packages are configured separately:
+By default, pool environments also include the curated data-science set: `pandas`, `polars`, `matplotlib`, `plotly`, and `altair`. Set `install_default_data_packages` to `false` to opt out while keeping the managed notebook runtime packages.
+
+Since uv, conda, and pixi have different package ecosystems, user extras are configured separately:
 
 ```json
 {
+  "install_default_data_packages": false,
   "uv": {
     "default_packages": ["numpy", "pandas", "matplotlib"]
   },
   "conda": {
     "default_packages": ["numpy", "pandas", "scikit-learn"]
+  },
+  "pixi": {
+    "default_packages": ["numpy"]
   }
 }
 ```

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -21,6 +21,7 @@ Environment variables:
 import asyncio
 import gc
 import inspect
+import json
 import os
 import subprocess
 import sys
@@ -429,9 +430,22 @@ def daemon_process(request):
         cache_dir = tmpdir / "cache"
         blob_dir = tmpdir / "blobs"
         workspace_dir = tmpdir / "workspace"
+        settings_doc = tmpdir / "settings.automerge"
+        settings_json = tmpdir / "settings.json"
         cache_dir.mkdir()
         blob_dir.mkdir()
         workspace_dir.mkdir()
+        settings_json.write_text(
+            json.dumps(
+                {
+                    # The app defaults pool envs to a richer data-science stack.
+                    # Integration tests exercise daemon/session behavior and run
+                    # many short-lived daemons, so keep their prewarm env minimal.
+                    "install_default_data_packages": False,
+                }
+            ),
+            encoding="utf-8",
+        )
         uv_pool_size = os.environ.get("RUNTIMED_TEST_UV_POOL_SIZE", "3")
         conda_pool_size = os.environ.get("RUNTIMED_TEST_CONDA_POOL_SIZE", "1")
 
@@ -451,6 +465,10 @@ def daemon_process(request):
             conda_pool_size,
             "--pixi-pool-size",
             "0",
+            "--settings-doc",
+            str(settings_doc),
+            "--settings-json",
+            str(settings_json),
         ]
 
         print(f"\n[test] Starting daemon: {' '.join(cmd)}", file=sys.stderr)

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -430,7 +430,6 @@ def daemon_process(request):
         cache_dir = tmpdir / "cache"
         blob_dir = tmpdir / "blobs"
         workspace_dir = tmpdir / "workspace"
-        settings_doc = tmpdir / "settings.automerge"
         settings_json = tmpdir / "settings.json"
         cache_dir.mkdir()
         blob_dir.mkdir()
@@ -465,8 +464,6 @@ def daemon_process(request):
             conda_pool_size,
             "--pixi-pool-size",
             "0",
-            "--settings-doc",
-            str(settings_doc),
             "--settings-json",
             str(settings_json),
         ]

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -63,6 +63,14 @@ export type SyncedSettings = {
    */
   pixi_pool_size: bigint;
   /**
+   * Install the curated data-science package set in prewarmed pool environments.
+   *
+   * When true, UV/Conda/Pixi pools include pandas, polars, matplotlib,
+   * plotly, and altair in addition to the managed notebook runtime. Project
+   * notebooks with explicit dependencies are unaffected.
+   */
+  install_default_data_packages: boolean;
+  /**
    * Enable the nteract data-experience kernel bootstrap (nteract/dx).
    * When true, the daemon installs `nteract-kernel-launcher` and `dx` into
    * UV kernel environments, launches kernels via `nteract_kernel_launcher`,

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -154,6 +154,7 @@ export function useSyncedSettings() {
   const [defaultUvPackages, setDefaultUvPackagesState] = useState<string[]>([]);
   const [defaultCondaPackages, setDefaultCondaPackagesState] = useState<string[]>([]);
   const [defaultPixiPackages, setDefaultPixiPackagesState] = useState<string[]>([]);
+  const [installDefaultDataPackages, setInstallDefaultDataPackagesState] = useState<boolean>(true);
   // Keep-alive duration in seconds (5s to 7 days)
   const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
   // Feature flags (auto-derived from FEATURE_FLAG_METADATA)
@@ -192,6 +193,9 @@ export function useSyncedSettings() {
         }
         if (Array.isArray(settings.pixi?.default_packages)) {
           setDefaultPixiPackagesState(settings.pixi.default_packages);
+        }
+        if (typeof settings.install_default_data_packages === "boolean") {
+          setInstallDefaultDataPackagesState(settings.install_default_data_packages);
         }
         // Handle keep_alive_secs: bigint from backend, convert to number
         if (typeof settings.keep_alive_secs === "bigint") {
@@ -256,6 +260,9 @@ export function useSyncedSettings() {
       }
       if (Array.isArray(event.payload.pixi?.default_packages)) {
         setDefaultPixiPackagesState(event.payload.pixi.default_packages);
+      }
+      if (typeof event.payload.install_default_data_packages === "boolean") {
+        setInstallDefaultDataPackagesState(event.payload.install_default_data_packages);
       }
       // Handle keep_alive_secs: bigint from backend, convert to number
       if (typeof keep_alive_secs === "bigint") {
@@ -336,6 +343,14 @@ export function useSyncedSettings() {
     }).catch((e) => console.warn("[settings] Failed to persist pixi packages:", e));
   }, []);
 
+  const setInstallDefaultDataPackages = useCallback((enabled: boolean) => {
+    setInstallDefaultDataPackagesState(enabled);
+    invoke("set_synced_setting", {
+      key: "install_default_data_packages",
+      value: enabled,
+    }).catch((e) => console.warn("[settings] Failed to persist install_default_data_packages:", e));
+  }, []);
+
   const setKeepAliveSecs = useCallback((secs: number) => {
     setKeepAliveSecsState(secs);
     invoke("set_synced_setting", {
@@ -397,6 +412,8 @@ export function useSyncedSettings() {
     setDefaultCondaPackages,
     defaultPixiPackages,
     setDefaultPixiPackages,
+    installDefaultDataPackages,
+    setInstallDefaultDataPackages,
     keepAliveSecs,
     setKeepAliveSecs,
     featureFlags,


### PR DESCRIPTION
## Summary

- add `install_default_data_packages` synced setting, defaulting on, with settings UI/docs/schema/bindings support
- include pandas, polars, matplotlib, plotly, and altair in UV/Conda/Pixi pool package sets when enabled
- keep retired pool env objects as fallback leases so stale-but-working envs can bridge cold pool rebuilds
- pass the full pool install set into warmup so the existing prewarm module imports the curated packages

## Design Source

Implements the design direction from #2506.

## Verification

- `cargo test -p runtimed-client --features ts-bindings settings_doc -- --nocapture`
- `cargo test -p runtimed test_prewarmed_packages -- --nocapture`
- `cargo test -p runtimed test_pool_take_falls_back_to_retired_env_when_available_empty -- --nocapture`
- `cargo test -p runtimed test_uv_prewarmed_packages_include_required_display_deps -- --nocapture`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
