### PR TITLE
chore(smoke): instrument kernel launch timing

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -253,8 +253,12 @@ jobs:
 
           $logOut = "$env:RUNNER_TEMP\runtimed.stdout.log"
           $logErr = "$env:RUNNER_TEMP\runtimed.stderr.log"
+          # The daemon CLI log level does not propagate to the runtime-agent
+          # subprocess, but RUST_LOG is inherited and keeps kernel-launch
+          # diagnostics visible in the collected stderr artifact.
+          $env:RUST_LOG = "info"
           $daemon = Start-Process -FilePath $env:RUNTIMED `
-            -ArgumentList @('run', '--uv-pool-size', '1', '--conda-pool-size', '0', '--pixi-pool-size', '0') `
+            -ArgumentList @('--log-level', 'info', 'run', '--uv-pool-size', '1', '--conda-pool-size', '0', '--pixi-pool-size', '0') `
             -WindowStyle Hidden -PassThru `
             -RedirectStandardOutput $logOut -RedirectStandardError $logErr
           Write-Host "Daemon pid: $($daemon.Id)"

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -201,6 +201,11 @@ impl KernelConnection for JupyterKernel {
         let launched_config = config.launched_config;
         let bootstrap_dx = launched_config.feature_flags.bootstrap_dx;
         let env_path = env.as_ref().map(|e| e.venv_path.clone());
+        let launch_started = std::time::Instant::now();
+        info!(
+            "[jupyter-kernel] Launch start: kernel_type={} env_source={} bootstrap_dx={} env_path={:?}",
+            kernel_type, env_source, bootstrap_dx, env_path
+        );
 
         // ── Build process command ────────────────────────────────────────
 
@@ -222,6 +227,11 @@ impl KernelConnection for JupyterKernel {
         let kernel_id: String =
             petname::petname(2, "-").unwrap_or_else(|| Uuid::new_v4().to_string());
         let connection_file_path = conn_dir.join(format!("{}.json", kernel_id));
+        info!(
+            "[jupyter-kernel] Connection file path selected: kernel_id={} path={}",
+            kernel_id,
+            connection_file_path.display()
+        );
 
         // Determine working directory
         let cwd = if let Some(ref path) = notebook_path {
@@ -705,7 +715,14 @@ impl KernelConnection for JupyterKernel {
                     serde_json::to_string_pretty(&connection_info)?,
                 )
                 .await?;
+                info!(
+                    "[jupyter-kernel] Wrote connection file: kernel_id={} transport=ipc path={} launch_elapsed_ms={}",
+                    kernel_id,
+                    connection_file_path.display(),
+                    launch_started.elapsed().as_millis()
+                );
 
+                let spawn_started = std::time::Instant::now();
                 let mut process = cmd.spawn()?;
                 let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =
                     Arc::new(StdMutex::new(VecDeque::with_capacity(STDERR_BUFFER_LINES)));
@@ -735,10 +752,12 @@ impl KernelConnection for JupyterKernel {
                     };
 
                 info!(
-                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=ipc, prefix={})",
+                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=ipc, prefix={}, spawn_elapsed_ms={}, launch_elapsed_ms={})",
                     process.id(),
                     kernel_id,
                     prefix.display(),
+                    spawn_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis(),
                 );
 
                 const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
@@ -826,10 +845,34 @@ impl KernelConnection for JupyterKernel {
                     serde_json::to_string_pretty(&connection_info)?,
                 )
                 .await?;
+                info!(
+                    "[jupyter-kernel] Wrote connection file: kernel_id={} transport=tcp path={} ports={:?} launch_elapsed_ms={}",
+                    kernel_id,
+                    connection_file_path.display(),
+                    ports,
+                    launch_started.elapsed().as_millis()
+                );
 
+                let bind_started = std::time::Instant::now();
                 let listeners = bind_kernel_port_listeners(ip, kernel_ports).await?;
+                info!(
+                    "[jupyter-kernel] Reserved TCP ports: kernel_id={} ports={:?} bind_elapsed_ms={} launch_elapsed_ms={}",
+                    kernel_id,
+                    ports,
+                    bind_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis()
+                );
                 #[cfg(windows)]
-                drop(listeners);
+                {
+                    drop(listeners);
+                    info!(
+                        "[jupyter-kernel] Released reserved TCP listeners before Windows kernel spawn: kernel_id={} ports={:?} launch_elapsed_ms={}",
+                        kernel_id,
+                        ports,
+                        launch_started.elapsed().as_millis()
+                    );
+                }
+                let spawn_started = std::time::Instant::now();
                 let mut process = cmd.spawn()?;
                 #[cfg(not(windows))]
                 drop(listeners);
@@ -862,10 +905,12 @@ impl KernelConnection for JupyterKernel {
                     };
 
                 info!(
-                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=tcp, ports={:?})",
+                    "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={}, transport=tcp, ports={:?}, spawn_elapsed_ms={}, launch_elapsed_ms={})",
                     process.id(),
                     kernel_id,
-                    ports
+                    ports,
+                    spawn_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis()
                 );
 
                 const STARTUP_CEILING: std::time::Duration = std::time::Duration::from_millis(3000);
@@ -981,8 +1026,43 @@ impl KernelConnection for JupyterKernel {
         }
 
         // Create iopub connection and spawn listener
-        let mut iopub =
-            runtimelib::create_client_iopub_connection(&connection_info, "", &session_id).await?;
+        let iopub_endpoint = connection_info.iopub_url();
+        let iopub_connect_started = std::time::Instant::now();
+        info!(
+            "[jupyter-kernel] Connecting IOPub: kernel_id={} endpoint={} launch_elapsed_ms={}",
+            kernel_id,
+            iopub_endpoint,
+            launch_started.elapsed().as_millis()
+        );
+        let mut iopub = match runtimelib::create_client_iopub_connection(
+            &connection_info,
+            "",
+            &session_id,
+        )
+        .await
+        {
+            Ok(conn) => {
+                info!(
+                        "[jupyter-kernel] IOPub connected: kernel_id={} endpoint={} connect_elapsed_ms={} launch_elapsed_ms={}",
+                        kernel_id,
+                        iopub_endpoint,
+                        iopub_connect_started.elapsed().as_millis(),
+                        launch_started.elapsed().as_millis()
+                    );
+                conn
+            }
+            Err(e) => {
+                error!(
+                        "[jupyter-kernel] IOPub connect failed: kernel_id={} endpoint={} connect_elapsed_ms={} launch_elapsed_ms={} error={}",
+                        kernel_id,
+                        iopub_endpoint,
+                        iopub_connect_started.elapsed().as_millis(),
+                        launch_started.elapsed().as_millis(),
+                        e
+                    );
+                return Err(e.into());
+            }
+        };
 
         // Create command channel for queue processing
         let (cmd_tx, cmd_rx) = mpsc::channel::<QueueCommand>(100);
@@ -2114,16 +2194,62 @@ impl KernelConnection for JupyterKernel {
         // ── Shell connection ─────────────────────────────────────────────
 
         let identity = runtimelib::peer_identity_for_session(&session_id)?;
-        let mut shell = runtimelib::create_client_shell_connection_with_identity(
+        let shell_endpoint = connection_info.shell_url();
+        let shell_connect_started = std::time::Instant::now();
+        info!(
+            "[jupyter-kernel] Connecting shell: kernel_id={} endpoint={} launch_elapsed_ms={}",
+            kernel_id,
+            shell_endpoint,
+            launch_started.elapsed().as_millis()
+        );
+        let mut shell = match runtimelib::create_client_shell_connection_with_identity(
             &connection_info,
             &session_id,
             identity,
         )
-        .await?;
+        .await
+        {
+            Ok(conn) => {
+                info!(
+                    "[jupyter-kernel] Shell connected: kernel_id={} endpoint={} connect_elapsed_ms={} launch_elapsed_ms={}",
+                    kernel_id,
+                    shell_endpoint,
+                    shell_connect_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis()
+                );
+                conn
+            }
+            Err(e) => {
+                error!(
+                    "[jupyter-kernel] Shell connect failed: kernel_id={} endpoint={} connect_elapsed_ms={} launch_elapsed_ms={} error={}",
+                    kernel_id,
+                    shell_endpoint,
+                    shell_connect_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis(),
+                    e
+                );
+                return Err(e.into());
+            }
+        };
 
         // Verify kernel is alive — race kernel_info_reply against process death
+        let kernel_info_started = std::time::Instant::now();
         let request: JupyterMessage = KernelInfoRequest::default().into();
-        shell.send(request).await?;
+        info!(
+            "[jupyter-kernel] Sending kernel_info_request: kernel_id={} launch_elapsed_ms={}",
+            kernel_id,
+            launch_started.elapsed().as_millis()
+        );
+        if let Err(e) = shell.send(request).await {
+            error!(
+                "[jupyter-kernel] kernel_info_request send failed: kernel_id={} elapsed_ms={} launch_elapsed_ms={} error={}",
+                kernel_id,
+                kernel_info_started.elapsed().as_millis(),
+                launch_started.elapsed().as_millis(),
+                e
+            );
+            return Err(e.into());
+        }
 
         let reply = tokio::select! {
             result = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()) => {
@@ -2142,12 +2268,21 @@ impl KernelConnection for JupyterKernel {
         match reply {
             Ok(msg) => {
                 info!(
-                    "[jupyter-kernel] Kernel alive: got {} reply",
-                    msg.header.msg_type
+                    "[jupyter-kernel] Kernel alive: got {} reply (kernel_id={} kernel_info_elapsed_ms={} launch_elapsed_ms={})",
+                    msg.header.msg_type,
+                    kernel_id,
+                    kernel_info_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis()
                 );
             }
             Err(e) => {
-                error!("[jupyter-kernel] {}", e);
+                error!(
+                    "[jupyter-kernel] Kernel info failed: kernel_id={} kernel_info_elapsed_ms={} launch_elapsed_ms={} error={}",
+                    kernel_id,
+                    kernel_info_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis(),
+                    e
+                );
                 // Abort process watcher to clean up orphaned kernel
                 process_watcher_task.abort();
                 return Err(e);
@@ -2438,6 +2573,13 @@ impl KernelConnection for JupyterKernel {
         );
 
         // ── Construct the kernel struct ──────────────────────────────────
+        info!(
+            "[jupyter-kernel] Launch complete: kernel_id={} kernel_type={} env_source={} launch_elapsed_ms={}",
+            kernel_id,
+            kernel_type,
+            env_source,
+            launch_started.elapsed().as_millis()
+        );
 
         let kernel = Self {
             kernel_type,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -724,6 +724,8 @@ async fn handle_runtime_agent_request(
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
             };
+            let launch_kernel_type = kernel_type.clone();
+            let launch_env_source = env_source.as_str().to_string();
             let config = KernelLaunchConfig {
                 kernel_type,
                 env_source: env_source.as_str().to_string(),
@@ -734,12 +736,19 @@ async fn handle_runtime_agent_request(
                 pooled_env,
             };
 
+            let launch_started = std::time::Instant::now();
             match JupyterKernel::launch(config, shared).await {
                 Ok((k, rx)) => {
                     let es = k.env_source().to_string();
                     *kernel = Some(k);
                     state.reset();
                     state.set_idle();
+                    info!(
+                        "[runtime-agent] LaunchKernel completed: type={} source={} elapsed_ms={}",
+                        launch_kernel_type,
+                        launch_env_source,
+                        launch_started.elapsed().as_millis()
+                    );
                     (
                         RuntimeAgentResponse::KernelLaunched {
                             env_source: notebook_protocol::connection::EnvSource::parse(&es),
@@ -747,12 +756,21 @@ async fn handle_runtime_agent_request(
                         Some(rx),
                     )
                 }
-                Err(e) => (
-                    RuntimeAgentResponse::Error {
-                        error: format!("Failed to launch kernel: {}", e),
-                    },
-                    None,
-                ),
+                Err(e) => {
+                    warn!(
+                        "[runtime-agent] LaunchKernel failed: type={} source={} elapsed_ms={} error={}",
+                        launch_kernel_type,
+                        launch_env_source,
+                        launch_started.elapsed().as_millis(),
+                        e
+                    );
+                    (
+                        RuntimeAgentResponse::Error {
+                            error: format!("Failed to launch kernel: {}", e),
+                        },
+                        None,
+                    )
+                }
             }
         }
 
@@ -810,6 +828,8 @@ async fn handle_runtime_agent_request(
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
             };
+            let launch_kernel_type = kernel_type.clone();
+            let launch_env_source = env_source.as_str().to_string();
             let config = KernelLaunchConfig {
                 kernel_type,
                 env_source: env_source.as_str().to_string(),
@@ -850,12 +870,19 @@ async fn handle_runtime_agent_request(
                 warn!("[runtime-state] {}", e);
             }
 
+            let launch_started = std::time::Instant::now();
             match JupyterKernel::launch(config, shared).await {
                 Ok((k, rx)) => {
                     let es = k.env_source().to_string();
                     *kernel = Some(k);
                     state.reset();
                     state.set_idle();
+                    info!(
+                        "[runtime-agent] RestartKernel completed: type={} source={} elapsed_ms={}",
+                        launch_kernel_type,
+                        launch_env_source,
+                        launch_started.elapsed().as_millis()
+                    );
                     (
                         RuntimeAgentResponse::KernelRestarted {
                             env_source: notebook_protocol::connection::EnvSource::parse(&es),
@@ -863,12 +890,21 @@ async fn handle_runtime_agent_request(
                         Some(rx),
                     )
                 }
-                Err(e) => (
-                    RuntimeAgentResponse::Error {
-                        error: format!("Failed to restart kernel: {}", e),
-                    },
-                    None,
-                ),
+                Err(e) => {
+                    warn!(
+                        "[runtime-agent] RestartKernel failed: type={} source={} elapsed_ms={} error={}",
+                        launch_kernel_type,
+                        launch_env_source,
+                        launch_started.elapsed().as_millis(),
+                        e
+                    );
+                    (
+                        RuntimeAgentResponse::Error {
+                            error: format!("Failed to restart kernel: {}", e),
+                        },
+                        None,
+                    )
+                }
             }
         }
 

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -20,8 +20,11 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import shutil
 import sys
+import tempfile
 from pathlib import Path
+from typing import Any
 
 # The MCP server's tool-result formatter uses ━ (U+2501) as a section
 # separator. Windows runners default to cp1252, which can't encode that.
@@ -43,6 +46,8 @@ TRANSIENT_KERNEL_LAUNCH_RE = re.compile(
     re.IGNORECASE,
 )
 MAX_PASS_ATTEMPTS = 3
+UV_POOL_READY_TIMEOUT_SECS = 180
+KERNEL_READY_TIMEOUT_SECS = 240
 
 
 class SmokeRetry(Exception):
@@ -72,6 +77,12 @@ def stdout_of(body: str) -> str:
 
 def parse_json_body(body: str) -> dict | None:
     """Best-effort parse for tool responses that are printed as JSON."""
+    parsed = parse_json_value(body)
+    return parsed if isinstance(parsed, dict) else None
+
+
+def parse_json_value(body: str) -> Any | None:
+    """Best-effort parse for tool responses that are printed as JSON."""
     text = body.strip()
     if not text:
         return None
@@ -88,7 +99,7 @@ def parse_json_body(body: str) -> dict | None:
         except json.JSONDecodeError:
             return None
 
-    return parsed if isinstance(parsed, dict) else None
+    return parsed
 
 
 def kernel_launch_error(body: str) -> str | None:
@@ -105,11 +116,128 @@ def kernel_launch_error(body: str) -> str | None:
     return str(details) if details else "kernel launch failed"
 
 
+def int_value(value) -> int:
+    """Best-effort integer coercion for daemon status counters."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+async def daemon_status(runt_exe: Path) -> dict | None:
+    """Read `runt daemon status --json` from the already-started daemon."""
+    proc = await asyncio.create_subprocess_exec(
+        str(runt_exe),
+        "daemon",
+        "status",
+        "--json",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _stderr = await proc.communicate()
+    if proc.returncode != 0:
+        return None
+
+    try:
+        parsed = json.loads(stdout.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return None
+
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def wait_for_uv_pool_ready(runt_exe: Path) -> None:
+    """Wait until the smoke's first notebook can claim a prewarmed UV env."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + UV_POOL_READY_TIMEOUT_SECS
+    last_summary = ""
+
+    while True:
+        status = await daemon_status(runt_exe)
+        if status:
+            uv = (status.get("pool_stats") or {}).get("uv") or {}
+            available = int_value(uv.get("available"))
+            warming = int_value(uv.get("warming"))
+            pool_size = int_value(uv.get("pool_size"))
+            failures = int_value(uv.get("consecutive_failures"))
+            retry_in = int_value(uv.get("retry_in_secs"))
+            summary = (
+                f"available={available} warming={warming} pool_size={pool_size} "
+                f"failures={failures} retry_in_secs={retry_in}"
+            )
+
+            if available > 0:
+                print(f"[smoke] UV pool ready: {summary}")
+                return
+
+            if summary != last_summary:
+                print(f"[smoke] waiting for UV pool: {summary}")
+                last_summary = summary
+        elif last_summary != "status-unavailable":
+            print("[smoke] waiting for daemon status")
+            last_summary = "status-unavailable"
+
+        if loop.time() >= deadline:
+            fail(f"UV pool did not become ready within {UV_POOL_READY_TIMEOUT_SECS}s")
+
+        await asyncio.sleep(1)
+
+
+async def wait_for_kernel_ready(
+    session: ClientSession,
+    notebook_id: str,
+    label: str,
+) -> None:
+    """Wait for a newly-created smoke notebook's kernel to become executable."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + KERNEL_READY_TIMEOUT_SECS
+    last_summary = ""
+
+    while True:
+        rooms_result = await session.call_tool("list_active_notebooks", {})
+        body = text_of(rooms_result)
+        if rooms_result.isError:
+            fail(f"[{label}] list_active_notebooks errored while waiting for kernel: {body}")
+
+        rooms = parse_json_value(body)
+        room = None
+        if isinstance(rooms, list):
+            for candidate in rooms:
+                if isinstance(candidate, dict) and candidate.get("notebook_id") == notebook_id:
+                    room = candidate
+                    break
+
+        if isinstance(room, dict):
+            status = str(room.get("kernel_status") or "")
+            summary = (
+                f"has_kernel={room.get('has_kernel')} "
+                f"status={status or 'unknown'} "
+                f"env_source={room.get('env_source') or 'unknown'}"
+            )
+
+            if status in {"idle", "busy"}:
+                print(f"[{label}] kernel ready: {summary}")
+                return
+            if status == "error":
+                fail(f"[{label}] kernel entered error state before execute: {body}")
+            if summary != last_summary:
+                print(f"[{label}] waiting for kernel: {summary}")
+                last_summary = summary
+        elif last_summary != "room-missing":
+            print(f"[{label}] waiting for notebook room {notebook_id}")
+            last_summary = "room-missing"
+
+        if loop.time() >= deadline:
+            fail(f"[{label}] kernel did not become ready within {KERNEL_READY_TIMEOUT_SECS}s")
+
+        await asyncio.sleep(1)
+
+
 async def create_notebook_checked(
     session: ClientSession,
     label: str,
     args: dict | None = None,
-) -> None:
+) -> str:
     """Create a notebook and fail/retry immediately if auto-launch failed."""
     create = await session.call_tool("create_notebook", args or {})
     body = text_of(create)
@@ -117,9 +245,14 @@ async def create_notebook_checked(
         fail(f"create_notebook({label}) errored: {body}")
     print(body)
 
+    parsed = parse_json_body(body)
+    notebook_id = parsed.get("notebook_id") if parsed else None
+    if not isinstance(notebook_id, str) or not notebook_id:
+        fail(f"create_notebook({label}) did not return notebook_id: {body}")
+
     error_details = kernel_launch_error(body)
     if not error_details:
-        return
+        return notebook_id
 
     message = f"create_notebook({label}) reported kernel launch error: {error_details}"
     if TRANSIENT_KERNEL_LAUNCH_RE.search(error_details):
@@ -177,6 +310,8 @@ async def run_cell_and_get_body(session: ClientSession, source: str, label: str)
 
     match = EXEC_ID_RE.search(body)
     if not match:
+        if "running" in body.lower():
+            raise SmokeRetry(f"execute_cell returned running without execution_id: {body}")
         fail(f"could not parse execution_id from execute_cell response: {body}")
     execution_id = match.group(1)
     print(f"[{label}] execution_id={execution_id} - polling get_results")
@@ -197,10 +332,18 @@ async def run_cell_and_get_body(session: ClientSession, source: str, label: str)
     fail(f"[{label}] execution did not complete within 240s")
 
 
-async def basic_pass(session: ClientSession) -> None:
+async def basic_pass(session: ClientSession, smoke_root: Path) -> None:
     """Sanity-check pass: ephemeral notebook + `print(1+1)`."""
+    working_dir = smoke_root / "basic"
+    working_dir.mkdir(parents=True, exist_ok=True)
+
     print("[basic] create_notebook")
-    await create_notebook_checked(session, "basic")
+    notebook_id = await create_notebook_checked(
+        session,
+        "basic",
+        {"working_dir": str(working_dir)},
+    )
+    await wait_for_kernel_ready(session, notebook_id, "basic")
 
     body = await run_cell_and_get_body(session, "print(1 + 1)", "basic")
     out = stdout_of(body)
@@ -209,10 +352,18 @@ async def basic_pass(session: ClientSession) -> None:
     print("[basic] PASS")
 
 
-async def polars_pass(session: ClientSession) -> None:
+async def polars_pass(session: ClientSession, smoke_root: Path) -> None:
     """Deeper pass: install polars in a fresh uv-backed notebook, render a DataFrame."""
+    working_dir = smoke_root / "polars"
+    working_dir.mkdir(parents=True, exist_ok=True)
+
     print("[polars] create_notebook(dependencies=['polars'])")
-    await create_notebook_checked(session, "polars", {"dependencies": ["polars"]})
+    notebook_id = await create_notebook_checked(
+        session,
+        "polars",
+        {"dependencies": ["polars"], "working_dir": str(working_dir)},
+    )
+    await wait_for_kernel_ready(session, notebook_id, "polars")
 
     # Final expression `df` triggers an execute_result with the polars repr
     # (text/html + text/plain). Asserting on column names and values keeps the
@@ -242,12 +393,34 @@ async def smoke(runt_exe: Path) -> None:
         tools = await session.list_tools()
         tool_names = sorted(t.name for t in tools.tools)
         print(f"[smoke] {len(tool_names)} tools available")
-        for required in ("create_notebook", "create_cell", "execute_cell", "get_results"):
+        for required in (
+            "list_active_notebooks",
+            "create_notebook",
+            "create_cell",
+            "execute_cell",
+            "get_results",
+        ):
             if required not in tool_names:
                 fail(f"required tool missing: {required}")
 
-        await run_smoke_pass("basic", basic_pass, session)
-        await run_smoke_pass("polars", polars_pass, session)
+        await wait_for_uv_pool_ready(runt_exe)
+
+        smoke_root_path = Path(tempfile.mkdtemp(prefix="nteract-smoke-"))
+        try:
+            print(f"[smoke] working directory root: {smoke_root_path}")
+
+            await run_smoke_pass(
+                "basic",
+                lambda active_session: basic_pass(active_session, smoke_root_path),
+                session,
+            )
+            await run_smoke_pass(
+                "polars",
+                lambda active_session: polars_pass(active_session, smoke_root_path),
+                session,
+            )
+        finally:
+            shutil.rmtree(smoke_root_path, ignore_errors=True)
         print("[smoke] ALL PASSES GREEN")
 
 


### PR DESCRIPTION
## Summary

- Add launch-phase timing logs around kernel connection file creation, TCP port reservation/drop, process spawn, IOPub connect, shell connect, and `kernel_info_request`.
- Make the Windows smoke daemon run with `RUST_LOG=info` and `--log-level info` so runtime-agent subprocess diagnostics are present in stderr artifacts.
- Isolate smoke-created notebooks in temp working directories so the basic pass does not accidentally auto-detect the repo checkout's `pyproject.toml`.
- Wait for the UV pool and each newly-created notebook kernel to become ready before executing smoke cells, so the gate does not race daemon pool warmup or inline environment launch.
- Keep runtime behavior instrumentation-only; this does not change kernel launch behavior or queue/error semantics.

## Context

Windows smoke has been failing with runtimelib's 30s ZeroMQ connect timeout. The current logs collapse several possible causes into one error, so this PR adds enough timing breadcrumbs to tell whether the delay is before process spawn, during channel readiness/connect, or after shell connection.

The first PR-branch smoke dispatch showed the basic pass was launching from the repo checkout and selecting `uv:pyproject`, which made a no-deps smoke notebook run through `uv run` against the desktop repo's own project file. The script now gives each smoke pass its own temp working directory so project-file detection only participates when the pass explicitly sets up dependencies.

After isolating the working directories, Linux smoke showed the expected follow-on races: first the daemon was `running` while `pool_stats.uv.available=0` and `warming=2`, then the polars pass created an inline-deps notebook and immediately executed while the kernel was still `starting`. The script now waits for UV pool availability and then polls `list_active_notebooks` for the specific notebook kernel to become executable before each pass; this changes only the smoke harness readiness gate.

## Verification

- `cargo check -p runtimed`
- `cargo xtask lint --fix`
- `cargo test -p runtimed`
- `python3 -m py_compile scripts/smoke-mcp.py`
