### PR TITLE
feat(runtimed): show uv project preparation phase

### DIFF
--- a/apps/notebook/src/hooks/__tests__/useEnvProgress.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEnvProgress.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
+import { resetRuntimeState, setRuntimeState } from "../../lib/runtime-state";
+import { useEnvProgress } from "../useEnvProgress";
+
+function cloneRuntimeState(): RuntimeState {
+  return structuredClone(DEFAULT_RUNTIME_STATE);
+}
+
+function EnvProgressProbe() {
+  const envProgress = useEnvProgress();
+  return (
+    <div>
+      <span data-testid="active">{String(envProgress.isActive)}</span>
+      <span data-testid="phase">{envProgress.phase ?? ""}</span>
+      <span data-testid="status">{envProgress.statusText}</span>
+    </div>
+  );
+}
+
+describe("useEnvProgress", () => {
+  afterEach(() => {
+    resetRuntimeState();
+  });
+
+  it("projects UV project preparation from runtime state", () => {
+    const state = cloneRuntimeState();
+    state.env.progress = {
+      env_type: "uv",
+      phase: "project_preparing",
+      source: "uv:pyproject",
+      project_path: "/tmp/project/pyproject.toml",
+    };
+    setRuntimeState(state);
+
+    render(<EnvProgressProbe />);
+
+    expect(screen.getByTestId("active")).toHaveTextContent("true");
+    expect(screen.getByTestId("phase")).toHaveTextContent("project_preparing");
+    expect(screen.getByTestId("status")).toHaveTextContent("Preparing UV project environment...");
+  });
+});

--- a/crates/kernel-env/src/progress.rs
+++ b/crates/kernel-env/src/progress.rs
@@ -84,6 +84,13 @@ pub enum EnvProgressPhase {
     CreatingVenv,
     /// Installing pip packages (UV-specific).
     InstallingPackages { packages: Vec<String> },
+    /// Preparing a project-managed environment before kernel launch.
+    ProjectPreparing {
+        /// Environment source that owns the project preparation.
+        source: String,
+        /// Project file path being prepared.
+        project_path: String,
+    },
     /// Environment is ready.
     Ready {
         env_path: String,
@@ -163,6 +170,12 @@ impl ProgressHandler for LogHandler {
             }
             EnvProgressPhase::InstallingPackages { packages } => {
                 log::info!("[{env_type}] Installing packages: {packages:?}");
+            }
+            EnvProgressPhase::ProjectPreparing {
+                source,
+                project_path,
+            } => {
+                log::info!("[{env_type}] Preparing project environment: {source} {project_path}");
             }
             EnvProgressPhase::Ready {
                 env_path,
@@ -421,4 +434,27 @@ impl Reporter for RattlerReporter {
     }
 
     fn on_pre_unlink_complete(&self, _index: usize, _success: bool) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_preparing_serializes_as_snake_case_phase() {
+        let value = serde_json::to_value(EnvProgressPhase::ProjectPreparing {
+            source: "uv:pyproject".to_string(),
+            project_path: "/tmp/project/pyproject.toml".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "phase": "project_preparing",
+                "source": "uv:pyproject",
+                "project_path": "/tmp/project/pyproject.toml",
+            })
+        );
+    }
 }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -8,6 +8,7 @@
 
 use runt_workspace::{cli_command_name, cli_notebook_alias_name};
 use std::fs;
+#[cfg(unix)]
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -540,7 +541,7 @@ fn read_user_path_registry_value() -> Result<String, String> {
         ));
     }
 
-    let mut buffer = vec![0u16; (byte_len as usize + 1) / 2];
+    let mut buffer = vec![0u16; (byte_len as usize).div_ceil(2)];
     let status = unsafe {
         RegQueryValueExW(
             key,
@@ -936,9 +937,9 @@ pub fn is_cli_installed_local() -> bool {
 
     #[cfg(target_os = "windows")]
     {
-        return windows_candidate_cli_dirs().iter().any(|dir| {
-            command_path(dir, cli_name).exists() && command_path(dir, nb_name).exists()
-        });
+        windows_candidate_cli_dirs()
+            .iter()
+            .any(|dir| command_path(dir, cli_name).exists() && command_path(dir, nb_name).exists())
     }
 
     #[cfg(unix)]

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -3012,6 +3012,30 @@ mod tests {
     }
 
     #[test]
+    fn test_set_env_progress_round_trips_project_preparing() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_env_progress(
+            "uv",
+            &serde_json::json!({
+                "phase": "project_preparing",
+                "source": "uv:pyproject",
+                "project_path": "/tmp/project/pyproject.toml",
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            doc.read_state().env.progress,
+            Some(serde_json::json!({
+                "env_type": "uv",
+                "phase": "project_preparing",
+                "source": "uv:pyproject",
+                "project_path": "/tmp/project/pyproject.toml",
+            }))
+        );
+    }
+
+    #[test]
     fn test_clear_env_progress_returns_to_none() {
         let mut doc = RuntimeStateDoc::new();
         doc.set_env_progress("uv", &serde_json::json!({ "phase": "offline_hit" }))

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -2308,6 +2308,13 @@ fn env_progress_message(phase: &EnvProgressPhase) -> String {
         EnvProgressPhase::InstallingPackages { packages } => {
             format!("Installing {} packages...", packages.len())
         }
+        EnvProgressPhase::ProjectPreparing { source, .. } => {
+            if source == "uv:pyproject" {
+                "Preparing UV project environment...".to_string()
+            } else {
+                "Preparing project environment...".to_string()
+            }
+        }
         EnvProgressPhase::Ready { .. } => "Environment ready".to_string(),
         EnvProgressPhase::Error { message } => format!("Environment error: {}", message),
     }
@@ -2337,6 +2344,12 @@ fn env_progress_dedupe_key(env_type: &str, phase: &EnvProgressPhase) -> String {
         EnvProgressPhase::CreatingVenv => format!("{}:creating_venv", env_type),
         EnvProgressPhase::InstallingPackages { .. } => {
             format!("{}:installing_packages", env_type)
+        }
+        EnvProgressPhase::ProjectPreparing {
+            source,
+            project_path,
+        } => {
+            format!("{}:project_preparing:{}:{}", env_type, source, project_path)
         }
         EnvProgressPhase::Ready { .. } => format!("{}:ready", env_type),
         EnvProgressPhase::Error { message } => format!("{}:error:{}", env_type, message),

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -128,6 +128,7 @@ fn env_progress_phase_name(phase: &EnvProgressPhase) -> &'static str {
         EnvProgressPhase::InstallComplete { .. } => "install_complete",
         EnvProgressPhase::CreatingVenv => "creating_venv",
         EnvProgressPhase::InstallingPackages { .. } => "installing_packages",
+        EnvProgressPhase::ProjectPreparing { .. } => "project_preparing",
         EnvProgressPhase::Ready { .. } => "ready",
         EnvProgressPhase::Error { .. } => "error",
     }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -234,17 +234,7 @@ impl KernelConnection for JupyterKernel {
         );
 
         // Determine working directory
-        let cwd = if let Some(ref path) = notebook_path {
-            if path.is_dir() {
-                path.to_path_buf()
-            } else {
-                path.parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(std::env::temp_dir)
-            }
-        } else {
-            runt_workspace::default_notebooks_dir().unwrap_or_else(|_| std::env::temp_dir())
-        };
+        let cwd = crate::uv_project::notebook_working_dir(notebook_path.as_deref());
 
         // Build kernel command based on kernel type
         let mut cmd = match kernel_type.as_str() {
@@ -294,32 +284,10 @@ impl KernelConnection for JupyterKernel {
                             env_source
                         );
                         let mut cmd = tokio::process::Command::new(&uv_path);
-                        let mut args: Vec<String> = vec![
-                            "run".into(),
-                            "--with".into(),
-                            "ipykernel".into(),
-                            "--with".into(),
-                            "uv".into(),
-                        ];
-                        if bootstrap_dx {
-                            // `dx` is on PyPI; the launcher is injected via
-                            // PYTHONPATH below so `-m nteract_kernel_launcher`
-                            // resolves without shadowing cwd in sys.path[0].
-                            args.push("--with".into());
-                            args.push("dx".into());
-                        }
-                        args.push("python".into());
-                        args.push("-Xfrozen_modules=off".into());
-                        args.push("-m".into());
-                        let launcher_module = if bootstrap_dx {
-                            "nteract_kernel_launcher"
-                        } else {
-                            "ipykernel_launcher"
-                        };
-                        args.push(launcher_module.into());
-                        args.push("-f".into());
-                        cmd.args(&args);
-                        cmd.arg(&connection_file_path);
+                        cmd.args(crate::uv_project::uv_pyproject_kernel_args(
+                            bootstrap_dx,
+                            &connection_file_path,
+                        ));
                         cmd.stdout(Stdio::null());
                         cmd.stderr(Stdio::piped());
                         if bootstrap_dx {
@@ -331,8 +299,7 @@ impl KernelConnection for JupyterKernel {
                             // cwd. `uv run` preserves env vars, and putting
                             // the launcher dir on PYTHONPATH keeps cwd at
                             // `sys.path[0]`.
-                            let dir = crate::launcher_cache::launcher_cache_dir().await?;
-                            cmd.env("PYTHONPATH", &dir);
+                            crate::uv_project::apply_bootstrap_pythonpath(&mut cmd).await?;
                         }
                         cmd
                     }

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -52,6 +52,7 @@ pub mod task_supervisor;
 pub mod terminal_size;
 pub(crate) mod trusted_packages;
 pub mod user_error;
+pub(crate) mod uv_project;
 
 pub fn trusted_packages_db_path() -> std::path::PathBuf {
     runtimed_client::daemon_base_dir().join("trusted-packages.sqlite")

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3480,6 +3480,45 @@ pub(crate) async fn auto_launch_kernel(
         (pooled_env, None)
     };
 
+    if matches!(env_source, EnvSource::Pyproject) {
+        match crate::uv_project::prepare_uv_pyproject_environment(
+            notebook_path_opt.as_deref(),
+            bootstrap_dx,
+            progress_handler.clone(),
+        )
+        .await
+        {
+            Ok(()) => {
+                if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
+                    warn!("[runtime-state] {}", e);
+                }
+            }
+            Err(e) => {
+                let details = format!("Failed to prepare UV project environment: {e}");
+                error!("[notebook-sync] {}", details);
+                reset_starting_state(room, None).await;
+                let error_phase = kernel_env::EnvProgressPhase::Error {
+                    message: details.clone(),
+                };
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::Error,
+                        None,
+                        Some(&details),
+                    )?;
+                    sd.set_kernel_info("python", "python", env_source.as_str())?;
+                    if let Ok(value) = serde_json::to_value(&error_phase) {
+                        sd.set_env_progress("uv", &value)?;
+                    }
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
+            }
+        }
+    }
+
     // Verify ipykernel is actually present in the prepared env before we
     // spawn the kernel. For UV/Conda inline + PEP 723, `prepare_environment_in`
     // always adds `ipykernel` to the install set, but cache hits skip the

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1234,6 +1234,45 @@ pub(crate) async fn handle(
         (pooled_env, None)
     };
 
+    if matches!(parsed_resolved, EnvSource::Pyproject) {
+        match crate::uv_project::prepare_uv_pyproject_environment(
+            notebook_path.as_deref(),
+            bootstrap_dx,
+            launch_progress_handler.clone(),
+        )
+        .await
+        {
+            Ok(()) => {
+                if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
+                    warn!("[runtime-state] {}", e);
+                }
+            }
+            Err(e) => {
+                let details = format!("Failed to prepare UV project environment: {e}");
+                error!("[notebook-sync] {}", details);
+                reset_starting_state(room, None).await;
+                let error_phase = kernel_env::EnvProgressPhase::Error {
+                    message: details.clone(),
+                };
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::Error,
+                        None,
+                        Some(&details),
+                    )?;
+                    sd.set_kernel_info("python", "python", parsed_resolved.as_str())?;
+                    if let Ok(value) = serde_json::to_value(&error_phase) {
+                        sd.set_env_progress("uv", &value)?;
+                    }
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return NotebookResponse::Error { error: details };
+            }
+        }
+    }
+
     // Verify ipykernel is present in the prepared env before we launch.
     // Mirrors the auto-launch gate in `notebook_sync_server/metadata.rs`:
     // the LaunchKernel RPC serves the toolbar restart button,

--- a/crates/runtimed/src/uv_project.rs
+++ b/crates/runtimed/src/uv_project.rs
@@ -1,0 +1,278 @@
+//! Helpers for `uv:pyproject` launches.
+//!
+//! Project-backed UV kernels use `uv run` directly instead of a daemon-owned
+//! cached environment. Keep the command construction here so the daemon-side
+//! prepare probe and the runtime-agent kernel launch cannot drift.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use kernel_env::{EnvProgressPhase, ProgressHandler};
+use tokio::process::Command;
+use tracing::info;
+
+use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
+
+pub(crate) fn notebook_working_dir(notebook_path: Option<&Path>) -> PathBuf {
+    if let Some(path) = notebook_path {
+        if path.is_dir() {
+            path.to_path_buf()
+        } else {
+            path.parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(std::env::temp_dir)
+        }
+    } else {
+        runt_workspace::default_notebooks_dir().unwrap_or_else(|_| std::env::temp_dir())
+    }
+}
+
+fn uv_run_base_args(bootstrap_dx: bool) -> Vec<OsString> {
+    let mut args = vec![
+        "run".into(),
+        "--with".into(),
+        "ipykernel".into(),
+        "--with".into(),
+        "uv".into(),
+    ];
+    if bootstrap_dx {
+        args.push("--with".into());
+        args.push("dx".into());
+    }
+    args
+}
+
+pub(crate) fn uv_pyproject_prepare_args(bootstrap_dx: bool) -> Vec<OsString> {
+    let mut args = uv_run_base_args(bootstrap_dx);
+    args.extend([
+        OsString::from("python"),
+        OsString::from("-Xfrozen_modules=off"),
+        OsString::from("-c"),
+        OsString::from("import ipykernel"),
+    ]);
+    args
+}
+
+pub(crate) fn uv_pyproject_kernel_args(
+    bootstrap_dx: bool,
+    connection_file: &Path,
+) -> Vec<OsString> {
+    let mut args = uv_run_base_args(bootstrap_dx);
+    let launcher_module = if bootstrap_dx {
+        "nteract_kernel_launcher"
+    } else {
+        "ipykernel_launcher"
+    };
+    args.extend([
+        OsString::from("python"),
+        OsString::from("-Xfrozen_modules=off"),
+        OsString::from("-m"),
+        OsString::from(launcher_module),
+        OsString::from("-f"),
+        connection_file.as_os_str().to_owned(),
+    ]);
+    args
+}
+
+pub(crate) async fn apply_bootstrap_pythonpath(cmd: &mut Command) -> Result<()> {
+    let dir = crate::launcher_cache::launcher_cache_dir().await?;
+    cmd.env("PYTHONPATH", &dir);
+    Ok(())
+}
+
+fn display_output(output: &[u8]) -> String {
+    String::from_utf8_lossy(output).trim().to_string()
+}
+
+fn command_failure_message(
+    status: std::process::ExitStatus,
+    output: std::process::Output,
+) -> String {
+    let stderr = display_output(&output.stderr);
+    let stdout = display_output(&output.stdout);
+    let detail = if stderr.is_empty() {
+        stdout
+    } else if stdout.is_empty() {
+        stderr
+    } else {
+        format!("{stderr}\n{stdout}")
+    };
+
+    if detail.is_empty() {
+        format!("uv project environment preparation failed with {status}")
+    } else {
+        format!("uv project environment preparation failed with {status}: {detail}")
+    }
+}
+
+pub(crate) async fn prepare_uv_pyproject_environment(
+    notebook_path: Option<&Path>,
+    bootstrap_dx: bool,
+    progress_handler: Arc<dyn ProgressHandler>,
+) -> Result<()> {
+    let cwd = notebook_working_dir(notebook_path);
+    let project_path = notebook_path
+        .and_then(|path| {
+            crate::project_file::find_nearest_project_file(
+                path,
+                &[crate::project_file::ProjectFileKind::PyprojectToml],
+            )
+        })
+        .map(|detected| detected.path)
+        .unwrap_or_else(|| cwd.join("pyproject.toml"));
+    let project_path_label = project_path.display().to_string();
+
+    progress_handler.on_progress(
+        "uv",
+        EnvProgressPhase::ProjectPreparing {
+            source: "uv:pyproject".to_string(),
+            project_path: project_path_label.clone(),
+        },
+    );
+
+    let uv_path = kernel_launch::tools::get_uv_path()
+        .await
+        .context("failed to locate uv executable")?;
+    let mut cmd = Command::new(&uv_path);
+    cmd.args(uv_pyproject_prepare_args(bootstrap_dx));
+    cmd.current_dir(&cwd);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env("COLUMNS", TERMINAL_COLUMNS_STR);
+    cmd.env("LINES", TERMINAL_LINES_STR);
+    if bootstrap_dx {
+        apply_bootstrap_pythonpath(&mut cmd).await?;
+        cmd.env("RUNT_BOOTSTRAP_DX", "1");
+    }
+
+    info!(
+        "[uv-project] Preparing UV project environment: project={} cwd={} bootstrap_dx={}",
+        project_path_label,
+        cwd.display(),
+        bootstrap_dx
+    );
+    let started = Instant::now();
+    let output = cmd.output().await.with_context(|| {
+        format!(
+            "failed to run uv project prepare probe in {}",
+            cwd.display()
+        )
+    })?;
+
+    if output.status.success() {
+        info!(
+            "[uv-project] UV project environment ready: project={} elapsed_ms={}",
+            project_path_label,
+            started.elapsed().as_millis()
+        );
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(command_failure_message(
+            output.status,
+            output
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_to_strings(args: Vec<OsString>) -> Vec<String> {
+        args.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn prepare_args_include_base_uv_packages() {
+        assert_eq!(
+            args_to_strings(uv_pyproject_prepare_args(false)),
+            vec![
+                "run",
+                "--with",
+                "ipykernel",
+                "--with",
+                "uv",
+                "python",
+                "-Xfrozen_modules=off",
+                "-c",
+                "import ipykernel",
+            ]
+        );
+    }
+
+    #[test]
+    fn prepare_args_include_dx_when_bootstrap_is_enabled() {
+        assert_eq!(
+            args_to_strings(uv_pyproject_prepare_args(true)),
+            vec![
+                "run",
+                "--with",
+                "ipykernel",
+                "--with",
+                "uv",
+                "--with",
+                "dx",
+                "python",
+                "-Xfrozen_modules=off",
+                "-c",
+                "import ipykernel",
+            ]
+        );
+    }
+
+    #[test]
+    fn kernel_args_match_prepare_prefix_and_launch_ipykernel() {
+        let args = args_to_strings(uv_pyproject_kernel_args(
+            false,
+            Path::new("/tmp/kernel.json"),
+        ));
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "--with",
+                "ipykernel",
+                "--with",
+                "uv",
+                "python",
+                "-Xfrozen_modules=off",
+                "-m",
+                "ipykernel_launcher",
+                "-f",
+                "/tmp/kernel.json",
+            ]
+        );
+    }
+
+    #[test]
+    fn kernel_args_use_nteract_launcher_with_bootstrap_dx() {
+        let args = args_to_strings(uv_pyproject_kernel_args(
+            true,
+            Path::new("/tmp/kernel.json"),
+        ));
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "--with",
+                "ipykernel",
+                "--with",
+                "uv",
+                "--with",
+                "dx",
+                "python",
+                "-Xfrozen_modules=off",
+                "-m",
+                "nteract_kernel_launcher",
+                "-f",
+                "/tmp/kernel.json",
+            ]
+        );
+    }
+}

--- a/packages/runtimed/src/env-progress.ts
+++ b/packages/runtimed/src/env-progress.ts
@@ -86,6 +86,10 @@ export function getEnvProgressStatusText(event: EnvProgressEvent): string {
       const e = event as Extract<EnvProgressPhase, { phase: "installing_packages" }>;
       return `Installing ${e.packages.length} packages...`;
     }
+    case "project_preparing":
+      return event.source === "uv:pyproject"
+        ? "Preparing UV project environment..."
+        : "Preparing project environment...";
     case "ready":
       return "Environment ready";
     case "error":

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -150,6 +150,7 @@ export type EnvProgressPhase =
   | { phase: "install_complete"; elapsed_ms: number }
   | { phase: "creating_venv" }
   | { phase: "installing_packages"; packages: string[] }
+  | { phase: "project_preparing"; source: string; project_path: string }
   | { phase: "ready"; env_path: string; python_path: string }
   | { phase: "error"; message: string };
 

--- a/packages/runtimed/tests/env-progress.test.ts
+++ b/packages/runtimed/tests/env-progress.test.ts
@@ -49,6 +49,22 @@ describe("env progress projection", () => {
     });
   });
 
+  it("projects UV project preparation as active toolbar progress", () => {
+    const event: EnvProgressEvent = {
+      env_type: "uv",
+      phase: "project_preparing",
+      source: "uv:pyproject",
+      project_path: "/tmp/project/pyproject.toml",
+    };
+
+    expect(projectEnvProgress(event)).toMatchObject({
+      isActive: true,
+      envType: "uv",
+      phase: "project_preparing",
+      statusText: "Preparing UV project environment...",
+    });
+  });
+
   it("uses a stable dismissal key across object field order", () => {
     const eventA = {
       env_type: "uv",

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -693,6 +693,37 @@ describe("SyncEngine", () => {
       expect(received[0].kernel.name).toBe("python3");
       engine.stop();
     });
+
+    it("preserves project preparation env progress from state sync", () => {
+      const state = makeRuntimeState({});
+      state.env.progress = {
+        env_type: "uv",
+        phase: "project_preparing",
+        source: "uv:pyproject",
+        project_path: "/tmp/project/pyproject.toml",
+      };
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(state),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const received: RuntimeState[] = [];
+      engine.runtimeState$.subscribe((s) => received.push(s));
+
+      transport.deliver(Array.from([0x05, 1]));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].env.progress).toEqual({
+        env_type: "uv",
+        phase: "project_preparing",
+        source: "uv:pyproject",
+        project_path: "/tmp/project/pyproject.toml",
+      });
+      engine.stop();
+    });
   });
 
   // ── Execution transitions ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add a daemon-visible `project_preparing` env progress phase for `uv:pyproject`
- Run a shared `uv run --with ipykernel --with uv ... python -c "import ipykernel"` prepare probe before runtime-agent launch/restart paths move into kernel launch/connect
- Reuse the same `uv:pyproject` command construction for the prepare probe and actual Jupyter kernel launch
- Project the new phase through the existing toolbar env-progress UI

## Stack

- Stacked on #2510 so CI includes the unrelated Windows clippy cleanup already split out there
- Retarget this PR to `main` after #2510 merges

## UV crate spike

The public `uv` crate surface is still CLI-shaped, and the CLI docs expose progress as terminal output controls rather than a machine-readable progress API. This PR follows the planned fallback: keep shelling out to `uv`, but surface a truthful coarse phase while `uv` is doing project sync/build work.

## Verification

- `cargo test -p kernel-env project_preparing_serializes_as_snake_case_phase`
- `cargo test -p runtimed uv_project`
- `pnpm test:run packages/runtimed/tests/env-progress.test.ts`
- `cargo clippy -p runtimed --all-targets -- -D warnings`
- `cargo clippy -p kernel-env --all-targets -- -D warnings`
- `cargo check -p runtimed-py`
- `cargo clippy -p runtimed-py --all-targets -- -D warnings`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
