### PR TITLE
fix(settings): make json canonical

### DIFF
--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -6,8 +6,9 @@
 //! - Windows: C:\Users\<User>\AppData\Roaming\nteract\settings.json
 //!
 //! Settings are synced across all peers (notebook windows, MCP clients) via an
-//! Automerge document owned by the daemon. The daemon writes the JSON mirror to
-//! disk. This module reads settings as a fallback when the daemon is unavailable.
+//! in-memory Automerge document owned by the daemon. `settings.json` is the
+//! persistent source of truth. This module reads settings as a fallback when the
+//! daemon is unavailable.
 //!
 //! Uses `runtimed::settings_doc::SyncedSettings` as the canonical settings type.
 

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -222,11 +222,6 @@ pub fn connections_dir() -> PathBuf {
     daemon_base_dir().join("connections")
 }
 
-/// Get the default path for the persisted Automerge settings document.
-pub fn default_settings_doc_path() -> PathBuf {
-    daemon_base_dir().join("settings.automerge")
-}
-
 /// Get the path to the settings JSON Schema file.
 pub fn settings_schema_path() -> PathBuf {
     dirs::config_dir()

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -494,6 +494,8 @@ impl SettingsDoc {
     /// truth; `settings.automerge` is read only as a migration source when the
     /// JSON file does not exist.
     pub fn load_or_create(automerge_path: &Path, settings_json_path: Option<&Path>) -> Self {
+        let mut should_write_default_json = true;
+
         if let Some(json_path) = settings_json_path {
             if json_path.exists() {
                 match std::fs::read_to_string(json_path)
@@ -506,10 +508,10 @@ impl SettingsDoc {
                     }
                     None => {
                         log::warn!(
-                            "[settings] Failed to load canonical settings.json from {:?}; using defaults",
+                            "[settings] Failed to load canonical settings.json from {:?}; trying legacy Automerge settings before defaults",
                             json_path
                         );
-                        return Self::new();
+                        should_write_default_json = false;
                     }
                 }
             }
@@ -541,8 +543,10 @@ impl SettingsDoc {
         info!("[settings] Creating new settings doc with defaults");
         let settings = Self::new();
         if let Some(json_path) = settings_json_path {
-            if let Err(e) = settings.save_json_mirror(json_path) {
-                log::warn!("[settings] Failed to write default settings.json: {e}");
+            if should_write_default_json {
+                if let Err(e) = settings.save_json_mirror(json_path) {
+                    log::warn!("[settings] Failed to write default settings.json: {e}");
+                }
             }
         }
         settings
@@ -1598,6 +1602,27 @@ mod tests {
         let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
         assert_eq!(saved.default_python_env, PythonEnvType::Conda);
         assert_eq!(saved.uv.default_packages, vec!["numpy"]);
+    }
+
+    #[test]
+    fn test_load_or_create_recovers_from_invalid_json_with_legacy_automerge() {
+        let tmp = TempDir::new().unwrap();
+        let automerge_path = tmp.path().join("settings.automerge");
+        let json_path = tmp.path().join("settings.json");
+
+        let mut legacy_doc = SettingsDoc::new();
+        legacy_doc.put("default_python_env", "pixi");
+        legacy_doc.put_list("conda.default_packages", &["scipy".to_string()]);
+        legacy_doc.save_to_file(&automerge_path).unwrap();
+        std::fs::write(&json_path, "{ not valid json").unwrap();
+
+        let recovered = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        assert_eq!(recovered.get("default_python_env").as_deref(), Some("pixi"));
+
+        let saved_json = std::fs::read_to_string(&json_path).unwrap();
+        let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
+        assert_eq!(saved.default_python_env, PythonEnvType::Pixi);
+        assert_eq!(saved.conda.default_packages, vec!["scipy"]);
     }
 
     #[test]

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -494,8 +494,6 @@ impl SettingsDoc {
     /// truth; `settings.automerge` is read only as a migration source when the
     /// JSON file does not exist.
     pub fn load_or_create(automerge_path: &Path, settings_json_path: Option<&Path>) -> Self {
-        let mut should_write_default_json = true;
-
         if let Some(json_path) = settings_json_path {
             if json_path.exists() {
                 match std::fs::read_to_string(json_path)
@@ -511,7 +509,6 @@ impl SettingsDoc {
                             "[settings] Failed to load canonical settings.json from {:?}; trying legacy Automerge settings before defaults",
                             json_path
                         );
-                        should_write_default_json = false;
                     }
                 }
             }
@@ -543,10 +540,8 @@ impl SettingsDoc {
         info!("[settings] Creating new settings doc with defaults");
         let settings = Self::new();
         if let Some(json_path) = settings_json_path {
-            if should_write_default_json {
-                if let Err(e) = settings.save_json_mirror(json_path) {
-                    log::warn!("[settings] Failed to write default settings.json: {e}");
-                }
+            if let Err(e) = settings.save_json_mirror(json_path) {
+                log::warn!("[settings] Failed to write default settings.json: {e}");
             }
         }
         settings
@@ -1623,6 +1618,22 @@ mod tests {
         let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
         assert_eq!(saved.default_python_env, PythonEnvType::Pixi);
         assert_eq!(saved.conda.default_packages, vec!["scipy"]);
+    }
+
+    #[test]
+    fn test_load_or_create_repairs_invalid_json_without_legacy_automerge() {
+        let tmp = TempDir::new().unwrap();
+        let automerge_path = tmp.path().join("settings.automerge");
+        let json_path = tmp.path().join("settings.json");
+
+        std::fs::write(&json_path, "{ not valid json").unwrap();
+
+        let recovered = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        assert_eq!(recovered.get_all(), SyncedSettings::default());
+
+        let saved_json = std::fs::read_to_string(&json_path).unwrap();
+        let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
+        assert_eq!(saved, SyncedSettings::default());
     }
 
     #[test]

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1,9 +1,9 @@
 //! Automerge-backed settings document for cross-window sync.
 //!
 //! Wraps an Automerge `AutoCommit` document with typed accessors for
-//! application settings. The daemon holds the canonical copy; each connected
+//! application settings. The daemon holds the live copy; each connected
 //! notebook window holds a local replica that syncs over the Automerge sync
-//! protocol.
+//! protocol. On disk, `settings.json` is canonical.
 //!
 //! The document uses nested maps for environment-specific settings:
 //!
@@ -485,41 +485,51 @@ impl SettingsDoc {
         Self { doc }
     }
 
-    /// Load a settings document from a saved binary, or create a new one with
-    /// defaults if the file doesn't exist or is invalid.
+    /// Load the canonical JSON settings, migrate a legacy Automerge settings
+    /// document once when JSON is missing, or create a new document with
+    /// defaults.
     ///
-    /// If `settings_json_path` points to an existing `settings.json`, its values
-    /// are migrated into the new Automerge document.
-    ///
-    /// Existing Automerge docs with old flat keys (`default_uv_packages`,
-    /// `default_conda_packages`) are migrated to the nested structure on load.
+    /// The returned `SettingsDoc` is still the in-memory sync document used by
+    /// the live settings protocol. On disk, `settings.json` is the source of
+    /// truth; `settings.automerge` is read only as a migration source when the
+    /// JSON file does not exist.
     pub fn load_or_create(automerge_path: &Path, settings_json_path: Option<&Path>) -> Self {
-        // Try loading existing Automerge document
+        if let Some(json_path) = settings_json_path {
+            if json_path.exists() {
+                match std::fs::read_to_string(json_path)
+                    .ok()
+                    .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+                {
+                    Some(json) => {
+                        info!("[settings] Loaded canonical settings from {:?}", json_path);
+                        return Self::from_json(&json);
+                    }
+                    None => {
+                        log::warn!(
+                            "[settings] Failed to load canonical settings.json from {:?}; using defaults",
+                            json_path
+                        );
+                        return Self::new();
+                    }
+                }
+            }
+        }
+
+        // One-time migration from the legacy Automerge settings document.
         if automerge_path.exists() {
             if let Ok(data) = std::fs::read(automerge_path) {
                 if let Ok(doc) = AutoCommit::load(&data) {
-                    info!("[settings] Loaded Automerge doc from {:?}", automerge_path);
+                    info!(
+                        "[settings] Migrating legacy Automerge settings from {:?}",
+                        automerge_path
+                    );
                     let mut settings = Self { doc };
                     settings.migrate_flat_to_nested();
                     settings.migrate_null_keep_alive();
 
-                    // Reconcile with settings.json so manual edits made while the
-                    // daemon was stopped are picked up (the file watcher only
-                    // catches changes that happen after it starts).
                     if let Some(json_path) = settings_json_path {
-                        if json_path.exists() {
-                            if let Ok(contents) = std::fs::read_to_string(json_path) {
-                                if let Ok(json) = serde_json::from_str(&contents) {
-                                    if settings.apply_json_changes(&json) {
-                                        info!("[settings] Reconciled Automerge doc with settings.json");
-                                        if let Err(e) = settings.save_to_file(automerge_path) {
-                                            log::warn!(
-                                                "[settings] Failed to persist reconciled Automerge doc: {e}"
-                                            );
-                                        }
-                                    }
-                                }
-                            }
+                        if let Err(e) = settings.save_json_mirror(json_path) {
+                            log::warn!("[settings] Failed to write migrated settings.json: {e}");
                         }
                     }
 
@@ -528,21 +538,14 @@ impl SettingsDoc {
             }
         }
 
-        // Try migrating from settings.json
+        info!("[settings] Creating new settings doc with defaults");
+        let settings = Self::new();
         if let Some(json_path) = settings_json_path {
-            if json_path.exists() {
-                if let Ok(contents) = std::fs::read_to_string(json_path) {
-                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
-                        info!("[settings] Migrating from {:?}", json_path);
-                        return Self::from_json(&json);
-                    }
-                }
+            if let Err(e) = settings.save_json_mirror(json_path) {
+                log::warn!("[settings] Failed to write default settings.json: {e}");
             }
         }
-
-        // Fall back to defaults
-        info!("[settings] Creating new settings doc with defaults");
-        Self::new()
+        settings
     }
 
     /// Create a settings document from parsed JSON (for migration from settings.json).
@@ -710,7 +713,7 @@ impl SettingsDoc {
         std::fs::write(path, data)
     }
 
-    /// Write a human-readable JSON mirror of the settings (for fallback/inspection).
+    /// Write the canonical human-readable JSON settings file.
     ///
     /// Injects a `$schema` key pointing to the companion schema file so editors
     /// can provide autocomplete and validation.
@@ -1544,7 +1547,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_or_create_persists_json_reconcile_into_existing_automerge_doc() {
+    fn test_load_or_create_prefers_json_over_existing_automerge_doc() {
         let tmp = TempDir::new().unwrap();
         let automerge_path = tmp.path().join("settings.automerge");
         let json_path = tmp.path().join("settings.json");
@@ -1568,10 +1571,33 @@ mod tests {
         let persisted = SettingsDoc::load_or_create(&automerge_path, None);
         assert_eq!(
             persisted.get("default_python_env").as_deref(),
-            Some("conda"),
-            "settings.json edits made while the daemon was stopped must persist into settings.automerge"
+            Some("uv"),
+            "loading canonical settings.json must not rewrite the legacy Automerge file"
         );
-        assert_eq!(persisted.get_list("uv.default_packages"), vec!["numpy"]);
+        assert_eq!(
+            persisted.get_list("uv.default_packages"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_load_or_create_migrates_legacy_automerge_to_json_when_json_missing() {
+        let tmp = TempDir::new().unwrap();
+        let automerge_path = tmp.path().join("settings.automerge");
+        let json_path = tmp.path().join("settings.json");
+
+        let mut legacy_doc = SettingsDoc::new();
+        legacy_doc.put("default_python_env", "conda");
+        legacy_doc.put_list("uv.default_packages", &["numpy".to_string()]);
+        legacy_doc.save_to_file(&automerge_path).unwrap();
+
+        let migrated = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        assert_eq!(migrated.get("default_python_env").as_deref(), Some("conda"));
+
+        let saved_json = std::fs::read_to_string(&json_path).unwrap();
+        let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
+        assert_eq!(saved.default_python_env, PythonEnvType::Conda);
+        assert_eq!(saved.uv.default_packages, vec!["numpy"]);
     }
 
     #[test]

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -38,7 +38,7 @@ pub enum SyncClientError {
 /// Client for the Automerge settings sync service.
 ///
 /// Holds a local Automerge document replica that stays in sync with the
-/// daemon's canonical copy via the Automerge sync protocol.
+/// daemon's live copy via the Automerge sync protocol.
 pub struct SyncClient<S> {
     doc: AutoCommit,
     peer_state: sync::State,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -80,18 +80,10 @@ pub struct DaemonConfig {
     /// retries push boot past the test's `wait_for_daemon` timeout, and
     /// for any other context where the stable-port UX isn't load-bearing.
     pub use_preferred_blob_port: bool,
-    /// Override for the persisted Automerge settings-document path.
+    /// Override for the canonical settings JSON path.
     ///
-    /// `None` (default) uses the channel's global path
-    /// (`daemon_base_dir()/settings.automerge`). Integration tests
-    /// override this to a per-test temp-dir path so dozens of parallel
-    /// daemons don't contend on the same on-disk file during boot.
-    pub settings_doc_path: Option<PathBuf>,
-    /// Override for the JSON mirror of the settings doc.
-    ///
-    /// Same story as `settings_doc_path`: global by default, per-test
-    /// when overridden. Integration tests set both to avoid write
-    /// contention under parallel boot.
+    /// Global by default, per-test when overridden. Integration tests set this
+    /// to avoid write contention under parallel boot.
     pub settings_json_path: Option<PathBuf>,
 }
 
@@ -116,28 +108,23 @@ impl Default for DaemonConfig {
             env_cache_max_age_secs: 86400, // 1 day
             env_cache_max_count: 10,
             use_preferred_blob_port: true,
-            settings_doc_path: None,
             settings_json_path: None,
         }
     }
 }
 
 impl DaemonConfig {
-    /// Resolve the Automerge settings-doc path: override when set,
-    /// otherwise the channel's global path.
-    pub fn resolved_settings_doc_path(&self) -> PathBuf {
-        self.settings_doc_path
-            .clone()
-            .unwrap_or_else(runtimed_client::default_settings_doc_path)
-    }
-
-    /// Resolve the JSON mirror path: override when set, otherwise the
+    /// Resolve the canonical settings JSON path: override when set, otherwise the
     /// channel's global path.
     pub fn resolved_settings_json_path(&self) -> PathBuf {
         self.settings_json_path
             .clone()
             .unwrap_or_else(runt_workspace::settings_json_path)
     }
+}
+
+fn legacy_settings_doc_path() -> PathBuf {
+    runtimed_client::daemon_base_dir().join("settings.automerge")
 }
 
 #[cfg(unix)]
@@ -1055,7 +1042,7 @@ pub struct Daemon {
     shutdown_notify: Arc<Notify>,
     /// Singleton lock - kept alive while daemon is running.
     _lock: DaemonLock,
-    /// Shared Automerge settings document.
+    /// Shared in-memory Automerge settings document for live sync.
     pub(crate) settings: Arc<RwLock<SettingsDoc>>,
     /// Broadcast channel to notify sync connections of settings changes.
     settings_changed: tokio::sync::broadcast::Sender<()>,
@@ -1228,10 +1215,10 @@ impl Daemon {
         let lock = DaemonLock::try_acquire(config.lock_dir.as_ref())
             .map_err(|info| DaemonAlreadyRunning { info })?;
 
-        // Load or create the settings document. Use the config-resolved
-        // paths so integration tests can point each daemon at a per-test
-        // temp file and avoid contention on the global settings doc.
-        let automerge_path = config.resolved_settings_doc_path();
+        // Load or create the in-memory settings document. settings.json is
+        // canonical; the legacy Automerge file is read only for one-time
+        // migration when JSON is missing.
+        let automerge_path = legacy_settings_doc_path();
         let json_path = config.resolved_settings_json_path();
         let mut settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
 
@@ -1246,7 +1233,7 @@ impl Daemon {
         // installs (onboarding_completed = false) and idempotent across
         // restarts.
         //
-        // Write both the Automerge doc and the JSON mirror immediately when
+        // Write the JSON settings file immediately when
         // the flag flips. Otherwise the change only persists if a settings
         // client happens to connect and trigger `persist_settings` in
         // `sync_server.rs` — a daemon that boots, runs briefly with no
@@ -1255,14 +1242,11 @@ impl Daemon {
             tracing::info!(
                 "[settings] Backfilled telemetry_consent_recorded for an existing onboarded install"
             );
-            if let Err(e) = settings.save_to_file(&automerge_path) {
+            if let Err(e) = settings.save_json_mirror(&json_path) {
                 tracing::warn!(
-                    "[settings] Failed to persist backfilled Automerge doc: {}",
+                    "[settings] Failed to persist backfilled settings.json: {}",
                     e
                 );
-            }
-            if let Err(e) = settings.save_json_mirror(&json_path) {
-                tracing::warn!("[settings] Failed to persist backfilled JSON mirror: {}", e);
             }
         }
 
@@ -1776,7 +1760,7 @@ impl Daemon {
         Ok(())
     }
 
-    /// Watch `settings.json` for external changes and apply them to the Automerge doc.
+    /// Watch `settings.json` for external changes and apply them to the in-memory Automerge doc.
     ///
     /// Uses the `notify` crate with a 500ms debouncer. When changes are detected,
     /// reads the file, parses it, and selectively applies any differences to the
@@ -1868,21 +1852,12 @@ impl Daemon {
                                 }
                             };
 
-                            // Apply changes to the Automerge doc
+                            // Apply changes to the in-memory Automerge doc.
+                            // settings.json is canonical, so do not write a
+                            // legacy settings.automerge file here.
                             let changed = {
                                 let mut doc = self.settings.write().await;
-                                let changed = doc.apply_json_changes(&json);
-                                if changed {
-                                    // Only persist the Automerge binary — do NOT write
-                                    // the JSON mirror back, as serde_json formatting
-                                    // differs from editors (e.g. arrays expand to one
-                                    // element per line) which causes unwanted churn.
-                                    let automerge_path = self.config.resolved_settings_doc_path();
-                                    if let Err(e) = doc.save_to_file(&automerge_path) {
-                                        warn!("[settings-watch] Failed to save Automerge doc: {}", e);
-                                    }
-                                }
-                                changed
+                                doc.apply_json_changes(&json)
                             };
 
                             if changed {
@@ -2198,7 +2173,6 @@ impl Daemon {
                     self.settings.clone(),
                     changed_tx,
                     changed_rx,
-                    self.config.resolved_settings_doc_path(),
                     self.config.resolved_settings_json_path(),
                 )
                 .await
@@ -5614,7 +5588,6 @@ mod tests {
             lock_dir: Some(temp_dir.path().to_path_buf()),
             room_eviction_delay_ms: Some(50),
             use_preferred_blob_port: false,
-            settings_doc_path: Some(temp_dir.path().join("settings.automerge")),
             settings_json_path: Some(temp_dir.path().join("settings.json")),
             ..Default::default()
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -123,8 +123,11 @@ impl DaemonConfig {
     }
 }
 
-fn legacy_settings_doc_path() -> PathBuf {
-    runtimed_client::daemon_base_dir().join("settings.automerge")
+fn legacy_settings_doc_path(config: &DaemonConfig) -> PathBuf {
+    match &config.settings_json_path {
+        Some(json_path) => json_path.with_file_name("settings.automerge"),
+        None => runtimed_client::daemon_base_dir().join("settings.automerge"),
+    }
 }
 
 #[cfg(unix)]
@@ -1218,7 +1221,7 @@ impl Daemon {
         // Load or create the in-memory settings document. settings.json is
         // canonical; the legacy Automerge file is read only for one-time
         // migration when JSON is missing.
-        let automerge_path = legacy_settings_doc_path();
+        let automerge_path = legacy_settings_doc_path(&config);
         let json_path = config.resolved_settings_json_path();
         let mut settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
 
@@ -5591,6 +5594,21 @@ mod tests {
             settings_json_path: Some(temp_dir.path().join("settings.json")),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn legacy_settings_doc_path_tracks_settings_json_override() {
+        let temp_dir = TempDir::new().unwrap();
+        let settings_json = temp_dir.path().join("isolated").join("settings.json");
+        let config = DaemonConfig {
+            settings_json_path: Some(settings_json.clone()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            legacy_settings_doc_path(&config),
+            settings_json.with_file_name("settings.automerge")
+        );
     }
 
     /// Plant a fake pool env on disk under `cache_dir` and register it in

--- a/crates/runtimed/src/daemon_telemetry.rs
+++ b/crates/runtimed/src/daemon_telemetry.rs
@@ -96,7 +96,7 @@ async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Clien
 }
 
 fn persist_settings(doc: &runtimed_client::settings_doc::SettingsDoc, json_path: &std::path::Path) {
-    if let Err(e) = doc.save_json_mirror(&json_path) {
+    if let Err(e) = doc.save_json_mirror(json_path) {
         tracing::warn!("[telemetry] failed to write settings.json: {e}");
     }
 }

--- a/crates/runtimed/src/daemon_telemetry.rs
+++ b/crates/runtimed/src/daemon_telemetry.rs
@@ -42,7 +42,7 @@ async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Clien
         let id = runtimed_client::settings_doc::ensure_install_id(&mut settings_doc);
         let generated = !had_id;
         if generated {
-            persist_settings(&mut settings_doc);
+            persist_settings(&settings_doc, &daemon.config.resolved_settings_json_path());
         }
         let snapshot = settings_doc.get_all();
         (snapshot, id, generated)
@@ -91,17 +91,12 @@ async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Clien
     {
         let mut settings_doc = daemon.settings.write().await;
         settings_doc.put_u64("telemetry_last_daemon_ping_at", now);
-        persist_settings(&mut settings_doc);
+        persist_settings(&settings_doc, &daemon.config.resolved_settings_json_path());
     }
 }
 
-fn persist_settings(doc: &mut runtimed_client::settings_doc::SettingsDoc) {
-    let automerge_path = runtimed_client::default_settings_doc_path();
-    let json_path = runtimed_client::settings_json_path();
-    if let Err(e) = doc.save_to_file(&automerge_path) {
-        tracing::warn!("[telemetry] failed to save Automerge doc: {e}");
-    }
+fn persist_settings(doc: &runtimed_client::settings_doc::SettingsDoc, json_path: &std::path::Path) {
     if let Err(e) = doc.save_json_mirror(&json_path) {
-        tracing::warn!("[telemetry] failed to write JSON mirror: {e}");
+        tracing::warn!("[telemetry] failed to write settings.json: {e}");
     }
 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -43,7 +43,6 @@ pub async fn handle_settings_sync_connection<R, W>(
     settings: Arc<RwLock<SettingsDoc>>,
     changed_tx: broadcast::Sender<()>,
     mut changed_rx: broadcast::Receiver<()>,
-    automerge_path: PathBuf,
     json_path: PathBuf,
 ) -> anyhow::Result<()>
 where
@@ -87,7 +86,7 @@ where
                         let doc_changed = before != after;
 
                         if doc_changed {
-                            persist_settings(&mut doc, &automerge_path, &json_path);
+                            persist_settings(&doc, &json_path);
                             let _ = changed_tx.send(());
                         }
 
@@ -114,12 +113,9 @@ where
     }
 }
 
-/// Persist the settings document to disk (both Automerge binary and JSON mirror).
-fn persist_settings(doc: &mut SettingsDoc, automerge_path: &Path, json_path: &Path) {
-    if let Err(e) = doc.save_to_file(automerge_path) {
-        warn!("[sync] Failed to save Automerge doc: {}", e);
-    }
+/// Persist the settings document to the canonical JSON file.
+fn persist_settings(doc: &SettingsDoc, json_path: &Path) {
     if let Err(e) = doc.save_json_mirror(json_path) {
-        warn!("[sync] Failed to write JSON mirror: {}", e);
+        warn!("[sync] Failed to write settings.json: {}", e);
     }
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -92,10 +92,8 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         // sequential `EADDRINUSE` retries push daemon boot past the
         // test's `wait_for_daemon` timeout. Skip straight to OS-assigned.
         use_preferred_blob_port: false,
-        // Pin settings files per-temp-dir so parallel daemons don't
-        // contend on the global `~/.cache/runt*/settings.automerge` +
-        // `~/.config/runt*/settings.json` pair at boot.
-        settings_doc_path: Some(temp_dir.path().join("settings.automerge")),
+        // Pin settings.json per-temp-dir so parallel daemons don't contend on
+        // the global `~/.config/runt*/settings.json` at boot.
         settings_json_path: Some(temp_dir.path().join("settings.json")),
         ..Default::default()
     }
@@ -433,9 +431,7 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
     let mut config = test_config(&temp_dir);
     let socket_path = config.socket_path.clone();
     let settings_dir = temp_dir.path().canonicalize().unwrap();
-    let settings_doc_path = settings_dir.join("settings.automerge");
     let settings_json_path = settings_dir.join("settings.json");
-    config.settings_doc_path = Some(settings_doc_path);
     config.settings_json_path = Some(settings_json_path.clone());
 
     let initial = serde_json::to_string_pretty(&SyncedSettings::default()).unwrap();
@@ -475,7 +471,7 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
 
     // `recv_changes` sends any required sync ack before returning. Give the
     // daemon a short window to process that ack; a regression would persist
-    // the stale client value back to the JSON mirror here.
+    // the stale client value back to settings.json here.
     sleep(Duration::from_millis(500)).await;
 
     let saved_json = std::fs::read_to_string(&settings_json_path).unwrap();
@@ -495,9 +491,7 @@ async fn test_settings_json_mirror_write_does_not_feedback_loop() {
     let mut config = test_config(&temp_dir);
     let socket_path = config.socket_path.clone();
     let settings_dir = temp_dir.path().canonicalize().unwrap();
-    let settings_doc_path = settings_dir.join("settings.automerge");
     let settings_json_path = settings_dir.join("settings.json");
-    config.settings_doc_path = Some(settings_doc_path);
     config.settings_json_path = Some(settings_json_path.clone());
 
     let initial = serde_json::to_string_pretty(&SyncedSettings::default()).unwrap();
@@ -529,7 +523,7 @@ async fn test_settings_json_mirror_write_does_not_feedback_loop() {
         .expect("observer sync should remain connected");
     assert_eq!(observed.theme, ThemeMode::Dark);
 
-    // The daemon persists the JSON mirror for the writer's Automerge change.
+    // The daemon persists settings.json for the writer's Automerge change.
     // The settings.json watcher will see that filesystem event; it must
     // recognize the mirror already matches the doc and avoid broadcasting
     // another settings change back to peers.
@@ -2352,12 +2346,12 @@ async fn test_pool_size_config_honored() {
     )
     .unwrap();
 
-    // Create a custom settings doc path for this test
-    let settings_doc_path = temp_dir.path().join("settings.amg");
+    // Create a custom legacy Automerge path for this test.
+    let automerge_path = temp_dir.path().join("settings.amg");
 
     // Test 1: Verify that from_json() correctly imports pool sizes during initial migration
     let settings_doc = runtimed_client::settings_doc::SettingsDoc::load_or_create(
-        &settings_doc_path,
+        &automerge_path,
         Some(&settings_path),
     );
 

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -477,6 +477,10 @@ async fn test_external_settings_json_edit_survives_settings_sync_ack() {
     let saved_json = std::fs::read_to_string(&settings_json_path).unwrap();
     let saved: SyncedSettings = serde_json::from_str(&saved_json).unwrap();
     assert_eq!(saved.default_python_env, PythonEnvType::Conda);
+    assert!(
+        !settings_dir.join("settings.automerge").exists(),
+        "external settings.json edits must not recreate legacy Automerge settings persistence"
+    );
 
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -118,7 +118,7 @@ Length-prefixed binary framing over a single Unix socket (Unix) or named pipe (W
 
 ### Settings.json file watcher
 
-The daemon watches `~/.config/nteract/settings.json` for external edits. Changes are debounced (500ms), applied to the Automerge settings doc, persisted as Automerge binary (not back to JSON, to avoid formatting churn), and broadcast to all connected sync clients.
+The daemon watches `~/.config/nteract/settings.json` for external edits. Changes are debounced (500ms), applied to the in-memory Automerge settings doc, and broadcast to all connected sync clients. The JSON file is the persistent source of truth; legacy `settings.automerge` is read only as a one-time migration source when JSON is missing.
 
 ### Service management
 
@@ -202,7 +202,7 @@ ROOT/
     default_packages: ["scipy"]
 ```
 
-The daemon holds the canonical document, persisted to `~/.cache/runt/settings.automerge` with a JSON mirror at `~/.config/nteract/settings.json`. Backward-compatible migration from flat keys (`default_uv_packages: "numpy, pandas"`) to nested structures.
+The daemon holds a live in-memory Automerge document for sync. Persistence is canonical JSON at `~/.config/nteract/settings.json`. Legacy `~/.cache/runt/settings.automerge` is migration-only: when JSON is missing, it is loaded once and written out as JSON. Backward-compatible migration from flat keys (`default_uv_packages: "numpy, pandas"`) to nested structures still runs during that import.
 
 **Wire protocol**: Length-prefixed binary frames (4-byte BE length + Automerge sync message). Bidirectional, long-lived connections. Broadcast channel notifies all peers when any peer changes a setting.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,22 +6,22 @@ nteract Desktop settings control default behavior for new notebooks, appearance,
 
 | Setting | Options | Default | Stored In |
 |---------|---------|---------|-----------|
-| Theme | light, dark, system | system | Synced (Automerge) + settings file |
-| Default runtime | python, deno | python | Synced (Automerge) + settings file |
-| Default Python env | uv, conda | uv | Synced (Automerge) + settings file |
-| Default uv packages | list of strings | (empty) | Synced (Automerge) + settings file |
-| Default conda packages | list of strings | (empty) | Synced (Automerge) + settings file |
-| Keep alive secs | integer | 30 | Synced (Automerge) + settings file |
-| Onboarding completed | boolean | false | Synced (Automerge) + settings file |
+| Theme | light, dark, system | system | `settings.json` + live Automerge sync |
+| Default runtime | python, deno | python | `settings.json` + live Automerge sync |
+| Default Python env | uv, conda | uv | `settings.json` + live Automerge sync |
+| Default uv packages | list of strings | (empty) | `settings.json` + live Automerge sync |
+| Default conda packages | list of strings | (empty) | `settings.json` + live Automerge sync |
+| Keep alive secs | integer | 30 | `settings.json` + live Automerge sync |
+| Onboarding completed | boolean | false | `settings.json` + live Automerge sync |
 
 ## How Settings Sync Works
 
-Settings are synced across all notebook windows via the runtimed daemon using Automerge. The daemon holds the canonical document; each notebook window maintains a local replica.
+Settings are persisted in `settings.json` and synced across all notebook windows via the runtimed daemon using an in-memory Automerge document. Each notebook window maintains a local replica.
 
-- **Source of truth:** The Automerge document in the daemon
-- **Persistence:** Settings are also written to `settings.json` in the same nested format
+- **Source of truth:** `settings.json`
+- **Live sync:** The daemon keeps an in-memory Automerge settings document for cross-window updates
 - **External edits:** The daemon watches `settings.json` for external changes (manual edits, CLI tools) and propagates them to all connected windows automatically
-- **Fallback:** When the daemon is unavailable, settings are read directly from `settings.json`
+- **Migration:** A legacy `settings.automerge` file is read only when `settings.json` is missing, then written out as JSON
 - **Theme special case:** Theme also uses webview localStorage to prevent a flash of unstyled content on startup
 
 When you change a setting in any window, it propagates to all other open windows in real time.
@@ -47,7 +47,7 @@ Environment-specific settings (packages, future: channels) live under `uv/` and 
 
 ## Settings File
 
-Settings are persisted to a JSON file shared across all notebook windows. The daemon is the sole writer; the notebook app reads the same nested JSON format as a fallback when the daemon is unavailable.
+Settings are persisted to a JSON file shared across all notebook windows. The daemon and CLI write the same nested JSON format.
 
 | Platform | Path |
 |----------|------|
@@ -55,7 +55,7 @@ Settings are persisted to a JSON file shared across all notebook windows. The da
 | Linux | `~/.config/nteract/settings.json` |
 | Windows | `C:\Users\<User>\AppData\Roaming\nteract\settings.json` |
 
-The file is created automatically when you first change a setting. You can also edit it by hand — changes are detected and applied automatically when the daemon is running.
+The file is created automatically on daemon startup. You can also edit it by hand — changes are detected and applied automatically when the daemon is running.
 
 Example:
 


### PR DESCRIPTION
## Summary

- make settings.json the canonical persisted settings source
- keep the Automerge SettingsDoc and SyncClient protocol as live in-memory sync only
- migrate legacy settings.automerge only when settings.json is missing, writing JSON once and avoiding future Automerge saves
- remove settings_doc_path/default_settings_doc_path plumbing and update docs/comments

## Verification

- cargo test -p runtimed-client settings_doc::tests --no-default-features
- cargo test -p runtimed --test integration settings_json --no-default-features
- cargo xtask lint --fix
- git diff --check
