### PR TITLE
feat(notebook): assistant side panel with daemon-proxied streaming chat

### DIFF
--- a/apps/notebook/e2e/assistant-panel.spec.ts
+++ b/apps/notebook/e2e/assistant-panel.spec.ts
@@ -25,10 +25,14 @@ test.describe("assistant side panel", () => {
     const panel = page.getByTestId("assistant-panel");
     await expect(panel).toBeVisible();
 
-    // Type a greeting and send.
+    // Type a greeting and send. Use pressSequentially (not fill) so the
+    // recording shows the text being entered character by character rather
+    // than appearing all at once.
     const input = panel.getByTestId("assistant-input");
     await input.click();
-    await input.fill("Hello! Please reply with a short friendly greeting.");
+    await input.pressSequentially("Hello! Please reply with a short friendly greeting.", {
+      delay: 40,
+    });
     await panel.getByTestId("assistant-send").click();
 
     // The user's message renders immediately.

--- a/apps/notebook/e2e/assistant-panel.spec.ts
+++ b/apps/notebook/e2e/assistant-panel.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { openNotebookRoom, waitForKernelStatus } from "./helpers";
+
+// Records a video of the assistant side panel making a REAL LLM call through
+// the daemon's `/assistant/chat` proxy (Anaconda-hosted Claude gateway). The
+// response is not mocked — the daemon resolves an API key via the `anaconda`
+// CLI and streams the upstream SSE back to the panel.
+//
+// Video is written to `test-results/` (see `video: "on"` below).
+test.use({ video: "on" });
+
+test.describe("assistant side panel", () => {
+  test("opens the panel, says hello, and streams a real LLM response", async ({ page }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    // Wait for the session to settle so the blob port (which the assistant
+    // client POSTs to) is resolved.
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    // Panel starts closed.
+    await expect(page.getByTestId("assistant-panel")).toHaveCount(0);
+
+    // Open it from the toolbar.
+    await page.getByTestId("assistant-toggle").click();
+    const panel = page.getByTestId("assistant-panel");
+    await expect(panel).toBeVisible();
+
+    // Type a greeting and send.
+    const input = panel.getByTestId("assistant-input");
+    await input.click();
+    await input.fill("Hello! Please reply with a short friendly greeting.");
+    await panel.getByTestId("assistant-send").click();
+
+    // The user's message renders immediately.
+    await expect(panel.getByTestId("assistant-message-user")).toContainText("Hello!");
+
+    // While the request is in flight the composer shows a Stop button; when the
+    // stream completes it flips back to Send. Wait for that transition so we
+    // assert on the FINISHED response, not the streaming "…" placeholder.
+    await expect(panel.getByTestId("assistant-stop")).toBeVisible({ timeout: 10_000 });
+    await expect(panel.getByTestId("assistant-send")).toBeVisible({ timeout: 60_000 });
+
+    // The finished assistant message must contain real streamed text — not the
+    // placeholder, an empty bubble, a "(stopped)" marker, or an error.
+    const assistantMessage = panel.getByTestId("assistant-message-assistant");
+    await expect(assistantMessage).toBeVisible();
+    const finalText = (await assistantMessage.innerText()).trim();
+    // eslint-disable-next-line no-console
+    console.log(`[assistant-panel] LLM response: ${JSON.stringify(finalText)}`);
+
+    await expect(assistantMessage).not.toHaveAttribute("data-role", "error");
+    expect(finalText.toLowerCase()).not.toContain("error:");
+    expect(finalText).not.toBe("(stopped)");
+    expect(finalText).not.toBe("…");
+    // A genuine greeting is more than a couple of characters.
+    expect(finalText.length).toBeGreaterThan(3);
+
+    // Give the recording a beat to capture the finished state.
+    await page.waitForTimeout(1_000);
+  });
+});

--- a/apps/notebook/gallery/App.tsx
+++ b/apps/notebook/gallery/App.tsx
@@ -4,6 +4,7 @@ import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { PrivacySection } from "../settings/sections/Privacy";
+import { StreamdownFixture } from "./StreamdownFixture";
 
 /**
  * Standalone component gallery.
@@ -64,6 +65,13 @@ export default function App() {
           <div className="max-w-lg border rounded-lg p-4 bg-card">
             <PrivacySectionDemo />
           </div>
+        </Section>
+
+        <Section
+          title="Assistant markdown (Streamdown)"
+          description="GitHub-flavored Markdown fixture rendered with the same Streamdown props used in the assistant side panel — headings, inline styles, lists, task lists, fenced code blocks, tables, images, and blockquotes."
+        >
+          <StreamdownFixture />
         </Section>
       </main>
     </div>

--- a/apps/notebook/gallery/StreamdownFixture.tsx
+++ b/apps/notebook/gallery/StreamdownFixture.tsx
@@ -1,0 +1,237 @@
+import { Streamdown } from "streamdown";
+
+const GFM_SAMPLE = `
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+###### Heading 6
+
+---
+
+## Paragraphs & inline
+
+A regular paragraph with **bold**, *italic*, ~~strikethrough~~, \`inline code\`, and a [link](https://example.com).
+
+You can also use __bold__, _italic_, and **_bold italic_** together.
+
+Superscript: E = mc^2^
+Subscript: H~2~O
+
+> This is a blockquote.
+>
+> It can span multiple paragraphs and contain **formatted** text.
+>
+> > Nested blockquotes work too.
+
+---
+
+## Lists
+
+Unordered list:
+
+- Item one
+- Item two
+  - Nested item A
+  - Nested item B
+    - Deeply nested
+- Item three
+
+Ordered list:
+
+1. First step
+2. Second step
+   1. Sub-step 2a
+   2. Sub-step 2b
+3. Third step
+
+Task list (GFM checkboxes):
+
+- [x] Design the feature
+- [x] Write tests
+- [ ] Ship to production
+- [ ] Write docs
+
+---
+
+## Code
+
+Inline \`code\` looks like this.
+
+Python block:
+
+\`\`\`python
+def hello_world():
+    print("Hello, World!")
+
+class Greeter:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def greet(self) -> str:
+        return f"Hello, {self.name}!"
+\`\`\`
+
+TypeScript block:
+
+\`\`\`typescript
+interface User {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+async function fetchUser(id: number): Promise<User> {
+  const response = await fetch(\`/api/users/\${id}\`);
+  if (!response.ok) throw new Error(\`HTTP \${response.status}\`);
+  return response.json() as Promise<User>;
+}
+\`\`\`
+
+Bash block:
+
+\`\`\`bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies and run tests
+npm ci
+npm test -- --coverage
+\`\`\`
+
+A block with no language specified:
+
+\`\`\`
+plain text / no syntax highlighting
+works here too
+\`\`\`
+
+---
+
+## Tables (GFM)
+
+| Name        | Type     | Default   | Description                        |
+| ----------- | -------- | --------- | ---------------------------------- |
+| \`timeout\`   | \`number\` | \`5000\`    | Request timeout in milliseconds    |
+| \`retries\`   | \`number\` | \`3\`       | Number of retry attempts           |
+| \`verbose\`   | \`boolean\`| \`false\`   | Enable verbose logging             |
+| \`endpoint\`  | \`string\` | \`"/api"\`  | Base URL for all requests          |
+
+Aligned columns:
+
+| Left aligned | Center aligned | Right aligned |
+| :----------- | :------------: | ------------: |
+| alpha        |    bravo       |         delta |
+| echo         |    foxtrot     |          golf |
+
+---
+
+## Images
+
+![A placeholder image](https://placehold.co/600x200/e2e8f0/475569?text=placeholder+image)
+
+---
+
+## Horizontal rules
+
+---
+
+***
+
+___
+
+---
+
+## Autolinks (GFM)
+
+Visit https://example.com or email support@example.com.
+
+---
+
+## HTML passthrough
+
+<details>
+<summary>Click to expand</summary>
+
+Hidden content revealed on click.
+
+</details>
+
+---
+
+## Long code block (scroll test)
+
+\`\`\`python
+# A deliberately long function to test horizontal scroll
+def process_data(input_data: list[dict], config: dict, verbose: bool = False, dry_run: bool = False) -> list[dict]:
+    """Process input data records according to the provided configuration, optionally in dry-run mode."""
+    results = []
+    for idx, record in enumerate(input_data):
+        if verbose:
+            print(f"[{idx + 1}/{len(input_data)}] Processing record id={record.get('id', 'unknown')}")
+        transformed = {k: v for k, v in record.items() if k not in config.get("exclude_fields", [])}
+        if not dry_run:
+            results.append(transformed)
+    return results
+\`\`\`
+
+---
+
+## Nested list with code
+
+1. Install the package:
+
+   \`\`\`bash
+   npm install streamdown
+   \`\`\`
+
+2. Import and use:
+
+   \`\`\`typescript
+   import { Streamdown } from "streamdown";
+   \`\`\`
+
+3. Profit.
+
+---
+
+## Mixed inline in table
+
+| Feature          | Status | Notes                            |
+| ---------------- | :----: | -------------------------------- |
+| **Bold cells**   |   ✅   | Works fine                       |
+| \`code in table\` |   ✅   | Renders inline code              |
+| [links](https://example.com) | ✅ | Clickable                  |
+| ~~strikethrough~~ |  ✅   | GFM extension                   |
+`.trim();
+
+export function StreamdownFixture() {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-foreground/80">
+        The exact <code className="text-xs bg-muted px-1 py-0.5 rounded">Streamdown</code> props
+        used in the assistant side panel, rendered against a comprehensive GitHub-flavored Markdown
+        fixture — headings, inline styles, lists, task lists, fenced code blocks with syntax
+        highlighting, tables, images, and more.
+      </p>
+
+      {/* Mimic the chat bubble wrapper from AssistantPanel */}
+      <div className="rounded-lg border bg-background p-4 max-w-2xl">
+        <Streamdown
+          mode="static"
+          className="prose prose-sm dark:prose-invert max-w-none [&_ul]:pl-5 [&_ol]:pl-5"
+          linkSafety={{ enabled: false }}
+          allowedTags={{ img: ["src", "alt", "title", "width", "height"] }}
+        >
+          {GFM_SAMPLE}
+        </Streamdown>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/gallery/StreamdownFixture.tsx
+++ b/apps/notebook/gallery/StreamdownFixture.tsx
@@ -1,4 +1,42 @@
-import { Streamdown } from "streamdown";
+import { Streamdown, type Components } from "streamdown";
+import {
+  CodeBlock,
+  CodeBlockActions,
+  CodeBlockCopyButton,
+  CodeBlockHeader,
+  CodeBlockTitle,
+  CodeBlockFilename,
+} from "@/components/ui/code-block";
+import type { BundledLanguage } from "shiki";
+
+const codeBlockComponents: Components = {
+  pre: ({ node }) => {
+    const codeEl = (
+      node as {
+        children?: Array<{
+          tagName?: string;
+          properties?: Record<string, unknown>;
+          children?: Array<{ value?: string }>;
+        }>;
+      }
+    )?.children?.find((c) => c.tagName === "code");
+    const className = String(codeEl?.properties?.className ?? "");
+    const lang = (className.match(/language-(\S+)/)?.[1] ?? "text") as BundledLanguage;
+    const code = codeEl?.children?.map((c) => c.value ?? "").join("") ?? "";
+    return (
+      <CodeBlock code={code} language={lang} className="my-4 not-prose">
+        <CodeBlockHeader>
+          <CodeBlockTitle>
+            <CodeBlockFilename>{lang}</CodeBlockFilename>
+          </CodeBlockTitle>
+          <CodeBlockActions>
+            <CodeBlockCopyButton />
+          </CodeBlockActions>
+        </CodeBlockHeader>
+      </CodeBlock>
+    );
+  },
+};
 
 const GFM_SAMPLE = `
 # Heading 1
@@ -226,6 +264,7 @@ export function StreamdownFixture() {
         <Streamdown
           mode="static"
           className="prose prose-sm dark:prose-invert max-w-none [&_ul]:pl-5 [&_ol]:pl-5"
+          components={codeBlockComponents}
           linkSafety={{ enabled: false }}
           allowedTags={{ img: ["src", "alt", "title", "width", "height"] }}
         >

--- a/apps/notebook/gallery/index.css
+++ b/apps/notebook/gallery/index.css
@@ -4,6 +4,7 @@
  * a drift from the real surface we're previewing.
  */
 @import "../settings/index.css";
+@import "streamdown/styles.css";
 
 /* The settings @source globs only cover settings/ and ../src/components/.
  * Add the two additional paths the gallery pulls components from so

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -52,6 +52,7 @@
     "remark-math": "^6.0.0",
     "runtimed": "workspace:*",
     "rxjs": "^7.8.2",
+    "shiki": "4.1.0",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.4.0"
   },

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -52,6 +52,7 @@
     "remark-math": "^6.0.0",
     "runtimed": "workspace:*",
     "rxjs": "^7.8.2",
+    "streamdown": "^2.5.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -92,6 +92,8 @@ import {
   DenoDependencyPanel as DenoDependencyHeader,
   UvDependencyPanel as DependencyHeader,
 } from "@/components/environment";
+import { Sparkles } from "lucide-react";
+import { AssistantPanel } from "./components/AssistantPanel";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { PixiDependencyHeader } from "./components/PixiDependencyHeader";
@@ -112,6 +114,7 @@ import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
+import { toggleAssistantPanel, useAssistantPanelOpen } from "./lib/assistant-panel-state";
 import { getBlobResolver, useBlobPort, useBlobResolver } from "./lib/blob-port";
 import { useRuntimeState } from "./lib/runtime-state";
 import {
@@ -429,6 +432,7 @@ function AppContent() {
   const globalFind = useGlobalFind(cellIds);
 
   const { activePanelId: activeRailPanel, collapsed: railCollapsed } = useNotebookRailUiState();
+  const assistantPanelOpen = useAssistantPanelOpen();
   const stageHadFocusBeforeRailTakeoverRef = useRef(false);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [envBuildDialogOpen, setEnvBuildDialogOpen] = useState(false);
@@ -2011,16 +2015,33 @@ function AppContent() {
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
           trailingControls={
-            // Connection/identity slot: renders nothing for a purely local
-            // session (isRemoteNotebookContext) — conditionality is the
-            // point. The source derives from daemon lifecycle events (the
-            // IPC transport's status is constant in practice), and the
-            // copy is scoped to the link it measures.
-            <NotebookConnectionIdentity
-              capabilities={shellCapabilities}
-              connectionStatus$={desktopConnectionStatus}
-              connectionLabel="Daemon connection"
-            />
+            <>
+              {/* Connection/identity slot: renders nothing for a purely local
+                  session (isRemoteNotebookContext) — conditionality is the
+                  point. The source derives from daemon lifecycle events (the
+                  IPC transport's status is constant in practice), and the
+                  copy is scoped to the link it measures. */}
+              <NotebookConnectionIdentity
+                capabilities={shellCapabilities}
+                connectionStatus$={desktopConnectionStatus}
+                connectionLabel="Daemon connection"
+              />
+              <button
+                type="button"
+                onClick={toggleAssistantPanel}
+                data-testid="assistant-toggle"
+                aria-pressed={assistantPanelOpen}
+                className={cn(
+                  "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+                  "bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400",
+                  assistantPanelOpen && "ring-1 ring-current/25",
+                )}
+                title={assistantPanelOpen ? "Close assistant" : "Open assistant"}
+              >
+                <Sparkles className="size-3" />
+                <span>Assistant</span>
+              </button>
+            </>
           }
         />
         {globalFind.isOpen && (
@@ -2059,6 +2080,7 @@ function AppContent() {
         />
         <NotebookDocumentShell
           capabilities={shellCapabilities}
+          asideRight={assistantPanelOpen ? <AssistantPanel /> : null}
           stageLabel="Notebook editor"
           notices={
             sourceIssueNotice ? (

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Sparkles, Square, X } from "lucide-react";
+import { ArrowUp, Check, Copy, RefreshCw, Sparkles, Square, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -7,8 +7,26 @@ import {
   type FormEvent,
   type KeyboardEvent,
 } from "react";
-import { Streamdown } from "streamdown";
+import { Streamdown, type Components } from "streamdown";
+import {
+  CodeBlock,
+  CodeBlockActions,
+  CodeBlockCopyButton,
+  CodeBlockHeader,
+  CodeBlockTitle,
+  CodeBlockFilename,
+} from "@/components/ui/code-block";
+import type { BundledLanguage } from "shiki";
+import { openUrl } from "../lib/open-url";
 import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { streamAssistantChat, type AssistantChatMessage } from "../lib/assistant-chat-client";
 import { logger } from "../lib/logger";
 import { setAssistantPanelOpen } from "../lib/assistant-panel-state";
@@ -34,7 +52,9 @@ function TypingIndicator() {
         <span
           key={i}
           className="size-1 rounded-full bg-foreground/40"
-          style={{ animation: `assistant-dot 1.4s cubic-bezier(0.4,0,0.6,1) ${i * 0.18}s infinite` }}
+          style={{
+            animation: `assistant-dot 1.4s cubic-bezier(0.4,0,0.6,1) ${i * 0.18}s infinite`,
+          }}
         />
       ))}
       <style>{`
@@ -51,6 +71,7 @@ function TypingIndicator() {
  * Assistant side panel — a standalone chat against the daemon's
  * `/assistant/chat` proxy. Does not read or write notebook state.
  */
+
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 720;
 const DEFAULT_WIDTH = 384;
@@ -60,12 +81,65 @@ export function AssistantPanel() {
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const dragStartX = useRef<number | null>(null);
   const dragStartWidth = useRef<number>(DEFAULT_WIDTH);
+
+  const markdownComponents: Components = {
+    a: ({ href, children }) => (
+      <a
+        role="link"
+        tabIndex={0}
+        className="cursor-pointer"
+        onClick={(e) => {
+          e.preventDefault();
+          if (href) setPendingUrl(href);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (href) setPendingUrl(href);
+          }
+        }}
+      >
+        {children}
+      </a>
+    ),
+    img: ({ src, alt, ...props }) => <img {...props} src={src} alt={alt ?? ""} />,
+    pre: ({ node, children: _children, ...props }) => {
+      // Extract language and code from the child <code> element
+      const codeEl = (
+        node as {
+          children?: Array<{
+            tagName?: string;
+            properties?: Record<string, unknown>;
+            children?: Array<{ value?: string }>;
+          }>;
+        }
+      )?.children?.find((c) => c.tagName === "code");
+      const className = String(codeEl?.properties?.className ?? "");
+      const lang = (className.match(/language-(\S+)/)?.[1] ?? "text") as BundledLanguage;
+      const code = codeEl?.children?.map((c) => c.value ?? "").join("") ?? "";
+
+      return (
+        <CodeBlock code={code} language={lang} className="my-4 not-prose" {...(props as object)}>
+          <CodeBlockHeader>
+            <CodeBlockTitle>
+              <CodeBlockFilename>{lang}</CodeBlockFilename>
+            </CodeBlockTitle>
+            <CodeBlockActions>
+              <CodeBlockCopyButton />
+            </CodeBlockActions>
+          </CodeBlockHeader>
+        </CodeBlock>
+      );
+    },
+  };
 
   const handleResizePointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
@@ -108,15 +182,58 @@ export function AssistantPanel() {
     abortRef.current?.abort();
   }, []);
 
+  const streamResponse = useCallback(
+    async (history: AssistantChatMessage[], assistantId: string) => {
+      setIsStreaming(true);
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const appendToken = (token: string) => {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + token } : m)),
+        );
+      };
+
+      try {
+        await streamAssistantChat({
+          messages: history,
+          onToken: appendToken,
+          signal: controller.signal,
+        });
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, isStreaming: false } : m)),
+        );
+      } catch (error) {
+        const aborted = controller.signal.aborted;
+        if (!aborted) logger.error("[assistant-chat] stream failed:", error);
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? {
+                  ...m,
+                  isStreaming: false,
+                  content: aborted
+                    ? m.content || "(stopped)"
+                    : m.content ||
+                      `Error: ${error instanceof Error ? error.message : String(error)}`,
+                  isError: !aborted && m.content.length === 0,
+                }
+              : m,
+          ),
+        );
+      } finally {
+        abortRef.current = null;
+        setIsStreaming(false);
+      }
+    },
+    [],
+  );
+
   const send = useCallback(async () => {
     const text = input.trim();
     if (!text || isStreaming) return;
 
-    const userMessage: ChatMessage = {
-      id: nextMessageId(),
-      role: "user",
-      content: text,
-    };
+    const userMessage: ChatMessage = { id: nextMessageId(), role: "user", content: text };
     const assistantId = nextMessageId();
     const assistantMessage: ChatMessage = {
       id: assistantId,
@@ -125,8 +242,7 @@ export function AssistantPanel() {
       isStreaming: true,
     };
 
-    // Build the OpenAI-style history from what we're about to render, so the
-    // request reflects the full conversation including this turn.
+    // Build the OpenAI-style history including this turn.
     const history: AssistantChatMessage[] = [
       ...messages.filter((m) => !m.isError).map((m) => ({ role: m.role, content: m.content })),
       { role: "user" as const, content: text },
@@ -134,50 +250,40 @@ export function AssistantPanel() {
 
     setMessages((prev) => [...prev, userMessage, assistantMessage]);
     setInput("");
-    setIsStreaming(true);
+    await streamResponse(history, assistantId);
+  }, [input, isStreaming, messages, streamResponse]);
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const appendToken = (token: string) => {
-      setMessages((prev) =>
-        prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + token } : m)),
-      );
-    };
-
-    try {
-      await streamAssistantChat({
-        messages: history,
-        onToken: appendToken,
-        signal: controller.signal,
+  const retry = useCallback(
+    async (messageId: string) => {
+      if (isStreaming) return;
+      // Find the assistant message to retry and replace it with a fresh one.
+      setMessages((prev) => {
+        const idx = prev.findIndex((m) => m.id === messageId);
+        if (idx === -1) return prev;
+        return prev.map((m, i) =>
+          i === idx ? { ...m, content: "", isStreaming: true, isError: false } : m,
+        );
       });
-      setMessages((prev) =>
-        prev.map((m) => (m.id === assistantId ? { ...m, isStreaming: false } : m)),
-      );
-    } catch (error) {
-      const aborted = controller.signal.aborted;
-      if (!aborted) logger.error("[assistant-chat] stream failed:", error);
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantId
-            ? {
-                ...m,
-                isStreaming: false,
-                // Preserve partial content on user-initiated stop; surface an
-                // error message only on a genuine failure.
-                content: aborted
-                  ? m.content || "(stopped)"
-                  : m.content || `Error: ${error instanceof Error ? error.message : String(error)}`,
-                isError: !aborted && m.content.length === 0,
-              }
-            : m,
-        ),
-      );
-    } finally {
-      abortRef.current = null;
-      setIsStreaming(false);
-    }
-  }, [input, isStreaming, messages]);
+      // Snapshot history up to (but not including) the target assistant message.
+      setMessages((prev) => {
+        const idx = prev.findIndex((m) => m.id === messageId);
+        const history = prev
+          .slice(0, idx)
+          .filter((m) => !m.isError)
+          .map((m) => ({ role: m.role, content: m.content }));
+        void streamResponse(history as AssistantChatMessage[], messageId);
+        return prev;
+      });
+    },
+    [isStreaming, streamResponse],
+  );
+
+  const copyMessage = useCallback((messageId: string, content: string) => {
+    void navigator.clipboard.writeText(content).then(() => {
+      setCopiedId(messageId);
+      setTimeout(() => setCopiedId((id) => (id === messageId ? null : id)), 2000);
+    });
+  }, []);
 
   const handleSubmit = useCallback(
     (event: FormEvent) => {
@@ -199,119 +305,183 @@ export function AssistantPanel() {
   );
 
   return (
-    <aside
-      data-testid="assistant-panel"
-      className="relative flex h-full shrink-0 flex-col border-l bg-background"
-      style={{ width }}
-      aria-label="Assistant"
-    >
-      {/* Resize handle */}
-      <div
-        className="absolute inset-y-0 left-0 w-1 cursor-col-resize hover:bg-primary/20 active:bg-primary/30"
-        onPointerDown={handleResizePointerDown}
-        onPointerMove={handleResizePointerMove}
-        onPointerUp={handleResizePointerUp}
-      />
-      <header className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
-        <Sparkles className="size-4 text-violet-500" />
-        <span className="text-sm font-medium">Assistant</span>
-        <div className="flex-1" />
-        <button
-          type="button"
-          onClick={() => setAssistantPanelOpen(false)}
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Close assistant"
-          aria-label="Close assistant"
-          data-testid="assistant-close"
-        >
-          <X className="size-4" />
-        </button>
-      </header>
-
-      <div
-        ref={scrollRef}
-        className="min-h-0 flex-1 space-y-3 overflow-y-auto px-3 py-3"
-        data-testid="assistant-messages"
+    <>
+      <Dialog
+        open={pendingUrl !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingUrl(null);
+        }}
       >
-        {messages.length === 0 ? (
-          <p className="mt-8 text-center text-sm text-muted-foreground">
-            Ask the assistant anything.
-          </p>
-        ) : (
-          messages.map((message) => (
-            <div
-              key={message.id}
-              data-testid={`assistant-message-${message.role}`}
-              data-role={message.role}
-              className={cn(
-                "flex flex-col gap-1",
-                message.role === "user" ? "items-end" : "items-start",
-              )}
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Open external link?</DialogTitle>
+            <DialogDescription className="break-all">{pendingUrl}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setPendingUrl(null)}
+              className="rounded px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted"
             >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (pendingUrl) void openUrl(pendingUrl);
+                setPendingUrl(null);
+              }}
+              className="rounded bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+            >
+              Open
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <aside
+        data-testid="assistant-panel"
+        className="relative flex h-full shrink-0 flex-col border-l bg-background"
+        style={{ width }}
+        aria-label="Assistant"
+      >
+        {/* Resize handle */}
+        <div
+          className="absolute inset-y-0 left-0 w-1 cursor-col-resize hover:bg-primary/20 active:bg-primary/30"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerUp}
+        />
+        <header className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
+          <Sparkles className="size-4 text-violet-500" />
+          <span className="text-sm font-medium">Assistant</span>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={() => setAssistantPanelOpen(false)}
+            className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Close assistant"
+            aria-label="Close assistant"
+            data-testid="assistant-close"
+          >
+            <X className="size-4" />
+          </button>
+        </header>
+
+        <div
+          ref={scrollRef}
+          className="min-h-0 flex-1 space-y-3 overflow-y-auto px-3 py-3"
+          data-testid="assistant-messages"
+        >
+          {messages.length === 0 ? (
+            <p className="mt-8 text-center text-sm text-muted-foreground">
+              Ask the assistant anything.
+            </p>
+          ) : (
+            messages.map((message) => (
               <div
+                key={message.id}
+                data-testid={`assistant-message-${message.role}`}
+                data-role={message.role}
                 className={cn(
-                  "rounded-lg px-3 py-2 text-sm",
-                  message.role === "user"
-                    ? "max-w-[85%] bg-primary text-primary-foreground whitespace-pre-wrap break-words"
-                    : "w-[calc(100%-2rem)] bg-muted text-foreground",
-                  message.isError && "bg-destructive/10 text-destructive",
+                  "group flex flex-col gap-1",
+                  message.role === "user" ? "items-end" : "items-start",
                 )}
               >
-                {message.role === "assistant" ? (
-                  message.content.length === 0 && message.isStreaming ? (
-                    <TypingIndicator />
+                <div
+                  className={cn(
+                    "rounded-lg px-3 py-2 text-sm",
+                    message.role === "user"
+                      ? "max-w-[85%] bg-primary text-primary-foreground whitespace-pre-wrap break-words"
+                      : "w-[calc(100%-2rem)] bg-muted text-foreground",
+                    message.isError && "bg-destructive/10 text-destructive",
+                  )}
+                >
+                  {message.role === "assistant" ? (
+                    message.content.length === 0 && message.isStreaming ? (
+                      <TypingIndicator />
+                    ) : (
+                      <Streamdown
+                        mode={message.isStreaming ? "streaming" : "static"}
+                        className="prose prose-sm dark:prose-invert max-w-none [&_ul]:pl-5 [&_ol]:pl-5"
+                        components={markdownComponents}
+                        linkSafety={{ enabled: false }}
+                        allowedTags={{ img: ["src", "alt", "title", "width", "height"] }}
+                      >
+                        {message.content}
+                      </Streamdown>
+                    )
                   ) : (
-                    <Streamdown
-                      mode={message.isStreaming ? "streaming" : "static"}
-                      className="prose prose-sm dark:prose-invert max-w-none [&_ul]:pl-5 [&_ol]:pl-5"
+                    <>{message.content}</>
+                  )}
+                </div>
+                {message.role === "assistant" && !message.isStreaming && (
+                  <div className="flex gap-1 px-1 opacity-0 transition-opacity group-hover:opacity-100">
+                    <button
+                      type="button"
+                      onClick={() => copyMessage(message.id, message.content)}
+                      title="Copy as markdown"
+                      aria-label="Copy as markdown"
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                     >
-                      {message.content}
-                    </Streamdown>
-                  )
-                ) : (
-                  <>
-                    {message.content}
-                  </>
+                      {copiedId === message.id ? (
+                        <Check className="size-3" />
+                      ) : (
+                        <Copy className="size-3" />
+                      )}
+                      {copiedId === message.id ? "Copied" : "Copy"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void retry(message.id)}
+                      disabled={isStreaming}
+                      title="Retry"
+                      aria-label="Retry"
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40"
+                    >
+                      <RefreshCw className="size-3" />
+                      Retry
+                    </button>
+                  </div>
                 )}
               </div>
-            </div>
-          ))
-        )}
-      </div>
-
-      <form onSubmit={handleSubmit} className="shrink-0 border-t p-3">
-        <div className="relative">
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(event) => setInput(event.target.value)}
-            onKeyDown={handleKeyDown}
-            rows={1}
-            placeholder="Message the assistant…"
-            data-testid="assistant-input"
-            className="block w-full resize-none overflow-hidden rounded-2xl border bg-background pl-3 pr-10 py-2 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-          />
-          <button
-            type={isStreaming ? "button" : "submit"}
-            onClick={isStreaming ? stop : undefined}
-            disabled={!isStreaming && input.trim().length === 0}
-            title={isStreaming ? "Stop" : "Send (⌘↵)"}
-            aria-label={isStreaming ? "Stop" : "Send"}
-            data-testid={isStreaming ? "assistant-stop" : "assistant-send"}
-            className={cn(
-              "absolute bottom-1 right-1 inline-flex size-7 items-center justify-center rounded-full transition-opacity",
-              isStreaming ? "bg-muted text-foreground" : "bg-primary text-primary-foreground",
-              !isStreaming && input.trim().length === 0 && "cursor-not-allowed opacity-40",
-            )}
-          >
-            {isStreaming ? (
-              <Square className="size-3" fill="currentColor" />
-            ) : (
-              <ArrowUp className="size-4" />
-            )}
-          </button>
+            ))
+          )}
         </div>
-      </form>
-    </aside>
+
+        <form onSubmit={handleSubmit} className="shrink-0 border-t p-3">
+          <div className="relative">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              rows={1}
+              placeholder="Message the assistant…"
+              data-testid="assistant-input"
+              className="block w-full resize-none overflow-hidden rounded-2xl border bg-background pl-3 pr-10 py-2 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+            />
+            <button
+              type={isStreaming ? "button" : "submit"}
+              onClick={isStreaming ? stop : undefined}
+              disabled={!isStreaming && input.trim().length === 0}
+              title={isStreaming ? "Stop" : "Send (⌘↵)"}
+              aria-label={isStreaming ? "Stop" : "Send"}
+              data-testid={isStreaming ? "assistant-stop" : "assistant-send"}
+              className={cn(
+                "absolute bottom-1 right-1 inline-flex size-7 items-center justify-center rounded-full transition-opacity",
+                isStreaming ? "bg-muted text-foreground" : "bg-primary text-primary-foreground",
+                !isStreaming && input.trim().length === 0 && "cursor-not-allowed opacity-40",
+              )}
+            >
+              {isStreaming ? (
+                <Square className="size-3" fill="currentColor" />
+              ) : (
+                <ArrowUp className="size-4" />
+              )}
+            </button>
+          </div>
+        </form>
+      </aside>
+    </>
   );
 }

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -31,14 +31,41 @@ function nextMessageId(): string {
  * Assistant side panel — a standalone chat against the daemon's
  * `/assistant/chat` proxy. Does not read or write notebook state.
  */
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 720;
+const DEFAULT_WIDTH = 384;
+
 export function AssistantPanel() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const dragStartX = useRef<number | null>(null);
+  const dragStartWidth = useRef<number>(DEFAULT_WIDTH);
+
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      dragStartX.current = event.clientX;
+      dragStartWidth.current = width;
+      (event.target as HTMLDivElement).setPointerCapture(event.pointerId);
+    },
+    [width],
+  );
+
+  const handleResizePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStartX.current === null) return;
+    const delta = dragStartX.current - event.clientX;
+    setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, dragStartWidth.current + delta)));
+  }, []);
+
+  const handleResizePointerUp = useCallback(() => {
+    dragStartX.current = null;
+  }, []);
 
   // Keep the transcript pinned to the bottom as tokens stream in.
   useEffect(() => {
@@ -154,9 +181,17 @@ export function AssistantPanel() {
   return (
     <aside
       data-testid="assistant-panel"
-      className="flex h-full w-[clamp(20rem,26vw,24rem)] shrink-0 flex-col border-l bg-background"
+      className="relative flex h-full shrink-0 flex-col border-l bg-background"
+      style={{ width }}
       aria-label="Assistant"
     >
+      {/* Resize handle */}
+      <div
+        className="absolute inset-y-0 left-0 w-1 cursor-col-resize hover:bg-primary/20 active:bg-primary/30"
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerUp}
+      />
       <header className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
         <Sparkles className="size-4 text-violet-500" />
         <span className="text-sm font-medium">Assistant</span>

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -1,0 +1,243 @@
+import { Send, Sparkles, Square, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { streamAssistantChat, type AssistantChatMessage } from "../lib/assistant-chat-client";
+import { logger } from "../lib/logger";
+import { setAssistantPanelOpen } from "../lib/assistant-panel-state";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  isStreaming?: boolean;
+  isError?: boolean;
+}
+
+let messageCounter = 0;
+function nextMessageId(): string {
+  messageCounter += 1;
+  return `msg-${messageCounter}`;
+}
+
+/**
+ * Assistant side panel — a standalone chat against the daemon's
+ * `/assistant/chat` proxy. Does not read or write notebook state.
+ */
+export function AssistantPanel() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Keep the transcript pinned to the bottom as tokens stream in.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  // Cancel any in-flight request on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isStreaming) return;
+
+    const userMessage: ChatMessage = {
+      id: nextMessageId(),
+      role: "user",
+      content: text,
+    };
+    const assistantId = nextMessageId();
+    const assistantMessage: ChatMessage = {
+      id: assistantId,
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+    };
+
+    // Build the OpenAI-style history from what we're about to render, so the
+    // request reflects the full conversation including this turn.
+    const history: AssistantChatMessage[] = [
+      ...messages.filter((m) => !m.isError).map((m) => ({ role: m.role, content: m.content })),
+      { role: "user" as const, content: text },
+    ];
+
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setInput("");
+    setIsStreaming(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const appendToken = (token: string) => {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + token } : m)),
+      );
+    };
+
+    try {
+      await streamAssistantChat({
+        messages: history,
+        onToken: appendToken,
+        signal: controller.signal,
+      });
+      setMessages((prev) =>
+        prev.map((m) => (m.id === assistantId ? { ...m, isStreaming: false } : m)),
+      );
+    } catch (error) {
+      const aborted = controller.signal.aborted;
+      if (!aborted) logger.error("[assistant-chat] stream failed:", error);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                isStreaming: false,
+                // Preserve partial content on user-initiated stop; surface an
+                // error message only on a genuine failure.
+                content: aborted
+                  ? m.content || "(stopped)"
+                  : m.content || `Error: ${error instanceof Error ? error.message : String(error)}`,
+                isError: !aborted && m.content.length === 0,
+              }
+            : m,
+        ),
+      );
+    } finally {
+      abortRef.current = null;
+      setIsStreaming(false);
+    }
+  }, [input, isStreaming, messages]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      void send();
+    },
+    [send],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Enter sends; Shift+Enter inserts a newline.
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        void send();
+      }
+    },
+    [send],
+  );
+
+  return (
+    <aside
+      data-testid="assistant-panel"
+      className="flex h-full w-[clamp(20rem,26vw,24rem)] shrink-0 flex-col border-l bg-background"
+      aria-label="Assistant"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
+        <Sparkles className="size-4 text-violet-500" />
+        <span className="text-sm font-medium">Assistant</span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => setAssistantPanelOpen(false)}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Close assistant"
+          aria-label="Close assistant"
+          data-testid="assistant-close"
+        >
+          <X className="size-4" />
+        </button>
+      </header>
+
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 space-y-3 overflow-y-auto px-3 py-3"
+        data-testid="assistant-messages"
+      >
+        {messages.length === 0 ? (
+          <p className="mt-8 text-center text-sm text-muted-foreground">
+            Ask the assistant anything.
+          </p>
+        ) : (
+          messages.map((message) => (
+            <div
+              key={message.id}
+              data-testid={`assistant-message-${message.role}`}
+              data-role={message.role}
+              className={cn(
+                "flex flex-col gap-1",
+                message.role === "user" ? "items-end" : "items-start",
+              )}
+            >
+              <div
+                className={cn(
+                  "max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm",
+                  message.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-foreground",
+                  message.isError && "bg-destructive/10 text-destructive",
+                )}
+              >
+                {message.content}
+                {message.isStreaming && message.content.length === 0 ? (
+                  <span className="text-muted-foreground">…</span>
+                ) : null}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex shrink-0 items-end gap-2 border-t p-3">
+        <textarea
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={2}
+          placeholder="Message the assistant…"
+          data-testid="assistant-input"
+          className="min-h-[2.5rem] flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+        {isStreaming ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="secondary"
+            onClick={stop}
+            title="Stop"
+            aria-label="Stop"
+            data-testid="assistant-stop"
+          >
+            <Square className="size-4" fill="currentColor" />
+          </Button>
+        ) : (
+          <Button
+            type="submit"
+            size="icon"
+            disabled={input.trim().length === 0}
+            title="Send"
+            aria-label="Send"
+            data-testid="assistant-send"
+          >
+            <Send className="size-4" />
+          </Button>
+        )}
+      </form>
+    </aside>
+  );
+}

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -7,6 +7,7 @@ import {
   type FormEvent,
   type KeyboardEvent,
 } from "react";
+import { Streamdown } from "streamdown";
 import { cn } from "@/lib/utils";
 import { streamAssistantChat, type AssistantChatMessage } from "../lib/assistant-chat-client";
 import { logger } from "../lib/logger";
@@ -194,17 +195,29 @@ export function AssistantPanel() {
             >
               <div
                 className={cn(
-                  "max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm",
+                  "max-w-[85%] rounded-lg px-3 py-2 text-sm",
                   message.role === "user"
-                    ? "bg-primary text-primary-foreground"
+                    ? "bg-primary text-primary-foreground whitespace-pre-wrap break-words"
                     : "bg-muted text-foreground",
                   message.isError && "bg-destructive/10 text-destructive",
                 )}
               >
-                {message.content}
-                {message.isStreaming && message.content.length === 0 ? (
-                  <span className="text-muted-foreground">…</span>
-                ) : null}
+                {message.role === "assistant" ? (
+                  message.content.length === 0 && message.isStreaming ? (
+                    <span className="text-muted-foreground">…</span>
+                  ) : (
+                    <Streamdown
+                      mode={message.isStreaming ? "streaming" : "static"}
+                      className="prose prose-sm dark:prose-invert max-w-none"
+                    >
+                      {message.content}
+                    </Streamdown>
+                  )
+                ) : (
+                  <>
+                    {message.content}
+                  </>
+                )}
               </div>
             </div>
           ))

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -250,10 +250,10 @@ export function AssistantPanel() {
             >
               <div
                 className={cn(
-                  "max-w-[85%] rounded-lg px-3 py-2 text-sm",
+                  "rounded-lg px-3 py-2 text-sm",
                   message.role === "user"
-                    ? "bg-primary text-primary-foreground whitespace-pre-wrap break-words"
-                    : "bg-muted text-foreground",
+                    ? "max-w-[85%] bg-primary text-primary-foreground whitespace-pre-wrap break-words"
+                    : "w-[calc(100%-2rem)] bg-muted text-foreground",
                   message.isError && "bg-destructive/10 text-destructive",
                 )}
               >

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -27,6 +27,26 @@ function nextMessageId(): string {
   return `msg-${messageCounter}`;
 }
 
+function TypingIndicator() {
+  return (
+    <span className="inline-flex items-center gap-1 py-0.5" aria-label="Typing">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="size-1 rounded-full bg-foreground/40"
+          style={{ animation: `assistant-dot 1.4s cubic-bezier(0.4,0,0.6,1) ${i * 0.18}s infinite` }}
+        />
+      ))}
+      <style>{`
+        @keyframes assistant-dot {
+          0%, 100% { opacity: 0.2; transform: scale(0.75); }
+          50% { opacity: 0.85; transform: scale(1); }
+        }
+      `}</style>
+    </span>
+  );
+}
+
 /**
  * Assistant side panel — a standalone chat against the daemon's
  * `/assistant/chat` proxy. Does not read or write notebook state.
@@ -239,7 +259,7 @@ export function AssistantPanel() {
               >
                 {message.role === "assistant" ? (
                   message.content.length === 0 && message.isStreaming ? (
-                    <span className="text-muted-foreground">…</span>
+                    <TypingIndicator />
                   ) : (
                     <Streamdown
                       mode={message.isStreaming ? "streaming" : "static"}

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -208,7 +208,7 @@ export function AssistantPanel() {
                   ) : (
                     <Streamdown
                       mode={message.isStreaming ? "streaming" : "static"}
-                      className="prose prose-sm dark:prose-invert max-w-none"
+                      className="prose prose-sm dark:prose-invert max-w-none [&_ul]:pl-5 [&_ol]:pl-5"
                     >
                       {message.content}
                     </Streamdown>

--- a/apps/notebook/src/components/AssistantPanel.tsx
+++ b/apps/notebook/src/components/AssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { Send, Sparkles, Square, X } from "lucide-react";
+import { ArrowUp, Sparkles, Square, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -7,7 +7,6 @@ import {
   type FormEvent,
   type KeyboardEvent,
 } from "react";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { streamAssistantChat, type AssistantChatMessage } from "../lib/assistant-chat-client";
 import { logger } from "../lib/logger";
@@ -38,12 +37,21 @@ export function AssistantPanel() {
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Keep the transcript pinned to the bottom as tokens stream in.
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages]);
+
+  // Auto-grow the textarea to fit its content.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [input]);
 
   // Cancel any in-flight request on unmount.
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -203,40 +211,38 @@ export function AssistantPanel() {
         )}
       </div>
 
-      <form onSubmit={handleSubmit} className="flex shrink-0 items-end gap-2 border-t p-3">
-        <textarea
-          value={input}
-          onChange={(event) => setInput(event.target.value)}
-          onKeyDown={handleKeyDown}
-          rows={2}
-          placeholder="Message the assistant…"
-          data-testid="assistant-input"
-          className="min-h-[2.5rem] flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        />
-        {isStreaming ? (
-          <Button
-            type="button"
-            size="icon"
-            variant="secondary"
-            onClick={stop}
-            title="Stop"
-            aria-label="Stop"
-            data-testid="assistant-stop"
+      <form onSubmit={handleSubmit} className="shrink-0 border-t p-3">
+        <div className="relative">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={1}
+            placeholder="Message the assistant…"
+            data-testid="assistant-input"
+            className="block w-full resize-none overflow-hidden rounded-2xl border bg-background pl-3 pr-10 py-2 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+          />
+          <button
+            type={isStreaming ? "button" : "submit"}
+            onClick={isStreaming ? stop : undefined}
+            disabled={!isStreaming && input.trim().length === 0}
+            title={isStreaming ? "Stop" : "Send (⌘↵)"}
+            aria-label={isStreaming ? "Stop" : "Send"}
+            data-testid={isStreaming ? "assistant-stop" : "assistant-send"}
+            className={cn(
+              "absolute bottom-1 right-1 inline-flex size-7 items-center justify-center rounded-full transition-opacity",
+              isStreaming ? "bg-muted text-foreground" : "bg-primary text-primary-foreground",
+              !isStreaming && input.trim().length === 0 && "cursor-not-allowed opacity-40",
+            )}
           >
-            <Square className="size-4" fill="currentColor" />
-          </Button>
-        ) : (
-          <Button
-            type="submit"
-            size="icon"
-            disabled={input.trim().length === 0}
-            title="Send"
-            aria-label="Send"
-            data-testid="assistant-send"
-          >
-            <Send className="size-4" />
-          </Button>
-        )}
+            {isStreaming ? (
+              <Square className="size-3" fill="currentColor" />
+            ) : (
+              <ArrowUp className="size-4" />
+            )}
+          </button>
+        </div>
       </form>
     </aside>
   );

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -4,6 +4,7 @@
 
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "streamdown/styles.css";
 @import "../../../src/styles/ansi.css";
 @import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";

--- a/apps/notebook/src/lib/assistant-chat-client.ts
+++ b/apps/notebook/src/lib/assistant-chat-client.ts
@@ -1,0 +1,113 @@
+import { getBlobPort } from "./blob-port";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Assistant chat client.
+//
+// A deliberately small client for the assistant side panel. It POSTs an
+// OpenAI-style chat completion to the daemon's `/assistant/chat` proxy (served
+// on the blob-server origin) and streams the SSE response back token by token.
+//
+// The daemon proxy owns auth (via the `anaconda` CLI) and the real upstream
+// URL/headers; this client just speaks OpenAI chat-completions to it. It does
+// NOT touch notebook/Automerge state — the panel is a standalone chat.
+// ---------------------------------------------------------------------------
+
+export interface AssistantChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface StreamChatOptions {
+  messages: AssistantChatMessage[];
+  /** Called for each streamed content token as it arrives. */
+  onToken: (token: string) => void;
+  /** Abort signal so the panel can cancel an in-flight request. */
+  signal?: AbortSignal;
+}
+
+/** Thrown when the daemon blob port isn't resolved yet (no daemon connection). */
+export class AssistantChatUnavailableError extends Error {
+  constructor() {
+    super("Assistant is unavailable — no daemon connection yet.");
+    this.name = "AssistantChatUnavailableError";
+  }
+}
+
+function assistantChatUrl(): string {
+  const port = getBlobPort();
+  if (port === null) throw new AssistantChatUnavailableError();
+  return `http://127.0.0.1:${port}/assistant/chat`;
+}
+
+/**
+ * Stream a chat completion. Resolves once the stream completes; rejects on
+ * transport/HTTP errors (or the caller aborting via `signal`).
+ */
+export async function streamAssistantChat({
+  messages,
+  onToken,
+  signal,
+}: StreamChatOptions): Promise<void> {
+  const url = assistantChatUrl();
+  logger.debug("[assistant-chat] POST", url);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages, stream: true }),
+    signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `Assistant request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  // Parse the OpenAI SSE stream: events are separated by a blank line, each
+  // event's payload lives on `data:` lines. `data: [DONE]` ends the stream.
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let separatorIndex: number;
+    while ((separatorIndex = buffer.indexOf("\n\n")) !== -1) {
+      const rawEvent = buffer.slice(0, separatorIndex);
+      buffer = buffer.slice(separatorIndex + 2);
+      handleEvent(rawEvent, onToken);
+    }
+  }
+  // Flush any trailing event without a terminating blank line.
+  if (buffer.trim().length > 0) handleEvent(buffer, onToken);
+}
+
+function handleEvent(rawEvent: string, onToken: (token: string) => void): void {
+  for (const line of rawEvent.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) continue;
+    const data = trimmed.slice("data:".length).trim();
+    if (data === "" || data === "[DONE]") continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      // Non-JSON keep-alive or partial chunk — ignore.
+      continue;
+    }
+
+    const token = (parsed as ChatCompletionChunk)?.choices?.[0]?.delta?.content;
+    if (typeof token === "string" && token.length > 0) onToken(token);
+  }
+}
+
+interface ChatCompletionChunk {
+  choices?: Array<{ delta?: { content?: string | null } }>;
+}

--- a/apps/notebook/src/lib/assistant-panel-state.ts
+++ b/apps/notebook/src/lib/assistant-panel-state.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// Assistant side-panel open/closed state.
+//
+// A hand-rolled `useSyncExternalStore` module store, mirroring the notebook
+// rail's `rail-ui-state.ts`. The assistant panel mounts on the right of the
+// document shell and is toggled from the toolbar; a single boolean is all the
+// UI state it needs.
+// ---------------------------------------------------------------------------
+
+let open = false;
+const subscribers = new Set<() => void>();
+
+function emit(): void {
+  for (const callback of subscribers) callback();
+}
+
+function subscribe(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+function getSnapshot(): boolean {
+  return open;
+}
+
+/** React hook — re-renders when the assistant panel opens or closes. */
+export function useAssistantPanelOpen(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+export function setAssistantPanelOpen(next: boolean): void {
+  if (open === next) return;
+  open = next;
+  emit();
+}
+
+export function toggleAssistantPanel(): void {
+  setAssistantPanelOpen(!open);
+}
+
+/** @internal Reset for test isolation. */
+export function _testResetAssistantPanel(): void {
+  open = false;
+  subscribers.clear();
+}

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -57,7 +57,7 @@ rattler_cache = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_solve = { workspace = true }
 rattler_virtual_packages = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 reqwest-middleware = { workspace = true }
 tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 

--- a/crates/runtimed/src/assistant_chat.rs
+++ b/crates/runtimed/src/assistant_chat.rs
@@ -1,0 +1,159 @@
+//! Assistant chat proxy.
+//!
+//! A deliberately small, hacky bridge that lets the notebook app's assistant
+//! side panel talk to Claude through Anaconda's hosted OpenAI-protocol gateway
+//! without shipping the full bundled Python assistant runtime that
+//! anaconda-desktop uses.
+//!
+//! Two moving parts:
+//!   1. Auth — we shell out to the `anaconda` CLI (`anaconda auth api-key`) to
+//!      obtain the signed-in user's API key. This mirrors how anaconda-desktop
+//!      hands `ANACONDA_AI_API_KEY` to its sidecar, minus the OAuth/connector
+//!      plumbing. The CLI is assumed to already be installed and logged in.
+//!   2. Proxy — we forward the browser's OpenAI-style chat completion request
+//!      to `https://anaconda.com/api/assistant/v3/bedrock/chat/completions`
+//!      with the bearer token + required client headers, and stream the SSE
+//!      response straight back to the browser.
+//!
+//! This is intentionally NOT wired through the Automerge notebook document or
+//! the framed socket protocol — the assistant panel is a standalone chat that
+//! does not touch notebook state.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Upstream Anaconda-hosted, OpenAI-protocol gateway (Bedrock-backed Claude).
+const ASSISTANT_API_BASE: &str = "https://anaconda.com/api/assistant/v3/bedrock";
+/// Default model id served by the gateway.
+pub const ASSISTANT_MODEL: &str = "us.anthropic.claude-sonnet-4-6";
+/// Required client headers — the gateway 400s without them.
+const CLIENT_SOURCE: &str = "anaconda-labs-prod";
+const CLIENT_VERSION: &str = "0.0.1";
+
+/// Error obtaining the Anaconda API key from the CLI.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("failed to run `anaconda auth api-key`: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("`anaconda auth api-key` exited with status {status}: {stderr}")]
+    NonZero { status: String, stderr: String },
+    #[error("`anaconda auth api-key` returned an empty key (not logged in?)")]
+    Empty,
+}
+
+/// Locate the `anaconda` CLI binary.
+///
+/// Order: `ANACONDA_CLI_BIN` env override, then `anaconda` on `PATH`, then a
+/// few common install locations (Homebrew, system, user miniconda/anaconda).
+/// The daemon does not necessarily inherit the interactive shell's `PATH`, so
+/// the fallbacks matter.
+fn resolve_anaconda_bin() -> PathBuf {
+    if let Ok(explicit) = std::env::var("ANACONDA_CLI_BIN") {
+        if !explicit.is_empty() {
+            return PathBuf::from(explicit);
+        }
+    }
+
+    let mut candidates: Vec<PathBuf> = vec![
+        PathBuf::from("/opt/homebrew/bin/anaconda"),
+        PathBuf::from("/usr/local/bin/anaconda"),
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        for rel in [
+            "miniconda3/bin/anaconda",
+            "anaconda3/bin/anaconda",
+            ".anaconda-desktop-itest/miniconda3/bin/anaconda",
+        ] {
+            candidates.push(home.join(rel));
+        }
+    }
+    if let Some(found) = candidates.into_iter().find(|p| p.exists()) {
+        return found;
+    }
+
+    // Last resort: rely on PATH resolution.
+    PathBuf::from("anaconda")
+}
+
+/// Resolve the Anaconda API key by invoking the `anaconda` CLI.
+///
+/// Hacky by design: assumes the `anaconda` CLI is installed and the user is
+/// logged in (`anaconda login`). Returns the trimmed key string.
+pub async fn fetch_api_key() -> Result<String, AuthError> {
+    let bin = resolve_anaconda_bin();
+    debug!("[assistant-chat] resolving api key via {}", bin.display());
+    let output = Command::new(&bin)
+        .args(["auth", "api-key"])
+        .stdin(Stdio::null())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(AuthError::NonZero {
+            status: output.status.to_string(),
+            stderr,
+        });
+    }
+
+    // The CLI prints the key (and possibly a trailing newline). Take the last
+    // non-empty line to be resilient to any leading banner noise.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let key = stdout
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+        .to_string();
+
+    if key.is_empty() {
+        return Err(AuthError::Empty);
+    }
+    Ok(key)
+}
+
+/// Forward a chat completion request to the Anaconda gateway.
+///
+/// `body` is the raw JSON body the browser sent (OpenAI chat-completions
+/// shape). We inject the model if absent and always request streaming. Returns
+/// the upstream `reqwest::Response` so the caller can stream the SSE body back
+/// to the browser verbatim.
+pub async fn forward_chat_completion(
+    api_key: &str,
+    mut body: serde_json::Value,
+) -> Result<reqwest::Response, reqwest::Error> {
+    if let Some(obj) = body.as_object_mut() {
+        obj.entry("model")
+            .or_insert_with(|| serde_json::Value::String(ASSISTANT_MODEL.to_string()));
+        // Force streaming — the panel renders tokens as they arrive.
+        obj.insert("stream".to_string(), serde_json::Value::Bool(true));
+    }
+
+    let url = format!("{ASSISTANT_API_BASE}/chat/completions");
+    debug!("[assistant-chat] forwarding chat completion to {url}");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .bearer_auth(api_key)
+        .header("Content-Type", "application/json")
+        .header("Accept", "text/event-stream")
+        .header("X-Client-Source", CLIENT_SOURCE)
+        .header("X-Client-Version", CLIENT_VERSION)
+        .json(&body)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        warn!(
+            "[assistant-chat] upstream returned status {}",
+            response.status()
+        );
+    }
+    Ok(response)
+}

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -178,9 +178,22 @@ async fn handle_request(
     req: Request<hyper::body::Incoming>,
     store: Arc<BlobStore>,
 ) -> Result<Response<ResponseBody>, Infallible> {
-    let path = req.uri().path();
-    let method = req.method();
+    let path = req.uri().path().to_string();
+    let method = req.method().clone();
 
+    // Assistant chat proxy (POST + CORS preflight). This is the one
+    // non-GET, non-read-only route on this server — it forwards an
+    // OpenAI-style chat completion to the Anaconda-hosted gateway and
+    // streams the SSE response back. See `assistant_chat`.
+    if path == "/assistant/chat" {
+        return Ok(match method {
+            Method::OPTIONS => assistant_chat_preflight(),
+            Method::POST => serve_assistant_chat(req).await,
+            _ => text_response(StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed"),
+        });
+    }
+
+    let path = path.as_str();
     let response = if method != Method::GET {
         text_response(StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed")
     } else if path == "/health" {
@@ -500,6 +513,102 @@ pub(crate) fn wrap_for_mcp_app(code: &[u8]) -> Vec<u8> {
     out.extend_from_slice(code);
     out.extend_from_slice(EPILOGUE);
     out
+}
+
+/// Common CORS headers for the assistant chat route so the notebook app
+/// (served from Vite / Tauri origins) can call the daemon blob origin.
+fn assistant_cors(builder: hyper::http::response::Builder) -> hyper::http::response::Builder {
+    builder
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        .header("Access-Control-Allow-Headers", "Content-Type")
+}
+
+/// Answer a CORS preflight for `/assistant/chat`.
+fn assistant_chat_preflight() -> Response<ResponseBody> {
+    assistant_cors(Response::builder().status(StatusCode::NO_CONTENT))
+        .body(full_body(Bytes::new()))
+        .unwrap_or_else(|_| {
+            text_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
+        })
+}
+
+/// JSON error response for the assistant chat route (with CORS headers).
+fn assistant_error(status: StatusCode, message: &str) -> Response<ResponseBody> {
+    let body = serde_json::json!({ "error": message }).to_string();
+    assistant_cors(
+        Response::builder()
+            .status(status)
+            .header("Content-Type", "application/json"),
+    )
+    .body(full_body(body))
+    .unwrap_or_else(|_| text_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error"))
+}
+
+/// Proxy a chat completion request to the Anaconda gateway and stream the
+/// SSE response back to the browser.
+async fn serve_assistant_chat(req: Request<hyper::body::Incoming>) -> Response<ResponseBody> {
+    // Read the request body (small — just chat messages).
+    let body_bytes = match req.into_body().collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            warn!("[assistant-chat] failed to read request body: {e}");
+            return assistant_error(StatusCode::BAD_REQUEST, "failed to read request body");
+        }
+    };
+    let json_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+        Ok(value) => value,
+        Err(e) => {
+            return assistant_error(StatusCode::BAD_REQUEST, &format!("invalid JSON body: {e}"));
+        }
+    };
+
+    // Resolve the Anaconda API key via the CLI.
+    let api_key = match crate::assistant_chat::fetch_api_key().await {
+        Ok(key) => key,
+        Err(e) => {
+            warn!("[assistant-chat] auth failed: {e}");
+            return assistant_error(
+                StatusCode::UNAUTHORIZED,
+                &format!("Anaconda auth failed: {e}"),
+            );
+        }
+    };
+
+    // Forward upstream.
+    let upstream = match crate::assistant_chat::forward_chat_completion(&api_key, json_body).await {
+        Ok(response) => response,
+        Err(e) => {
+            warn!("[assistant-chat] upstream request failed: {e}");
+            return assistant_error(StatusCode::BAD_GATEWAY, &format!("upstream error: {e}"));
+        }
+    };
+
+    let status = StatusCode::from_u16(upstream.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let content_type = upstream
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("text/event-stream")
+        .to_string();
+
+    // Stream the upstream body straight through, mapping reqwest errors to
+    // io::Error for the StreamBody type.
+    let byte_stream = upstream
+        .bytes_stream()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
+    let body = StreamBody::new(byte_stream.map_ok(Frame::data)).boxed();
+
+    assistant_cors(
+        Response::builder()
+            .status(status)
+            .header("Content-Type", content_type)
+            .header("Cache-Control", "no-store")
+            .header("X-Accel-Buffering", "no"),
+    )
+    .body(body)
+    .unwrap_or_else(|_| text_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error"))
 }
 
 /// Build a simple text response.

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -24,6 +24,7 @@ pub use runtimed_settings_sync as sync_client;
 // Server-only modules (not in runtimed-client)
 // ============================================================================
 
+pub mod assistant_chat;
 pub(crate) mod async_outcome;
 pub mod blob_server;
 pub mod blob_store;

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "runtimed": "workspace:*",
+    "shiki": "4.1.0",
     "tailwind-merge": "^3.4.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       runtimed:
         specifier: workspace:*
         version: link:packages/runtimed
+      shiki:
+        specifier: 4.1.0
+        version: 4.1.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -540,6 +543,9 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      shiki:
+        specifier: 4.1.0
+        version: 4.1.0
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      streamdown:
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -9,6 +9,8 @@ export interface NotebookDocumentShellProps {
    */
   rootElement?: "div" | "main";
   rail?: ReactNode;
+  /** Optional panel rendered to the right of the notebook stage (e.g. assistant). */
+  asideRight?: ReactNode;
   toolbar?: ReactNode;
   notices?: ReactNode;
   children: ReactNode;
@@ -24,6 +26,7 @@ export interface NotebookDocumentShellProps {
 export function NotebookDocumentShell({
   rootElement = "div",
   rail,
+  asideRight,
   toolbar,
   notices,
   children,
@@ -74,6 +77,7 @@ export function NotebookDocumentShell({
         >
           {children}
         </section>
+        {asideRight}
       </div>
     </Root>
   );

--- a/src/components/ui/code-block.tsx
+++ b/src/components/ui/code-block.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import type { ComponentProps, CSSProperties, HTMLAttributes } from "react";
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { BundledLanguage, BundledTheme, HighlighterGeneric, ThemedToken } from "shiki";
+import { createHighlighter } from "shiki";
+
+const isItalic = (fontStyle: number | undefined) => fontStyle && fontStyle & 1;
+const isBold = (fontStyle: number | undefined) => fontStyle && fontStyle & 2;
+const isUnderline = (fontStyle: number | undefined) => fontStyle && fontStyle & 4;
+
+interface KeyedToken {
+  token: ThemedToken;
+  key: string;
+}
+interface KeyedLine {
+  tokens: KeyedToken[];
+  key: string;
+}
+
+const addKeysToTokens = (lines: ThemedToken[][]): KeyedLine[] =>
+  lines.map((line, lineIdx) => ({
+    key: `line-${lineIdx}`,
+    tokens: line.map((token, tokenIdx) => ({
+      key: `line-${lineIdx}-${tokenIdx}`,
+      token,
+    })),
+  }));
+
+const TokenSpan = ({ token }: { token: ThemedToken }) => (
+  <span
+    className="dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)]"
+    style={
+      {
+        backgroundColor: token.bgColor,
+        color: token.color,
+        fontStyle: isItalic(token.fontStyle) ? "italic" : undefined,
+        fontWeight: isBold(token.fontStyle) ? "bold" : undefined,
+        textDecoration: isUnderline(token.fontStyle) ? "underline" : undefined,
+        ...token.htmlStyle,
+      } as CSSProperties
+    }
+  >
+    {token.content}
+  </span>
+);
+
+const LINE_NUMBER_CLASSES = cn(
+  "block",
+  "before:content-[counter(line)]",
+  "before:inline-block",
+  "before:[counter-increment:line]",
+  "before:w-8",
+  "before:mr-4",
+  "before:text-right",
+  "before:text-muted-foreground/50",
+  "before:font-mono",
+  "before:select-none",
+);
+
+const LineSpan = ({
+  keyedLine,
+  showLineNumbers,
+}: {
+  keyedLine: KeyedLine;
+  showLineNumbers: boolean;
+}) => (
+  <span className={showLineNumbers ? LINE_NUMBER_CLASSES : "block"}>
+    {keyedLine.tokens.length === 0
+      ? "\n"
+      : keyedLine.tokens.map(({ token, key }) => <TokenSpan key={key} token={token} />)}
+  </span>
+);
+
+type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
+  code: string;
+  language: BundledLanguage;
+  showLineNumbers?: boolean;
+};
+
+interface TokenizedCode {
+  tokens: ThemedToken[][];
+  fg: string;
+  bg: string;
+}
+
+interface CodeBlockContextType {
+  code: string;
+}
+
+const CodeBlockContext = createContext<CodeBlockContextType>({ code: "" });
+
+const highlighterCache = new Map<
+  string,
+  Promise<HighlighterGeneric<BundledLanguage, BundledTheme>>
+>();
+
+const tokensCache = new Map<string, TokenizedCode>();
+
+const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>();
+
+const getTokensCacheKey = (code: string, language: BundledLanguage) => {
+  const start = code.slice(0, 100);
+  const end = code.length > 100 ? code.slice(-100) : "";
+  return `${language}:${code.length}:${start}:${end}`;
+};
+
+const getHighlighter = (
+  language: BundledLanguage,
+): Promise<HighlighterGeneric<BundledLanguage, BundledTheme>> => {
+  const cached = highlighterCache.get(language);
+  if (cached) return cached;
+  const highlighterPromise = createHighlighter({
+    langs: [language],
+    themes: ["github-light", "github-dark"],
+  });
+  highlighterCache.set(language, highlighterPromise);
+  return highlighterPromise;
+};
+
+const createRawTokens = (code: string): TokenizedCode => ({
+  bg: "transparent",
+  fg: "inherit",
+  tokens: code
+    .split("\n")
+    .map((line) => (line === "" ? [] : [{ color: "inherit", content: line } as ThemedToken])),
+});
+
+export const highlightCode = (
+  code: string,
+  language: BundledLanguage,
+  callback?: (result: TokenizedCode) => void,
+): TokenizedCode | null => {
+  const key = getTokensCacheKey(code, language);
+  const cached = tokensCache.get(key);
+  if (cached) return cached;
+
+  if (callback) {
+    if (!subscribers.has(key)) subscribers.set(key, new Set());
+    subscribers.get(key)?.add(callback);
+  }
+
+  getHighlighter(language)
+    .then((highlighter) => {
+      const availableLangs = highlighter.getLoadedLanguages();
+      const langToUse = availableLangs.includes(language) ? language : "text";
+      const result = highlighter.codeToTokens(code, {
+        lang: langToUse,
+        themes: { dark: "github-dark", light: "github-light" },
+      });
+      const tokenized: TokenizedCode = {
+        bg: result.bg ?? "transparent",
+        fg: result.fg ?? "inherit",
+        tokens: result.tokens,
+      };
+      tokensCache.set(key, tokenized);
+      const subs = subscribers.get(key);
+      if (subs) {
+        for (const sub of subs) sub(tokenized);
+        subscribers.delete(key);
+      }
+    })
+    .catch((error) => {
+      console.error("Failed to highlight code:", error);
+      subscribers.delete(key);
+    });
+
+  return null;
+};
+
+const CodeBlockBody = memo(
+  ({
+    tokenized,
+    showLineNumbers,
+    className,
+  }: {
+    tokenized: TokenizedCode;
+    showLineNumbers: boolean;
+    className?: string;
+  }) => {
+    const preStyle = useMemo(
+      () => ({ backgroundColor: tokenized.bg, color: tokenized.fg }),
+      [tokenized.bg, tokenized.fg],
+    );
+    const keyedLines = useMemo(() => addKeysToTokens(tokenized.tokens), [tokenized.tokens]);
+
+    return (
+      <pre
+        className={cn(
+          "dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)] m-0 p-4 text-sm",
+          className,
+        )}
+        style={preStyle}
+      >
+        <code
+          className={cn(
+            "font-mono text-sm",
+            showLineNumbers && "[counter-increment:line_0] [counter-reset:line]",
+          )}
+        >
+          {keyedLines.map((keyedLine) => (
+            <LineSpan key={keyedLine.key} keyedLine={keyedLine} showLineNumbers={showLineNumbers} />
+          ))}
+        </code>
+      </pre>
+    );
+  },
+  (prev, next) =>
+    prev.tokenized === next.tokenized &&
+    prev.showLineNumbers === next.showLineNumbers &&
+    prev.className === next.className,
+);
+
+CodeBlockBody.displayName = "CodeBlockBody";
+
+export const CodeBlockContainer = ({
+  className,
+  language,
+  style,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { language: string }) => (
+  <div
+    className={cn(
+      "group relative w-full overflow-hidden rounded-md border bg-background text-foreground",
+      className,
+    )}
+    data-language={language}
+    style={{ containIntrinsicSize: "auto 200px", contentVisibility: "auto", ...style }}
+    {...props}
+  />
+);
+
+export const CodeBlockHeader = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex items-center justify-between border-b bg-muted/80 px-3 py-2 text-muted-foreground text-xs",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
+
+export const CodeBlockTitle = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex items-center gap-2", className)} {...props}>
+    {children}
+  </div>
+);
+
+export const CodeBlockFilename = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLSpanElement>) => (
+  <span className={cn("font-mono", className)} {...props}>
+    {children}
+  </span>
+);
+
+export const CodeBlockActions = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("-my-1 -mr-1 flex items-center gap-2", className)} {...props}>
+    {children}
+  </div>
+);
+
+export const CodeBlockContent = ({
+  code,
+  language,
+  showLineNumbers = false,
+}: {
+  code: string;
+  language: BundledLanguage;
+  showLineNumbers?: boolean;
+}) => {
+  const rawTokens = useMemo(() => createRawTokens(code), [code]);
+  const syncTokens = useMemo(
+    () => highlightCode(code, language) ?? rawTokens,
+    [code, language, rawTokens],
+  );
+  const [asyncTokens, setAsyncTokens] = useState<TokenizedCode | null>(null);
+  const asyncKeyRef = useRef({ code, language });
+
+  if (asyncKeyRef.current.code !== code || asyncKeyRef.current.language !== language) {
+    asyncKeyRef.current = { code, language };
+    setAsyncTokens(null);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    highlightCode(code, language, (result) => {
+      if (!cancelled) setAsyncTokens(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
+
+  const tokenized = asyncTokens ?? syncTokens;
+
+  return (
+    <div className="relative overflow-auto">
+      <CodeBlockBody showLineNumbers={showLineNumbers} tokenized={tokenized} />
+    </div>
+  );
+};
+
+export const CodeBlock = ({
+  code,
+  language,
+  showLineNumbers = false,
+  className,
+  children,
+  ...props
+}: CodeBlockProps) => {
+  const contextValue = useMemo(() => ({ code }), [code]);
+
+  return (
+    <CodeBlockContext.Provider value={contextValue}>
+      <CodeBlockContainer className={className} language={language} {...props}>
+        {children}
+        <CodeBlockContent code={code} language={language} showLineNumbers={showLineNumbers} />
+      </CodeBlockContainer>
+    </CodeBlockContext.Provider>
+  );
+};
+
+export type CodeBlockCopyButtonProps = ComponentProps<typeof Button> & {
+  onCopy?: () => void;
+  onError?: (error: Error) => void;
+  timeout?: number;
+};
+
+export const CodeBlockCopyButton = ({
+  onCopy,
+  onError,
+  timeout = 2000,
+  children,
+  className,
+  ...props
+}: CodeBlockCopyButtonProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<number>(0);
+  const { code } = useContext(CodeBlockContext);
+
+  const copyToClipboard = useCallback(async () => {
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+      onError?.(new Error("Clipboard API not available"));
+      return;
+    }
+    try {
+      if (!isCopied) {
+        await navigator.clipboard.writeText(code);
+        setIsCopied(true);
+        onCopy?.();
+        timeoutRef.current = window.setTimeout(() => setIsCopied(false), timeout);
+      }
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  }, [code, onCopy, onError, timeout, isCopied]);
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const Icon = isCopied ? CheckIcon : CopyIcon;
+
+  return (
+    <Button
+      className={cn("shrink-0", className)}
+      onClick={copyToClipboard}
+      size="icon"
+      variant="ghost"
+      {...props}
+    >
+      {children ?? <Icon size={14} />}
+    </Button>
+  );
+};
+
+export type CodeBlockLanguageSelectorProps = ComponentProps<typeof Select>;
+export const CodeBlockLanguageSelector = (props: CodeBlockLanguageSelectorProps) => (
+  <Select {...props} />
+);
+
+export type CodeBlockLanguageSelectorTriggerProps = ComponentProps<typeof SelectTrigger>;
+export const CodeBlockLanguageSelectorTrigger = ({
+  className,
+  ...props
+}: CodeBlockLanguageSelectorTriggerProps) => (
+  <SelectTrigger
+    className={cn("h-7 border-none bg-transparent px-2 text-xs shadow-none", className)}
+    size="sm"
+    {...props}
+  />
+);
+
+export type CodeBlockLanguageSelectorValueProps = ComponentProps<typeof SelectValue>;
+export const CodeBlockLanguageSelectorValue = (props: CodeBlockLanguageSelectorValueProps) => (
+  <SelectValue {...props} />
+);
+
+export type CodeBlockLanguageSelectorContentProps = ComponentProps<typeof SelectContent>;
+export const CodeBlockLanguageSelectorContent = ({
+  align = "end",
+  ...props
+}: CodeBlockLanguageSelectorContentProps) => <SelectContent align={align} {...props} />;
+
+export type CodeBlockLanguageSelectorItemProps = ComponentProps<typeof SelectItem>;
+export const CodeBlockLanguageSelectorItem = (props: CodeBlockLanguageSelectorItemProps) => (
+  <SelectItem {...props} />
+);


### PR DESCRIPTION
Adds an assistant side panel that streams a chat against the daemon's `/assistant/chat` proxy (`crates/runtimed/src/assistant_chat.rs`) without reading or writing notebook state, wired into the notebook shell via `assistant-panel-state` and a resizable `AssistantPanel`. Assistant replies render markdown through Streamdown with Shiki-highlighted code blocks (new `src/components/ui/code-block.tsx`), guard external links behind an "open link?" confirm dialog, and expose per-message Copy and Retry actions. Also extends `blob_server.rs`, adds a Streamdown gallery fixture for visual review, and covers the panel with a Playwright e2e spec.

All lint checks pass locally (`cargo xtask lint --fix`). Left as a draft pending CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)