### PR TITLE
feat(ui): unify user avatar and move sign out into the account dropdown

### DIFF
--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -866,19 +866,6 @@ body {
   flex: 0 0 auto;
 }
 
-.nb-avatar-me {
-  display: grid;
-  width: 32px;
-  height: 32px;
-  flex: 0 0 auto;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--nb-avatar-bg, var(--uv));
-  color: var(--nb-avatar-fg, #fff);
-  font-size: 12px;
-  font-weight: 700;
-}
-
 .cloud-dashboard,
 .cloud-notebook-signed-out,
 .cloud-notebook-list-state,
@@ -1932,7 +1919,8 @@ body {
     height: 34px;
   }
 
-  .nb-header-actions button {
+  /* The account-menu trigger keeps its shared-component sizing at every width. */
+  .nb-header-actions button:not([data-slot="notebook-account-menu-trigger"]) {
     width: 2.25rem;
     min-width: 2.25rem;
     padding-inline: 0;
@@ -1940,7 +1928,7 @@ body {
     font-size: 0;
   }
 
-  .nb-header-actions button svg {
+  .nb-header-actions button:not([data-slot="notebook-account-menu-trigger"]) svg {
     width: 1rem;
     height: 1rem;
   }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type CSSProperties,
-  type FormEvent,
-} from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   AlertCircle,
   ArrowUpRight,
@@ -17,8 +10,12 @@ import {
   Search,
   Sparkles,
 } from "lucide-react";
-import { colorForActorIdentity, contrastColorForActorIdentity } from "runtimed";
+// Not the `@/components/notebook` barrel: it pulls the notebook route into this
+// chunk and collapses the notebook-route CSS split `copy-viewer-assets` needs.
+import { NotebookAccountMenu } from "@/components/notebook/NotebookAccountMenu";
+import type { NotebookActorIdentity } from "@/components/notebook/capabilities";
 import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -398,15 +395,12 @@ export function CloudNotebookListView({
   const [currentUserAvatar, setCurrentUserAvatar] = useState<string | null>(null);
   // Prefer the unified user store's display name (delivered with the list
   // response) over auth-claim parsing for the header identity.
-  const currentUserInitials = currentUserDisplay
-    ? cloudNotebookInitialsFromLabel(currentUserDisplay)
-    : cloudNotebookListCurrentUserInitials(authState);
-  // Deterministic per-identity avatar color via the same palette/contrast
-  // helpers as presence and cursors, but keyed on a best-effort self identity
-  // (auth claims, not the room actor label), so it replaces the fixed brand fill
-  // now; an exact cross-surface match waits on the user store's canonical
-  // self principal.
-  const currentUserColorKey = cloudNotebookListCurrentUserColorKey(authState);
+  const currentUserActor = cloudNotebookListCurrentUserActor(
+    authState,
+    currentUserDisplay,
+    currentUserAvatar,
+  );
+  const currentUserAccountDetail = cloudNotebookListAccountDetail(authState, currentUserDisplay);
 
   return (
     <main className="cloud-notebook-list-page nb-app">
@@ -452,32 +446,16 @@ export function CloudNotebookListView({
                   )}
                   {createState === "starting" ? "Creating" : "New notebook"}
                 </Button>
-                <Button type="button" variant="ghost" aria-label="Sign out" onClick={signOut}>
-                  <LogOut aria-hidden="true" />
-                  <span className="nb-btn-label">Sign out</span>
-                </Button>
-                <span
-                  className="nb-avatar-me"
-                  style={
-                    currentUserAvatar
-                      ? undefined
-                      : ({
-                          "--nb-avatar-bg": colorForActorIdentity(currentUserColorKey),
-                          "--nb-avatar-fg": contrastColorForActorIdentity(currentUserColorKey),
-                        } as CSSProperties)
-                  }
-                  title={currentUserDisplay ?? headerDetail}
+                <NotebookAccountMenu
+                  actor={currentUserActor}
+                  detail={currentUserDisplay ?? headerDetail}
+                  accountDetail={currentUserAccountDetail}
                 >
-                  {currentUserAvatar ? (
-                    <img
-                      className="nb-avatar-img"
-                      src={currentUserAvatar}
-                      alt={currentUserDisplay ?? headerDetail}
-                    />
-                  ) : (
-                    currentUserInitials
-                  )}
-                </span>
+                  <DropdownMenuItem onSelect={signOut}>
+                    <LogOut aria-hidden="true" />
+                    Sign out
+                  </DropdownMenuItem>
+                </NotebookAccountMenu>
               </div>
             </>
           ) : null}
@@ -710,35 +688,41 @@ function cloudNotebookListHeaderDetail(
   return firstName ? `by ${firstName}` : "Signed in";
 }
 
-function cloudNotebookListCurrentUserInitials(authState: CloudPrototypeAuthState): string {
+function cloudNotebookListCurrentUserActor(
+  authState: CloudPrototypeAuthState,
+  displayName: string | null,
+  avatarUrl: string | null,
+): NotebookActorIdentity {
   const label =
+    displayName?.trim() ||
     authState.oidcClaims?.name?.trim() ||
     authState.oidcClaims?.email?.trim() ||
     (authState.mode === "dev" ? authState.user?.trim() : "") ||
     "You";
-  return cloudNotebookInitialsFromLabel(label);
-}
-
-function cloudNotebookListCurrentUserColorKey(authState: CloudPrototypeAuthState): string {
-  return (
+  const id =
     authState.oidcClaims?.sub?.trim() ||
     (authState.mode === "dev" ? authState.user?.trim() : "") ||
     authState.oidcClaims?.email?.trim() ||
-    "you"
-  );
+    "you";
+  return {
+    id,
+    label,
+    detail: null,
+    kind: "human",
+    imageUrl: avatarUrl,
+  };
 }
 
-function cloudNotebookInitialsFromLabel(label: string): string {
-  const parts = label
-    .replace(/[_+.-]+/gu, " ")
-    .trim()
-    .split(/\s+/u)
-    .filter(Boolean);
-  const initials =
-    parts.length >= 2
-      ? `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`
-      : (parts[0]?.slice(0, 2) ?? "YO");
-  return initials.toUpperCase();
+function cloudNotebookListAccountDetail(
+  authState: CloudPrototypeAuthState,
+  displayName: string | null,
+): string | null {
+  const email = authState.oidcClaims?.email?.trim();
+  if (!email) {
+    return authState.mode === "dev" ? "Local auth" : null;
+  }
+  const label = displayName?.trim() || authState.oidcClaims?.name?.trim() || "";
+  return email === label ? null : email;
 }
 
 function cloudNotebookListFirstName(authState: CloudPrototypeAuthState): string | null {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { AlertCircle, Check, Info, Loader2, LogIn, PanelLeftOpen, X } from "lucide-react";
+import { AlertCircle, Check, Info, Loader2, LogIn, LogOut, PanelLeftOpen, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import {
   useHasIsolatedOutputs,
@@ -55,6 +55,7 @@ import {
   type NotebookCommentDraftTarget,
 } from "@/components/notebook";
 import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
   openNotebookRailPanel,
   setActiveNotebookRailPanel,
@@ -144,6 +145,7 @@ import { cloudResponseError } from "./cloud-response";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
+import { clearCachedCloudNotebookList } from "./notebook-list-cache";
 import type { CloudAccessRequestNoticeProjection } from "./cloud-access-request-state";
 import {
   cloudNotebookCatalogAccessFromCatalogResponse,
@@ -1474,6 +1476,25 @@ export function NotebookViewer({
     accessRequest.reset();
     refreshAuthState();
   }, [accessRequest, refreshAuthState]);
+  // Clears the same state the notebook home clears — app session, dev auth,
+  // and the cached list — so signing out in one surface cannot leave the other
+  // showing a stale identity or notebook list.
+  const signOutOfNotebook = useCallback(() => {
+    auth.clearAppSessionStatus();
+    void clearCloudAppSession()
+      .catch((error: unknown) => {
+        console.warn("[notebook-cloud] app session clear failed", error);
+      })
+      .finally(() => auth.refreshAppSessionStatus());
+    try {
+      clearCachedCloudNotebookList(window.localStorage);
+    } catch {
+      // Private-mode storage denial is not a sign-out failure.
+    }
+    clearCloudPrototypeDevAuth(window.localStorage);
+    accessRequest.reset();
+    refreshAuthState();
+  }, [accessRequest, auth, refreshAuthState]);
   const beginNotebookAuth = useCallback(async () => {
     const method = cloudSignInMethodForConfig(authConfig);
     if (method === "oidc" && authConfig.oidc) {
@@ -1718,6 +1739,13 @@ export function NotebookViewer({
           <NotebookConnectionIdentity
             capabilities={shellCapabilities}
             connectionStatus$={connectionStatus$}
+            accountDetail={authState.oidcClaims?.email?.trim() ?? null}
+            accountActions={
+              <DropdownMenuItem onSelect={signOutOfNotebook}>
+                <LogOut aria-hidden="true" />
+                Sign out
+              </DropdownMenuItem>
+            }
           />
         ) : null
       }

--- a/src/components/notebook/NotebookAccountMenu.tsx
+++ b/src/components/notebook/NotebookAccountMenu.tsx
@@ -1,0 +1,81 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { NotebookActorAvatar } from "./NotebookIdentity";
+import type { NotebookActorIdentity } from "./capabilities";
+
+// The hover surface stays rounded-md (never a pill), but the focus ring hugs
+// the circular avatar instead of this box — so it is drawn on the Avatar via
+// `group-focus-visible:` rather than on the trigger.
+export const NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS =
+  "group inline-flex h-8 shrink-0 items-center justify-center rounded-md px-0.5 text-foreground transition-colors hover:bg-muted/60 focus-visible:outline-none";
+
+export interface NotebookAccountMenuProps {
+  actor: NotebookActorIdentity;
+  detail?: string;
+  accountDetail?: string | null;
+  showStatus?: boolean;
+  statusClassName?: string;
+  triggerExtra?: ReactNode;
+  triggerClassName?: string;
+  triggerProps?: ComponentProps<"button"> & Record<`data-${string}`, string | undefined>;
+  align?: "start" | "center" | "end";
+  children: ReactNode;
+}
+
+export function NotebookAccountMenu({
+  actor,
+  detail,
+  accountDetail,
+  showStatus = false,
+  statusClassName,
+  triggerExtra,
+  triggerClassName,
+  triggerProps,
+  align = "end",
+  children,
+}: NotebookAccountMenuProps) {
+  const triggerCopy = detail ?? actor.label;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS, triggerClassName)}
+        data-slot="notebook-account-menu-trigger"
+        data-actor-kind={actor.kind}
+        title={triggerCopy}
+        {...triggerProps}
+      >
+        <span aria-hidden="true">
+          <NotebookActorAvatar
+            actor={actor}
+            className="border-0 ring-ring ring-offset-1 ring-offset-background group-focus-visible:ring-2"
+            size="default"
+            showStatus={showStatus}
+            statusClassName={statusClassName}
+          />
+        </span>
+        <span className="sr-only">{triggerCopy}</span>
+        {triggerExtra}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="min-w-56">
+        <DropdownMenuLabel className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate">{actor.label}</span>
+          {accountDetail ? (
+            <span className="truncate text-xs font-normal text-muted-foreground">
+              {accountDetail}
+            </span>
+          ) : null}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { ConnectionStatus } from "runtimed";
 import { cn } from "@/lib/utils";
+import { NotebookAccountMenu } from "./NotebookAccountMenu";
 import { NotebookActorAvatar } from "./NotebookIdentity";
 import { notebookToolbarActors } from "./NotebookToolbarIdentity";
 import type { NotebookShellCapabilities } from "./capabilities";
@@ -64,6 +65,8 @@ export interface NotebookConnectionIdentityProps {
    */
   connectionLabel?: string;
   className?: string;
+  accountActions?: ReactNode;
+  accountDetail?: string | null;
 }
 
 export function NotebookConnectionIdentity({
@@ -71,6 +74,8 @@ export function NotebookConnectionIdentity({
   connectionStatus$,
   connectionLabel,
   className,
+  accountActions,
+  accountDetail,
 }: NotebookConnectionIdentityProps) {
   const { status, announcedStatus } = useConnectionStatus(connectionStatus$);
   const statusText = formatStatusText(status, connectionLabel);
@@ -93,6 +98,35 @@ export function NotebookConnectionIdentity({
 
   const detail = `${actor.label} — ${statusText}`;
 
+  // Announces status CHANGES only — empty on initial render so a mount never
+  // speaks, and sources dedup repeated values so flaps don't spam.
+  const liveRegion = (
+    <span className="sr-only" aria-live="polite">
+      {announcement}
+    </span>
+  );
+
+  if (accountActions) {
+    return (
+      <NotebookAccountMenu
+        actor={actor}
+        detail={detail}
+        accountDetail={accountDetail}
+        showStatus
+        statusClassName={connectionDotTone(status)}
+        triggerExtra={liveRegion}
+        triggerClassName={cn(status !== "online" && "opacity-70", className)}
+        triggerProps={{
+          "data-slot": "notebook-connection-identity",
+          "data-state": status,
+          "data-actor-kind": actor.kind,
+        }}
+      >
+        {accountActions}
+      </NotebookAccountMenu>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -111,17 +145,12 @@ export function NotebookConnectionIdentity({
         <NotebookActorAvatar
           actor={actor}
           className="border-0"
-          size="sm"
+          size="default"
           statusClassName={connectionDotTone(status)}
         />
       </span>
       <span className="sr-only">{detail}</span>
-      {/* Announces status CHANGES only — empty on initial render so a mount
-          never speaks, and sources dedup repeated values so flaps don't
-          spam. */}
-      <span className="sr-only" aria-live="polite">
-        {announcement}
-      </span>
+      {liveRegion}
     </div>
   );
 }

--- a/src/components/notebook/__tests__/NotebookAccountMenu.test.tsx
+++ b/src/components/notebook/__tests__/NotebookAccountMenu.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS, NotebookAccountMenu } from "../NotebookAccountMenu";
+import type { NotebookActorIdentity } from "../capabilities";
+
+function actor(overrides: Partial<NotebookActorIdentity> = {}): NotebookActorIdentity {
+  return {
+    id: "user:anaconda:leslie",
+    label: "Leslie D.",
+    detail: null,
+    kind: "human",
+    ...overrides,
+  };
+}
+
+function renderMenu(props: Partial<Parameters<typeof NotebookAccountMenu>[0]> = {}) {
+  return render(
+    <NotebookAccountMenu actor={actor()} {...props}>
+      <DropdownMenuItem>Sign out</DropdownMenuItem>
+    </NotebookAccountMenu>,
+  );
+}
+
+function trigger(container: HTMLElement): HTMLElement {
+  const element = container.querySelector<HTMLElement>(
+    '[data-slot="notebook-account-menu-trigger"]',
+  );
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+describe("NotebookAccountMenu", () => {
+  it("renders the avatar as the menu trigger with no visible caret or label", () => {
+    // The avatar IS the affordance: the toolbar gains a menu without gaining
+    // chrome, so the trigger stays icon-only at every width.
+    const { container } = renderMenu();
+    const element = trigger(container);
+
+    expect(element.querySelector('[data-slot="notebook-actor-avatar"]')).not.toBeNull();
+
+    const clone = element.cloneNode(true) as HTMLElement;
+    for (const hidden of Array.from(
+      clone.querySelectorAll('.sr-only, [data-slot="avatar-fallback"]'),
+    )) {
+      hidden.remove();
+    }
+    expect(clone.textContent?.trim()).toBe("");
+  });
+
+  it("keeps the trigger quiet: borderless, shadow-free, and not a pill", () => {
+    // Mirrors the NotebookConnectionIdentity quiet-chrome guardrail so the
+    // account menu cannot reintroduce the raised-bubble look on either surface.
+    const { container } = renderMenu();
+    const element = trigger(container);
+
+    expect(element.classList.contains("rounded-md")).toBe(true);
+    expect(element.classList.contains("rounded-full")).toBe(false);
+    expect(element.classList.contains("border")).toBe(false);
+    expect(element.querySelector('[data-slot="notebook-actor-avatar"]')?.classList).toContain(
+      "border-0",
+    );
+    for (const node of [element, ...Array.from(element.querySelectorAll("*"))]) {
+      for (const token of Array.from(node.classList)) {
+        expect(token.startsWith("shadow")).toBe(false);
+      }
+    }
+  });
+
+  it("exposes the actor label as accessible copy, not as avatar initials", () => {
+    // Without aria-hidden a screen reader would read "LD Leslie D.".
+    const { container } = renderMenu();
+    const element = trigger(container);
+
+    expect(
+      element.querySelector('[data-slot="notebook-actor-avatar"]')?.closest("[aria-hidden]"),
+    ).not.toBeNull();
+    expect(element.querySelector(".sr-only")?.textContent).toBe("Leslie D.");
+  });
+
+  it("prefers host-composed detail copy over the bare label", () => {
+    // The notebook view composes identity + connection state so the trigger
+    // never asserts more than the host measures.
+    const { container } = renderMenu({ detail: "Leslie D. — Connected" });
+    const element = trigger(container);
+
+    expect(element.title).toBe("Leslie D. — Connected");
+    expect(element.querySelector(".sr-only")?.textContent).toBe("Leslie D. — Connected");
+  });
+
+  it("omits the status dot unless the host asks for one", () => {
+    // The dot means a live notebook room; the notebook home does not measure
+    // one, so it must not appear there.
+    const { container: quiet } = renderMenu();
+    expect(quiet.querySelector('[data-slot="avatar-badge"]')).toBeNull();
+
+    const { container: withDot } = renderMenu({
+      showStatus: true,
+      statusClassName: "bg-emerald-500",
+    });
+    const badge = withDot.querySelector('[data-slot="avatar-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.classList.contains("bg-emerald-500")).toBe(true);
+  });
+
+  it("opens the menu and renders host-owned actions with the identity header", async () => {
+    // Account actions are host policy (session/dev-auth/cache clearing), so
+    // the component owns the frame and the host owns the items.
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const { container } = render(
+      <NotebookAccountMenu actor={actor()} accountDetail="leslie@anaconda.com">
+        <DropdownMenuItem onSelect={onSelect}>Sign out</DropdownMenuItem>
+      </NotebookAccountMenu>,
+    );
+
+    await user.click(trigger(container));
+
+    expect(screen.getByText("leslie@anaconda.com")).toBeTruthy();
+    const item = screen.getByRole("menuitem", { name: "Sign out" });
+
+    await user.click(item);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one exported trigger treatment so the two surfaces cannot drift", () => {
+    // The regression this component exists to prevent: the notebook home and
+    // the notebook view previously drew self-identity from unrelated systems
+    // (a hand-rolled span vs the shared Avatar). Both now render the same
+    // trigger class.
+    const { container } = renderMenu();
+    const element = trigger(container);
+
+    for (const token of NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS.split(/\s+/)) {
+      expect(element.classList.contains(token)).toBe(true);
+    }
+  });
+});

--- a/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
+++ b/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
 import type { ConnectionStatus } from "runtimed";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { readOnlyNotebookShellCapabilities } from "../capabilities";
 import {
   NotebookConnectionIdentity,
@@ -322,6 +323,76 @@ describe("NotebookConnectionIdentity", () => {
     const slot = slotElement(container);
     expect(slot.dataset.actorKind).toBe("human");
     expect(slot.querySelector('[data-slot="notebook-actor-avatar"]')).not.toBeNull();
+  });
+
+  describe("account-menu mode", () => {
+    function renderWithActions(status: ConnectionStatus = "online") {
+      const source = new FakeStatusSource(status);
+      return {
+        source,
+        ...render(
+          <NotebookConnectionIdentity
+            capabilities={cloudCapabilities()}
+            connectionStatus$={source}
+            accountDetail="alice@anaconda.com"
+            accountActions={<DropdownMenuItem>Sign out</DropdownMenuItem>}
+          />,
+        ),
+      };
+    }
+
+    it("becomes the shared account-menu trigger when a host passes actions", () => {
+      // Cloud surfaces converge on one trigger; the slot keeps its identity
+      // so the existing data-slot/state contract still holds.
+      const { container } = renderWithActions();
+      const slot = slotElement(container);
+
+      expect(slot.tagName).toBe("BUTTON");
+      expect(slot.dataset.state).toBe("online");
+      expect(slot.dataset.actorKind).toBe("human");
+      // The host's data-slot wins, so existing selectors keep resolving.
+      expect(slot.getAttribute("data-slot")).toBe("notebook-connection-identity");
+      expect(slot.getAttribute("aria-haspopup")).toBe("menu");
+      expect(slot.querySelector('[data-slot="notebook-actor-avatar"]')).not.toBeNull();
+    });
+
+    it("keeps the connectivity dot and its tone in menu mode", () => {
+      // The dot is why this slot exists — wiring a menu must not drop it.
+      const { container, source } = renderWithActions("online");
+      expect(dotElement(container).classList.contains("bg-emerald-500")).toBe(true);
+
+      act(() => source.next("reconnecting"));
+      expect(slotElement(container).dataset.state).toBe("reconnecting");
+      expect(dotElement(container).classList.contains("animate-pulse")).toBe(true);
+      expect(slotElement(container).classList.contains("opacity-70")).toBe(true);
+    });
+
+    it("still announces status changes politely from the menu trigger", () => {
+      const { container, source } = renderWithActions("online");
+      expect(liveRegion(container).textContent).toBe("");
+
+      act(() => source.next("offline"));
+      expect(liveRegion(container).textContent).toBe("Offline");
+    });
+
+    it("renders no account chrome for a purely local desktop session", () => {
+      // Desktop passes no actions, but even if it did, local identity stays
+      // quiet — conditionality precedes the menu.
+      const source = new FakeStatusSource("online");
+      const { container } = render(
+        <NotebookConnectionIdentity
+          capabilities={localCapabilities()}
+          connectionStatus$={source}
+          accountActions={<DropdownMenuItem>Sign out</DropdownMenuItem>}
+        />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("keeps the static badge when no actions are passed (desktop path)", () => {
+      const { container } = renderSlot(cloudCapabilities());
+      expect(slotElement(container).tagName).toBe("DIV");
+    });
   });
 });
 

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -187,6 +187,11 @@ export {
   type NotebookConnectionStatusSource,
 } from "./NotebookConnectionIdentity";
 export {
+  NotebookAccountMenu,
+  NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS,
+  type NotebookAccountMenuProps,
+} from "./NotebookAccountMenu";
+export {
   NotebookToolbarIdentity,
   notebookToolbarActors,
   type NotebookToolbarIdentityProps,

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -41,7 +41,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs",
+        "bg-accent text-accent-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs",
         className,
       )}
       {...props}
@@ -83,7 +83,7 @@ function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) 
     <div
       data-slot="avatar-group-count"
       className={cn(
-        "bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        "bg-accent text-accent-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
         className,
       )}
       {...props}


### PR DESCRIPTION
Unifies the user avatar styling between the notebook home and notebook view, and moves "Sign out" from a standalone button into the avatar's dropdown menu on both surfaces.
<img width="1137" height="173" alt="image" src="https://github.com/user-attachments/assets/ff1ecd43-58c1-46b7-b219-43878de66daf" />
<img width="334" height="164" alt="image" src="https://github.com/user-attachments/assets/bba57d48-6e7e-41a7-98e9-76204ebc43a2" />
