### PR TITLE
docs(outputs): document manifest blobs[] and clarify the dx namespace

### DIFF
--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -150,7 +150,7 @@ New clients receive widget topology via RuntimeStateDoc sync and widget state vi
 
 ### Reserved comm namespace: `nteract.dx.*`
 
-The `nteract.dx.*` prefix is reserved for nteract's own kernel-side protocols. `comm_open` / `comm_msg` / `comm_close` traffic for this namespace is filtered out of runtime comm topology/state and `NotebookBroadcast::Comm`, so it never reaches `WidgetStore`. v1 has no live `nteract.dx.blob` handler; reserved messages are dropped with a warning, and current blob refs ride IOPub `display_data` buffers through `preflight_ref_buffers`.
+The `nteract.dx.*` prefix is reserved for nteract's own kernel-side protocols. `comm_open` / `comm_msg` / `comm_close` traffic for this namespace is filtered out of runtime comm topology/state and `NotebookBroadcast::Comm`, so it never reaches `WidgetStore`. v1 has no live `nteract.dx.blob` handler; reserved messages are dropped with a warning, and current kernel-emitted output blobs ride IOPub rich-output buffers (`display_data`, `execute_result`, or `update_display_data`) through `preflight_ref_buffers`.
 
 ## Development workflow
 

--- a/crates/runtimed/src/dx_blob_comm.rs
+++ b/crates/runtimed/src/dx_blob_comm.rs
@@ -5,9 +5,11 @@
 //! [`NotebookBroadcast::Comm`], and dropped with a `warn!` log carrying
 //! the raw target name.
 //!
-//! v1 has no live handlers — the blob upload path rides IOPub `display_data`
-//! buffers instead (see [`output_store::preflight_ref_buffers`]). The
-//! namespace stays reserved for future bidirectional subsystems
+//! No target in this namespace has a handler. Kernels do not need one to reach
+//! the blob store: bytes ride IOPub `display_data` buffers, which
+//! [`output_store::preflight_ref_buffers`] hash-verifies and commits. That path
+//! is live and is the supported way to upload. The namespace stays reserved for
+//! future bidirectional subsystems
 //! (push-down predicates, streaming Arrow, `dx.attach`); when those
 //! ship, they grow named variants on [`DxTarget`] with dispatch handlers.
 
@@ -16,7 +18,8 @@ pub const DX_NAMESPACE_PREFIX: &str = "nteract.dx.";
 
 /// Reserved target name for kernel-initiated blob uploads.
 ///
-/// Not used in v1. Blob bytes ride IOPub `display_data` buffers.
+/// This comm target has no handler. Uploads go through IOPub `display_data`
+/// buffers, which is a live path and not a fallback.
 pub const DX_BLOB_TARGET: &str = "nteract.dx.blob";
 
 /// Returns true if `target_name` starts with `nteract.dx.` and has at least

--- a/crates/runtimed/src/dx_blob_comm.rs
+++ b/crates/runtimed/src/dx_blob_comm.rs
@@ -5,8 +5,10 @@
 //! [`NotebookBroadcast::Comm`], and dropped with a `warn!` log carrying
 //! the raw target name.
 //!
-//! v1 has no live handlers — the blob upload path rides IOPub `display_data`
-//! buffers instead (see [`output_store::preflight_ref_buffers`]). The
+//! No target in this namespace has a handler. Kernel-emitted output blobs
+//! instead ride IOPub rich-output buffers (`display_data`, `execute_result`, or
+//! `update_display_data`), which [`output_store::preflight_ref_buffers`]
+//! hash-verifies and commits before manifest creation. That path is live. The
 //! namespace stays reserved for future bidirectional subsystems
 //! (push-down predicates, streaming Arrow, `dx.attach`); when those
 //! ship, they grow named variants on [`DxTarget`] with dispatch handlers.
@@ -16,7 +18,8 @@ pub const DX_NAMESPACE_PREFIX: &str = "nteract.dx.";
 
 /// Reserved target name for kernel-initiated blob uploads.
 ///
-/// Not used in v1. Blob bytes ride IOPub `display_data` buffers.
+/// This comm target has no handler. Kernel-emitted output blobs go through
+/// IOPub rich-output buffers, which is a live path and not a fallback.
 pub const DX_BLOB_TARGET: &str = "nteract.dx.blob";
 
 /// Returns true if `target_name` starts with `nteract.dx.` and has at least

--- a/docs/adr/blob-ref-and-chunk-manifest-protocol.md
+++ b/docs/adr/blob-ref-and-chunk-manifest-protocol.md
@@ -161,6 +161,13 @@ Each `chunks[]` entry names a blob ref by hash. Each chunk is independently
 decodable as an Arrow IPC stream mini-stream. Consumers concatenate logical
 rows in ascending `index` order, not by reassembling raw bytes.
 
+A manifest may also carry `blobs[]`, a side-car list of refs the manifest owns
+that are not part of the row stream. Unlike `chunks[]`, entries are not ordered
+and carry no row semantics; they are addressable payloads the renderer resolves
+on demand. Ref collection already walks this slot alongside `chunks[]` and
+`coalesced` in the publish path (`crates/runt-publish/src/lib.rs`), in hosted
+snapshot dependency collection, and in the cloud viewer.
+
 The manifest may later grow `coalesced` entries for derived artifacts. Unknown
 fields must be preserved at save/load boundaries.
 
@@ -179,7 +186,8 @@ blobs explicit:
 ```
 
 The transform applies only to known blob-bearing manifest slots such as
-`chunks[].hash`, `coalesced.hash`, and `coalesced.segments[].hash`. A schema
+`chunks[].hash`, `blobs[].hash`, `coalesced.hash`, and
+`coalesced.segments[].hash`. A schema
 fingerprint like `schema.hash` remains a string until schema bytes are stored
 as an actual blob.
 

--- a/docs/adr/blob-ref-and-chunk-manifest-protocol.md
+++ b/docs/adr/blob-ref-and-chunk-manifest-protocol.md
@@ -161,6 +161,19 @@ Each `chunks[]` entry names a blob ref by hash. Each chunk is independently
 decodable as an Arrow IPC stream mini-stream. Consumers concatenate logical
 rows in ascending `index` order, not by reassembling raw bytes.
 
+Some live and published manifests also carry `blobs[]`, a side-car list of refs
+that are not part of the row stream. Unlike `chunks[]`, entries are not ordered
+and carry no row semantics. `OutputManifest::blob_refs`, `runt-publish`
+snapshot collection, and notebook-cloud blob-ref collection walk this slot
+alongside `chunks[]` and `coalesced` so the referenced payloads can be uploaded
+and resolved on demand.
+
+`blobs[]` is not yet a complete runtime-storage contract: the daemon's
+active-room GC walker does not retain its entries, and the durable `.ipynb`
+save/load transform below does not process them: neither the externalize nor
+restore step visits this slot. Producers must not depend on `blobs[]` until
+both paths are implemented.
+
 The manifest may later grow `coalesced` entries for derived artifacts. Unknown
 fields must be preserved at save/load boundaries.
 


### PR DESCRIPTION
Two documentation accuracy fixes found while investigating the large-cell payload problem in #4103 and #4105.

## Document the live `blobs[]` boundary

The Arrow manifest ADR documents `chunks[]` and `coalesced`, but not the existing `blobs[]` side-car slot. `OutputManifest::blob_refs`, `runt-publish` snapshot collection, and notebook-cloud blob-ref collection already walk that slot so referenced payloads can be uploaded and resolved on demand.

The ADR now distinguishes unordered side-car refs from the ordered row stream and records the current durability boundary: active-room GC does not retain `blobs[]` entries, and neither the externalize nor restore step in the `.ipynb` save/load transform visits the slot. Producers must not depend on `blobs[]` until both paths are implemented.

## Clarify the dx namespace

`nteract.dx.blob` is reserved but has no handler. Kernel-emitted output blobs use IOPub rich-output buffers (`display_data`, `execute_result`, and `update_display_data`); `preflight_ref_buffers` hash-verifies and commits those buffers before manifest creation. The comment now describes that live path without making it sound like the buffer path is unused or merely a fallback.

No behavior change.

## Verification

- `cargo xtask lint --fix`
- `python3 -m py_compile scripts/ci/check-docs-guidance.py`
- `python3 scripts/ci/check-docs-guidance.py --paths-json '["docs/adr/blob-ref-and-chunk-manifest-protocol.md","crates/runtimed/AGENTS.md"]'`
- `cargo test -p runtimed dx_blob_comm` — 2 passed
