### PR TITLE
feat(notebook-cloud): add settings drawer for theme and mode

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -20,6 +20,7 @@ import {
   Rows3,
   Search,
   Server,
+  Settings,
   ShieldCheck,
   SlidersHorizontal,
   SquareCode,
@@ -75,6 +76,12 @@ const catalogGroups = [
         description: "Notebook home, continuation, workstation context, and sharing previews.",
         href: "/docs/cloud-dashboard",
         icon: LayoutDashboard,
+      },
+      {
+        title: "Settings drawer",
+        description: "Account and appearance preferences sliding in from the avatar menu.",
+        href: "/docs/settings-drawer",
+        icon: Settings,
       },
       {
         title: "Site chrome",

--- a/apps/elements/components/settings-drawer-example.tsx
+++ b/apps/elements/components/settings-drawer-example.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { LogOut, Settings } from "lucide-react";
+import { useState } from "react";
+import {
+  NotebookAccountMenu,
+  NotebookSettingsDrawer,
+  type NotebookActorIdentity,
+} from "@/components/notebook";
+import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import type { ColorTheme } from "@/bindings";
+import type { ThemeMode } from "@/hooks/useTheme";
+import { Eyebrow } from "@/components/surface-primitives";
+
+const signedInActor: NotebookActorIdentity = {
+  id: "user:anaconda:leslie",
+  label: "Leslie Dominguez",
+  detail: null,
+  kind: "human",
+};
+
+const scenarios: Array<{
+  id: string;
+  title: string;
+  description: string;
+  actor: NotebookActorIdentity | null;
+  accountDetail: string | null;
+  initialTheme: ThemeMode;
+  initialColorTheme?: ColorTheme;
+}> = [
+  {
+    id: "signed-in",
+    title: "Signed in",
+    description:
+      "The full drawer: appearance plus a read-only account block. Sign-out stays a host-owned action.",
+    actor: signedInActor,
+    accountDetail: "leslie@anaconda.com",
+    initialTheme: "system",
+    initialColorTheme: "classic",
+  },
+  {
+    id: "cream-palette",
+    title: "Cream palette",
+    description:
+      "Palette is orthogonal to light/dark — each palette defines both modes, so this dark surface is still on a palette choice.",
+    actor: signedInActor,
+    accountDetail: "leslie@anaconda.com",
+    initialTheme: "dark",
+    initialColorTheme: "cream",
+  },
+  {
+    id: "no-email",
+    title: "No account detail",
+    description:
+      "Identity without a resolvable email — the secondary line collapses instead of rendering an empty row.",
+    actor: signedInActor,
+    accountDetail: null,
+    initialTheme: "dark",
+    initialColorTheme: "classic",
+  },
+  {
+    id: "no-palette-writer",
+    title: "No palette writer",
+    description:
+      "Desktop owns palette through daemon-synced settings, so a host that passes no palette gets the mode row alone rather than a dead control.",
+    actor: signedInActor,
+    accountDetail: "leslie@anaconda.com",
+    initialTheme: "system",
+  },
+  {
+    id: "signed-out",
+    title: "Signed out",
+    description:
+      "A public viewer gets appearance only. No identity means no account section at all.",
+    actor: null,
+    accountDetail: null,
+    initialTheme: "light",
+    initialColorTheme: "classic",
+  },
+];
+
+export function SettingsDrawerExample() {
+  return (
+    <div className="flex flex-col gap-6">
+      {scenarios.map((scenario) => (
+        <SettingsDrawerScenario key={scenario.id} scenario={scenario} />
+      ))}
+    </div>
+  );
+}
+
+function SettingsDrawerScenario({ scenario }: { scenario: (typeof scenarios)[number] }) {
+  const [open, setOpen] = useState(false);
+  const [theme, setTheme] = useState<ThemeMode>(scenario.initialTheme);
+  const [colorTheme, setColorTheme] = useState<ColorTheme | undefined>(scenario.initialColorTheme);
+
+  return (
+    <section className="flex flex-col gap-3 rounded-md border border-border p-4">
+      <div className="flex flex-col gap-1">
+        <Eyebrow>{scenario.title}</Eyebrow>
+        <p className="text-sm text-muted-foreground">{scenario.description}</p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <NotebookAccountMenu
+          actor={scenario.actor ?? { ...signedInActor, label: "Public viewer", kind: "public" }}
+          accountDetail={scenario.accountDetail}
+        >
+          <DropdownMenuItem onSelect={() => setOpen(true)}>
+            <Settings aria-hidden="true" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <LogOut aria-hidden="true" />
+            Sign out
+          </DropdownMenuItem>
+        </NotebookAccountMenu>
+        <span className="text-xs text-muted-foreground">
+          Selected theme: <code>{theme}</code>
+          {colorTheme ? (
+            <>
+              {" · palette: "}
+              <code>{colorTheme}</code>
+            </>
+          ) : null}
+        </span>
+      </div>
+
+      <NotebookSettingsDrawer
+        open={open}
+        onOpenChange={setOpen}
+        theme={theme}
+        onThemeChange={setTheme}
+        colorTheme={colorTheme}
+        onColorThemeChange={colorTheme ? setColorTheme : undefined}
+        actor={scenario.actor}
+        accountDetail={scenario.accountDetail}
+        accountActions={
+          <Button type="button" variant="outline" size="sm" className="self-start">
+            <LogOut aria-hidden="true" />
+            Sign out
+          </Button>
+        }
+      />
+    </section>
+  );
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -44,6 +44,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Cloud notebook shell](/docs/cloud-notebook-shell)
 - [Full shell composition](/docs/full-shell-composition)
 - [Cloud dashboard](/docs/cloud-dashboard)
+- [Settings drawer](/docs/settings-drawer)
 - [Site chrome](/docs/site-chrome)
 - [Unhappy states](/docs/unhappy-states)
 - [Skeleton](/docs/skeleton)

--- a/apps/elements/content/docs/settings-drawer.mdx
+++ b/apps/elements/content/docs/settings-drawer.mdx
@@ -1,0 +1,56 @@
+---
+title: Settings drawer
+description: The cloud account and appearance drawer opened from the avatar menu.
+---
+
+import { SettingsDrawerExample } from "@/components/settings-drawer-example";
+
+Hosted surfaces have no second window to open, so app-level preferences slide in
+from the right over the current page. The drawer is reached from the account
+menu on the avatar — the same trigger on the notebook home and inside a
+notebook — so both cloud surfaces expose one settings entry point.
+
+<SettingsDrawerExample />
+
+## Scope
+
+Appearance and account identity are app facts, not notebook facts. The drawer
+reads and writes the browser-local theme preference every cloud view already
+consumes, and shows the signed-in identity read-only. It does not touch
+`NotebookDoc`, `RuntimeStateDoc`, execution state, or the catalog, so opening it
+over a live notebook changes nothing about the room.
+
+## Appearance: two orthogonal axes
+
+Mode (light/dark/system) and palette (classic/cream) are independent — each
+palette defines both a light and a dark surface, so neither control is a subset
+of the other. `system` stays a distinct mode rather than collapsing to its
+resolved value, because following the OS is itself the preference.
+
+Palette reaches non-React consumers through one write: the host sets
+`data-color-theme` on `<html>`, and markdown, static highlighting, Sift accents,
+and the isolated output iframes pick it up from there. That is why the swatches
+scope the attribute to themselves — a swatch without it would preview whichever
+palette is currently live instead of the one it offers.
+
+Both halves of the palette contract gate together. A host that passes a palette
+but no setter would render a control that discards clicks, so the row appears
+only when the host can actually write. Desktop owns palette through
+daemon-synced settings and passes neither, which is the `No palette writer`
+scenario above.
+
+## State ownership
+
+The drawer is fully controlled: the host passes `theme` and `onThemeChange`, so
+the single writer stays the host's `useTheme(...)` call and the drawer never
+becomes a second source of truth for a preference. The same rule covers the
+account section — sign-out is passed in as a host-owned action rather than
+implemented here, because clearing an app session, dev auth, and cached catalog
+data is host policy.
+
+## States
+
+Account chrome is conditional. With no resolvable identity the account section
+is absent rather than empty, which is what a public viewer sees; an identity
+without an email renders the label alone instead of reserving a blank secondary
+line. Appearance is always present because it applies signed in or out.

--- a/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
+++ b/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
@@ -1,4 +1,5 @@
 export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
+export const CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY = "nteract.cloud.viewer.color-theme";
 
 export function viewerThemeFirstPaintStyle(): string {
   return `html {
@@ -47,5 +48,17 @@ export function viewerThemeBootstrapScript(): string {
   root.classList.toggle("light", resolved === "light");
   root.dataset.theme = resolved;
   root.style.colorScheme = resolved;
+
+  let storedPalette;
+  try {
+    storedPalette = window.localStorage?.getItem(${JSON.stringify(
+      CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+    )});
+  } catch {}
+  if (storedPalette === "cream") {
+    root.setAttribute("data-color-theme", storedPalette);
+  } else {
+    root.removeAttribute("data-color-theme");
+  }
 })();`;
 }

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import vm from "node:vm";
 import {
+  CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
   CLOUD_VIEWER_THEME_STORAGE_KEY,
   resolveCloudViewerTheme,
   storedCloudViewerTheme,
@@ -62,6 +63,33 @@ describe("cloud viewer theme helpers", () => {
     assert.equal(result.colorScheme, "dark");
     assert.deepEqual(result.classes, ["dark"]);
   });
+
+  it("uses a palette storage key distinct from the mode key", () => {
+    assert.equal(CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY, "nteract.cloud.viewer.color-theme");
+    assert.notEqual(CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY, CLOUD_VIEWER_THEME_STORAGE_KEY);
+  });
+
+  it("seeds a saved cream palette before the bundle CSS loads", () => {
+    const result = runBootstrapTheme({
+      storedTheme: "dark",
+      systemPrefersDark: false,
+      storedPalette: "cream",
+    });
+
+    assert.equal(result.colorTheme, "cream");
+    assert.equal(result.datasetTheme, "dark");
+  });
+
+  it("leaves the palette attribute off for classic and unknown values", () => {
+    for (const storedPalette of ["classic", "sepia", null]) {
+      const result = runBootstrapTheme({
+        storedTheme: "light",
+        systemPrefersDark: false,
+        storedPalette,
+      });
+      assert.equal(result.colorTheme, undefined, `palette ${String(storedPalette)}`);
+    }
+  });
 });
 
 function storageLike(values: Map<string, string>): Pick<Storage, "getItem"> {
@@ -75,11 +103,19 @@ function storageLike(values: Map<string, string>): Pick<Storage, "getItem"> {
 function runBootstrapTheme({
   storedTheme,
   systemPrefersDark,
+  storedPalette = null,
 }: {
   storedTheme: string | null;
   systemPrefersDark: boolean;
-}): { classes: string[]; datasetTheme: string | undefined; colorScheme: string | undefined } {
+  storedPalette?: string | null;
+}): {
+  classes: string[];
+  datasetTheme: string | undefined;
+  colorScheme: string | undefined;
+  colorTheme: string | undefined;
+} {
   const classes = new Set<string>();
+  const attributes = new Map<string, string>();
   const root = {
     classList: {
       toggle(name: string, enabled: boolean): void {
@@ -90,6 +126,12 @@ function runBootstrapTheme({
         }
       },
     },
+    setAttribute(name: string, value: string): void {
+      attributes.set(name, value);
+    },
+    removeAttribute(name: string): void {
+      attributes.delete(name);
+    },
     dataset: {} as { theme?: string },
     style: {} as { colorScheme?: string },
   };
@@ -99,6 +141,9 @@ function runBootstrapTheme({
     window: {
       localStorage: {
         getItem(key: string): string | null {
+          if (key === CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY) {
+            return storedPalette;
+          }
           assert.equal(key, CLOUD_VIEWER_THEME_STORAGE_KEY);
           return storedTheme;
         },
@@ -114,5 +159,6 @@ function runBootstrapTheme({
     classes: Array.from(classes).sort(),
     datasetTheme: root.dataset.theme,
     colorScheme: root.style.colorScheme,
+    colorTheme: attributes.get("data-color-theme"),
   };
 }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -8,11 +8,13 @@ import {
   Plus,
   RotateCcw,
   Search,
+  Settings,
   Sparkles,
 } from "lucide-react";
 // Not the `@/components/notebook` barrel: it pulls the notebook route into this
 // chunk and collapses the notebook-route CSS split `copy-viewer-assets` needs.
 import { NotebookAccountMenu } from "@/components/notebook/NotebookAccountMenu";
+import { NotebookSettingsDrawer } from "@/components/notebook/NotebookSettingsDrawer";
 import type { NotebookActorIdentity } from "@/components/notebook/capabilities";
 import { Button } from "@/components/ui/button";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -25,6 +27,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { useColorThemePreference } from "@/hooks/useColorThemePreference";
 import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
@@ -69,7 +72,11 @@ import {
   readCachedCloudNotebookList,
   writeCachedCloudNotebookList,
 } from "./notebook-list-cache";
-import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
+import {
+  applyDocumentTheme,
+  CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+  CLOUD_VIEWER_THEME_STORAGE_KEY,
+} from "./theme";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { preloadNotebookRoute } from "./notebook-route-preload";
 
@@ -85,7 +92,11 @@ export function CloudNotebookListView({
   appSessionWaitDeadlineMs,
   authConfig,
 }: CloudNotebookListViewProps) {
-  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { colorTheme, setColorTheme } = useColorThemePreference(
+    CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+  );
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const auth = useCloudAuthStore();
   const [bootstrap, setBootstrap] = useState<CloudNotebookListBootstrap | null>(() =>
     loadCloudNotebookListBootstrap(),
@@ -451,6 +462,10 @@ export function CloudNotebookListView({
                   detail={currentUserDisplay ?? headerDetail}
                   accountDetail={currentUserAccountDetail}
                 >
+                  <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
+                    <Settings aria-hidden="true" />
+                    Settings
+                  </DropdownMenuItem>
                   <DropdownMenuItem onSelect={signOut}>
                     <LogOut aria-hidden="true" />
                     Sign out
@@ -486,6 +501,31 @@ export function CloudNotebookListView({
           onTitleChange={setCreateTitle}
         />
       ) : null}
+      <NotebookSettingsDrawer
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        theme={theme}
+        onThemeChange={setTheme}
+        colorTheme={colorTheme}
+        onColorThemeChange={setColorTheme}
+        actor={signedIn ? currentUserActor : null}
+        accountDetail={currentUserAccountDetail}
+        accountActions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={() => {
+              setSettingsOpen(false);
+              signOut();
+            }}
+          >
+            <LogOut aria-hidden="true" />
+            Sign out
+          </Button>
+        }
+      />
 
       <section className="cloud-notebook-list-content" aria-label="Notebook list">
         {listState.kind === "loading" ? (

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -8,7 +8,17 @@ import {
   type ReactNode,
 } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { AlertCircle, Check, Info, Loader2, LogIn, LogOut, PanelLeftOpen, X } from "lucide-react";
+import {
+  AlertCircle,
+  Check,
+  Info,
+  Loader2,
+  LogIn,
+  LogOut,
+  PanelLeftOpen,
+  Settings,
+  X,
+} from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import {
   useHasIsolatedOutputs,
@@ -24,6 +34,8 @@ import {
 import {
   NotebookAccessGate,
   NotebookConnectionIdentity,
+  NotebookSettingsDrawer,
+  notebookToolbarActors,
   NotebookCommentsPanel,
   NotebookDocumentToolbar,
   navigateNotebookOutlineItem,
@@ -55,6 +67,7 @@ import {
   type NotebookCommentDraftTarget,
 } from "@/components/notebook";
 import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate";
+import { Button } from "@/components/ui/button";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
   openNotebookRailPanel,
@@ -67,6 +80,7 @@ import {
   useDemoteDetachedOutputCommentThreads,
 } from "@/components/notebook/output-comment-demotion";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
+import { useColorThemePreference } from "@/hooks/useColorThemePreference";
 import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
 import {
@@ -152,7 +166,11 @@ import {
   cloudNotebookSyncScopeForCatalogAccess,
   createCloudNotebookCatalogAccessLoader,
 } from "./cloud-notebook-catalog-access";
-import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
+import {
+  applyDocumentTheme,
+  CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+  CLOUD_VIEWER_THEME_STORAGE_KEY,
+} from "./theme";
 import { replaceCloudNotebookModeInCurrentUrl } from "./cloud-notebook-mode";
 import {
   CloudAccessFactsStore,
@@ -267,7 +285,11 @@ export function NotebookViewer({
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
-  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { colorTheme, setColorTheme } = useColorThemePreference(
+    CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+  );
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const commentsUiEnabled = config.featureFlags?.enable_comments === true;
   const { store: widgetStore } = useWidgetStoreRequired();
   // Selected interaction mode and the user's edit-access request are owned by the
@@ -1741,10 +1763,16 @@ export function NotebookViewer({
             connectionStatus$={connectionStatus$}
             accountDetail={authState.oidcClaims?.email?.trim() ?? null}
             accountActions={
-              <DropdownMenuItem onSelect={signOutOfNotebook}>
-                <LogOut aria-hidden="true" />
-                Sign out
-              </DropdownMenuItem>
+              <>
+                <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
+                  <Settings aria-hidden="true" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={signOutOfNotebook}>
+                  <LogOut aria-hidden="true" />
+                  Sign out
+                </DropdownMenuItem>
+              </>
             }
           />
         ) : null
@@ -1969,6 +1997,31 @@ export function NotebookViewer({
           onCancel={handleCancelSourceComment}
         />
       ) : null}
+      <NotebookSettingsDrawer
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        theme={theme}
+        onThemeChange={setTheme}
+        colorTheme={colorTheme}
+        onColorThemeChange={setColorTheme}
+        actor={notebookToolbarActors(shellCapabilities)[0] ?? null}
+        accountDetail={authState.oidcClaims?.email?.trim() ?? null}
+        accountActions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={() => {
+              setSettingsOpen(false);
+              signOutOfNotebook();
+            }}
+          >
+            <LogOut aria-hidden="true" />
+            Sign out
+          </Button>
+        }
+      />
     </NotebookHostProvider>
   );
 }

--- a/apps/notebook-cloud/viewer/theme.ts
+++ b/apps/notebook-cloud/viewer/theme.ts
@@ -1,5 +1,8 @@
 import { CLOUD_VIEWER_THEME_STORAGE_KEY } from "../src/viewer-theme-bootstrap.ts";
-export { CLOUD_VIEWER_THEME_STORAGE_KEY } from "../src/viewer-theme-bootstrap.ts";
+export {
+  CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
+  CLOUD_VIEWER_THEME_STORAGE_KEY,
+} from "../src/viewer-theme-bootstrap.ts";
 
 export type CloudViewerThemeMode = "light" | "dark" | "system";
 export type ResolvedCloudViewerTheme = "light" | "dark";

--- a/src/components/notebook/NotebookAccountMenu.tsx
+++ b/src/components/notebook/NotebookAccountMenu.tsx
@@ -10,9 +10,6 @@ import {
 import { NotebookActorAvatar } from "./NotebookIdentity";
 import type { NotebookActorIdentity } from "./capabilities";
 
-// The hover surface stays rounded-md (never a pill), but the focus ring hugs
-// the circular avatar instead of this box — so it is drawn on the Avatar via
-// `group-focus-visible:` rather than on the trigger.
 export const NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS =
   "group inline-flex h-8 shrink-0 items-center justify-center rounded-md px-0.5 text-foreground transition-colors hover:bg-muted/60 focus-visible:outline-none";
 
@@ -55,7 +52,7 @@ export function NotebookAccountMenu({
         <span aria-hidden="true">
           <NotebookActorAvatar
             actor={actor}
-            className="border-0 ring-ring ring-offset-1 ring-offset-background group-focus-visible:ring-2"
+            className="border-0 ring-ring group-focus-visible:ring-1"
             size="default"
             showStatus={showStatus}
             statusClassName={statusClassName}

--- a/src/components/notebook/NotebookSettingsDrawer.tsx
+++ b/src/components/notebook/NotebookSettingsDrawer.tsx
@@ -1,0 +1,201 @@
+import { Monitor, Moon, Sun, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import type { ColorTheme } from "@/bindings";
+import type { ThemeMode } from "@/hooks/useTheme";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { NotebookActorAvatar } from "./NotebookIdentity";
+import type { NotebookActorIdentity } from "./capabilities";
+
+export interface NotebookSettingsDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+  colorTheme?: ColorTheme;
+  onColorThemeChange?: (colorTheme: ColorTheme) => void;
+  actor?: NotebookActorIdentity | null;
+  accountDetail?: string | null;
+  accountActions?: ReactNode;
+  className?: string;
+}
+
+const themeOptions: Array<{ value: ThemeMode; label: string; icon: LucideIcon }> = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
+const colorThemeOptions: Array<{ value: ColorTheme; label: string }> = [
+  { value: "classic", label: "Classic" },
+  { value: "cream", label: "Cream" },
+];
+
+export function NotebookSettingsDrawer({
+  open,
+  onOpenChange,
+  theme,
+  onThemeChange,
+  colorTheme,
+  onColorThemeChange,
+  actor,
+  accountDetail,
+  accountActions,
+  className,
+}: NotebookSettingsDrawerProps) {
+  const showPalette = Boolean(colorTheme && onColorThemeChange);
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className={cn("w-full gap-0 sm:max-w-md", className)}
+        data-slot="notebook-settings-drawer"
+      >
+        <SheetHeader className="border-b">
+          <SheetTitle>Settings</SheetTitle>
+          <SheetDescription>
+            Preferences for this browser. Notebook content is unaffected.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-4">
+          <NotebookSettingsSection
+            title="Appearance"
+            description="Applies to every notebook you open in this browser."
+          >
+            <div
+              role="radiogroup"
+              aria-label="Theme"
+              className="grid grid-cols-3 gap-2"
+              data-slot="notebook-settings-theme"
+            >
+              {themeOptions.map((option) => {
+                const Icon = option.icon;
+                return (
+                  <NotebookSettingsOption
+                    key={option.value}
+                    label={option.label}
+                    selected={theme === option.value}
+                    onSelect={() => onThemeChange(option.value)}
+                    data-slot="notebook-settings-theme-option"
+                    data-theme-value={option.value}
+                  >
+                    <Icon className="size-4" aria-hidden="true" />
+                  </NotebookSettingsOption>
+                );
+              })}
+            </div>
+
+            {showPalette ? (
+              <div className="flex flex-col gap-2">
+                <span className="text-xs text-muted-foreground">Theme</span>
+                <div
+                  role="radiogroup"
+                  aria-label="Theme"
+                  className="grid grid-cols-2 gap-2"
+                  data-slot="notebook-settings-theme"
+                >
+                  {colorThemeOptions.map((option) => (
+                    <NotebookSettingsOption
+                      key={option.value}
+                      label={option.label}
+                      selected={colorTheme === option.value}
+                      onSelect={() => onColorThemeChange?.(option.value)}
+                      data-slot="notebook-settings-palette-option"
+                      data-color-theme-value={option.value}
+                    >
+                      <span
+                        aria-hidden="true"
+                        data-color-theme={option.value === "classic" ? undefined : option.value}
+                        className="size-4 rounded-full border border-border bg-background"
+                      />
+                    </NotebookSettingsOption>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </NotebookSettingsSection>
+
+          {actor ? (
+            <NotebookSettingsSection title="Account">
+              <div className="flex min-w-0 items-center gap-3">
+                <span aria-hidden="true">
+                  <NotebookActorAvatar actor={actor} className="border-0" showStatus={false} />
+                </span>
+                <span className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {actor.label}
+                  </span>
+                  {accountDetail ? (
+                    <span className="truncate text-xs text-muted-foreground">{accountDetail}</span>
+                  ) : null}
+                </span>
+              </div>
+              {accountActions ? <div className="flex flex-col">{accountActions}</div> : null}
+            </NotebookSettingsSection>
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function NotebookSettingsOption({
+  label,
+  selected,
+  onSelect,
+  children,
+  ...props
+}: {
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+  children: ReactNode;
+} & Record<`data-${string}`, string | undefined>) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      data-selected={selected ? "true" : "false"}
+      onClick={onSelect}
+      className={cn(
+        "flex flex-col items-center gap-1.5 rounded-md border px-3 py-3 text-xs transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        selected
+          ? "border-primary/40 bg-muted font-medium text-foreground"
+          : "border-border text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+      )}
+      {...props}
+    >
+      {children}
+      {label}
+    </button>
+  );
+}
+
+function NotebookSettingsSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3" data-slot="notebook-settings-section">
+      <div className="flex flex-col gap-0.5">
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/components/notebook/__tests__/NotebookSettingsDrawer.test.tsx
+++ b/src/components/notebook/__tests__/NotebookSettingsDrawer.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookSettingsDrawer } from "../NotebookSettingsDrawer";
+import type { NotebookActorIdentity } from "../capabilities";
+
+function actor(overrides: Partial<NotebookActorIdentity> = {}): NotebookActorIdentity {
+  return {
+    id: "user:anaconda:leslie",
+    label: "Leslie D.",
+    detail: null,
+    kind: "human",
+    ...overrides,
+  };
+}
+
+function renderDrawer(props: Partial<Parameters<typeof NotebookSettingsDrawer>[0]> = {}) {
+  const onOpenChange = vi.fn();
+  const onThemeChange = vi.fn();
+  const onColorThemeChange = vi.fn();
+  const result = render(
+    <NotebookSettingsDrawer
+      open
+      onOpenChange={onOpenChange}
+      theme="system"
+      onThemeChange={onThemeChange}
+      colorTheme="classic"
+      onColorThemeChange={onColorThemeChange}
+      actor={actor()}
+      accountDetail="leslie@anaconda.com"
+      {...props}
+    />,
+  );
+  return { ...result, onOpenChange, onThemeChange, onColorThemeChange };
+}
+
+function themeOption(value: string): HTMLElement {
+  const element = document.querySelector<HTMLElement>(`[data-theme-value="${value}"]`);
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+function paletteOption(value: string): HTMLElement {
+  const element = document.querySelector<HTMLElement>(`[data-color-theme-value="${value}"]`);
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+describe("NotebookSettingsDrawer", () => {
+  it("renders as a right-side drawer", () => {
+    renderDrawer();
+    const content = document.querySelector('[data-slot="notebook-settings-drawer"]');
+    expect(content).not.toBeNull();
+    expect(content?.className).toContain("data-[state=open]:slide-in-from-right");
+    expect(content?.className).toContain("right-0");
+  });
+
+  it("renders nothing while closed", () => {
+    renderDrawer({ open: false });
+    expect(document.querySelector('[data-slot="notebook-settings-drawer"]')).toBeNull();
+  });
+
+  it("marks the current theme selected without resolving system to light or dark", () => {
+    renderDrawer({ theme: "system" });
+    expect(themeOption("system").getAttribute("aria-checked")).toBe("true");
+    expect(themeOption("light").getAttribute("aria-checked")).toBe("false");
+    expect(themeOption("dark").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("reports theme choices to the host instead of storing them locally", async () => {
+    const user = userEvent.setup();
+    const { onThemeChange } = renderDrawer({ theme: "system" });
+
+    await user.click(themeOption("dark"));
+    expect(onThemeChange).toHaveBeenCalledWith("dark");
+    expect(themeOption("system").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("marks the current palette selected independently of light/dark", () => {
+    renderDrawer({ theme: "dark", colorTheme: "cream" });
+    expect(paletteOption("cream").getAttribute("aria-checked")).toBe("true");
+    expect(paletteOption("classic").getAttribute("aria-checked")).toBe("false");
+    expect(themeOption("dark").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("reports palette choices to the host instead of storing them locally", async () => {
+    const user = userEvent.setup();
+    const { onColorThemeChange } = renderDrawer({ colorTheme: "classic" });
+
+    await user.click(paletteOption("cream"));
+    expect(onColorThemeChange).toHaveBeenCalledWith("cream");
+    expect(paletteOption("classic").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("omits the palette row on hosts with no palette writer", () => {
+    renderDrawer({ colorTheme: undefined, onColorThemeChange: undefined });
+    expect(document.querySelector("[data-color-theme-value]")).toBeNull();
+    expect(themeOption("system").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("scopes each palette swatch to the palette it previews", () => {
+    renderDrawer({ colorTheme: "classic" });
+    expect(paletteOption("cream").querySelector("[data-color-theme='cream']")).not.toBeNull();
+    expect(paletteOption("classic").querySelector("[data-color-theme]")).toBeNull();
+  });
+
+  it("shows the account identity read-only with host-owned actions", async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn();
+    renderDrawer({
+      accountActions: (
+        <button type="button" onClick={onSignOut}>
+          Sign out
+        </button>
+      ),
+    });
+
+    expect(screen.getByText("Leslie D.")).toBeTruthy();
+    expect(screen.getByText("leslie@anaconda.com")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the account section entirely when there is no identity", () => {
+    renderDrawer({ actor: null, accountDetail: null });
+    expect(screen.queryByText("Account")).toBeNull();
+    expect(screen.getByText("Appearance")).toBeTruthy();
+  });
+
+  it("drops the secondary line when an identity has no email", () => {
+    renderDrawer({ accountDetail: null });
+    expect(screen.getByText("Account")).toBeTruthy();
+    expect(screen.getByText("Leslie D.")).toBeTruthy();
+    expect(screen.queryByText("leslie@anaconda.com")).toBeNull();
+  });
+
+  it("keeps focus rings on the design-law treatment", () => {
+    renderDrawer();
+    const option = themeOption("light");
+    expect(option.className).toContain("focus-visible:ring-1");
+    expect(option.className).toContain("focus-visible:ring-ring");
+    expect(option.className).not.toContain("ring-offset");
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -191,6 +191,7 @@ export {
   NOTEBOOK_ACCOUNT_MENU_TRIGGER_CLASS,
   type NotebookAccountMenuProps,
 } from "./NotebookAccountMenu";
+export { NotebookSettingsDrawer, type NotebookSettingsDrawerProps } from "./NotebookSettingsDrawer";
 export {
   NotebookToolbarIdentity,
   notebookToolbarActors,

--- a/src/hooks/useColorThemePreference.ts
+++ b/src/hooks/useColorThemePreference.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ColorTheme } from "@/bindings";
+
+export function isValidColorTheme(value: string): value is ColorTheme {
+  return value === "classic" || value === "cream";
+}
+
+function getStoredColorTheme(storageKey: string): ColorTheme {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored && isValidColorTheme(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore
+  }
+  return "classic";
+}
+
+function applyColorThemeToDOM(colorTheme: ColorTheme) {
+  const html = document.documentElement;
+  if (colorTheme === "classic") {
+    html.removeAttribute("data-color-theme");
+  } else {
+    html.setAttribute("data-color-theme", colorTheme);
+  }
+}
+
+export function useColorThemePreference(storageKey: string) {
+  const [colorTheme, setColorThemeState] = useState<ColorTheme>(() =>
+    getStoredColorTheme(storageKey),
+  );
+
+  const setColorTheme = useCallback(
+    (next: ColorTheme) => {
+      setColorThemeState(next);
+      try {
+        localStorage.setItem(storageKey, next);
+      } catch {
+        // ignore
+      }
+    },
+    [storageKey],
+  );
+
+  useEffect(() => {
+    applyColorThemeToDOM(colorTheme);
+  }, [colorTheme]);
+
+  return { colorTheme, setColorTheme };
+}


### PR DESCRIPTION
Adds a settings drawer to the cloud notebook viewer so users can switch light/dark/system mode and color theme (classic/cream).
- New NotebookSettingsDrawer component, wired into the account menu
- New useColorThemePreference hook to persist the color theme choice
- Cloud viewer bootstraps the saved theme on load (viewer-theme-bootstrap.ts)
- Elements docs/example page for the new drawer
- Tests for the drawer and viewer theme bootstrap

https://github.com/user-attachments/assets/889da6aa-1a67-43f8-a79d-648e7771b215


