### PR TITLE
feat(notebook): use daemon output document in browser host

### DIFF
--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -31,6 +31,7 @@ Host-platform side effects (Tauri IPC, plugin calls, window chrome) flow through
 | `host.daemon` | `isConnected`, `reconnect`, `getInfo`, `getReadyInfo`, optional `autoReconnect` (backoff + terminal failed-load latch) |
 | `host.daemonEvents` | `onReady` / `onProgress` / `onDisconnected` / `onUnavailable` |
 | `host.relay` | `notifySyncReady()` outbound signal |
+| `host.outputDocumentUrl` | Optional host-supplied isolated output document URL |
 | `host.blobs` | `port()` — daemon blob-server HTTP port |
 | `host.trust` | `verify()` / `approve()` |
 | `host.deps` | Dependency validation (`checkTyposquats`) |

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -137,6 +137,7 @@ import { useNotebookActionPolicy } from "./lib/notebook-action-policy";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { hostedNotebookWindowTitle } from "./lib/hosted-notebook-url";
+import { useOutputHostContext } from "./lib/output-host-context";
 import { fileSourceIssueNotice, notebookDocumentIsDirty } from "./lib/notebook-file-state";
 import {
   attachExecutionPerformanceId,
@@ -315,6 +316,7 @@ function resolveCommOutputs(
 
 function AppContent() {
   const host = useNotebookHost();
+  const outputHostContext = useOutputHostContext(host);
   const blobUploader = useMemo<BlobUploader>(
     () => (bytes, mediaType, durability) => putBlob(host.transport, bytes, mediaType, durability),
     [host],
@@ -2270,6 +2272,7 @@ function AppContent() {
                   commentThreadsByCell={commentsUiEnabled ? sourceCommentThreadsByCell : undefined}
                   pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                   markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
+                  outputHostContext={outputHostContext}
                 />
               </BokehSessionRuntimeProvider>
             </CrdtBridgeProvider>

--- a/apps/notebook/src/lib/__tests__/output-host-context.test.ts
+++ b/apps/notebook/src/lib/__tests__/output-host-context.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vite-plus/test";
+import { act, renderHook } from "@testing-library/react";
+import type { NotebookHost } from "@nteract/notebook-host";
+import { createOutputHostContext, useOutputHostContext } from "../output-host-context";
+
+describe("createOutputHostContext", () => {
+  it("projects a host-supplied output document URL into renderer context", () => {
+    expect(createOutputHostContext(" http://127.0.0.1:48123/output-frame ")).toEqual({
+      nteract: { outputDocumentUrl: "http://127.0.0.1:48123/output-frame" },
+    });
+  });
+
+  it("leaves browser rendering on its srcDoc fallback without a URL", () => {
+    expect(createOutputHostContext(null)).toBeUndefined();
+  });
+
+  it("refreshes renderer context when relay ready changes the host URL", () => {
+    let outputDocumentUrl: string | null = null;
+    let ready: (() => void) | null = null;
+    const host = {
+      get outputDocumentUrl() {
+        return outputDocumentUrl;
+      },
+      daemonEvents: {
+        onReady(callback: () => void) {
+          ready = callback;
+          return () => {
+            ready = null;
+          };
+        },
+      },
+    } as unknown as NotebookHost;
+
+    const { result } = renderHook(() => useOutputHostContext(host));
+    expect(result.current).toBeUndefined();
+
+    act(() => {
+      outputDocumentUrl = "http://127.0.0.1:49152/output-frame";
+      ready?.();
+    });
+    expect(result.current).toEqual({
+      nteract: { outputDocumentUrl: "http://127.0.0.1:49152/output-frame" },
+    });
+  });
+});

--- a/apps/notebook/src/lib/output-host-context.ts
+++ b/apps/notebook/src/lib/output-host-context.ts
@@ -1,0 +1,27 @@
+import { useEffect, useMemo, useState } from "react";
+import type { NotebookHost } from "@nteract/notebook-host";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+
+export function createOutputHostContext(
+  outputDocumentUrl: string | null,
+): NteractEmbedHostContextPatch | undefined {
+  const documentUrl = outputDocumentUrl?.trim();
+  if (!documentUrl) return undefined;
+  return { nteract: { outputDocumentUrl: documentUrl } };
+}
+
+/** Keep the renderer context aligned with relay-ready blob-port changes. */
+export function useOutputHostContext(
+  host: NotebookHost,
+): NteractEmbedHostContextPatch | undefined {
+  const [outputDocumentUrl, setOutputDocumentUrl] = useState(host.outputDocumentUrl ?? null);
+
+  useEffect(() => {
+    setOutputDocumentUrl(host.outputDocumentUrl ?? null);
+    return host.daemonEvents.onReady(() => {
+      setOutputDocumentUrl(host.outputDocumentUrl ?? null);
+    });
+  }, [host]);
+
+  return useMemo(() => createOutputHostContext(outputDocumentUrl), [outputDocumentUrl]);
+}

--- a/docs/memos/host-neutral-notebook-web-artifacts.md
+++ b/docs/memos/host-neutral-notebook-web-artifacts.md
@@ -42,9 +42,13 @@ package it as a separate release asset. The archive carries:
 - `SHA256SUMS`, covering the payload and manifest.
 
 The daemon continues to embed and serve the isolated-output renderer plugins it
-already owns. The manifest records that division explicitly. An embedding host
-serves the archive from its own isolated origin, supplies the browser relay, and
-refuses a daemon whose source revision differs.
+already owns. It also serves the canonical isolated output document from the
+blob server's `/output-frame` route with output-specific CSP headers. The
+manifest records that division explicitly. An embedding host serves the archive
+from its own isolated origin, supplies the browser relay, and refuses a daemon
+whose source revision differs. The browser host derives `outputDocumentUrl`
+from the relay's current blob port and passes it through `NotebookHost`; until a
+blob port is available, browser rendering keeps the existing `srcDoc` fallback.
 
 ## Proposed first-pass contract
 
@@ -57,10 +61,16 @@ versions, missing runtime WASM, unsafe file paths, and payload checksum drift.
 They may allow an unstamped local development daemon, but a stamped source
 revision mismatch fails closed before notebook traffic is relayed.
 
+Hosts remain responsible for making the daemon blob server reachable from the
+browser without proxying `/output-frame` through the notebook application
+origin, allowing the loopback frame URL in the application CSP, and preserving
+the iframe sandbox without `allow-same-origin`.
+
 ## Adoption sequence
 
 - Validate a locally built archive and matching daemon by exercising one synced
-  cell through a packaged host and observing its output.
+  rich-output cell through a packaged host, observing its output, and confirming
+  the isolated frame uses the daemon `/output-frame` URL rather than `srcDoc`.
 - Consume the versioned release asset and daemon from one tag, retain
   integrity/version checks, and document installer ownership. Release
   publication and signing remain separate operational gates.

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -504,6 +504,9 @@ export async function createBrowserHost(
 
   return {
     name: "browser",
+    get outputDocumentUrl() {
+      return blobPort === null ? null : `http://127.0.0.1:${blobPort}/output-frame`;
+    },
     transport,
     daemon: {
       async isConnected() {

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -438,6 +438,13 @@ export interface HostSettings {
  */
 export interface NotebookHost {
   readonly name: "tauri" | "electron" | "browser" | (string & {});
+  /**
+   * Optional host-supplied isolated output document. Browser hosts can expose
+   * the daemon blob server's CSP-scoped frame shell; other hosts keep their
+   * existing frame source. Browser values may change after a relay-ready event
+   * reports the current blob port.
+   */
+  readonly outputDocumentUrl?: string | null;
   readonly transport: NotebookTransport;
   readonly daemon: HostDaemon;
   readonly daemonEvents: HostDaemonEvents;

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -78,6 +78,7 @@ describe("createBrowserHost()", () => {
 
     const ws = FakeWebSocket.instances[0];
     expect(ws.url).toContain("token=dev-token");
+    expect(host.outputDocumentUrl).toBe("http://127.0.0.1:48123/output-frame");
 
     const ready = vi.fn();
     host.daemonEvents.onReady(ready);
@@ -110,6 +111,31 @@ describe("createBrowserHost()", () => {
       "http://127.0.0.1:48124/blob/abc123",
     );
     await expect(host.daemon.getReadyInfo()).resolves.toMatchObject({ notebook_id: "nb-1" });
+    expect(host.outputDocumentUrl).toBe("http://127.0.0.1:48124/output-frame");
+  });
+
+  it("keeps output documents optional until the relay reports a blob port", async () => {
+    FakeWebSocket.instances = [];
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ...config, blob_port: null }),
+    })) as unknown as typeof fetch;
+    const host = await createBrowserHost({
+      fetchImpl,
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+
+    expect(host.outputDocumentUrl).toBeNull();
+    ws.open();
+    ws.message(
+      JSON.stringify({
+        type: "ready",
+        payload: { notebook_id: "nb-1" },
+        blob_port: 49152,
+      }),
+    );
+    expect(host.outputDocumentUrl).toBe("http://127.0.0.1:49152/output-frame");
   });
 
   it("buffers daemon frames until the relay is marked ready", async () => {


### PR DESCRIPTION
## Summary

- expose an optional live `NotebookHost.outputDocumentUrl` from the browser host
- derive the URL from the relay's current daemon blob port
- pass the host value through `NotebookView.outputHostContext`
- retain the existing `srcDoc` fallback until a blob port is available

## Motivation

Browser embedding hosts may serve the notebook application under a restrictive parent Content Security Policy. The `srcdoc` output-frame fallback inherits that policy, which can block the isolated frame's inline bootstrap and dynamic renderer-plugin installation.

runtimed already serves the canonical sandboxed output shell at `http://127.0.0.1:<blob_port>/output-frame` with output-specific CSP headers. Reusing that document keeps renderer execution off the notebook application origin and avoids packaging a duplicate shell.

The iframe sandbox remains unchanged and continues to omit `allow-same-origin`. Embedding hosts remain responsible for allowing the daemon output-frame URL in their `frame-src` policy.

## Verification

- focused notebook-host and output-context tests
- notebook and notebook-cloud TypeScript checks
- runtimed `/output-frame` route test
- `cargo xtask lint --fix`

## Stack

This draft is stacked on #4132 so the host-neutral artifact memo documents the complete browser embedding contract. It can be rebased onto `main` after that PR lands.
