### PR TITLE
feat(node): read durable cell outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -843,8 +843,16 @@ jobs:
       - name: Build runtimed-node N-API package
         run: pnpm --dir packages/runtimed-node build:debug
 
+      - name: Build runtimed daemon for native session integration
+        run: cargo build -p runtimed
+
       - name: Test runtimed-node Arrow IPC native integration
         run: vp test run packages/runtimed-node/tests/arrow-ipc.test.ts
+        env:
+          RUNTIMED_NODE_NATIVE_INTEGRATION: "1"
+
+      - name: Test runtimed-node native session integration
+        run: vp test run packages/runtimed-node/tests/session-native.test.ts
         env:
           RUNTIMED_NODE_NATIVE_INTEGRATION: "1"
 

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -116,6 +116,14 @@ pub struct SnapshotPairBytes {
     pub comments_doc_heads: Vec<String>,
 }
 
+/// One cell's durable output manifests and the widget state needed to resolve
+/// them, captured from a single shared-document snapshot.
+#[derive(Clone, Debug)]
+pub struct CellOutputsSnapshot {
+    pub outputs: Vec<serde_json::Value>,
+    pub runtime_state: RuntimeState,
+}
+
 impl std::fmt::Debug for DocHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DocHandle")
@@ -182,14 +190,7 @@ impl DocHandle {
     /// owns mutable widget state; this returns the client-facing projection.
     pub fn get_runtime_state(&self) -> Result<RuntimeState, SyncError> {
         let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
-        let mut runtime_state = state.state_doc.read_state();
-        let comm_states = state.comms_doc.get_comms();
-        for (comm_id, comm_state) in comm_states {
-            if let Some(entry) = runtime_state.comms.get_mut(&comm_id) {
-                entry.state = comm_state;
-            }
-        }
-        Ok(runtime_state)
+        Ok(project_runtime_state(&state))
     }
 
     // =====================================================================
@@ -556,6 +557,42 @@ impl DocHandle {
         } else {
             Some(outputs)
         }
+    }
+
+    /// Capture a cell's output manifests and projected widget state atomically.
+    ///
+    /// Unlike [`Self::get_cell_outputs`], this distinguishes a missing cell
+    /// (`None`) from an existing cell without outputs (`Some` with an empty
+    /// output list). Cell existence, its execution pointer, RuntimeStateDoc,
+    /// and CommsDoc are read while holding the same shared-state lock so output
+    /// resolution cannot combine unrelated document snapshots.
+    pub fn get_cell_outputs_snapshot(
+        &self,
+        cell_id: &str,
+    ) -> Result<Option<CellOutputsSnapshot>, SyncError> {
+        let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        let Some((_, cells_id)) = state
+            .doc
+            .get(&automerge::ROOT, "cells")
+            .map_err(SyncError::Automerge)?
+        else {
+            return Ok(None);
+        };
+        if state
+            .doc
+            .get(&cells_id, cell_id)
+            .map_err(SyncError::Automerge)?
+            .is_none()
+        {
+            return Ok(None);
+        }
+        let outputs = read_execution_id(&state.doc, cell_id)
+            .map(|execution_id| state.state_doc.get_outputs(&execution_id))
+            .unwrap_or_default();
+        Ok(Some(CellOutputsSnapshot {
+            outputs,
+            runtime_state: project_runtime_state(&state),
+        }))
     }
 
     /// Get a single cell's current execution pointer.
@@ -1205,6 +1242,16 @@ fn document_contains_heads(
     Ok(true)
 }
 
+fn project_runtime_state(state: &SharedDocState) -> RuntimeState {
+    let mut runtime_state = state.state_doc.read_state();
+    for (comm_id, comm_state) in state.comms_doc.get_comms() {
+        if let Some(entry) = runtime_state.comms.get_mut(&comm_id) {
+            entry.state = comm_state;
+        }
+    }
+    runtime_state
+}
+
 /// Read the execution_id for a cell directly from a raw AutoCommit document.
 fn read_execution_id(doc: &AutoCommit, cell_id: &str) -> Option<String> {
     let (_, cells_id) = doc.get(&automerge::ROOT, "cells").ok().flatten()?;
@@ -1312,6 +1359,50 @@ mod tests {
 
         let replacement = test_handle();
         assert!(!replacement.contains_notebook_heads(&required).unwrap());
+    }
+
+    #[test]
+    fn cell_output_snapshot_distinguishes_missing_empty_and_durable_outputs() {
+        let handle = test_handle();
+        assert!(handle
+            .get_cell_outputs_snapshot("missing")
+            .unwrap()
+            .is_none());
+
+        handle
+            .with_doc(|doc| {
+                let mut notebook = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                notebook.add_cell_after("cell-1", "code", None)?;
+                *doc = notebook.into_inner();
+                Ok::<_, automerge::AutomergeError>(())
+            })
+            .unwrap()
+            .unwrap();
+        let empty = handle
+            .get_cell_outputs_snapshot("cell-1")
+            .unwrap()
+            .expect("existing cell");
+        assert!(empty.outputs.is_empty());
+
+        let manifest = serde_json::json!({
+            "output_id": "out-1",
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "42\n"
+        });
+        {
+            let mut state = handle.doc.lock().unwrap();
+            let mut notebook = notebook_doc::NotebookDoc::wrap(std::mem::take(&mut state.doc));
+            notebook.set_execution_id("cell-1", Some("exec-1")).unwrap();
+            state.doc = notebook.into_inner();
+            state.state_doc.create_execution("exec-1").unwrap();
+            state.state_doc.append_output("exec-1", &manifest).unwrap();
+        }
+        let durable = handle
+            .get_cell_outputs_snapshot("cell-1")
+            .unwrap()
+            .expect("existing cell");
+        assert_eq!(durable.outputs, vec![manifest]);
     }
 
     #[tokio::test]

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -30,7 +30,8 @@ use runtime_doc::{diff_executions, ExecutionViewProjector, ProjectContext, Proje
 const VALID_CELL_TYPES: &[&str] = &["code", "markdown", "raw"];
 
 type CommMap = std::collections::HashMap<String, runtime_doc::CommDocEntry>;
-type JsonCallback = ThreadsafeFunction<String, (), (String,), napi::Status, false, false, 0>;
+type JsonCallback =
+    ThreadsafeFunction<String, (), FnArgs<(String,)>, napi::Status, false, false, 0>;
 
 /// Stable JSON contract for `Session.sessionStatus$`.
 ///
@@ -521,7 +522,7 @@ fn json_callback(callback: Function<'_, (String,), ()>) -> Result<JsonCallback> 
     callback
         .build_threadsafe_function::<String>()
         .callee_handled::<false>()
-        .build_callback(|ctx| Ok((ctx.value,)))
+        .build_callback(|ctx| Ok(FnArgs::from((ctx.value,))))
 }
 
 fn emit_json<T: Serialize>(callback: &JsonCallback, value: &T) {

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -997,27 +997,29 @@ impl Session {
     /// does not exist and an empty array when it exists without outputs.
     #[napi]
     pub async fn get_cell_outputs(&self, cell_id: String) -> Result<Option<Vec<JsOutput>>> {
-        let (handle, blob_base_url, blob_store_path) = {
+        let (snapshot, blob_base_url, blob_store_path) = {
             let st = self.state.lock().await;
+            let handle = st
+                .handle
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Not connected"))?;
+            let snapshot = handle
+                .get_cell_outputs_snapshot(&cell_id)
+                .map_err(to_napi_err)?;
             (
-                st.handle
-                    .as_ref()
-                    .ok_or_else(|| Error::from_reason("Not connected"))?
-                    .clone(),
+                snapshot,
                 st.blob_base_url.clone(),
                 st.blob_store_path.clone(),
             )
         };
-        if handle.get_cell(&cell_id).is_none() {
+        let Some(snapshot) = snapshot else {
             return Ok(None);
-        }
-        let output_manifests = handle.get_cell_outputs(&cell_id).unwrap_or_default();
-        let comms = handle.get_runtime_state().ok().map(|state| state.comms);
+        };
         let resolved = shared_resolver::resolve_cell_outputs(
-            &output_manifests,
+            &snapshot.outputs,
             &blob_base_url,
             &blob_store_path,
-            comms.as_ref(),
+            Some(&snapshot.runtime_state.comms),
         )
         .await;
         let outputs = resolved

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -992,6 +992,41 @@ impl Session {
         Ok(handle.get_cell(&cell_id).map(js_cell_from_snapshot))
     }
 
+    /// Return one cell's durable outputs, resolved through the same blob and
+    /// widget-aware path used by execution results. Returns null when the cell
+    /// does not exist and an empty array when it exists without outputs.
+    #[napi]
+    pub async fn get_cell_outputs(&self, cell_id: String) -> Result<Option<Vec<JsOutput>>> {
+        let (handle, blob_base_url, blob_store_path) = {
+            let st = self.state.lock().await;
+            (
+                st.handle
+                    .as_ref()
+                    .ok_or_else(|| Error::from_reason("Not connected"))?
+                    .clone(),
+                st.blob_base_url.clone(),
+                st.blob_store_path.clone(),
+            )
+        };
+        if handle.get_cell(&cell_id).is_none() {
+            return Ok(None);
+        }
+        let output_manifests = handle.get_cell_outputs(&cell_id).unwrap_or_default();
+        let comms = handle.get_runtime_state().ok().map(|state| state.comms);
+        let resolved = shared_resolver::resolve_cell_outputs(
+            &output_manifests,
+            &blob_base_url,
+            &blob_store_path,
+            comms.as_ref(),
+        )
+        .await;
+        let outputs = resolved
+            .into_iter()
+            .map(to_js_output)
+            .collect::<napi::Result<Vec<_>>>()?;
+        Ok(Some(outputs))
+    }
+
     /// Create a cell without executing it. Returns the new cell ID.
     #[napi]
     pub async fn create_cell(

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -15,7 +15,10 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
-use notebook_sync::{BroadcastReceiver, DocHandle};
+use notebook_sync::{
+    BroadcastReceiver, ConnectionState, DocHandle, InitialLoadPhase, NotebookDocPhase,
+    RuntimeStatePhase, SyncStatus,
+};
 use runtimed_client::client::PoolClient;
 use runtimed_outputs::output_resolver as shared_resolver;
 use runtimed_outputs::resolved_output::DataValue as SharedDataValue;
@@ -28,6 +31,55 @@ const VALID_CELL_TYPES: &[&str] = &["code", "markdown", "raw"];
 
 type CommMap = std::collections::HashMap<String, runtime_doc::CommDocEntry>;
 type JsonCallback = ThreadsafeFunction<String, (), (String,), napi::Status, false, false, 0>;
+
+/// Stable JSON contract for `Session.sessionStatus$`.
+///
+/// `notebook_sync::SyncStatus` is an internal Rust type whose default Serde
+/// representation uses Rust enum variant names. Keep that representation out
+/// of the JavaScript API and mirror the browser session-status wire shape here.
+#[derive(Serialize)]
+struct SessionStatusJson<'a> {
+    connection: &'static str,
+    notebook_doc: &'static str,
+    runtime_state: &'static str,
+    initial_load: InitialLoadPhaseJson<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+enum InitialLoadPhaseJson<'a> {
+    NotNeeded,
+    Streaming,
+    Ready,
+    Failed { reason: &'a str },
+}
+
+impl<'a> From<&'a SyncStatus> for SessionStatusJson<'a> {
+    fn from(status: &'a SyncStatus) -> Self {
+        Self {
+            connection: match status.connection {
+                ConnectionState::Connected => "connected",
+                ConnectionState::Disconnected => "disconnected",
+            },
+            notebook_doc: match status.notebook_doc {
+                NotebookDocPhase::Pending => "pending",
+                NotebookDocPhase::Syncing => "syncing",
+                NotebookDocPhase::Interactive => "interactive",
+            },
+            runtime_state: match status.runtime_state {
+                RuntimeStatePhase::Pending => "pending",
+                RuntimeStatePhase::Syncing => "syncing",
+                RuntimeStatePhase::Ready => "ready",
+            },
+            initial_load: match &status.initial_load {
+                InitialLoadPhase::NotNeeded => InitialLoadPhaseJson::NotNeeded,
+                InitialLoadPhase::Streaming => InitialLoadPhaseJson::Streaming,
+                InitialLoadPhase::Ready => InitialLoadPhaseJson::Ready,
+                InitialLoadPhase::Failed { reason } => InitialLoadPhaseJson::Failed { reason },
+            },
+        }
+    }
+}
 
 // ── Options ────────────────────────────────────────────────────────────
 
@@ -730,9 +782,9 @@ impl Session {
         let mut rx = handle.subscribe_status();
         let tsfn = json_callback(callback)?;
         let task = spawn_event_task(async move {
-            emit_json(&tsfn, &*rx.borrow_and_update());
+            emit_json(&tsfn, &SessionStatusJson::from(&*rx.borrow_and_update()));
             while rx.changed().await.is_ok() {
-                emit_json(&tsfn, &*rx.borrow_and_update());
+                emit_json(&tsfn, &SessionStatusJson::from(&*rx.borrow_and_update()));
             }
         });
         Ok(EventSubscription::new(task))
@@ -2284,6 +2336,31 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
     use std::path::Path;
+
+    #[test]
+    fn session_status_json_matches_the_javascript_contract() {
+        let status = SyncStatus {
+            connection: ConnectionState::Disconnected,
+            notebook_doc: NotebookDocPhase::Interactive,
+            runtime_state: RuntimeStatePhase::Ready,
+            initial_load: InitialLoadPhase::Failed {
+                reason: "daemon connection closed".to_string(),
+            },
+        };
+
+        assert_eq!(
+            serde_json::to_value(SessionStatusJson::from(&status)).unwrap(),
+            json!({
+                "connection": "disconnected",
+                "notebook_doc": "interactive",
+                "runtime_state": "ready",
+                "initial_load": {
+                    "phase": "failed",
+                    "reason": "daemon connection closed"
+                }
+            }),
+        );
+    }
 
     #[test]
     fn resolve_socket_path_prefers_explicit_override() {

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -242,7 +242,9 @@ sessions.
 - `Session.runtimeState$`, `Session.executionTransitions$`,
   `Session.executionViewChanges$`, `Session.cellChanges$`, `Session.broadcasts$`,
   and `Session.sessionStatus$` expose the same projected event families used by
-  the browser sync engine.
+  the browser sync engine. `sessionStatus$` includes the native connection state,
+  so long-lived hosts can discard a session after it reports `disconnected`
+  instead of mutating a detached local document.
 - `Session.getExecutionView()` returns the current materialized execution view:
   non-null notebook cell pointers, execution snapshots keyed by `execution_id`,
   and the execution-ID-first queue projection. Use this for status surfaces;

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -192,6 +192,8 @@ sessions.
 - `shutdownNotebook(notebookId, options)` shuts down a notebook room by ID.
 - `getExecutionResult(executionId, options)` reads a result by execution ID.
 - `Session.listCells()` and `Session.getCell(cellId)` inspect notebook cells.
+  `Session.getCellOutputs(cellId)` reads that cell's durable outputs with blob
+  and widget references resolved, returning `null` when the cell is absent.
 - `Session.createCell(source, options)`, `Session.setCell(cellId, options)`,
   `Session.deleteCell(cellId)`, and `Session.moveCell(cellId, options)` provide
   direct notebook editing without MCP JSON round-trips. `createCell()` appends

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -213,7 +213,9 @@ sessions.
 - `Session.runtimeState$`, `Session.executionTransitions$`,
   `Session.executionViewChanges$`, `Session.cellChanges$`, `Session.broadcasts$`,
   and `Session.sessionStatus$` expose the same projected event families used by
-  the browser sync engine.
+  the browser sync engine. `sessionStatus$` includes the native connection state,
+  so long-lived hosts can discard a session after it reports `disconnected`
+  instead of mutating a detached local document.
 - `Session.getExecutionView()` returns the current materialized execution view:
   non-null notebook cell pointers, execution snapshots keyed by `execution_id`,
   and the execution-ID-first queue projection. Use this for status surfaces;

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -243,7 +243,8 @@ sessions.
   `Session.executionViewChanges$`, `Session.cellChanges$`, `Session.broadcasts$`,
   and `Session.sessionStatus$` expose the same projected event families used by
   the browser sync engine. `sessionStatus$` includes the native connection state,
-  so long-lived hosts can discard a session after it reports `disconnected`
+  replays the current status to late subscribers, and lets long-lived hosts
+  discard a session after it reports `disconnected`
   instead of mutating a detached local document.
 - `Session.getExecutionView()` returns the current materialized execution view:
   non-null notebook cell pointers, execution snapshots keyed by `execution_id`,

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -221,6 +221,8 @@ sessions.
 - `shutdownNotebook(notebookId, options)` shuts down a notebook room by ID.
 - `getExecutionResult(executionId, options)` reads a result by execution ID.
 - `Session.listCells()` and `Session.getCell(cellId)` inspect notebook cells.
+  `Session.getCellOutputs(cellId)` reads that cell's durable outputs with blob
+  and widget references resolved, returning `null` when the cell is absent.
 - `Session.createCell(source, options)`, `Session.setCell(cellId, options)`,
   `Session.deleteCell(cellId)`, and `Session.moveCell(cellId, options)` provide
   direct notebook editing without MCP JSON round-trips. `createCell()` appends

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -214,7 +214,8 @@ sessions.
   `Session.executionViewChanges$`, `Session.cellChanges$`, `Session.broadcasts$`,
   and `Session.sessionStatus$` expose the same projected event families used by
   the browser sync engine. `sessionStatus$` includes the native connection state,
-  so long-lived hosts can discard a session after it reports `disconnected`
+  replays the current status to late subscribers, and lets long-lived hosts
+  discard a session after it reports `disconnected`
   instead of mutating a detached local document.
 - `Session.getExecutionView()` returns the current materialized execution view:
   non-null notebook cell pointers, execution snapshots keyed by `execution_id`,

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -249,6 +249,11 @@ export class Session {
   exportSnapshotPair(): Promise<SnapshotPair>;
   listCells(): Promise<CellSnapshot[]>;
   getCell(cellId: string): Promise<CellSnapshot | null>;
+  /**
+   * Return durable outputs for a cell, resolved through the session's blob and
+   * widget state. Returns null when the cell does not exist.
+   */
+  getCellOutputs(cellId: string): Promise<JsOutput[] | null>;
   createCell(source: string, options?: CreateCellOptions): Promise<string>;
   setCell(cellId: string, options: SetCellOptions): Promise<boolean>;
   deleteCell(cellId: string): Promise<boolean>;

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -13,6 +13,7 @@ export type {
 
 export type NotebookDocPhase = "pending" | "syncing" | "interactive";
 export type RuntimeStatePhase = "pending" | "syncing" | "ready";
+export type SessionConnectionState = "connected" | "disconnected";
 
 export type InitialLoadPhase =
   | { phase: "not_needed" }
@@ -21,6 +22,7 @@ export type InitialLoadPhase =
   | { phase: "failed"; reason: string };
 
 export interface SessionStatus {
+  connection: SessionConnectionState;
   notebook_doc: NotebookDocPhase;
   runtime_state: RuntimeStatePhase;
   initial_load: InitialLoadPhase;

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -1,6 +1,6 @@
 "use strict";
 
-const { Subject } = require("rxjs");
+const { ReplaySubject, Subject } = require("rxjs");
 const { parseJsonEvent } = require("./napi-observables.cjs");
 
 class Session {
@@ -13,7 +13,10 @@ class Session {
     this._executionViewChangesSubject = new Subject();
     this._cellChangesSubject = new Subject();
     this._broadcastsSubject = new Subject();
-    this._sessionStatusSubject = new Subject();
+    // Native status subscriptions synchronously emit their current value when
+    // registered. Replay it so a host that subscribes after Session
+    // construction cannot miss an already-disconnected handle.
+    this._sessionStatusSubject = new ReplaySubject(1);
     this.runtimeState$ = this._runtimeStateSubject.asObservable();
     this.executionTransitions$ = this._executionTransitionsSubject.asObservable();
     this.executionViewChanges$ = this._executionViewChangesSubject.asObservable();

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -119,6 +119,10 @@ class Session {
     return this._native.getCell(cellId);
   }
 
+  getCellOutputs(cellId) {
+    return this._native.getCellOutputs(cellId);
+  }
+
   createCell(source, options) {
     return this._native.createCell(source, options);
   }

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -41,7 +41,7 @@ class Session {
     if (typeof nativeSession.onSessionStatus === "function") {
       this._subscriptions.push(
         nativeSession.onSessionStatus((json) =>
-          this._sessionStatusSubject.next(parseJsonEvent(json)),
+          this._sessionStatusSubject.next(parseSessionStatus(json)),
         ),
       );
     }
@@ -221,6 +221,59 @@ class Session {
     this._sessionStatusSubject.complete();
     return this._native.close();
   }
+}
+
+function parseSessionStatus(json) {
+  const status = parseJsonEvent(json);
+  return {
+    connection: enumPhase(status.connection, "connection", ["connected", "disconnected"]),
+    notebook_doc: enumPhase(status.notebook_doc, "notebook_doc", [
+      "pending",
+      "syncing",
+      "interactive",
+    ]),
+    runtime_state: enumPhase(status.runtime_state, "runtime_state", [
+      "pending",
+      "syncing",
+      "ready",
+    ]),
+    initial_load: initialLoadPhase(status.initial_load),
+  };
+}
+
+function enumPhase(value, field, allowed) {
+  if (typeof value !== "string") throw new TypeError(`Invalid session status ${field}`);
+  const normalized = value.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  if (!allowed.includes(normalized)) {
+    throw new TypeError(`Invalid session status ${field}: ${value}`);
+  }
+  return normalized;
+}
+
+function initialLoadPhase(value) {
+  const allowed = ["not_needed", "streaming", "ready", "failed"];
+  if (typeof value === "string") {
+    const phase = enumPhase(value, "initial_load", allowed);
+    if (phase === "failed") throw new TypeError("Invalid failed session status initial_load");
+    return { phase };
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if (typeof value.phase === "string") {
+      const phase = enumPhase(value.phase, "initial_load.phase", allowed);
+      if (phase === "failed") {
+        if (typeof value.reason !== "string") {
+          throw new TypeError("Invalid failed session status initial_load.reason");
+        }
+        return { phase, reason: value.reason };
+      }
+      return { phase };
+    }
+    const failed = value.Failed ?? value.failed;
+    if (failed && typeof failed === "object" && typeof failed.reason === "string") {
+      return { phase: "failed", reason: failed.reason };
+    }
+  }
+  throw new TypeError("Invalid session status initial_load");
 }
 
 function normalizePackages(packages) {

--- a/packages/runtimed-node/tests/session-native.test.ts
+++ b/packages/runtimed-node/tests/session-native.test.ts
@@ -20,6 +20,11 @@ type Output = {
 };
 
 type Session = {
+  sessionStatus$: {
+    subscribe(observer: {
+      next?: (status: { connection: "connected" | "disconnected" }) => void;
+    }): { unsubscribe(): void };
+  };
   createCell(source: string, options?: { cellType?: "code" | "markdown" }): Promise<string>;
   approveTrust(): Promise<void>;
   executeCell(cellId: string, options?: { timeoutMs?: number }): Promise<unknown>;
@@ -55,7 +60,24 @@ async function openSession(): Promise<Session> {
     peerLabel: "runtimed-node-native-test",
   });
   sessions.push(session);
+  await waitForConnectedStatus(session);
   return session;
+}
+
+async function waitForConnectedStatus(session: Session): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for native connected session status")),
+      10_000,
+    );
+    session.sessionStatus$.subscribe({
+      next: (status) => {
+        if (status.connection !== "connected") return;
+        clearTimeout(timeout);
+        resolve();
+      },
+    });
+  });
 }
 
 async function waitForSocket(timeoutMs = 60_000): Promise<void> {

--- a/packages/runtimed-node/tests/session-native.test.ts
+++ b/packages/runtimed-node/tests/session-native.test.ts
@@ -1,0 +1,184 @@
+import { createRequire } from "node:module";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+
+const require = createRequire(import.meta.url);
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const runNativeIntegration = process.env.RUNTIMED_NODE_NATIVE_INTEGRATION === "1";
+const describeNative = runNativeIntegration ? describe : describe.skip;
+
+type Output = {
+  outputType: string;
+  name?: string;
+  text?: string;
+  dataJson?: string;
+  blobPathsJson?: string;
+};
+
+type Session = {
+  createCell(source: string, options?: { cellType?: "code" | "markdown" }): Promise<string>;
+  approveTrust(): Promise<void>;
+  executeCell(cellId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+  getCellOutputs(cellId: string): Promise<Output[] | null>;
+  close(): Promise<void>;
+  shutdownNotebook(): Promise<boolean>;
+};
+
+type RuntimedNode = {
+  openNotebookPath(
+    notebookPath: string,
+    options: { socketPath: string; peerLabel: string },
+  ): Promise<Session>;
+};
+
+let daemon: ChildProcess | undefined;
+let root = "";
+let socketPath = "";
+let notebookPath = "";
+const environmentCache =
+  process.env.RUNTIMED_NODE_TEST_CACHE ?? path.join(os.tmpdir(), "runtimed-node-native-env-cache");
+let api: RuntimedNode | undefined;
+const sessions: Session[] = [];
+
+function runtimeApi(): RuntimedNode {
+  if (!api) throw new Error("native integration is not initialized");
+  return api;
+}
+
+async function openSession(): Promise<Session> {
+  const session = await runtimeApi().openNotebookPath(notebookPath, {
+    socketPath,
+    peerLabel: "runtimed-node-native-test",
+  });
+  sessions.push(session);
+  return session;
+}
+
+async function waitForSocket(timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) return;
+    if (daemon?.exitCode !== null) {
+      throw new Error(`runtimed exited before creating its socket (${daemon?.exitCode})`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for runtimed socket at ${socketPath}`);
+}
+
+async function executeWhenReady(session: Session, cellId: string): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (true) {
+    try {
+      await session.executeCell(cellId, { timeoutMs: 180_000 });
+      return;
+    } catch (error) {
+      if (!String(error).includes("pool empty") || Date.now() >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+}
+
+describeNative("@runtimed/node native session outputs", () => {
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "runtimed-node-session-"));
+    socketPath = path.join(root, "runtimed.sock");
+    notebookPath = path.join(root, "analysis.ipynb");
+    fs.writeFileSync(
+      notebookPath,
+      JSON.stringify({
+        cells: [],
+        metadata: {
+          kernelspec: { display_name: "Python 3", language: "python", name: "python3" },
+        },
+        nbformat: 4,
+        nbformat_minor: 5,
+      }),
+    );
+    const binary = path.join(repositoryRoot, "target/debug/runtimed");
+    if (!fs.existsSync(binary)) {
+      throw new Error("Build the daemon with `cargo build -p runtimed` before this test.");
+    }
+    daemon = spawn(
+      binary,
+      [
+        "run",
+        "--socket",
+        socketPath,
+        "--cache-dir",
+        environmentCache,
+        "--blob-store-dir",
+        path.join(root, "blobs"),
+        "--uv-pool-size",
+        "1",
+        "--conda-pool-size",
+        "0",
+        "--pixi-pool-size",
+        "0",
+        "--log-level",
+        "warn",
+      ],
+      { cwd: root, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    await waitForSocket();
+    api = require("../src/index.cjs") as RuntimedNode;
+  }, 90_000);
+
+  afterAll(async () => {
+    for (const session of sessions.splice(0).reverse()) {
+      await session.close().catch(() => undefined);
+    }
+    daemon?.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      if (!daemon || daemon.exitCode !== null) return resolve();
+      const timeout = setTimeout(() => {
+        daemon?.kill("SIGKILL");
+        resolve();
+      }, 5_000);
+      daemon.once("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+  });
+
+  it("distinguishes missing and empty cells, then resolves durable outputs after reopen", async () => {
+    const first = await openSession();
+    await expect(first.getCellOutputs("missing-cell")).resolves.toBeNull();
+
+    const emptyCell = await first.createCell("# no outputs", { cellType: "markdown" });
+    await expect(first.getCellOutputs(emptyCell)).resolves.toEqual([]);
+
+    const executedCell = await first.createCell(
+      [
+        "from IPython.display import display",
+        "print(6 * 7)",
+        'display({"text/plain": "durable-rich", "application/octet-stream": b"x" * 131072}, raw=True)',
+      ].join("\n"),
+      { cellType: "code" },
+    );
+    await first.approveTrust();
+    await executeWhenReady(first, executedCell);
+    await first.close();
+    sessions.splice(sessions.indexOf(first), 1);
+
+    const reopened = await openSession();
+    const outputs = await reopened.getCellOutputs(executedCell);
+    expect(outputs).not.toBeNull();
+    expect(outputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ outputType: "stream", name: "stdout", text: "42\n" }),
+      ]),
+    );
+    const rich = outputs?.find((output) => output.outputType === "display_data");
+    expect(rich?.dataJson).toContain("durable-rich");
+    expect(rich?.dataJson).toContain("application/octet-stream");
+    expect(rich?.blobPathsJson).toBeDefined();
+  }, 240_000);
+});

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -28,6 +28,29 @@ const { Session } = require("../src/session.cjs") as {
 };
 
 describe("@runtimed/node Session wrapper", () => {
+  it("replays native status emitted during session construction", () => {
+    const disconnected = {
+      connection: "disconnected",
+      notebook_doc: "interactive",
+      runtime_state: "ready",
+      initial_load: { phase: "failed", reason: "daemon connection closed" },
+    };
+    const native = {
+      notebookId: "nb-1",
+      onSessionStatus: vi.fn((callback: (json: string) => void) => {
+        callback(JSON.stringify(disconnected));
+        return { dispose: vi.fn() };
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const session = new Session(native);
+    const received: unknown[] = [];
+
+    session.sessionStatus$.subscribe({ next: (value) => received.push(value) });
+
+    expect(received).toEqual([disconnected]);
+  });
+
   it("exposes native session disconnect status across current and legacy encodings", () => {
     let statusCallback: ((json: string) => void) | null = null;
     const native = {

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -14,6 +14,11 @@ const { Session } = require("../src/session.cjs") as {
         unsubscribe: () => void;
       };
     };
+    sessionStatus$: {
+      subscribe: (observer: { next?: (value: unknown) => void }) => {
+        unsubscribe: () => void;
+      };
+    };
     getExecutionView: () => unknown;
     runCell: (source: string, options?: Record<string, unknown>) => Promise<unknown>;
     exportSnapshotPair: () => Promise<unknown>;
@@ -23,6 +28,39 @@ const { Session } = require("../src/session.cjs") as {
 };
 
 describe("@runtimed/node Session wrapper", () => {
+  it("exposes native session disconnect status across current and legacy encodings", () => {
+    let statusCallback: ((json: string) => void) | null = null;
+    const native = {
+      notebookId: "nb-1",
+      onSessionStatus: vi.fn((callback: (json: string) => void) => {
+        statusCallback = callback;
+        return { dispose: vi.fn() };
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const session = new Session(native);
+    const received: unknown[] = [];
+    session.sessionStatus$.subscribe({ next: (value) => received.push(value) });
+
+    const disconnected = {
+      connection: "disconnected",
+      notebook_doc: "interactive",
+      runtime_state: "ready",
+      initial_load: { phase: "failed", reason: "daemon connection closed" },
+    };
+    statusCallback?.(JSON.stringify(disconnected));
+    statusCallback?.(
+      JSON.stringify({
+        connection: "Disconnected",
+        notebook_doc: "Interactive",
+        runtime_state: "Ready",
+        initial_load: { Failed: { reason: "daemon connection closed" } },
+      }),
+    );
+
+    expect(received).toEqual([disconnected, disconnected]);
+  });
+
   it("emits execution transitions keyed only by execution id", () => {
     let transitionCallback: ((json: string) => void) | null = null;
     const native = {

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -17,6 +17,7 @@ const { Session } = require("../src/session.cjs") as {
     getExecutionView: () => unknown;
     runCell: (source: string, options?: Record<string, unknown>) => Promise<unknown>;
     exportSnapshotPair: () => Promise<unknown>;
+    getCellOutputs: (cellId: string) => Promise<unknown>;
     close: () => Promise<void>;
   };
 };
@@ -317,5 +318,18 @@ describe("@runtimed/node Session wrapper", () => {
 
     await expect(session.exportSnapshotPair()).resolves.toBe(snapshot);
     expect(native.exportSnapshotPair).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes durable cell output reads through to the native session", async () => {
+    const outputs = [{ outputType: "stream", name: "stdout", text: "42\n" }];
+    const native = {
+      notebookId: "nb-1",
+      getCellOutputs: vi.fn(async () => outputs),
+      close: vi.fn(async () => {}),
+    };
+    const session = new Session(native);
+
+    await expect(session.getCellOutputs("cell-1")).resolves.toBe(outputs);
+    expect(native.getCellOutputs).toHaveBeenCalledWith("cell-1");
   });
 });


### PR DESCRIPTION
## Summary

- expose `Session.getCellOutputs(cellId)` from the native Node binding and high-level wrapper
- resolve durable RuntimeStateDoc output manifests through the same blob- and widget-aware path used by execution results
- capture cell existence, execution pointer, outputs, and widget state from one shared document snapshot before asynchronous blob resolution
- distinguish a missing cell (`null`) from an existing cell with no outputs (`[]`)
- expose the native connection state through `Session.sessionStatus$`, using the stable browser-style status shape and replaying the current status so late subscribers can discard disconnected sessions

This builds on the merged native notebook relay in #4134.

## Motivation

Native notebook hosts can already edit and execute stable synced cells through `@runtimed/node`. Reading durable outputs through the same session completes the host-side read path without introducing an MCP or filesystem side channel. Exposing disconnection on that session prevents hosts from treating detached local document mutations as durable work.

## Verification

- `cargo test -p runtimed-node` (25 passed)
- focused `notebook-sync` snapshot semantics test
- `vp test run packages/runtimed-node/tests` (18 passed, 4 skipped)
- `pnpm --dir packages/runtimed-node build:debug`
- automated native/daemon integration: distinguish missing and empty cells, execute `print(6 * 7)` plus a blob-backed rich output, reopen the notebook through a second native session, and resolve the durable outputs and blob paths
- native/daemon status integration: verify the Node-API callback delivers a scalar JSON event and a late `sessionStatus$` subscriber receives the current connected state
- `cargo xtask lint --fix`
