### PR TITLE
fix(node): hydrate execution view before session return

### DIFF
--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -618,6 +618,25 @@ impl Session {
         Ok(EventSubscription::new(task))
     }
 
+    /// Return a complete execution-view changeset for synchronous wrapper hydration.
+    #[napi]
+    pub fn get_execution_view_snapshot(&self) -> Result<String> {
+        let handle = {
+            let st = self
+                .state
+                .try_lock()
+                .map_err(|_| Error::from_reason("Session state busy"))?;
+            st.handle
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Not connected"))?
+                .clone()
+        };
+        let state = handle.get_runtime_state().map_err(to_napi_err)?;
+        let cell_pointers = handle.get_cell_execution_pointers().map_err(to_napi_err)?;
+        let changeset = ExecutionViewProjector::default().project_all(cell_pointers, &state);
+        serde_json::to_string(&changeset).map_err(to_napi_err)
+    }
+
     /// Subscribe to shared execution-view changes. Callback receives a JSON string.
     #[napi]
     pub fn on_execution_view_change(

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -8,6 +8,12 @@ class Session {
     this._native = nativeSession;
     this._subscriptions = [];
     this._executionView = emptyExecutionView();
+    if (typeof nativeSession.getExecutionViewSnapshot === "function") {
+      applyExecutionViewChangeset(
+        this._executionView,
+        parseJsonEvent(nativeSession.getExecutionViewSnapshot()),
+      );
+    }
     this._runtimeStateSubject = new Subject();
     this._executionTransitionsSubject = new Subject();
     this._executionViewChangesSubject = new Subject();

--- a/packages/runtimed-node/tests/session-native.test.ts
+++ b/packages/runtimed-node/tests/session-native.test.ts
@@ -45,6 +45,7 @@ type Session = {
     terminalStatus?: string;
   }>;
   getExecutionView(): {
+    cell_execution_ids: Record<string, string>;
     executions: Record<string, { status: string }>;
     queue: null | {
       executing_execution_id?: string | null;
@@ -269,7 +270,19 @@ describeNative("@runtimed/node native session outputs", () => {
     await first.close();
     sessions.splice(sessions.indexOf(first), 1);
 
-    const reopened = await openSession();
+    const reopened = await runtimeApi().openNotebookPath(notebookPath, {
+      socketPath,
+      peerLabel: "runtimed-node-native-test",
+    });
+    sessions.push(reopened);
+    expect(reopened.getExecutionView()).toMatchObject({
+      cell_execution_ids: { [executedCell]: executionId },
+      executions: { [executionId]: { status: "done" } },
+    });
+    await expect(reopened.queueExistingCell(executedCell, { executionId })).resolves.toEqual({
+      cellId: executedCell,
+      executionId,
+    });
     const outputs = await reopened.getCellOutputs(executedCell);
     expect(outputs).not.toBeNull();
     expect(outputs).toEqual(

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -28,6 +28,92 @@ const { Session } = require("../src/session.cjs") as {
 };
 
 describe("@runtimed/node Session wrapper", () => {
+  it("seeds the execution view synchronously before live changes arrive", () => {
+    let viewCallback: ((json: string) => void) | null = null;
+    const native = {
+      notebookId: "nb-1",
+      getExecutionViewSnapshot: vi.fn(() =>
+        JSON.stringify({
+          cell_pointer_changes: [["cell-1", "exec-1"]],
+          execution_upserts: [
+            [
+              "exec-1",
+              {
+                execution_count: null,
+                status: "queued",
+                success: null,
+                output_ids: [],
+              },
+            ],
+          ],
+          queue: {
+            executing_execution_id: null,
+            queued_execution_ids: ["exec-1"],
+            notebook: {
+              executing_cell_id: null,
+              queued_cell_ids: ["cell-1"],
+            },
+          },
+        }),
+      ),
+      onExecutionViewChange: vi.fn((callback: (json: string) => void) => {
+        viewCallback = callback;
+        return { dispose: vi.fn() };
+      }),
+      close: vi.fn(async () => {}),
+    };
+
+    const session = new Session(native);
+
+    expect(session.getExecutionView()).toEqual({
+      cell_execution_ids: { "cell-1": "exec-1" },
+      executions: {
+        "exec-1": {
+          execution_count: null,
+          status: "queued",
+          success: null,
+          output_ids: [],
+        },
+      },
+      queue: {
+        executing_execution_id: null,
+        queued_execution_ids: ["exec-1"],
+        notebook: {
+          executing_cell_id: null,
+          queued_cell_ids: ["cell-1"],
+        },
+      },
+    });
+
+    viewCallback?.(
+      JSON.stringify({
+        execution_upserts: [
+          [
+            "exec-1",
+            {
+              execution_count: 1,
+              status: "running",
+              success: null,
+              output_ids: [],
+            },
+          ],
+        ],
+        queue: {
+          executing_execution_id: "exec-1",
+          queued_execution_ids: [],
+          notebook: {
+            executing_cell_id: "cell-1",
+            queued_cell_ids: [],
+          },
+        },
+      }),
+    );
+    expect(session.getExecutionView()).toMatchObject({
+      executions: { "exec-1": { status: "running" } },
+      queue: { executing_execution_id: "exec-1" },
+    });
+  });
+
   it("replays native status emitted during session construction", () => {
     const disconnected = {
       connection: "disconnected",


### PR DESCRIPTION
## Summary

- expose a synchronous native execution-view snapshot for newly opened Node sessions
- seed the JavaScript Session projection before returning it to callers
- cover immediate reopen state and idempotent execution-ID retries

## Why

A reopened session can have fully synchronized notebook and runtime documents before the non-blocking execution-view callback reaches JavaScript. During that window, `getExecutionView()` returned an empty projection even though an execution was already queued, running, or terminal. Callers recovering work by stable execution ID could therefore miss durable state.

The wrapper now hydrates its projection synchronously from the native handle, then continues applying the existing live changesets.

## Validation

- `pnpm test:run packages/runtimed-node/tests/session.test.ts`
- `cargo test -p runtimed-node`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=<workspace> RUNTIMED_NODE_NATIVE_INTEGRATION=1 pnpm test:run packages/runtimed-node/tests/session-native.test.ts`
- `cargo xtask lint --fix`
