### PR TITLE
fix(ui): keep notebook controls attached to stage

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -367,6 +367,7 @@ function CloudNotebookShellExampleContent() {
           toolbarClassName="bg-background/95 backdrop-blur"
           toolbarLabel="Cloud notebook session"
           rail={rail}
+          railPanelPlacement="stage"
           capabilities={shellCapabilities}
         >
           <CloudNotebookDocument />

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -356,7 +356,7 @@ function CloudNotebookShellExampleContent() {
           className="h-[720px] bg-background text-foreground"
           stageClassName="bg-background"
           toolbar={
-            <CloudNotebookChrome
+            <CloudAppChrome
               connection="live"
               mode={mode}
               onModeChange={setMode}
@@ -364,6 +364,13 @@ function CloudNotebookShellExampleContent() {
               scenario={scenario}
             />
           }
+          toolbarPlacement="shell"
+          stageToolbar={
+            <NotebookToolbarFrame className="static top-auto z-auto bg-background/95">
+              <CloudNotebookToolbar mode={mode} scenario={scenario} />
+            </NotebookToolbarFrame>
+          }
+          stageToolbarPlacement="stage-content"
           toolbarClassName="bg-background/95 backdrop-blur"
           toolbarLabel="Cloud notebook session"
           rail={rail}
@@ -456,7 +463,7 @@ function BrowserFrame() {
   );
 }
 
-function CloudNotebookChrome({
+function CloudAppChrome({
   connection,
   mode,
   onModeChange,
@@ -478,7 +485,6 @@ function CloudNotebookChrome({
         people={people}
         scenario={scenario}
       />
-      <CloudNotebookToolbar mode={mode} scenario={scenario} />
     </NotebookToolbarFrame>
   );
 }

--- a/apps/elements/components/full-shell-composition-example.tsx
+++ b/apps/elements/components/full-shell-composition-example.tsx
@@ -280,7 +280,7 @@ export function FullShellCompositionExample() {
         rootElement="main"
         className={cn(
           "h-dvh bg-background text-foreground",
-          "max-[760px]:[&_[data-slot=notebook-document-stage]]:hidden",
+          "max-[760px]:[&_[data-slot=notebook-document-stage-content]]:hidden",
           "max-[760px]:[&_[data-testid=notebook-rail]]:w-full",
           "max-[760px]:[&_[data-slot=notebook-rail-panel]]:min-w-0",
           "max-[760px]:[&_[data-slot=notebook-rail-panel]]:max-w-none",
@@ -290,6 +290,7 @@ export function FullShellCompositionExample() {
         toolbarLabel="Full shell composition toolbar"
         stageClassName="bg-muted/20"
         stageLabel="Full notebook composition"
+        railPanelPlacement="stage"
         capabilities={capabilities}
         toolbar={
           <FullShellToolbar

--- a/apps/elements/components/full-shell-composition-example.tsx
+++ b/apps/elements/components/full-shell-composition-example.tsx
@@ -27,7 +27,10 @@ import {
   type NotebookViewCell,
 } from "@/components/notebook";
 import type { CommentsProjection } from "@/components/notebook/comment-types";
-import type { NotebookRailPanelId } from "@/components/notebook-rail";
+import {
+  NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  type NotebookRailPanelId,
+} from "@/components/notebook-rail";
 import {
   flushCellUIState,
   setFocusedCellId as setNotebookFocusedCellId,
@@ -278,31 +281,32 @@ export function FullShellCompositionExample() {
     <NotebookHostProvider host={notebookHost}>
       <NotebookDocumentShell
         rootElement="main"
-        className={cn(
-          "h-dvh bg-background text-foreground",
-          "max-[760px]:[&_[data-slot=notebook-document-stage-content]]:hidden",
-          "max-[760px]:[&_[data-testid=notebook-rail]]:w-full",
-          "max-[760px]:[&_[data-slot=notebook-rail-panel]]:min-w-0",
-          "max-[760px]:[&_[data-slot=notebook-rail-panel]]:max-w-none",
-          "max-[760px]:[&_[data-slot=notebook-rail-panel]]:flex-1",
-        )}
-        toolbarClassName="border-b border-border bg-background/95"
+        className="h-dvh bg-background text-foreground"
+        toolbarClassName="bg-background/95"
         toolbarLabel="Full shell composition toolbar"
+        toolbarPlacement="stage"
         stageClassName="bg-muted/20"
         stageLabel="Full notebook composition"
         railPanelPlacement="stage"
         capabilities={capabilities}
         toolbar={
-          <FullShellToolbar
+          <FullShellHeader
             capabilities={capabilities}
             interaction={interaction}
             mode={mode}
-            activePanel={activePanel}
             onModeChange={setMode}
+          />
+        }
+        stageToolbar={
+          <FullShellCommandToolbar
+            capabilities={capabilities}
+            activePanel={activePanel}
             onTogglePackages={() => setActivePanel("packages")}
             onToggleWorkstations={() => setActivePanel("workstations")}
           />
         }
+        stageToolbarPlacement="stage-content"
+        stageContentClassName={NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME}
         rail={
           <NotebookDocumentRail
             viewModel={scenario.viewModel}
@@ -399,32 +403,19 @@ export function FullShellCompositionExample() {
   );
 }
 
-function FullShellToolbar({
-  activePanel,
+function FullShellHeader({
   capabilities,
   interaction,
   mode,
   onModeChange,
-  onTogglePackages,
-  onToggleWorkstations,
 }: {
-  activePanel: NotebookRailPanelId;
   capabilities: NotebookShellCapabilities;
   interaction: NotebookInteractionModeProjection;
   mode: NotebookInteractionMode;
   onModeChange: (mode: NotebookInteractionMode) => void;
-  onTogglePackages: () => void;
-  onToggleWorkstations: () => void;
 }) {
-  const runtimeStatus: NotebookCommandToolbarStatus = {
-    state: capabilities.canExecute ? "idle" : "unknown",
-    label: "Current Python",
-    ariaLabel: "Runtime: Current Python idle",
-    title: scenario.runtimeLabel,
-  };
-
   return (
-    <NotebookToolbarFrame className="static top-auto z-auto border-b-0 bg-background/95">
+    <NotebookToolbarFrame className="static top-auto z-auto bg-background/95">
       <NotebookDocumentHeader
         capabilities={capabilities}
         className={cn(
@@ -465,6 +456,30 @@ function FullShellToolbar({
           </button>
         }
       />
+    </NotebookToolbarFrame>
+  );
+}
+
+function FullShellCommandToolbar({
+  activePanel,
+  capabilities,
+  onTogglePackages,
+  onToggleWorkstations,
+}: {
+  activePanel: NotebookRailPanelId;
+  capabilities: NotebookShellCapabilities;
+  onTogglePackages: () => void;
+  onToggleWorkstations: () => void;
+}) {
+  const runtimeStatus: NotebookCommandToolbarStatus = {
+    state: capabilities.canExecute ? "idle" : "unknown",
+    label: "Current Python",
+    ariaLabel: "Runtime: Current Python idle",
+    title: scenario.runtimeLabel,
+  };
+
+  return (
+    <NotebookToolbarFrame className="static top-auto z-auto bg-background/95">
       <div className="min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <NotebookCommandToolbar
           capabilities={capabilities}

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -124,8 +124,10 @@ export function RailOutlineExample() {
   return (
     <NotebookHostProvider host={notebookHost}>
       <NotebookDocumentShell
-        className="not-prose min-h-[560px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm md:min-h-[700px] max-[599.98px]:[&_[data-slot=notebook-document-stage]]:hidden max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:min-w-0 max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:max-w-none max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:flex-1 max-[599.98px]:[&_[data-testid=notebook-rail]]:w-full"
-        stageClassName="min-w-[320px] bg-fd-muted/20"
+        className="not-prose min-h-[560px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm md:min-h-[700px] max-[599.98px]:[&_[data-slot=notebook-document-stage-content]]:hidden max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:min-w-0 max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:max-w-none max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:flex-1 max-[599.98px]:[&_[data-testid=notebook-rail]]:w-full"
+        stageClassName="min-w-0 bg-fd-muted/20"
+        stageContentClassName="min-w-[320px]"
+        railPanelPlacement="stage"
         toolbarClassName="border-b border-fd-border"
         toolbarLabel="Notebook fixture toolbar"
         stageLabel="Elements notebook scenario"

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -128,6 +128,7 @@ export function RailOutlineExample() {
         stageClassName="min-w-0 bg-fd-muted/20"
         stageContentClassName="min-w-[320px]"
         railPanelPlacement="stage"
+        toolbarPlacement="stage-content"
         toolbarClassName="border-b border-fd-border"
         toolbarLabel="Notebook fixture toolbar"
         stageLabel="Elements notebook scenario"

--- a/apps/elements/content/docs/full-shell-composition.mdx
+++ b/apps/elements/content/docs/full-shell-composition.mdx
@@ -9,6 +9,11 @@ This route composes the shared notebook shell at browser scale: app chrome,
 command toolbar, outline/packages/workstation rail, production notebook cells,
 and the comments panel against deterministic fixture state.
 
+The app and document header stays beside the icon rail. The notebook command
+row and notebook content share the panel's live edge, so both move together
+when a panel opens beneath the commands. This keeps the L-shaped boundary
+structural instead of covering a mismatched corner with an overlap.
+
 <Link
   href="/full-shell-composition"
   className="not-prose my-6 inline-flex h-10 items-center rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground"

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -46,8 +46,9 @@ outline rail.
   the production projection path from materialized markdown headings.
 - Contextual selection depends on `outlineCellIds`: a focused code cell inside a
   section highlights the nearest preceding markdown heading.
-- Outline panel chrome is intentionally sparse. The panel title names the mode,
-  and the rows carry the useful context without an extra item-count badge.
+- Outline panel chrome is intentionally sparse. The active rail control names
+  the mode, so the outline rows begin immediately without a redundant panel
+  title or item-count badge.
 - Notebook active-section tracking still belongs to the app shell through
   viewport observation and `resolveNotebookOutlineSelection`; this page only
   fixtures the active item.

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -589,14 +589,17 @@ test("cloud rail takes over constrained widths instead of pushing the stage offs
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /@media \(max-width: 599\.98px\)/);
-  assert.match(sourceText, /\.cloud-notebook-rail\[data-collapsed="false"\]\s*\{/);
   assert.match(
     sourceText,
-    /\.cloud-notebook-rail\[data-collapsed="false"\] \[data-slot="notebook-rail-panel"\]\s*\{/,
+    /\.cloud-notebook-stage > \[data-slot="notebook-document-stage-body"\]\s*\{[\s\S]*display: grid;[\s\S]*grid-template-columns: auto minmax\(0, 1fr\);/,
   );
   assert.match(
     sourceText,
-    /\.cloud-notebook-rail\[data-collapsed="false"\] \+ \[data-slot="notebook-document-stage"\]\s*\{/,
+    /\[data-slot="notebook-document-rail-panel-host"\]:has\(\[data-slot="notebook-rail-panel"\]\)\s*\{[\s\S]*grid-column: 1 \/ -1;/,
+  );
+  assert.match(
+    sourceText,
+    /\[data-slot="notebook-document-rail-panel-host"\]:has\(\[data-slot="notebook-rail-panel"\]\)\s*\+ \[data-slot="notebook-document-stage-content"\]\s*\{[\s\S]*display: none;/,
   );
 });
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -125,7 +125,7 @@ test("cloud callback keeps sign-in handoff in the entry surface language", () =>
   assert.match(callbackSource, /cloud-oidc-layout/);
   assert.match(callbackSource, /setAttribute\("aria-label", "nteract sign-in callback"\)/);
   assert.match(callbackSource, /cloud-oidc-panel/);
-  assert.match(callbackSource, /returning to the notebook/);
+  assert.match(callbackSource, /Returning you to your notebook/);
   assert.match(callbackSource, /Try again/);
   assert.match(callbackSource, /Back to nteract/);
   assert.match(callbackSource, /status\.kind/);
@@ -200,8 +200,13 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(
     sourceText,
-    /<NotebookDocumentToolbar[\s\S]*frameClassName="z-20"[\s\S]*headerClassName="cloud-room-toolbar"[\s\S]*commandToolbar=\{\{[\s\S]*addAfterCellId: toolbarAddAfterCellId/,
+    /<NotebookDocumentToolbar[\s\S]*frameClassName="z-20"[\s\S]*headerClassName="cloud-room-toolbar"/,
   );
+  assert.match(
+    sourceText,
+    /const stageToolbar = showCloudCommandToolbar \? \([\s\S]*<NotebookToolbarFrame className="cloud-notebook-stage-toolbar">[\s\S]*<NotebookCommandToolbar[\s\S]*addAfterCellId=\{toolbarAddAfterCellId\}/,
+  );
+  assert.match(sourceText, /stageToolbarPlacement="stage-content"/);
   assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(
     sourceText,
@@ -213,8 +218,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sourceText, /cloudNotebookTitleDisplay,/);
   assert.match(sourceText, /cloudNotebookUrlAfterRename,/);
-  assert.match(titleSourceText, /homeLink: "cloud-notebook-home-link"/);
-  assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
+  assert.match(titleSourceText, /import \{ DocumentTitle \}/);
+  assert.match(titleSourceText, /<DocumentTitle/);
+  assert.match(titleSourceText, /classNames=\{cloudNotebookTitleClassNames\}/);
   assert.match(titleSourceText, /renameButtonTitle="Rename notebook"/);
   assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
   assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
@@ -256,18 +262,16 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.ok(dismissedNotice, "expected a dismissed-request notice branch");
   assert.match(dismissedNotice[0], /icon=\{<Info \/>\}/);
   assert.doesNotMatch(dismissedNotice[0], /AlertCircle/);
-  // The connection/identity slot is filled by the shared quiet component:
+  // The rail's trailing connection/identity slot is filled by the shared quiet component:
   // avatar + connectivity dot, driven by the stable status bridge. It must
   // never regress into a text pill or a second status label surface. The
-  // match is scoped to the module that owns the slot (not the whole
-  // corpus) so an identityControls regression cannot false-pass against a
-  // mount elsewhere.
-  const slotOwnerSource = viewerFileContaining("identityControls=");
+  // match is scoped to the module that owns the slot (not the whole corpus).
+  const slotOwnerSource = viewerFileContaining("const identityControls =");
   assert.match(
     slotOwnerSource,
-    /identityControls=\{[\s\S]{0,400}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{connectionStatus\$\}/,
+    /const identityControls =[\s\S]{0,400}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{connectionStatus\$\}[\s\S]{0,800}?trailingSlot=\{identityControls\}/,
   );
-  assert.doesNotMatch(sourceText, /identityControls=\{null\}/);
+  assert.doesNotMatch(sourceText, /trailingSlot=\{null\}/);
   // Session-side bridge wiring order (comment-enforced invariants, pinned):
   // attach follows each replacement transport; teardown paths report the
   // retry BEFORE the dispose emits its terminal "offline"; the effect
@@ -454,7 +458,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     sharingSourceText,
     /import \{ Popover, PopoverContent, PopoverTrigger \} from "@\/components\/ui\/popover";/,
   );
-  assert.match(sharingSourceText, /<Popover open=\{open\} onOpenChange=\{setOpen\}>/);
+  assert.match(sharingSourceText, /<Popover open=\{open\} onOpenChange=\{handleOpenChange\}>/);
   assert.match(sharingSourceText, /<PopoverTrigger asChild>/);
   assert.match(
     sharingSourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -210,7 +210,7 @@ test("cloud command toolbar inserts below the focused cell before falling back t
   );
   assert.match(
     sourceText,
-    /<NotebookDocumentToolbar[\s\S]*commandToolbar=\{\{[\s\S]*addAfterCellId: toolbarAddAfterCellId/,
+    /const stageToolbar = showCloudCommandToolbar \? \([\s\S]*<NotebookCommandToolbar[\s\S]*addAfterCellId=\{toolbarAddAfterCellId\}/,
   );
 });
 
@@ -504,14 +504,13 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
     sourceText,
     /const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar\(shellCapabilities, \{[\s\S]*reserve: editAccessPending,[\s\S]*\}\)/,
   );
-  assert.match(sourceText, /reserveCommandToolbar=\{editAccessPending\}/);
-  assert.match(sourceText, /addCellControlsDisabled: editAccessPending/);
-  assert.match(sourceText, /runtimeStatus: cloudRuntimeStatus/);
-  assert.match(sourceText, /onStartRuntime: handleCloudStartRuntime/);
-  assert.match(sourceText, /onInterruptRuntime: handleCloudInterruptRuntime/);
-  assert.match(sourceText, /onRestartRuntime: handleCloudRestartRuntime/);
-  assert.match(sourceText, /onRunAllCells: handleCloudRunAllCells/);
-  assert.match(sourceText, /onRestartAndRunAll: handleCloudRestartAndRunAll/);
+  assert.match(sourceText, /addCellControlsDisabled=\{editAccessPending\}/);
+  assert.match(sourceText, /runtimeStatus=\{cloudRuntimeStatus\}/);
+  assert.match(sourceText, /onStartRuntime=\{handleCloudStartRuntime\}/);
+  assert.match(sourceText, /onInterruptRuntime=\{handleCloudInterruptRuntime\}/);
+  assert.match(sourceText, /onRestartRuntime=\{handleCloudRestartRuntime\}/);
+  assert.match(sourceText, /onRunAllCells=\{handleCloudRunAllCells\}/);
+  assert.match(sourceText, /onRestartAndRunAll=\{handleCloudRestartAndRunAll\}/);
   assert.doesNotMatch(sourceText, /CloudNotebookEditModePlaceholder/);
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);
@@ -553,7 +552,7 @@ test("cloud mobile shell gives the collapsed rail a toolbar entrypoint", () => {
   assert.match(sourceText, /setNotebookRailCollapsed\(false\);/);
   assert.match(
     sourceText,
-    /leadingControls: \(\s*<button[\s\S]*className="cloud-mobile-rail-toggle hidden h-8 w-8[\s\S]*aria-label="Open notebook panels"[\s\S]*onClick=\{handleOpenMobileRail\}/,
+    /leadingControls=\{\s*<button[\s\S]*className="cloud-mobile-rail-toggle hidden h-8 w-8[\s\S]*aria-label="Open notebook panels"[\s\S]*onClick=\{handleOpenMobileRail\}/,
   );
   assert.match(
     cssText,
@@ -569,7 +568,7 @@ test("cloud mobile shell gives the collapsed rail a toolbar entrypoint", () => {
   );
   assert.match(
     cssText,
-    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-notebook-rail\[data-collapsed="false"\]\s*\{[\s\S]*width: 100%;/,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\[data-slot="notebook-document-rail-panel-host"\]:has\(\[data-slot="notebook-rail-panel"\]\)\s*\{[\s\S]*grid-column: 1 \/ -1;/,
   );
 });
 
@@ -776,7 +775,7 @@ test("readable cloud notebooks leave disconnected compute to the existing runtim
 
   assert.doesNotMatch(sourceText, /ComputeDisconnectedNotice/);
   assert.doesNotMatch(sourceText, /shouldRenderComputeDisconnectedNotice/);
-  assert.match(sourceText, /onStartRuntime: handleCloudStartRuntime/);
+  assert.match(sourceText, /onStartRuntime=\{handleCloudStartRuntime\}/);
   assert.match(sourceText, /workstationAction/);
 });
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -230,7 +230,7 @@ body {
   overflow: hidden;
 }
 
-.cloud-notebook-stage > [data-slot="notebook-document-toolbar"],
+.cloud-notebook-shell > [data-slot="notebook-document-toolbar"],
 .cloud-notebook-stage [data-slot="notebook-document-stage-toolbar"] {
   flex: 0 0 auto;
   z-index: 16;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -231,7 +231,7 @@ body {
 }
 
 .cloud-notebook-stage > [data-slot="notebook-document-toolbar"],
-.cloud-notebook-stage > [data-slot="notebook-document-stage-toolbar"] {
+.cloud-notebook-stage [data-slot="notebook-document-stage-toolbar"] {
   flex: 0 0 auto;
   z-index: 16;
 }
@@ -240,15 +240,23 @@ body {
   position: static;
 }
 
-/* The rail strip stays at the left edge of the page content; its expanded panel
-   portals into this stage-owned host so it slides out under the utility bar and
-   beside the notebook content. */
+/* The rail strip stays at the left edge of the page content. The expanded panel
+   portals into the first column while notebook commands and content share the
+   second column, so all notebook-local chrome follows the live stage edge. */
 .cloud-notebook-stage > [data-slot="notebook-document-stage-body"] {
-  display: flex;
+  display: grid;
   min-height: 0;
   min-width: 0;
   flex: 1;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
+}
+
+.cloud-notebook-stage [data-slot="notebook-document-stage-content-toolbar"] {
+  position: relative;
+  z-index: 16;
+  min-width: 0;
 }
 
 .cloud-notebook-stage [data-slot="notebook-document-rail-panel-host"] {
@@ -674,7 +682,7 @@ body {
      keys off the host actually holding a panel rather than rail adjacency. */
   .cloud-notebook-stage
     [data-slot="notebook-document-rail-panel-host"]:has([data-slot="notebook-rail-panel"]) {
-    flex: 1;
+    grid-column: 1 / -1;
     min-width: 0;
   }
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -240,6 +240,30 @@ body {
   position: static;
 }
 
+/* The rail strip stays at the left edge of the page content; its expanded panel
+   portals into this stage-owned host so it slides out under the utility bar and
+   beside the notebook content. */
+.cloud-notebook-stage > [data-slot="notebook-document-stage-body"] {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.cloud-notebook-stage [data-slot="notebook-document-rail-panel-host"] {
+  z-index: 15;
+}
+
+.cloud-notebook-stage-content {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 /* Region chrome only — do not restyle [data-slot="notebook-notice"] /
    notebook-notice-stack; shared NotebookNotice owns tone, border-b, padding,
    and stack gap. Size to content so multi-notice stacks and disclosures are
@@ -645,18 +669,26 @@ body {
     min-height: 2rem;
   }
 
-  .cloud-notebook-rail[data-collapsed="false"] {
-    width: 100%;
-    max-width: 100%;
+  /* An expanded panel takes over the stage instead of squeezing the notebook
+     content offscreen. The panel is portalled into the stage, so the takeover
+     keys off the host actually holding a panel rather than rail adjacency. */
+  .cloud-notebook-stage
+    [data-slot="notebook-document-rail-panel-host"]:has([data-slot="notebook-rail-panel"]) {
+    flex: 1;
+    min-width: 0;
   }
 
-  .cloud-notebook-rail[data-collapsed="false"] [data-slot="notebook-rail-panel"] {
+  .cloud-notebook-stage
+    [data-slot="notebook-document-rail-panel-host"]
+    [data-slot="notebook-rail-panel"] {
     min-width: 0;
     max-width: none;
     flex: 1;
   }
 
-  .cloud-notebook-rail[data-collapsed="false"] + [data-slot="notebook-document-stage"] {
+  .cloud-notebook-stage
+    [data-slot="notebook-document-rail-panel-host"]:has([data-slot="notebook-rail-panel"])
+    + [data-slot="notebook-document-stage-content"] {
     display: none;
   }
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1952,6 +1952,8 @@ export function NotebookViewer({
         noticesClassName="cloud-notebook-notices"
         capabilities={shellCapabilities}
         rail={notebookStageGated ? undefined : rail}
+        railPanelPlacement="stage"
+        stageContentClassName="cloud-notebook-stage-content"
         stageLabel="Hosted notebook"
       >
         <h1 className="sr-only">{notebookTitle.title}</h1>

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1946,6 +1946,7 @@ export function NotebookViewer({
         toolbar={toolbar}
         toolbarPlacement="stage"
         stageToolbar={stageToolbar}
+        stageToolbarPlacement="stage-content"
         toolbarLabel="Notebook view status and controls"
         notices={notices}
         noticesPlacement="stage"

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1944,7 +1944,7 @@ export function NotebookViewer({
         }
         stageClassName="cloud-notebook-stage"
         toolbar={toolbar}
-        toolbarPlacement="stage"
+        toolbarPlacement="shell"
         stageToolbar={stageToolbar}
         stageToolbarPlacement="stage-content"
         toolbarLabel="Notebook view status and controls"

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2057,8 +2057,8 @@ function AppContent() {
               </NotebookNotice>
             ) : null
           }
-          toolbarPlacement="stage"
-          toolbarClassName="-ml-0.5 shrink-0 bg-background"
+          toolbarPlacement="stage-content"
+          toolbarClassName="shrink-0 bg-background"
           toolbarLabel="Notebook execution and runtime controls"
           toolbar={
             <NotebookToolbar
@@ -2092,8 +2092,8 @@ function AppContent() {
             />
           }
           stageClassName="min-w-0 flex-1"
-          // The expanded panel slides out inside the stage, under the utility
-          // bar; the rail strip stays at the left edge of the page content.
+          // The expanded panel is hosted inside the stage, while the notebook
+          // controls and content stay attached to the same live stage edge.
           railPanelPlacement="stage"
           stageContentClassName={cn(!railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME)}
           rail={

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -172,7 +172,7 @@ function focusActiveRailButtonWhenStageIsHidden(
   const activeElement = document.activeElement;
   if (!(activeElement instanceof HTMLElement)) return;
 
-  const stage = document.querySelector('[data-slot="notebook-document-stage"]');
+  const stage = document.querySelector('[data-slot="notebook-document-stage-content"]');
   const focusWasInStage = stage?.contains(activeElement);
   const focusWasClearedFromHiddenStage =
     stageHadFocusBeforeTakeover && activeElement === document.body;
@@ -452,7 +452,7 @@ function AppContent() {
     if (typeof document === "undefined") return;
 
     const handleFocusIn = (event: FocusEvent) => {
-      const stage = document.querySelector('[data-slot="notebook-document-stage"]');
+      const stage = document.querySelector('[data-slot="notebook-document-stage-content"]');
       stageHadFocusBeforeRailTakeoverRef.current = Boolean(
         event.target instanceof Node && stage?.contains(event.target),
       );
@@ -2091,10 +2091,11 @@ function AppContent() {
               onRestartToUpdate={restartToUpdate}
             />
           }
-          stageClassName={cn(
-            "min-w-0 flex-1",
-            !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
-          )}
+          stageClassName="min-w-0 flex-1"
+          // The expanded panel slides out inside the stage, under the utility
+          // bar; the rail strip stays at the left edge of the page content.
+          railPanelPlacement="stage"
+          stageContentClassName={cn(!railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME)}
           rail={
             <NotebookDocumentRail
               trailingSlot={

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -97,7 +97,7 @@ export function NotebookRail({
       activePanelId={activePanelId}
       collapsed={collapsed}
       items={railButtons}
-      panelTitle={title}
+      panelTitle={title ?? undefined}
       panelAction={activePanelId === "workstations" ? workstationsPanelAction : undefined}
       leadingSlot={leadingSlot}
       trailingSlot={trailingSlot}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -84,14 +84,7 @@ export function NotebookRail({
       ? [{ id: "workstations" as const, label: "Workstations", icon: Server }]
       : []),
   ];
-  const title =
-    activePanelId === "packages"
-      ? "Packages"
-      : activePanelId === "comments"
-        ? "Discussions"
-        : activePanelId === "workstations"
-          ? "Workstations"
-          : null;
+  const title = activePanelId === "workstations" ? "Workstations" : null;
   return (
     <Rail
       activePanelId={activePanelId}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -91,7 +91,7 @@ export function NotebookRail({
         ? "Discussions"
         : activePanelId === "workstations"
           ? "Workstations"
-          : "Outline";
+          : null;
   return (
     <Rail
       activePanelId={activePanelId}

--- a/src/components/notebook-rail/NotebookRailHomeButton.tsx
+++ b/src/components/notebook-rail/NotebookRailHomeButton.tsx
@@ -19,8 +19,8 @@ export function NotebookRailHomeButton({
       title={label}
       data-slot="notebook-rail-home"
       className={cn(
-        "flex size-9 items-center justify-center rounded-xl bg-foreground text-background transition-colors",
-        "hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        "flex size-9 items-center justify-center rounded-md bg-foreground text-background transition-colors",
+        "hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         className,
       )}
     >

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -149,7 +149,7 @@ describe("NotebookRail", () => {
     );
 
     expect(screen.getByRole("button", { name: "Discussions" })).toBeVisible();
-    expect(screen.getByRole("heading", { name: "Discussions" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Discussions" })).not.toBeInTheDocument();
     expect(screen.getByText("Thread list")).toBeVisible();
   });
 
@@ -211,8 +211,8 @@ describe("NotebookRail", () => {
     );
   });
 
-  it("keeps package metadata out of the title row", () => {
-    render(
+  it("omits redundant package panel header chrome", () => {
+    const { container } = render(
       <NotebookRail
         activePanelId="packages"
         collapsed={false}
@@ -223,7 +223,8 @@ describe("NotebookRail", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
+    expect(screen.queryByRole("heading", { name: "Packages" })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="rail-panel-header"]')).toBeNull();
     expect(screen.queryByText("../pyproject.toml · 25 packages")).not.toBeInTheDocument();
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -8,6 +8,7 @@ import {
   NotebookOutlinePanel,
   NotebookRail,
 } from "../NotebookRail";
+import { NotebookRailHomeButton } from "../NotebookRailHomeButton";
 
 const outlineItems = [
   {
@@ -35,6 +36,16 @@ const outlineItems = [
 ];
 
 describe("NotebookRail", () => {
+  it("keeps the home control in the shared rail button family", () => {
+    render(<NotebookRailHomeButton href="/n" />);
+
+    expect(screen.getByRole("link", { name: "Notebooks" })).toHaveClass(
+      "rounded-md",
+      "focus-visible:ring-1",
+      "focus-visible:ring-ring",
+    );
+  });
+
   it("explains how to populate an empty outline", () => {
     render(
       <NotebookRail

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -358,7 +358,7 @@ describe("NotebookRail", () => {
     expect(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY).toBe("(max-width: 599.98px)");
     expect(NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME).toBe("max-[599.98px]:hidden");
     expect(NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES).toContain(
-      "max-[599.98px]:w-[calc(100vw-3rem)]",
+      "max-[599.98px]:w-[calc(100vw-3.5rem)]",
     );
   });
 

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -18,8 +18,13 @@ export interface NotebookDocumentShellProps {
    */
   railPanelPlacement?: "rail" | "stage";
   toolbar?: ReactNode;
-  toolbarPlacement?: "shell" | "stage";
+  /**
+   * `stage-content` keeps notebook-local controls attached to the notebook
+   * column when a stage-hosted rail panel opens.
+   */
+  toolbarPlacement?: "shell" | "stage" | "stage-content";
   stageToolbar?: ReactNode;
+  stageToolbarPlacement?: "stage" | "stage-content";
   notices?: ReactNode;
   noticesPlacement?: "shell" | "stage";
   children: ReactNode;
@@ -41,6 +46,7 @@ export function NotebookDocumentShell({
   toolbar,
   toolbarPlacement = "shell",
   stageToolbar,
+  stageToolbarPlacement = "stage",
   notices,
   noticesPlacement = "shell",
   children,
@@ -58,6 +64,10 @@ export function NotebookDocumentShell({
   // node exists and its panel portal can target it on the same commit pass.
   const [railPanelSlotNode, setRailPanelSlotNode] = useState<HTMLDivElement | null>(null);
   const hostsRailPanelInStage = railPanelPlacement === "stage";
+  const toolbarInStageContent = toolbarPlacement === "stage-content";
+  const stageToolbarInStageContent =
+    Boolean(stageToolbar) && stageToolbarPlacement === "stage-content";
+  const hasStageContentToolbar = toolbarInStageContent || stageToolbarInStageContent;
   const toolbarSlot = toolbar ? (
     <div
       className={toolbarClassName}
@@ -96,25 +106,54 @@ export function NotebookDocumentShell({
           aria-label={stageLabel}
           data-slot="notebook-document-stage"
         >
-          {toolbarPlacement === "stage" ? toolbarSlot : null}
+          {toolbarPlacement === "stage" || (!hostsRailPanelInStage && toolbarInStageContent)
+            ? toolbarSlot
+            : null}
           {noticesPlacement === "stage" ? noticesSlot : null}
-          {stageToolbar ? (
+          {stageToolbar &&
+          (stageToolbarPlacement === "stage" ||
+            (!hostsRailPanelInStage && stageToolbarInStageContent)) ? (
             <div data-slot="notebook-document-stage-toolbar">{stageToolbar}</div>
           ) : null}
           {hostsRailPanelInStage ? (
             <div
-              className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+              className={cn(
+                "grid min-h-0 min-w-0 flex-1 grid-cols-[auto_minmax(0,1fr)] overflow-hidden",
+                hasStageContentToolbar
+                  ? "grid-rows-[auto_minmax(0,1fr)]"
+                  : "grid-rows-[minmax(0,1fr)]",
+              )}
               data-slot="notebook-document-stage-body"
             >
+              {hasStageContentToolbar ? (
+                <div
+                  className="col-start-2 row-start-1 min-w-0"
+                  data-slot="notebook-document-stage-content-toolbar"
+                >
+                  {toolbarInStageContent ? toolbarSlot : null}
+                  {stageToolbarInStageContent ? (
+                    <div data-slot="notebook-document-stage-toolbar">{stageToolbar}</div>
+                  ) : null}
+                </div>
+              ) : null}
               {/* Portal target for the expanded rail panel: it slides out here,
-                  under the utility bar, while the rail strip stays on the left. */}
+                  beneath the notebook command row, while the rail strip stays
+                  on the left. Its width also anchors the command row and the
+                  notebook content to the same live stage edge. */}
               <div
                 ref={setRailPanelSlotNode}
-                className="flex min-h-0 shrink-0"
+                className={cn(
+                  "col-start-1 flex min-h-0 shrink-0",
+                  hasStageContentToolbar ? "row-start-2" : "row-start-1",
+                )}
                 data-slot="notebook-document-rail-panel-host"
               />
               <div
-                className={cn("flex min-h-0 min-w-0 flex-1 flex-col", stageContentClassName)}
+                className={cn(
+                  "col-start-2 flex min-h-0 min-w-0 flex-1 flex-col",
+                  hasStageContentToolbar ? "row-start-2" : "row-start-1",
+                  stageContentClassName,
+                )}
                 data-slot="notebook-document-stage-content"
               >
                 {children}

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -1,4 +1,5 @@
-import type { ElementType, ReactNode } from "react";
+import { useState, type ElementType, type ReactNode } from "react";
+import { RailPanelSlotProvider } from "@/components/rail";
 import { cn } from "@/lib/utils";
 import type { NotebookShellCapabilities } from "./capabilities";
 
@@ -9,6 +10,13 @@ export interface NotebookDocumentShellProps {
    */
   rootElement?: "div" | "main";
   rail?: ReactNode;
+  /**
+   * `rail` keeps an expanded rail panel inside the rail column, level with the
+   * toolbar chrome. `stage` hosts it in the stage instead, so the panel slides
+   * out below the utility bar and beside the notebook content while the rail's
+   * icon strip stays at the far left of the page content.
+   */
+  railPanelPlacement?: "rail" | "stage";
   toolbar?: ReactNode;
   toolbarPlacement?: "shell" | "stage";
   stageToolbar?: ReactNode;
@@ -18,6 +26,8 @@ export interface NotebookDocumentShellProps {
   capabilities?: NotebookShellCapabilities;
   className?: string;
   stageClassName?: string;
+  /** Applied to the notebook content column beside a stage-hosted rail panel. */
+  stageContentClassName?: string;
   toolbarClassName?: string;
   toolbarLabel?: string;
   noticesClassName?: string;
@@ -27,6 +37,7 @@ export interface NotebookDocumentShellProps {
 export function NotebookDocumentShell({
   rootElement = "div",
   rail,
+  railPanelPlacement = "rail",
   toolbar,
   toolbarPlacement = "shell",
   stageToolbar,
@@ -36,12 +47,17 @@ export function NotebookDocumentShell({
   capabilities,
   className,
   stageClassName,
+  stageContentClassName,
   toolbarClassName,
   toolbarLabel,
   noticesClassName,
   stageLabel = "Notebook",
 }: NotebookDocumentShellProps) {
   const Root = rootElement as ElementType;
+  // Callback-ref state (not a ref) so the rail re-renders once the host slot
+  // node exists and its panel portal can target it on the same commit pass.
+  const [railPanelSlotNode, setRailPanelSlotNode] = useState<HTMLDivElement | null>(null);
+  const hostsRailPanelInStage = railPanelPlacement === "stage";
   const toolbarSlot = toolbar ? (
     <div
       className={toolbarClassName}
@@ -57,7 +73,7 @@ export function NotebookDocumentShell({
     </div>
   ) : null;
 
-  return (
+  const shell = (
     <Root
       className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", className)}
       data-authenticated={capabilities?.auth.canUseAuthenticatedIdentity}
@@ -85,9 +101,36 @@ export function NotebookDocumentShell({
           {stageToolbar ? (
             <div data-slot="notebook-document-stage-toolbar">{stageToolbar}</div>
           ) : null}
-          {children}
+          {hostsRailPanelInStage ? (
+            <div
+              className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+              data-slot="notebook-document-stage-body"
+            >
+              {/* Portal target for the expanded rail panel: it slides out here,
+                  under the utility bar, while the rail strip stays on the left. */}
+              <div
+                ref={setRailPanelSlotNode}
+                className="flex min-h-0 shrink-0"
+                data-slot="notebook-document-rail-panel-host"
+              />
+              <div
+                className={cn("flex min-h-0 min-w-0 flex-1 flex-col", stageContentClassName)}
+                data-slot="notebook-document-stage-content"
+              >
+                {children}
+              </div>
+            </div>
+          ) : (
+            children
+          )}
         </section>
       </div>
     </Root>
+  );
+
+  return hostsRailPanelInStage ? (
+    <RailPanelSlotProvider node={railPanelSlotNode}>{shell}</RailPanelSlotProvider>
+  ) : (
+    shell
   );
 }

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -60,8 +60,9 @@ export function NotebookDocumentShell({
   stageLabel = "Notebook",
 }: NotebookDocumentShellProps) {
   const Root = rootElement as ElementType;
-  // Callback-ref state (not a ref) so the rail re-renders once the host slot
-  // node exists and its panel portal can target it on the same commit pass.
+  // Callback-ref state lets the provider publish the host after it commits.
+  // Until that rerender, Rail's no-host fallback keeps an expanded panel inline
+  // instead of dropping it during portal setup.
   const [railPanelSlotNode, setRailPanelSlotNode] = useState<HTMLDivElement | null>(null);
   const hostsRailPanelInStage = railPanelPlacement === "stage";
   const toolbarInStageContent = toolbarPlacement === "stage-content";

--- a/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
@@ -42,7 +42,7 @@ describe("NotebookDocumentRail", () => {
     expect(screen.getByText("Package details")).toBeVisible();
   });
 
-  it("keeps the package title row free of view-model summaries", () => {
+  it("omits redundant package header chrome and view-model summaries", () => {
     render(
       <NotebookDocumentRail
         viewModel={viewModel}
@@ -54,7 +54,7 @@ describe("NotebookDocumentRail", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Packages" })).toBeVisible();
+    expect(screen.queryByRole("heading", { name: "Packages" })).not.toBeInTheDocument();
     expect(screen.queryByText("uv · 2 packages")).not.toBeInTheDocument();
     expect(screen.getByText("Package details")).toBeVisible();
   });

--- a/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ListTree } from "lucide-react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { Rail } from "@/components/rail";
 import { NotebookDocumentShell } from "../NotebookDocumentShell";
@@ -96,6 +98,27 @@ describe("NotebookDocumentShell", () => {
     expect(stageContent).toContainElement(screen.getByLabelText("Notebook cells"));
   });
 
+  it("keeps an expanded panel mounted while its portal placement changes", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<StageHostedRailHarness />);
+
+    const panelHost = () =>
+      container.querySelector('[data-slot="notebook-document-rail-panel-host"]');
+    const rail = () => screen.getByTestId("rail");
+
+    expect(panelHost()).not.toContainElement(screen.queryByTestId("outline-content"));
+
+    await user.click(screen.getByRole("button", { name: "Expand panel" }));
+    expect(panelHost()).toContainElement(screen.getByTestId("outline-content"));
+
+    await user.click(screen.getByRole("button", { name: "Place panel in rail" }));
+    expect(panelHost()).toBeNull();
+    expect(rail()).toContainElement(screen.getByTestId("outline-content"));
+
+    await user.click(screen.getByRole("button", { name: "Place panel in stage" }));
+    expect(panelHost()).toContainElement(screen.getByTestId("outline-content"));
+  });
+
   it("exposes host capabilities for adapters and smoke tests", () => {
     const capabilities: NotebookShellCapabilities = {
       canRead: true,
@@ -147,3 +170,38 @@ describe("NotebookDocumentShell", () => {
     expect(shell).toHaveAttribute("data-can-write-runtime-state", "false");
   });
 });
+
+function StageHostedRailHarness() {
+  const [collapsed, setCollapsed] = useState(true);
+  const [placement, setPlacement] = useState<"rail" | "stage">("stage");
+
+  return (
+    <>
+      <button type="button" onClick={() => setCollapsed(false)}>
+        Expand panel
+      </button>
+      <button type="button" onClick={() => setPlacement("rail")}>
+        Place panel in rail
+      </button>
+      <button type="button" onClick={() => setPlacement("stage")}>
+        Place panel in stage
+      </button>
+      <NotebookDocumentShell
+        railPanelPlacement={placement}
+        rail={
+          <Rail
+            activePanelId="outline"
+            collapsed={collapsed}
+            items={[{ id: "outline", label: "Outline", icon: ListTree }]}
+            onActivePanelChange={vi.fn()}
+            onCollapsedChange={setCollapsed}
+          >
+            <div data-testid="outline-content">Outline content</div>
+          </Rail>
+        }
+      >
+        <section aria-label="Notebook cells">cells</section>
+      </NotebookDocumentShell>
+    </>
+  );
+}

--- a/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import { ListTree } from "lucide-react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { Rail } from "@/components/rail";
 import { NotebookDocumentShell } from "../NotebookDocumentShell";
 import type { NotebookShellCapabilities } from "../capabilities";
 
@@ -48,6 +50,50 @@ describe("NotebookDocumentShell", () => {
 
     expect(container.querySelector("main[data-slot='notebook-document-shell']")).not.toBeNull();
     expect(screen.getByLabelText("Hosted notebook")).toBeVisible();
+  });
+
+  it("keeps stage-content controls and notebook content on the panel-aware column", () => {
+    const { container } = render(
+      <NotebookDocumentShell
+        railPanelPlacement="stage"
+        toolbar={<button type="button">Run</button>}
+        toolbarPlacement="stage-content"
+        stageToolbar={<button type="button">Restart</button>}
+        stageToolbarPlacement="stage-content"
+        rail={
+          <Rail
+            activePanelId="outline"
+            collapsed={false}
+            items={[{ id: "outline", label: "Outline", icon: ListTree }]}
+            onActivePanelChange={vi.fn()}
+            onCollapsedChange={vi.fn()}
+          >
+            <div data-testid="outline-content">Outline content</div>
+          </Rail>
+        }
+      >
+        <section aria-label="Notebook cells">cells</section>
+      </NotebookDocumentShell>,
+    );
+
+    const stageBody = container.querySelector('[data-slot="notebook-document-stage-body"]');
+    const contentToolbar = container.querySelector(
+      '[data-slot="notebook-document-stage-content-toolbar"]',
+    );
+    const panelHost = container.querySelector('[data-slot="notebook-document-rail-panel-host"]');
+    const stageContent = container.querySelector('[data-slot="notebook-document-stage-content"]');
+
+    expect(stageBody).toHaveClass(
+      "grid-cols-[auto_minmax(0,1fr)]",
+      "grid-rows-[auto_minmax(0,1fr)]",
+    );
+    expect(contentToolbar).toHaveClass("col-start-2", "row-start-1");
+    expect(contentToolbar).toContainElement(screen.getByRole("button", { name: "Run" }));
+    expect(contentToolbar).toContainElement(screen.getByRole("button", { name: "Restart" }));
+    expect(panelHost).toHaveClass("col-start-1", "row-start-2");
+    expect(panelHost).toContainElement(screen.getByTestId("outline-content"));
+    expect(stageContent).toHaveClass("col-start-2", "row-start-2");
+    expect(stageContent).toContainElement(screen.getByLabelText("Notebook cells"));
   });
 
   it("exposes host capabilities for adapters and smoke tests", () => {

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -20,7 +20,8 @@ export interface RailProps<PanelId extends string = string> {
   activePanelId: PanelId;
   collapsed: boolean;
   items: readonly RailItem<PanelId>[];
-  panelTitle?: ReactNode;
+  /** Omit when the active rail control already names the panel. */
+  panelTitle?: string;
   children: ReactNode;
   onActivePanelChange: (panelId: PanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -59,7 +59,7 @@ export function Rail<PanelId extends string = string>({
   const panel = collapsed ? null : (
     <div
       className={cn(
-        "flex min-h-0 max-w-[calc(100vw-3.5rem)] flex-col border-r bg-background",
+        "flex min-h-0 max-w-[calc(100vw-3.5rem)] flex-col border-r bg-muted/20",
         panelClassName,
         RAIL_TAKEOVER_PANEL_CLASS_NAMES,
       )}
@@ -91,30 +91,46 @@ export function Rail<PanelId extends string = string>({
       data-collapsed={collapsed ? "true" : "false"}
       data-panel-hosted={panelSlotNode ? "true" : "false"}
     >
-      {/* Keep `w-14` paired with the 3.5rem takeover calculation above. */}
-      <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r bg-background px-2 py-3">
-        {leadingSlot ? <div className="mb-4 flex flex-col items-center">{leadingSlot}</div> : null}
-        {items.map((item) => (
-          <RailButton
-            key={item.id}
-            label={item.label}
-            icon={item.icon}
-            active={!collapsed && activePanelId === item.id}
-            disabled={item.disabled}
-            onClick={() => {
-              if (item.disabled) return;
-              if (!collapsed && activePanelId === item.id) {
-                onCollapsedChange(true);
-                return;
-              }
-              onActivePanelChange(item.id);
-              onCollapsedChange(false);
-            }}
-          />
-        ))}
-        {trailingSlot ? (
-          <div className="mt-auto flex flex-col items-center pt-4">{trailingSlot}</div>
-        ) : null}
+      {/* Keep `w-14` paired with the 3.5rem takeover calculation above.
+          The explicit rows mirror the shell's command row and body: the
+          leading cell stays borderless, while the body cell owns the
+          collapsed drawer boundary. */}
+      <div
+        className="grid min-h-0 w-14 shrink-0 grid-rows-[2.5rem_minmax(0,1fr)] bg-background"
+        data-slot="rail-strip-grid"
+      >
+        <div className="flex min-h-0 items-center justify-center" data-slot="rail-leading-slot">
+          {leadingSlot}
+        </div>
+        <div
+          className={cn(
+            "flex min-h-0 flex-col items-center gap-1 px-2 py-3",
+            collapsed && "border-r",
+          )}
+          data-slot="rail-body"
+        >
+          {items.map((item) => (
+            <RailButton
+              key={item.id}
+              label={item.label}
+              icon={item.icon}
+              active={!collapsed && activePanelId === item.id}
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return;
+                if (!collapsed && activePanelId === item.id) {
+                  onCollapsedChange(true);
+                  return;
+                }
+                onActivePanelChange(item.id);
+                onCollapsedChange(false);
+              }}
+            />
+          ))}
+          {trailingSlot ? (
+            <div className="mt-auto flex flex-col items-center pt-4">{trailingSlot}</div>
+          ) : null}
+        </div>
       </div>
 
       {panelSlotNode ? null : panel}

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -1,6 +1,8 @@
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
+import { useRailPanelSlot } from "./rail-panel-slot";
 
 export const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
 export const RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
@@ -50,11 +52,37 @@ export function Rail<PanelId extends string = string>({
   panelSlot = "rail-panel",
   panelTitleRowSlot = "rail-panel-title-row",
 }: RailProps<PanelId>) {
-  return (
+  const panelSlotNode = useRailPanelSlot();
+  const panel = collapsed ? null : (
+    <div
+      className={cn(
+        "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col border-r bg-background",
+        panelClassName,
+        RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+      )}
+      data-slot={panelSlot}
+    >
+      <div className="border-b px-4 py-3">
+        <div className="flex flex-col gap-1.5">
+          <div
+            className="flex min-w-0 flex-wrap items-center justify-between gap-2"
+            data-slot={panelTitleRowSlot}
+          >
+            <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
+            {panelAction}
+          </div>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
+    </div>
+  );
+
+  const strip = (
     <aside
-      className={cn("flex min-h-0 shrink-0 border-r bg-background", className)}
+      className={cn("flex min-h-0 shrink-0 bg-background", className)}
       data-testid={dataTestId}
       data-collapsed={collapsed ? "true" : "false"}
+      data-panel-hosted={panelSlotNode ? "true" : "false"}
     >
       <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r bg-background px-2 py-3">
         {leadingSlot ? <div className="mb-4 flex flex-col items-center">{leadingSlot}</div> : null}
@@ -81,30 +109,17 @@ export function Rail<PanelId extends string = string>({
         ) : null}
       </div>
 
-      {!collapsed && (
-        <div
-          className={cn(
-            "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
-            panelClassName,
-            RAIL_TAKEOVER_PANEL_CLASS_NAMES,
-          )}
-          data-slot={panelSlot}
-        >
-          <div className="border-b px-4 py-3">
-            <div className="flex flex-col gap-1.5">
-              <div
-                className="flex min-w-0 flex-wrap items-center justify-between gap-2"
-                data-slot={panelTitleRowSlot}
-              >
-                <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
-                {panelAction}
-              </div>
-            </div>
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
-        </div>
-      )}
+      {panelSlotNode ? null : panel}
     </aside>
+  );
+
+  return panelSlotNode && panel ? (
+    <>
+      {strip}
+      {createPortal(panel, panelSlotNode)}
+    </>
+  ) : (
+    strip
   );
 }
 

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -7,7 +7,7 @@ import { useRailPanelSlot } from "./rail-panel-slot";
 export const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
 export const RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
 export const RAIL_TAKEOVER_PANEL_CLASS_NAMES =
-  "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
+  "max-[599.98px]:w-[calc(100vw-3.5rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
 
 export interface RailItem<PanelId extends string = string> {
   id: PanelId;
@@ -20,7 +20,7 @@ export interface RailProps<PanelId extends string = string> {
   activePanelId: PanelId;
   collapsed: boolean;
   items: readonly RailItem<PanelId>[];
-  panelTitle: string;
+  panelTitle?: ReactNode;
   children: ReactNode;
   onActivePanelChange: (panelId: PanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -53,26 +53,31 @@ export function Rail<PanelId extends string = string>({
   panelTitleRowSlot = "rail-panel-title-row",
 }: RailProps<PanelId>) {
   const panelSlotNode = useRailPanelSlot();
+  const showPanelHeader = panelTitle != null || panelAction != null;
   const panel = collapsed ? null : (
     <div
       className={cn(
-        "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col border-r bg-background",
+        "flex min-h-0 max-w-[calc(100vw-3.5rem)] flex-col border-r bg-background",
         panelClassName,
         RAIL_TAKEOVER_PANEL_CLASS_NAMES,
       )}
       data-slot={panelSlot}
     >
-      <div className="border-b px-4 py-3">
-        <div className="flex flex-col gap-1.5">
-          <div
-            className="flex min-w-0 flex-wrap items-center justify-between gap-2"
-            data-slot={panelTitleRowSlot}
-          >
-            <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
-            {panelAction}
+      {showPanelHeader ? (
+        <div className="border-b px-4 py-3" data-slot="rail-panel-header">
+          <div className="flex flex-col gap-1.5">
+            <div
+              className="flex min-w-0 flex-wrap items-center justify-between gap-2"
+              data-slot={panelTitleRowSlot}
+            >
+              {panelTitle != null ? (
+                <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
+              ) : null}
+              {panelAction}
+            </div>
           </div>
         </div>
-      </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
     </div>
   );
@@ -150,8 +155,8 @@ export function RailButton({
       onClick={onClick}
       data-slot={dataSlot}
       className={cn(
-        "flex size-9 items-center justify-center rounded-xl text-xs transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        "flex size-9 items-center justify-center rounded-md text-xs transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         active
           ? "bg-foreground text-background"
           : "text-foreground/70 hover:bg-muted hover:text-foreground",

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -6,6 +6,7 @@ import { useRailPanelSlot } from "./rail-panel-slot";
 
 export const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
 export const RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
+// 3.5rem is the `w-14` icon strip below; takeover width must stay in lockstep.
 export const RAIL_TAKEOVER_PANEL_CLASS_NAMES =
   "max-[599.98px]:w-[calc(100vw-3.5rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
 
@@ -90,6 +91,7 @@ export function Rail<PanelId extends string = string>({
       data-collapsed={collapsed ? "true" : "false"}
       data-panel-hosted={panelSlotNode ? "true" : "false"}
     >
+      {/* Keep `w-14` paired with the 3.5rem takeover calculation above. */}
       <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r bg-background px-2 py-3">
         {leadingSlot ? <div className="mb-4 flex flex-col items-center">{leadingSlot}</div> : null}
         {items.map((item) => (

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -42,6 +42,8 @@ describe("Rail", () => {
       "w-64",
       ...RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
+    expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass("bg-muted/20");
     expect(container.querySelector('[data-slot="example-rail-title-row"]')).toHaveClass(
       "flex-wrap",
     );
@@ -103,6 +105,30 @@ describe("Rail", () => {
     expect(screen.getByTestId("outline-content")).toBeVisible();
   });
 
+  it("reserves a command-row-height leading slot even without a leading control", () => {
+    const { container } = render(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={items}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        Outline
+      </Rail>,
+    );
+
+    expect(container.querySelector('[data-slot="rail-strip-grid"]')).toHaveClass(
+      "grid-rows-[2.5rem_minmax(0,1fr)]",
+    );
+    expect(container.querySelector('[data-slot="rail-leading-slot"]')).not.toHaveClass(
+      "border-b",
+      "border-r",
+    );
+    expect(container.querySelector('[data-slot="rail-strip-grid"]')).not.toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="rail-strip-grid"]')).toHaveClass("bg-background");
+  });
+
   it("expands and selects a panel while collapsed", () => {
     const onActivePanelChange = vi.fn();
     const onCollapsedChange = vi.fn();
@@ -123,6 +149,40 @@ describe("Rail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Packages" }));
     expect(onActivePanelChange).toHaveBeenCalledWith("packages");
     expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("moves the outer boundary from the collapsed strip to the expanded panel", () => {
+    const { container, rerender } = render(
+      <Rail
+        activePanelId="outline"
+        collapsed
+        items={items}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        Outline
+      </Rail>,
+    );
+
+    expect(container.querySelector('[data-slot="rail-leading-slot"]')).not.toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="rail-body"]')).toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="rail-panel"]')).toBeNull();
+
+    rerender(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={items}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        Outline
+      </Rail>,
+    );
+
+    expect(container.querySelector('[data-slot="rail-leading-slot"]')).not.toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="rail-body"]')).not.toHaveClass("border-r");
+    expect(container.querySelector('[data-slot="rail-panel"]')).toHaveClass("border-r");
   });
 
   it("does not invoke callbacks for disabled rail items", () => {

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -86,6 +86,23 @@ describe("Rail", () => {
     expect(screen.queryByRole("button", { name: "Collapse rail" })).not.toBeInTheDocument();
   });
 
+  it("omits redundant panel header chrome when no title or action is provided", () => {
+    const { container } = render(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={items}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        <div data-testid="outline-content">Outline</div>
+      </Rail>,
+    );
+
+    expect(container.querySelector('[data-slot="rail-panel-header"]')).toBeNull();
+    expect(screen.getByTestId("outline-content")).toBeVisible();
+  });
+
   it("expands and selects a panel while collapsed", () => {
     const onActivePanelChange = vi.fn();
     const onCollapsedChange = vi.fn();
@@ -139,6 +156,9 @@ describe("RailButton", () => {
     expect(screen.getByRole("button", { name: "Outline" })).toHaveClass(
       "bg-foreground",
       "text-background",
+      "rounded-md",
+      "focus-visible:ring-1",
+      "focus-visible:ring-ring",
     );
   });
 

--- a/src/components/rail/index.ts
+++ b/src/components/rail/index.ts
@@ -8,3 +8,4 @@ export {
   type RailItem,
   type RailProps,
 } from "./Rail";
+export { RailPanelSlotProvider, useRailPanelSlot } from "./rail-panel-slot";

--- a/src/components/rail/rail-panel-slot.tsx
+++ b/src/components/rail/rail-panel-slot.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Host-owned DOM node that an expanded rail panel renders into.
+ *
+ * The rail's icon strip stays where the host puts it (far left of the page
+ * content). When a host provides a slot node, the expandable panel portals into
+ * it instead of sitting inside the rail `aside`, so the panel can open below the
+ * utility bar and beside the notebook content while the strip keeps full height.
+ *
+ * `null` (the default) keeps the panel inside the rail — standalone rails and
+ * fixtures need no host wiring.
+ */
+const RailPanelSlotContext = createContext<HTMLElement | null>(null);
+
+export function useRailPanelSlot(): HTMLElement | null {
+  return useContext(RailPanelSlotContext);
+}
+
+export function RailPanelSlotProvider({
+  node,
+  children,
+}: {
+  node: HTMLElement | null;
+  children: ReactNode;
+}) {
+  return <RailPanelSlotContext.Provider value={node}>{children}</RailPanelSlotContext.Provider>;
+}


### PR DESCRIPTION
## Summary

- Carry Erika Yee’s panel-under-toolbar layout forward from #4157 on a clean `main` base, preserving her original commit authorship.
- Model the notebook shell as an explicit rail / drawer / stage grid so the visual boundary belongs to the collapsed rail and moves to the drawer edge when expanded.
- Keep the rail and notebook command bar on the same white surface while giving expanded drawer contents a subtle background distinction.
- Remove redundant Outline, Packages, and Discussions headings; retain the Workstations title/action row where it still carries controls.
- Place the cloud app header across the full shell width and keep notebook commands attached to the notebook stage below it.
- Keep the Elements cloud fixture structurally aligned with the production cloud composition.

## Context and attribution

This PR starts by replaying Erika’s `3997f7c1f` follow-up from #4157 with its original authorship, then builds the shared desktop/cloud rail-drawer structure on top of that direction. #4156 was the earlier layout exploration that led into this implementation.

## Verification

- `cargo xtask lint --fix`
- 49 focused component tests across the rail, notebook rail, and notebook document shell
- Notebook Cloud TypeScript check
- Notebook Cloud viewer production build
- Elements TypeScript check
- Human visual review in the desktop development app and rendered cloud fixture, covering collapsed and expanded rail states
