### PR TITLE
feat(dev): isolate macOS desktop worktrees

### DIFF
--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -12,6 +12,10 @@ description: >
 
 | Task | Command |
 |------|---------|
+| Start full dev loop | `cargo xtask dev` |
+| Report app + daemon identity | `cargo xtask dev status` |
+| Focus exact macOS dev app | `cargo xtask dev focus` |
+| Restart app + daemon cleanly | `cargo xtask dev --fresh` |
 | Start dev daemon | `cargo xtask dev-daemon` |
 | Full build | `cargo xtask build` |
 | Rust-only rebuild | `cargo xtask build --rust-only` |
@@ -65,13 +69,29 @@ cargo xtask wasm sift        # only sift-wasm
 ### Fast iteration
 
 ```bash
+cargo xtask dev
+```
+
+This is the normal desktop workflow: it starts the per-worktree daemon, waits for
+readiness, launches the hot-reload app, and stops the daemon it started when the
+app exits. On macOS the app has a distinct per-worktree display name, bundle ID,
+and process record. Inspect or focus that exact process with:
+
+```bash
+cargo xtask dev status
+cargo xtask dev focus
+```
+
+After Tauri bootstrap or listener changes, use `cargo xtask dev --fresh` to reset
+only this worktree's app and daemon. Use the split workflow when the daemon must
+remain independently managed:
+
+```bash
 # Terminal 1
 cargo xtask dev-daemon
 
 # Terminal 2
-cargo xtask build --rust-only     # Fast rebuild (reuses frontend assets)
-cargo xtask build --rust-only --skip-tauri  # Faster compile check for Rust sidecars
-cargo xtask run                   # Run the bundled binary
+cargo xtask notebook
 ```
 
 ### Testing
@@ -84,7 +104,7 @@ cargo test -p runtimed test_daemon_ping_pong    # Specific test
 
 ### Per-worktree isolation
 
-`cargo xtask dev-daemon`, `cargo xtask notebook`, and `cargo xtask run-mcp` derive the git worktree automatically. State lives at `<cache>/runt-nightly/worktrees/{hash}/`. Set `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` only for raw `./target/debug/runt` commands outside xtask.
+`cargo xtask dev`, `cargo xtask dev-daemon`, `cargo xtask notebook`, and `cargo xtask run-mcp` derive the git worktree automatically. State lives at `<cache>/runt-nightly/worktrees/{hash}/`. Set `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` only for raw `./target/debug/runt` commands outside xtask.
 
 ## Python Bindings
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,23 @@ Use `nteract-dev` for development against this worktree. The `nteract` and
 changes. If `nteract-dev` is unavailable, use `cargo xtask`; do not substitute
 an installed notebook server. Full server details are in the scoped MCP rules.
 
+For desktop source work, prefer `cargo xtask dev`. It starts the worktree-local
+daemon and hot-reload app together and stops the daemon it started when the app
+exits. On macOS, each worktree launches with a distinct `nteract Dev <hash>`
+name and bundle identifier so it does not alias an installed stable or Nightly
+app. Use `cargo xtask dev status` for the exact app PID, executable, identity,
+Vite URL, and daemon socket; use `cargo xtask dev focus` to activate that exact
+process. Accessibility automation must select the reported `Automation PID`,
+not resolve an application named `nteract` through LaunchServices.
+
+After changing Tauri bootstrap or listener setup, use `cargo xtask dev --fresh`
+to reset and relaunch this worktree's app and daemon. Use
+`cargo xtask dev reset` when a clean stop is needed without relaunching. Reserve
+`cargo xtask notebook` for an app-only loop when the worktree daemon is already
+managed separately. These commands derive and export the worktree namespace;
+`direnv allow` is still useful for an interactive shell but is not required for
+xtask isolation.
+
 Before every commit, run:
 
 ```bash
@@ -57,8 +74,9 @@ Run the narrow tests for the code you changed, then widen verification when the
 risk or subsystem guide calls for it. Use the `testing` skill for repository
 test workflows.
 
-`cargo xtask notebook` opens a GUI and blocks until it quits. Let the developer
-run it from their own terminal.
+Desktop dev commands open a GUI and block until it quits. Let the developer run
+them from their own terminal unless the task explicitly requires live desktop
+validation.
 
 ## Commits and reviews
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,12 @@ cargo xtask dev
 
 | Workflow | Command | Use when |
 |----------|---------|----------|
-| One-shot setup + dev | `cargo xtask dev` | First-time setup plus daemon + app in one command |
-| Hot reload | `cargo xtask notebook` | Iterating on React UI |
+| Full dev loop | `cargo xtask dev` | Setup plus the per-worktree daemon and hot-reload app |
+| Clean dev restart | `cargo xtask dev --fresh` | Recover from stale Tauri listeners, bootstrap, or daemon state |
+| Dev status | `cargo xtask dev status` | Show the exact app identity, PID, executable, Vite URL, and daemon socket |
+| Focus dev app | `cargo xtask dev focus` | Activate this worktree's exact macOS app process |
+| Reset dev state | `cargo xtask dev reset` | Stop this worktree's app and daemon without affecting installed apps |
+| App-only hot reload | `cargo xtask notebook` | Run the app when the per-worktree daemon is already managed separately |
 | Standalone Vite | `cargo xtask vite` | Multi-window testing (Vite survives window closes) |
 | Attach to Vite | `cargo xtask notebook --attach` | Connect Tauri to already-running Vite |
 | Debug build | `cargo xtask build` | Full debug build (frontend + rust) |
@@ -229,9 +233,33 @@ cargo xtask dev
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
 | Generate icons | `cargo xtask icons [source.png]` | Generate icon variants from source image |
 
-`cargo xtask dev` runs the first-time bootstrap (`pnpm install` + `cargo xtask build`),
-starts the per-worktree dev daemon, waits for it to be ready, and then launches the
-notebook app. For repeat launches, use `cargo xtask dev --skip-install --skip-build`.
+`cargo xtask dev` installs dependencies, ensures generated artifacts, starts the
+per-worktree dev daemon, waits for it to be ready, and then launches the notebook
+app with hot reload. It stops the daemon it started when the app exits. For repeat
+launches, use `cargo xtask dev --skip-install --skip-build`.
+
+On macOS, every worktree gets a cached app wrapper with a distinct name and bundle
+identifier, such as `nteract Dev f0f9d9` and
+`org.nteract.desktop.dev.f0f9d99b161f`. This keeps unsigned source builds separate
+from installed stable and Nightly apps without changing release packaging or
+claiming `.ipynb` file associations. Use `cargo xtask dev status` to obtain the
+live automation PID. Accessibility scripts should select the System Events process
+by that PID instead of asking LaunchServices for an app named `nteract`:
+
+```applescript
+set devPid to 12345 -- copy Automation PID from `cargo xtask dev status`
+tell application "System Events"
+  tell first application process whose unix id is devPid
+    -- perform UI automation here
+  end tell
+end tell
+```
+
+Frontend edits continue through Vite hot reload. After changes to Tauri bootstrap
+or event-listener setup, use `cargo xtask dev --fresh` to terminate only this
+worktree's exact app process, stop its daemon, and relaunch both cleanly. The
+equivalent manual sequence is `cargo xtask dev reset` followed by
+`cargo xtask dev`.
 
 ### Build order
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4292,6 +4292,85 @@ fn correct_window_scale(window: &tauri::WebviewWindow, saved_scale_factor: Optio
     let _ = window.set_size(tauri::PhysicalSize::new(corrected_width, corrected_height));
 }
 
+fn write_dev_app_state(app: &tauri::App) -> Result<Option<PathBuf>, String> {
+    if !runt_workspace::is_dev_mode() {
+        return Ok(None);
+    }
+
+    let workspace = runt_workspace::get_workspace_path()
+        .ok_or_else(|| "dev mode is active but the worktree path is unavailable".to_string())?;
+    let identity = runt_workspace::dev_app_identity_for_workspace(&workspace);
+    let state_path = runt_workspace::dev_app_state_path()
+        .ok_or_else(|| "dev app state path is unavailable".to_string())?;
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("could not resolve the dev app executable: {error}"))?;
+    let vite_port = std::env::var("RUNTIMED_VITE_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .or_else(runt_workspace::default_vite_port)
+        .unwrap_or(5174);
+    let started_at_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+    let state = runt_workspace::DevAppState {
+        identity: identity.clone(),
+        pid: std::process::id(),
+        executable,
+        workspace,
+        daemon_socket: runt_workspace::default_socket_path(),
+        vite_url: format!("http://localhost:{vite_port}"),
+        started_at_unix_ms,
+    };
+
+    if app.config().identifier != identity.bundle_identifier {
+        return Err(format!(
+            "Tauri dev identifier mismatch: expected {}, got {}",
+            identity.bundle_identifier,
+            app.config().identifier
+        ));
+    }
+    if app.config().product_name.as_deref() != Some(identity.display_name.as_str()) {
+        return Err(format!(
+            "Tauri dev product name mismatch: expected {}, got {:?}",
+            identity.display_name,
+            app.config().product_name
+        ));
+    }
+
+    if let Some(parent) = state_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    let temporary = state_path.with_extension(format!("json.{}.tmp", state.pid));
+    let serialized = serde_json::to_vec_pretty(&state)
+        .map_err(|error| format!("could not serialize dev app state: {error}"))?;
+    std::fs::write(&temporary, serialized)
+        .map_err(|error| format!("could not write {}: {error}", temporary.display()))?;
+    std::fs::rename(&temporary, &state_path).map_err(|error| {
+        format!(
+            "could not publish dev app state {}: {error}",
+            state_path.display()
+        )
+    })?;
+    Ok(Some(state_path))
+}
+
+fn clear_dev_app_state_for_pid(pid: u32) {
+    let Some(state_path) = runt_workspace::dev_app_state_path() else {
+        return;
+    };
+    let recorded_pid = std::fs::read(&state_path)
+        .ok()
+        .and_then(|contents| serde_json::from_slice::<runt_workspace::DevAppState>(&contents).ok())
+        .map(|state| state.pid);
+    if recorded_pid == Some(pid) {
+        let _ = std::fs::remove_file(state_path);
+    }
+}
+
 /// Run the notebook Tauri app.
 ///
 /// If `notebook_path` is Some, opens that file. If None, creates a new empty notebook.
@@ -4735,6 +4814,17 @@ pub fn run(
         .setup(move |app| {
             let setup_start = std::time::Instant::now();
             log::info!("[startup] App setup starting");
+
+            match write_dev_app_state(app) {
+                Ok(Some(path)) => log::info!(
+                    "[startup] Development app identity: {} (PID {}, state {})",
+                    app.config().identifier,
+                    std::process::id(),
+                    path.display()
+                ),
+                Ok(None) => {}
+                Err(error) => log::warn!("[startup] Failed to publish dev app identity: {error}"),
+            }
 
             // Ensure ~/notebooks directory exists for new notebook saves and kernel CWD
             let notebooks_dir = ensure_notebooks_directory()
@@ -5514,6 +5604,7 @@ pub fn run(
             if let Err(e) = session::save_session(&registry_for_session, app_handle) {
                 log::error!("[session] Failed to save session: {}", e);
             }
+            clear_dev_app_state_for_pid(std::process::id());
         }
 
         // Handle file associations (macOS only).

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4344,6 +4344,7 @@ fn write_dev_app_state(app: &tauri::App) -> Result<Option<PathBuf>, String> {
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
     }
+    let _state_lock = lock_dev_app_state(&state_path)?;
     let temporary = state_path.with_extension(format!("json.{}.tmp", state.pid));
     let serialized = serde_json::to_vec_pretty(&state)
         .map_err(|error| format!("could not serialize dev app state: {error}"))?;
@@ -4358,9 +4359,30 @@ fn write_dev_app_state(app: &tauri::App) -> Result<Option<PathBuf>, String> {
     Ok(Some(state_path))
 }
 
+fn lock_dev_app_state(state_path: &Path) -> Result<std::fs::File, String> {
+    let lock_path = state_path.with_extension("lock");
+    let lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| format!("could not open {}: {error}", lock_path.display()))?;
+    lock.lock()
+        .map_err(|error| format!("could not lock {}: {error}", lock_path.display()))?;
+    Ok(lock)
+}
+
 fn clear_dev_app_state_for_pid(pid: u32) {
     let Some(state_path) = runt_workspace::dev_app_state_path() else {
         return;
+    };
+    let _state_lock = match lock_dev_app_state(&state_path) {
+        Ok(lock) => lock,
+        Err(error) => {
+            log::warn!("[shutdown] Failed to lock development app state: {error}");
+            return;
+        }
     };
     let recorded_pid = std::fs::read(&state_path)
         .ok()

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -6,7 +6,7 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -196,6 +196,54 @@ pub const NTERACT_BUNDLE_IDENTIFIERS: &[&str] =
 
 /// Legacy bundle identifiers that should no longer be the default `.ipynb` handler.
 pub const STALE_BUNDLE_IDENTIFIERS: &[&str] = &["com.runtimed.notebook"];
+
+/// A macOS-resolvable identity for a source-built desktop app.
+///
+/// Release builds keep the stable/nightly identities above. Development builds
+/// add the worktree hash so multiple source checkouts do not alias each other
+/// or an installed application in AppKit and accessibility tooling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DevAppIdentity {
+    pub workspace_hash: String,
+    pub display_name: String,
+    pub bundle_identifier: String,
+}
+
+/// Runtime record written by a development desktop process.
+///
+/// The PID is intentionally paired with the executable and workspace paths.
+/// Callers must validate those fields against the live process before focusing
+/// or terminating it because PIDs can be reused after a crash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DevAppState {
+    pub identity: DevAppIdentity,
+    pub pid: u32,
+    pub executable: PathBuf,
+    pub workspace: PathBuf,
+    pub daemon_socket: PathBuf,
+    pub vite_url: String,
+    pub started_at_unix_ms: u64,
+}
+
+/// Derive the source-built desktop identity for one worktree.
+pub fn dev_app_identity_for_workspace(workspace: &Path) -> DevAppIdentity {
+    let workspace_hash = worktree_hash(workspace);
+    DevAppIdentity {
+        display_name: format!("nteract Dev {}", &workspace_hash[..6]),
+        bundle_identifier: format!("org.nteract.desktop.dev.{workspace_hash}"),
+        workspace_hash,
+    }
+}
+
+/// Derive the source-built desktop identity for the active worktree.
+pub fn dev_app_identity() -> Option<DevAppIdentity> {
+    get_workspace_path().map(|workspace| dev_app_identity_for_workspace(&workspace))
+}
+
+/// Per-worktree process record for the source-built desktop app.
+pub fn dev_app_state_path() -> Option<PathBuf> {
+    is_dev_mode().then(|| daemon_base_dir().join("dev-app.json"))
+}
 
 /// Human-readable channel name for display.
 pub fn channel_display_name() -> &'static str {
@@ -1353,6 +1401,26 @@ mod tests {
         let path1 = Path::new("/path/one");
         let path2 = Path::new("/path/two");
         assert_ne!(worktree_hash(path1), worktree_hash(path2));
+    }
+
+    #[test]
+    fn dev_app_identity_is_distinct_and_bundle_safe_per_worktree() {
+        let first = dev_app_identity_for_workspace(Path::new("/tmp/nteract-one"));
+        let second = dev_app_identity_for_workspace(Path::new("/tmp/nteract-two"));
+
+        assert_ne!(first, second);
+        assert_eq!(first.workspace_hash.len(), 12);
+        assert_eq!(
+            first.display_name,
+            format!("nteract Dev {}", &first.workspace_hash[..6])
+        );
+        assert_eq!(
+            first.bundle_identifier,
+            format!("org.nteract.desktop.dev.{}", first.workspace_hash)
+        );
+        assert!(first.bundle_identifier.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '.' || character == '-'
+        }));
     }
 
     #[test]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -54,10 +54,17 @@ fn main() {
     }
 
     match args[0].as_str() {
-        "dev" => {
-            let options = parse_dev_options(&args);
-            cmd_dev(options.notebook, options.skip_install, options.skip_build);
-        }
+        "dev" => match parse_dev_command(&args) {
+            DevCommand::Launch(options) => cmd_dev(
+                options.notebook,
+                options.skip_install,
+                options.skip_build,
+                options.fresh,
+            ),
+            DevCommand::Status => cmd_dev_status(),
+            DevCommand::Focus => cmd_dev_focus(),
+            DevCommand::Reset => cmd_dev_reset(),
+        },
         "notebook" => {
             let attach = args.iter().any(|a| a == "--attach");
             let notebook = args
@@ -173,8 +180,12 @@ fn print_help() {
 
 Development:
   dev [notebook.ipynb]         Setup once, start dev daemon + notebook app
+  dev --fresh                  Reset this worktree's app + daemon, then launch
   dev --skip-build             Reuse existing build artifacts before launch
   dev --skip-install           Reuse existing pnpm install before launch
+  dev status                   Report this worktree's exact app, PID, and daemon
+  dev focus                    Focus this worktree's exact app process (macOS)
+  dev reset                    Stop this worktree's app + daemon cleanly
   notebook [notebook.ipynb]    Start hot-reload dev server (dev mode, safe)
   notebook --attach [notebook] Attach Tauri to existing Vite server
   vite                       Start Vite server standalone
@@ -671,10 +682,26 @@ struct DevOptions<'a> {
     notebook: Option<&'a str>,
     skip_install: bool,
     skip_build: bool,
+    fresh: bool,
 }
 
-fn parse_dev_options(args: &[String]) -> DevOptions<'_> {
-    DevOptions {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DevCommand<'a> {
+    Launch(DevOptions<'a>),
+    Status,
+    Focus,
+    Reset,
+}
+
+fn parse_dev_command(args: &[String]) -> DevCommand<'_> {
+    match args.get(1).map(String::as_str) {
+        Some("status") => return DevCommand::Status,
+        Some("focus") => return DevCommand::Focus,
+        Some("reset") => return DevCommand::Reset,
+        _ => {}
+    }
+
+    DevCommand::Launch(DevOptions {
         notebook: args
             .iter()
             .skip(1)
@@ -682,10 +709,15 @@ fn parse_dev_options(args: &[String]) -> DevOptions<'_> {
             .map(String::as_str),
         skip_install: args.iter().any(|arg| arg == "--skip-install"),
         skip_build: args.iter().any(|arg| arg == "--skip-build"),
-    }
+        fresh: args.iter().any(|arg| arg == "--fresh"),
+    })
 }
 
-fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
+fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool, fresh: bool) {
+    if fresh {
+        cmd_dev_reset();
+        println!();
+    }
     require_pnpm();
     require_tauri();
 
@@ -772,11 +804,20 @@ fn cmd_notebook(notebook: Option<&str>, attach: bool) {
 }
 
 fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bool) -> ExitStatus {
+    ensure_no_running_dev_app();
+
     // Delete bundled marker since we're building a dev binary
     let marker = notebook_bundled_marker_path();
     let _ = fs::remove_file(marker);
 
     let vite_port = resolve_vite_port(force_dev_mode);
+    let identity = current_dev_app_identity();
+    println!(
+        "Development app: {} ({})",
+        identity.display_name, identity.bundle_identifier
+    );
+    println!("Worktree identity: {}", identity.workspace_hash);
+    let dev_runner = macos_dev_app_runner();
     let mut command = Command::new("cargo");
 
     if attach {
@@ -786,11 +827,13 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 
         // Skip beforeDevCommand (Vite is already running), set devUrl,
         // and drop externalBin so sidecar binaries aren't required in dev
-        let config = format!(
-            r#"{{"build":{{"devUrl":"http://localhost:{port}","beforeDevCommand":""}},"bundle":{{"externalBin":[]}}}}"#
-        );
+        let config = dev_tauri_config(Some(&port), true, &identity);
 
-        let mut args = vec!["tauri", "dev", "--config", &config, "--", "-p", "notebook"];
+        let mut args = vec!["tauri", "dev", "--config", &config];
+        if let Some(runner) = dev_runner.as_deref() {
+            args.extend(["--runner", runner]);
+        }
+        args.extend(["--", "-p", "notebook"]);
         if let Some(path) = notebook {
             args.extend(["--", path]);
         }
@@ -801,17 +844,15 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 
         // Always override externalBin so sidecar binaries aren't required
         // in dev mode (the daemon is started separately via dev-daemon)
-        let config_override = match vite_port.as_ref() {
-            Some(port) => {
-                println!("Using RUNTIMED_VITE_PORT={port}");
-                format!(
-                    r#"{{"build":{{"devUrl":"http://localhost:{port}"}},"bundle":{{"externalBin":[]}}}}"#
-                )
-            }
-            None => r#"{"bundle":{"externalBin":[]}}"#.to_string(),
-        };
+        if let Some(port) = vite_port.as_ref() {
+            println!("Using RUNTIMED_VITE_PORT={port}");
+        }
+        let config_override = dev_tauri_config(vite_port.as_deref(), false, &identity);
 
         let mut args = vec!["tauri", "dev", "--config", &config_override];
+        if let Some(runner) = dev_runner.as_deref() {
+            args.extend(["--runner", runner]);
+        }
         args.extend(["--", "-p", "notebook"]);
         if let Some(path) = notebook {
             args.extend(["--", path]);
@@ -826,11 +867,80 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
     if let Some(ref port) = vite_port {
         command.env("RUNTIMED_VITE_PORT", port);
     }
+    if cfg!(target_os = "macos") {
+        command
+            .env(
+                "NTERACT_DEV_BINARY_PATH",
+                cargo_debug_binary_path("notebook"),
+            )
+            .env(
+                "NTERACT_DEV_APP_BUNDLE_PATH",
+                dev_state_dir().join(format!("{}.app", identity.display_name)),
+            )
+            .env("NTERACT_DEV_APP_DISPLAY_NAME", &identity.display_name)
+            .env("NTERACT_DEV_APP_BUNDLE_ID", &identity.bundle_identifier);
+    }
 
     command.status().unwrap_or_else(|e| {
         eprintln!("Failed to run cargo tauri dev: {e}");
         exit(1);
     })
+}
+
+fn macos_dev_app_runner() -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let path = workspace_root_or_exit().join("scripts/macos-dev-app-runner.py");
+    if !path.exists() {
+        eprintln!(
+            "macOS development app runner is missing: {}",
+            path.display()
+        );
+        exit(1);
+    }
+    Some(path.to_string_lossy().into_owned())
+}
+
+fn current_dev_app_identity() -> runt_workspace::DevAppIdentity {
+    let workspace = runt_workspace::get_workspace_path().unwrap_or_else(|| {
+        eprintln!("Error: could not resolve the current git worktree for the dev app identity.");
+        exit(1);
+    });
+    runt_workspace::dev_app_identity_for_workspace(&workspace)
+}
+
+fn dev_tauri_config(
+    vite_port: Option<&str>,
+    attach: bool,
+    identity: &runt_workspace::DevAppIdentity,
+) -> String {
+    let mut build = serde_json::Map::new();
+    if let Some(port) = vite_port {
+        build.insert(
+            "devUrl".to_string(),
+            serde_json::Value::String(format!("http://localhost:{port}")),
+        );
+    }
+    if attach {
+        build.insert(
+            "beforeDevCommand".to_string(),
+            serde_json::Value::String(String::new()),
+        );
+    }
+
+    serde_json::json!({
+        "productName": identity.display_name,
+        "identifier": identity.bundle_identifier,
+        "build": build,
+        "bundle": {
+            "externalBin": [],
+            // A dev executable must never become a LaunchServices candidate
+            // for opening notebooks owned by an installed stable/nightly app.
+            "fileAssociations": []
+        }
+    })
+    .to_string()
 }
 
 fn cmd_vite() {
@@ -3000,17 +3110,395 @@ fn notebook_bundled_marker_path() -> PathBuf {
 }
 
 fn dev_socket_path() -> PathBuf {
+    dev_state_dir().join("runtimed.sock")
+}
+
+fn dev_state_dir() -> PathBuf {
     let workspace = runt_workspace::get_workspace_path().unwrap_or_else(|| {
         eprintln!("Error: could not resolve current git worktree.");
         exit(1);
     });
-    let hash = runt_workspace::worktree_hash(&workspace);
     dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join(runt_workspace::cache_namespace())
         .join("worktrees")
-        .join(hash)
-        .join("runtimed.sock")
+        .join(runt_workspace::worktree_hash(&workspace))
+}
+
+fn dev_app_state_path() -> PathBuf {
+    dev_state_dir().join("dev-app.json")
+}
+
+#[derive(Debug)]
+struct RunningDevApp {
+    state: runt_workspace::DevAppState,
+    live_name: Option<String>,
+    live_bundle_identifier: Option<String>,
+    live_executable: PathBuf,
+}
+
+#[derive(Debug)]
+enum DevAppInspection {
+    NotRecorded,
+    Running(RunningDevApp),
+    Stale {
+        state: runt_workspace::DevAppState,
+        reason: String,
+    },
+}
+
+fn inspect_dev_app() -> DevAppInspection {
+    let state_path = dev_app_state_path();
+    let contents = match fs::read(&state_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return DevAppInspection::NotRecorded;
+        }
+        Err(error) => {
+            eprintln!("Failed to read {}: {error}", state_path.display());
+            return DevAppInspection::NotRecorded;
+        }
+    };
+    let state: runt_workspace::DevAppState = match serde_json::from_slice(&contents) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!("Failed to parse {}: {error}", state_path.display());
+            return DevAppInspection::NotRecorded;
+        }
+    };
+
+    match live_dev_app_info(state.pid) {
+        Ok(Some((live_executable, live_name, live_bundle_identifier))) => {
+            let expected = canonical_path_or_original(&state.executable);
+            let actual = canonical_path_or_original(&live_executable);
+            if expected != actual {
+                return DevAppInspection::Stale {
+                    state,
+                    reason: format!(
+                        "PID now belongs to {} instead of {}",
+                        actual.display(),
+                        expected.display()
+                    ),
+                };
+            }
+            DevAppInspection::Running(RunningDevApp {
+                state,
+                live_name,
+                live_bundle_identifier,
+                live_executable: actual,
+            })
+        }
+        Ok(None) => DevAppInspection::Stale {
+            state,
+            reason: "recorded PID is no longer running".to_string(),
+        },
+        Err(reason) => DevAppInspection::Stale { state, reason },
+    }
+}
+
+fn canonical_path_or_original(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(target_os = "macos")]
+fn live_dev_app_info(
+    pid: u32,
+) -> Result<Option<(PathBuf, Option<String>, Option<String>)>, String> {
+    // NSRunningApplication can briefly retain a cached object after the Unix
+    // process has exited, so establish liveness before asking AppKit for its
+    // bundle metadata.
+    if !process_is_live(pid) {
+        return Ok(None);
+    }
+    let script = format!(
+        r#"ObjC.import("AppKit");
+const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier({pid});
+if (!app || Boolean(app.terminated)) {{
+  JSON.stringify(null);
+}} else {{
+  const unwrap = value => value ? ObjC.unwrap(value) : null;
+  JSON.stringify({{
+    executable: unwrap(app.executableURL.path),
+    name: unwrap(app.localizedName),
+    bundleIdentifier: unwrap(app.bundleIdentifier)
+  }});
+}}"#
+    );
+    let output = Command::new("osascript")
+        .args(["-l", "JavaScript", "-e", &script])
+        .output()
+        .map_err(|error| format!("failed to inspect PID {pid} through AppKit: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "AppKit process inspection failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("invalid AppKit process response: {error}"))?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(executable) = value.get("executable").and_then(serde_json::Value::as_str) else {
+        return Err(format!("PID {pid} has no executable URL"));
+    };
+    Ok(Some((
+        PathBuf::from(executable),
+        value
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        value
+            .get("bundleIdentifier")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+    )))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn live_dev_app_info(
+    pid: u32,
+) -> Result<Option<(PathBuf, Option<String>, Option<String>)>, String> {
+    let state = fs::read_to_string(dev_app_state_path())
+        .ok()
+        .and_then(|contents| serde_json::from_str::<runt_workspace::DevAppState>(&contents).ok());
+    let Some(state) = state else {
+        return Ok(None);
+    };
+    let running = process_is_live(pid);
+    Ok(running.then(|| (state.executable, None, None)))
+}
+
+fn process_is_live(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn ensure_no_running_dev_app() {
+    match inspect_dev_app() {
+        DevAppInspection::Running(app) => {
+            eprintln!(
+                "{} is already running for this worktree (PID {}).",
+                app.state.identity.display_name, app.state.pid
+            );
+            eprintln!("Focus it with: cargo xtask dev focus");
+            eprintln!("Restart it cleanly with: cargo xtask dev --fresh");
+            exit(1);
+        }
+        DevAppInspection::Stale { reason, .. } => {
+            eprintln!("Removing stale dev app record: {reason}");
+            let _ = fs::remove_file(dev_app_state_path());
+        }
+        DevAppInspection::NotRecorded => {}
+    }
+}
+
+fn cmd_dev_status() {
+    let workspace = workspace_root_or_exit();
+    let identity = runt_workspace::dev_app_identity_for_workspace(&workspace);
+    println!("Worktree: {}", workspace.display());
+    println!(
+        "App identity: {} ({})",
+        identity.display_name, identity.bundle_identifier
+    );
+    match inspect_dev_app() {
+        DevAppInspection::Running(app) => {
+            println!("Desktop: running (PID {})", app.state.pid);
+            println!("Executable: {}", app.live_executable.display());
+            println!(
+                "macOS name: {}",
+                app.live_name.as_deref().unwrap_or("<not reported>")
+            );
+            println!(
+                "macOS bundle ID: {}",
+                app.live_bundle_identifier
+                    .as_deref()
+                    .unwrap_or("<not reported>")
+            );
+            println!("Automation PID: {}", app.state.pid);
+            println!("Vite: {}", app.state.vite_url);
+        }
+        DevAppInspection::Stale { state, reason } => {
+            println!("Desktop: stale record (PID {}): {reason}", state.pid);
+        }
+        DevAppInspection::NotRecorded => println!("Desktop: not running"),
+    }
+    println!(
+        "Daemon: {}",
+        if dev_daemon_running() {
+            "running"
+        } else {
+            "not running"
+        }
+    );
+    println!("Daemon socket: {}", dev_socket_path().display());
+}
+
+fn cmd_dev_focus() {
+    let DevAppInspection::Running(app) = inspect_dev_app() else {
+        eprintln!("No live development app is recorded for this worktree.");
+        eprintln!("Start it with: cargo xtask dev");
+        exit(1);
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"ObjC.import("AppKit");
+const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier({});
+JSON.stringify({{ activated: app ? Boolean(app.activateWithOptions(3)) : false }});"#,
+            app.state.pid
+        );
+        let output = Command::new("osascript")
+            .args(["-l", "JavaScript", "-e", &script])
+            .output()
+            .unwrap_or_else(|error| {
+                eprintln!("Failed to request AppKit activation: {error}");
+                exit(1);
+            });
+        let activated = output.status.success()
+            && serde_json::from_slice::<serde_json::Value>(&output.stdout)
+                .ok()
+                .and_then(|value| value.get("activated").and_then(serde_json::Value::as_bool))
+                .unwrap_or(false);
+        if !activated {
+            eprintln!(
+                "AppKit could not focus PID {}: {}",
+                app.state.pid,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            exit(1);
+        }
+        println!(
+            "Focused {} (PID {}).",
+            app.state.identity.display_name, app.state.pid
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        eprintln!("cargo xtask dev focus is currently supported on macOS only.");
+        exit(1);
+    }
+}
+
+fn cmd_dev_reset() {
+    match inspect_dev_app() {
+        DevAppInspection::Running(app) => {
+            println!(
+                "Stopping {} (PID {})...",
+                app.state.identity.display_name, app.state.pid
+            );
+            terminate_dev_app(app.state.pid);
+        }
+        DevAppInspection::Stale { reason, .. } => {
+            println!("Removing stale dev app record ({reason}).");
+        }
+        DevAppInspection::NotRecorded => println!("Development app is not running."),
+    }
+    let _ = fs::remove_file(dev_app_state_path());
+
+    if dev_daemon_running() {
+        let cli = dev_runt_cli_binary();
+        if !cli.exists() {
+            eprintln!(
+                "Development daemon is running, but {} is unavailable to stop it.",
+                cli.display()
+            );
+            exit(1);
+        }
+        println!("Stopping this worktree's development daemon...");
+        let mut command = Command::new(cli);
+        command.args(["daemon", "stop"]);
+        apply_worktree_env(&mut command, true);
+        let status = command.status().unwrap_or_else(|error| {
+            eprintln!("Failed to stop development daemon: {error}");
+            exit(1);
+        });
+        if !status.success() {
+            eprintln!("Development daemon stop failed with status {status}.");
+            exit(status.code().unwrap_or(1));
+        }
+    } else {
+        println!("Development daemon is not running.");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn terminate_dev_app(pid: u32) {
+    request_appkit_termination(pid, false);
+
+    for _ in 0..50 {
+        if matches!(live_dev_app_info(pid), Ok(None)) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    eprintln!("Development app did not quit within 5 seconds; forcing PID {pid} to terminate.");
+    request_appkit_termination(pid, true);
+
+    for _ in 0..20 {
+        if matches!(live_dev_app_info(pid), Ok(None)) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    eprintln!("Development app PID {pid} is still running after force termination.");
+    exit(1);
+}
+
+#[cfg(target_os = "macos")]
+fn request_appkit_termination(pid: u32, force: bool) {
+    let selector = if force { "forceTerminate" } else { "terminate" };
+    let force_script = format!(
+        r#"ObjC.import("AppKit");
+const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier({pid});
+JSON.stringify({{ requested: app ? Boolean(app.{selector}) : true }});"#
+    );
+    let output = Command::new("osascript")
+        .args(["-l", "JavaScript", "-e", &force_script])
+        .output()
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to request development app termination: {error}");
+            exit(1);
+        });
+    if !output.status.success() {
+        eprintln!(
+            "AppKit could not send {selector} to PID {pid}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        exit(1);
+    }
+    if serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .ok()
+        .and_then(|value| value.get("requested").and_then(serde_json::Value::as_bool))
+        .is_none()
+    {
+        eprintln!("AppKit returned an invalid {selector} response for PID {pid}.");
+        exit(1);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn terminate_dev_app(pid: u32) {
+    let status = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to terminate development app PID {pid}: {error}");
+            exit(1);
+        });
+    if !status.success() {
+        eprintln!("Failed to terminate development app PID {pid}.");
+        exit(1);
+    }
 }
 
 fn cmd_dev_daemon(release: bool) {
@@ -5316,23 +5804,55 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn parse_dev_options_reads_flags_and_path() {
+    fn parse_dev_command_reads_launch_flags_and_path() {
         let args = vec![
             "dev".to_string(),
             "--skip-install".to_string(),
             "notebooks/demo.ipynb".to_string(),
             "--skip-build".to_string(),
+            "--fresh".to_string(),
         ];
 
-        let options = parse_dev_options(&args);
+        let command = parse_dev_command(&args);
         assert_eq!(
-            options,
-            DevOptions {
+            command,
+            DevCommand::Launch(DevOptions {
                 notebook: Some("notebooks/demo.ipynb"),
                 skip_install: true,
                 skip_build: true,
-            }
+                fresh: true,
+            })
         );
+    }
+
+    #[test]
+    fn parse_dev_command_reads_lifecycle_commands() {
+        assert_eq!(
+            parse_dev_command(&["dev".to_string(), "status".to_string()]),
+            DevCommand::Status
+        );
+        assert_eq!(
+            parse_dev_command(&["dev".to_string(), "focus".to_string()]),
+            DevCommand::Focus
+        );
+        assert_eq!(
+            parse_dev_command(&["dev".to_string(), "reset".to_string()]),
+            DevCommand::Reset
+        );
+    }
+
+    #[test]
+    fn dev_tauri_config_isolates_identity_and_file_associations() {
+        let identity = runt_workspace::dev_app_identity_for_workspace(Path::new("/tmp/nteract"));
+        let config: serde_json::Value =
+            serde_json::from_str(&dev_tauri_config(Some("6123"), true, &identity)).unwrap();
+
+        assert_eq!(config["productName"], identity.display_name);
+        assert_eq!(config["identifier"], identity.bundle_identifier);
+        assert_eq!(config["build"]["devUrl"], "http://localhost:6123");
+        assert_eq!(config["build"]["beforeDevCommand"], "");
+        assert_eq!(config["bundle"]["externalBin"], serde_json::json!([]));
+        assert_eq!(config["bundle"]["fileAssociations"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3137,6 +3137,8 @@ struct RunningDevApp {
     live_executable: PathBuf,
 }
 
+type LiveDevAppInfo = (PathBuf, Option<String>, Option<String>);
+
 #[derive(Debug)]
 enum DevAppInspection {
     NotRecorded,
@@ -3201,9 +3203,7 @@ fn canonical_path_or_original(path: &Path) -> PathBuf {
 }
 
 #[cfg(target_os = "macos")]
-fn live_dev_app_info(
-    pid: u32,
-) -> Result<Option<(PathBuf, Option<String>, Option<String>)>, String> {
+fn live_dev_app_info(pid: u32) -> Result<Option<LiveDevAppInfo>, String> {
     // NSRunningApplication can briefly retain a cached object after the Unix
     // process has exited, so establish liveness before asking AppKit for its
     // bundle metadata.
@@ -3256,9 +3256,7 @@ if (!app || Boolean(app.terminated)) {{
 }
 
 #[cfg(not(target_os = "macos"))]
-fn live_dev_app_info(
-    pid: u32,
-) -> Result<Option<(PathBuf, Option<String>, Option<String>)>, String> {
+fn live_dev_app_info(pid: u32) -> Result<Option<LiveDevAppInfo>, String> {
     let state = fs::read_to_string(dev_app_state_path())
         .ok()
         .and_then(|contents| serde_json::from_str::<runt_workspace::DevAppState>(&contents).ok());
@@ -3266,7 +3264,7 @@ fn live_dev_app_info(
         return Ok(None);
     };
     let running = process_is_live(pid);
-    Ok(running.then(|| (state.executable, None, None)))
+    Ok(running.then_some((state.executable, None, None)))
 }
 
 fn process_is_live(pid: u32) -> bool {

--- a/docs/runbooks/macos-setup.md
+++ b/docs/runbooks/macos-setup.md
@@ -113,3 +113,36 @@ Subsequent launches skip slow steps:
 cargo xtask dev --skip-install   # skip pnpm install if deps haven't changed
 cargo xtask dev --skip-build     # reuse existing build artifacts
 ```
+
+### Development app identity and recovery
+
+Source-built macOS apps use a per-worktree wrapper in the development cache.
+The wrapper has a resolvable identity such as `nteract Dev f0f9d9` with bundle
+identifier `org.nteract.desktop.dev.f0f9d99b161f`; it does not replace stable or
+Nightly and does not register notebook file associations. Release bundle names,
+identifiers, signing, and packaging remain unchanged.
+
+```bash
+cargo xtask dev status  # exact PID, executable, app identity, Vite URL, and socket
+cargo xtask dev focus   # activate that exact NSRunningApplication on macOS
+cargo xtask dev reset   # stop only this worktree's app and daemon
+```
+
+For accessibility automation, copy the `Automation PID` from `dev status` and
+target the System Events process whose `unix id` matches it. Do not address an
+application by the generic name `nteract`; LaunchServices may resolve an installed
+stable or Nightly bundle instead of the source-built process.
+
+Vite handles ordinary frontend hot reload. If a Tauri bootstrap or listener has
+survived in a stale state, restart both halves of the worktree-local development
+session with:
+
+```bash
+cargo xtask dev --fresh
+```
+
+The command validates the recorded PID and executable before terminating the app,
+clears stale process metadata, stops the daemon at this worktree's socket, and then
+launches a clean daemon and desktop process. `direnv allow` remains recommended for
+an interactive shell, but xtask also derives and exports the worktree namespace
+explicitly.

--- a/scripts/macos-dev-app-runner.py
+++ b/scripts/macos-dev-app-runner.py
@@ -48,6 +48,8 @@ def write_app_bundle(bundle: Path, binary: Path, display_name: str, bundle_id: s
         "CFBundleInfoDictionaryVersion": "6.0",
         "CFBundleName": display_name,
         "CFBundlePackageType": "APPL",
+        # Deliberately synthetic: release versioning and crash reporting apply
+        # only to packaged apps, while this wrapper is a disposable dev flavor.
         "CFBundleShortVersionString": "0.0.0",
         "CFBundleVersion": "1",
         "LSMinimumSystemVersion": "11.0",

--- a/scripts/macos-dev-app-runner.py
+++ b/scripts/macos-dev-app-runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Cargo runner that executes a Tauri dev binary from an isolated macOS app bundle."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"{name} is required by the nteract macOS dev app runner")
+    return value
+
+
+def split_runner_args(arguments: list[str]) -> tuple[list[str], list[str]]:
+    if not arguments or arguments[0] != "run":
+        raise SystemExit(
+            "the nteract macOS dev app runner expected cargo-style arguments beginning with 'run'"
+        )
+    try:
+        separator = arguments.index("--")
+    except ValueError:
+        separator = len(arguments)
+    return ["build", *arguments[1:separator]], arguments[separator + 1 :]
+
+
+def write_app_bundle(bundle: Path, binary: Path, display_name: str, bundle_id: str) -> Path:
+    contents = bundle / "Contents"
+    macos = contents / "MacOS"
+    macos.mkdir(parents=True, exist_ok=True)
+    executable = macos / "notebook"
+    executable.unlink(missing_ok=True)
+    try:
+        os.link(binary, executable)
+    except OSError:
+        shutil.copy2(binary, executable)
+
+    info = {
+        "CFBundleDisplayName": display_name,
+        "CFBundleExecutable": "notebook",
+        "CFBundleIdentifier": bundle_id,
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": display_name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "0.0.0",
+        "CFBundleVersion": "1",
+        "LSMinimumSystemVersion": "11.0",
+        "NSHighResolutionCapable": True,
+        "NSPrincipalClass": "NSApplication",
+    }
+    with (contents / "Info.plist").open("wb") as handle:
+        plistlib.dump(info, handle, sort_keys=True)
+    return executable
+
+
+def main() -> int:
+    if sys.platform != "darwin":
+        raise SystemExit("the nteract macOS dev app runner can only run on macOS")
+
+    build_args, app_args = split_runner_args(sys.argv[1:])
+    cargo = os.environ.get("CARGO", "cargo")
+    result = subprocess.run([cargo, *build_args], check=False)
+    if result.returncode:
+        return result.returncode
+
+    binary = Path(required_env("NTERACT_DEV_BINARY_PATH")).resolve(strict=True)
+    bundle = Path(required_env("NTERACT_DEV_APP_BUNDLE_PATH"))
+    display_name = required_env("NTERACT_DEV_APP_DISPLAY_NAME")
+    bundle_id = required_env("NTERACT_DEV_APP_BUNDLE_ID")
+    executable = write_app_bundle(bundle, binary, display_name, bundle_id)
+
+    print(f"Launching {display_name} from {bundle}", flush=True)
+    os.execv(executable, [str(executable), *app_args])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- launch source-built macOS desktop processes from a cached per-worktree `.app` wrapper with a distinct display name and bundle identifier
- add `cargo xtask dev status`, `focus`, `reset`, and `--fresh` so the exact app and worktree daemon can be inspected, activated, or restarted together
- publish and validate an atomic per-worktree app process record, including PID, executable, daemon socket, Vite URL, and intended identity
- document PID-based accessibility automation and make `cargo xtask dev` the recommended orchestrated desktop workflow in the canonical `AGENTS.md`, README, macOS runbook, and daemon development skill

## Why

Raw `cargo tauri dev` executables are linker-signed but are not launched from an application bundle. On macOS, AppKit consequently reports no bundle identifier and the generic executable name `notebook`; name- or bundle-based automation can then resolve an installed stable or Nightly app instead of the source process.

The dev-only runner keeps Tauri's watcher lifecycle while executing the rebuilt binary from an isolated cached app wrapper. Each worktree derives a stable identity such as:

```text
nteract Dev f0f9d9
org.nteract.desktop.dev.f0f9d99b161f
```

Stable and Nightly Tauri configuration, signing, packaging, and file associations are unchanged. The dev override explicitly removes file associations.

## Usage

```bash
cargo xtask dev
cargo xtask dev status
cargo xtask dev focus
cargo xtask dev --fresh
cargo xtask dev reset
```

Accessibility automation should copy the `Automation PID` from `cargo xtask dev status` and select the System Events process by Unix PID. `dev --fresh` validates the recorded PID and executable, terminates only that worktree's app, lets its one-shot launcher clean up its daemon, and relaunches both.

## Validation

- `cargo xtask lint --fix`
- `python3 scripts/ci/check-docs-guidance.py --paths-json '["AGENTS.md"]'`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" cargo clippy -p notebook --all-targets -- -D warnings`
- `cargo test -p runt-workspace -p xtask` (83 tests)
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" cargo check -p notebook`
- live macOS launch: AppKit reported `nteract Dev f0f9d9`, `org.nteract.desktop.dev.f0f9d99b161f`, and the cached wrapper executable
- live `cargo xtask dev focus`: activated the recorded PID
- live Rust hot reload: old wrapper PID exited and the replacement PID/state record appeared, including after adding the advisory lock that prevents old-process cleanup from racing new-process publication
- live `cargo xtask dev --fresh`: stopped the exact old process and daemon, then launched a new isolated pair
- live `cargo xtask dev reset`: returned this worktree to app/daemon idle while the separate `stage-attached-rail-panel` app and daemon remained running

## Known CI baseline failure

The Windows cross-target Clippy lane fails on unchanged `crates/kernel-launch/src/tools.rs:691` (`extracted_binary` is unused under Windows cfg). The same error fails this [main-branch baseline run](https://github.com/nteract/nteract/actions/runs/32127451508/job/95681141696); this PR does not modify `kernel-launch`. All other checks pass.
