### PR TITLE
docs(agents): streamline repository guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,141 +2,100 @@
 
 <!-- This file is canonical. CLAUDE.md is a symlink to AGENTS.md. -->
 
-Subsystem details live in nested `AGENTS.md` files next to code, auto-loaded
-rules live in `.claude/rules/`, and repository skills live in `.agents/skills/`.
-Claude reads the same skills through the `.claude/skills` symlink. Run
-`cargo xtask help` for build commands.
+## Start here
 
-## Project positioning
+- Confirm the worktree, branch, and existing diff before editing.
+- Read the nearest `AGENTS.md` for every file you change. Claude also loads
+  matching rules from `.claude/rules/`; other tools should inspect those rules
+  when they apply.
+- Use the repository skills in `.agents/skills/` for subsystem workflows.
+  Claude sees the same skills through `.claude/skills`.
+- Run `cargo xtask help` for the current build and test commands.
+- Discover files from the checkout. Keep paths in this guide only when they are
+  canonical entry points; do not maintain subsystem file inventories here.
 
-nteract is a local-first, agent-ready notebook environment where humans, kernels, and AI agents work against the same live notebook document set. Describe that in concrete system terms: Automerge-backed notebook state, explicit runtime state, daemon-owned kernels, outputs, and execution, and programmatic control through the same runtime model. Avoid broad AI slogans; prefer the mechanics users and developers can verify.
+## What nteract is
 
-## Documentation taxonomy
+nteract is a local-first notebook application. Notebook content is stored in
+Automerge documents. The runtimed daemon owns kernels, execution, outputs, and
+save/recovery behavior. Desktop, cloud, and programmatic clients use the same
+notebook and runtime protocols.
 
-Use `docs/README.md` as the front door for repo documentation. Start working
-notes in `.context/` while exploring. Do not create a persistent doc for routine
-implementation notes, test plans, or context that only explains the current
-patch; use the PR description, code comments, or final response instead.
+Use the project names when they matter: `NotebookDoc` for notebook content,
+`RuntimeStateDoc` for kernel and execution state, `CommsDoc` for widget state,
+and `CommentsDoc` for comments. Describe concrete mechanisms rather than
+inventing product labels.
 
-Promote `.context/` notes into `docs/` only when they should persist for product,
-design, engineering, research, or AI collaborators. Use `docs/memos/` for shared
-thinking, research, options, and RFC-style proposals; do not file exploratory
-work as a Draft ADR just because it mentions architecture. Graduate durable
-technical decisions to `docs/adr/`, durable product requirements to `docs/prd/`,
-scoped execution work to `docs/plans/`, evidence and follow-up lists to
-`docs/audits/`, benchmark evidence to `docs/measurements/`, operational
-procedures to `docs/runbooks/`.
+## Working in the repository
 
-## Design system and Elements
+- Inspect the implementation and its tests before changing behavior. Do not
+  infer a contract from a type name, UI symptom, or stale document.
+- For frontend or product-surface work, use the `frontend-dev` skill and follow
+  the nearest subsystem guide. Shared notebook UI should behave the same in
+  desktop and cloud unless the host difference is intentional.
+- Automerge documents and daemon-owned runtime documents hold shared notebook
+  state. React state is for local UI state, not a second copy of notebook or
+  runtime state.
+- Use `docs/README.md` to find maintained design and operations documents.
+  Keep temporary investigation notes in `.context/`. Do not add a permanent
+  document for notes that belong only to the current patch or PR.
 
-For UI, design-system, or product-surface work, start with the
-`frontend-dev` repo skill and `apps/elements/content/docs/index.mdx` before
-editing app code. This includes Elements, cloud dashboard, notebook shell,
-toolbar, cells, output rendering, comments, runtime/package UI, search, themes,
-and shared components.
+## Development environment
 
-Treat `apps/elements` as the stable review artifact layer for visual notebook
-surfaces. The catalog details live in the Elements docs and `frontend-dev`
-skill, not in this top-level routing file.
+Use `nteract-dev` for development against this worktree. The `nteract` and
+`nteract-nightly` servers are for inspecting installed builds, not source
+changes. If `nteract-dev` is unavailable, use `cargo xtask`; do not substitute
+an installed notebook server. Full server details are in the scoped MCP rules.
 
-Then read the nested ownership rules for the code you will touch:
-`apps/notebook/src/AGENTS.md` for desktop/shared notebook app wiring,
-`apps/notebook-cloud/AGENTS.md` for hosted cloud shell, authority, and viewer
-boundaries, and `src/components/ui/AGENTS.md` for shared UI, cell, editor, and
-output primitives. For notebook shell convergence, also read
-`docs/adr/notebook-host-shell-convergence.md`.
-
-Use those files to keep cloud app chrome separate from the shared notebook
-shell. Host-specific auth, ACL, sharing, workstation, routing, and side-effect
-boundaries should not fork common notebook presentation without an explicit
-reason.
-
-## Frontend reactive state and RxJS
-
-For RxJS, shared-store, `useSyncExternalStore`, or WASM-backed projection work,
-start with the `frontend-dev` repo skill and
-`docs/adr/frontend-sync-bridge.md`. This includes
-`packages/runtimed/src/sync-engine.ts`, `packages/runtimed/src/*store*.ts`,
-`packages/runtimed/src/observable-store.ts`, `packages/runtimed/src/poll.ts`,
-`src/components/notebook/state/*`, `apps/notebook/src/lib/notebook-sync-store-bridge.ts`,
-`apps/notebook-cloud/viewer/*store*.ts`,
-`apps/notebook-cloud/viewer/use-cloud-*-store.ts`, and
-`apps/notebook-cloud/viewer/browser-signals.ts`.
-
-Use the durable owner first: Automerge documents, RuntimeStateDoc, CommsDoc,
-CommentsDoc, or host-owned API/session facts. React state is local UI state,
-not a second source of truth. Keep RxJS sources private, expose readonly
-observables or named domain hooks, and test timers/cancellation with virtual
-time. Any async path that writes into a store after `await` must prove the
-current handle/session/auth/endpoint still matches or carry an activation
-epoch that invalidates stale completions.
-
-## MCP servers
-
-Three may be visible. Pick by purpose. Full details in `.claude/rules/mcp-servers.md` (auto-loaded everywhere).
-
-- **`nteract-dev`** — default for development. Per-worktree dev daemon. Owner/isolated mode exposes dev tools (`up`, `down`, `status`, `logs`, `vite_logs`); attach mode (Codex) exposes read-only supervisor tools (`status`, `logs`, `vite_logs`) plus proxied notebook tools. Prefer `up` over manual `cargo xtask dev-daemon`.
-- **`nteract-nightly`** — system nightly daemon. Diagnostics only.
-- **`nteract`** — system stable daemon. Diagnostics only.
-- **Codex plugin notebook servers** (`nteract-notebook`, `nightly`, or older `notebook` tool names) — installed release/plugin surfaces. Diagnostics only for source work; they may attach to a different active notebook than the local Browser/Vite app.
-
-If `nteract-dev` is unavailable, fall back to `cargo xtask` (derives the worktree env on its own). Use system or installed plugin MCP servers only for diagnostics.
-
-## Required before commit
+Before every commit, run:
 
 ```bash
 cargo xtask lint --fix
 ```
 
-CI rejects unformatted PRs. `cargo xtask help` is the source of truth for build commands.
+Run the narrow tests for the code you changed, then widen verification when the
+risk or subsystem guide calls for it. Use the `testing` skill for repository
+test workflows.
 
-## Commit and PR title format
+`cargo xtask notebook` opens a GUI and blocks until it quits. Let the developer
+run it from their own terminal.
 
-Conventional Commits: `<type>(<optional-scope>)!: <short imperative summary>`
+## Commits and reviews
 
-Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `revert`.
+Use Conventional Commits for commit and PR titles:
 
-## Code review
+```text
+<type>(<optional-scope>)!: <short imperative summary>
+```
 
-For independent model-assisted reviews initiated from a developer workstation,
-use the repository-independent `kilo-review` skill and its source-read-only
-workflow. Repository-hosted Pullfrog reviews remain a separate supported path.
-Establish the exact review target and mutation boundary first, give each
-reviewer the shared `.agents/reviewers/nteract-code-review-rubric.md`, and choose
-distinct reviewer lenses that match the change. Treat every model finding as
-advisory: verify it against the checkout, assign a disposition, and rerun
-relevant checks after any fix before declaring the review clear.
+Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
+`build`, `perf`, `revert`.
 
-## Load-bearing invariants
+For reviews started on a developer workstation, use the repository-independent
+Kilo review workflow. Repository-hosted Pullfrog reviews remain supported. Give
+reviewers `.agents/reviewers/nteract-code-review-rubric.md`, define the exact
+review target and mutation boundary, and verify every finding against the
+checkout. Model findings are advisory. After a fix, rerun the relevant checks
+before calling the review clear.
 
-Most invariants auto-load from `.claude/rules/*.md` and nested `AGENTS.md` files when you edit matching paths. A few that don't fit any path scope:
+## Repository-wide rules
 
-### Tokio mutex guards stay within synchronous blocks
+### Do not hold Tokio locks across `await`
 
-Hold a `tokio::sync::Mutex` or `RwLock` guard only within a synchronous block — release before any `.await`. Convoy deadlocks if the holder suspends. CI enforces via `cargo test -p runtimed --test tokio_mutex_lint`. Use block scoping (not `drop()`) so the lint can verify. Prefer owned state in `select!` loops over `Arc<Mutex<...>>`. Use `std::sync::Mutex` for sync-only access.
+Keep a `tokio::sync::Mutex` or `RwLock` guard inside a synchronous block so it
+is released before `.await`. Use block scope rather than `drop()`; CI checks
+this with `cargo test -p runtimed --test tokio_mutex_lint`. Prefer owned state
+in `select!` loops and `std::sync::Mutex` for sync-only access.
 
-### Cell list uses stable DOM order
+### Execute synced notebook cells
 
-`apps/notebook/src/components/NotebookView.tsx` renders cells in stable DOM order (sorted by cell ID) and uses CSS `order` for visual positioning. Iterating `cellIds` directly causes React's `insertBefore` on reorder, destroying iframes — visible as white flashes, lost widget state, re-rendered outputs. Iterate `stableDomOrder`; the parent is `display: flex; flex-direction: column` and each child sets `order`.
+Execution tied to notebook state must reference a synced `cell_id`. Create or
+edit the cell in the Automerge document, wait for sync when needed, and execute
+by `cell_id`. Do not send a separate code string that can differ from the live
+notebook seen by other peers.
 
-### Runtime control-plane signals are not output transport
+### Preserve notebook dependency metadata
 
-Kernel lifecycle signals (`KernelIdle`, `ExecutionDone`, `CellError`, `KernelDied`) must never share bounded output/work transport with stdout floods, display churn, or widget output replay. Route them through a separate reliable control path and drain them before bounded output work so interrupts and queue release cannot be backpressured by manifests, blob writes, or Automerge output mutations.
-
-Stream output may use bounded, lossy periodic flushes, but ordering boundaries cannot. Flush stdout/stderr through the stream committer priority path before clearing terminal state for display/error outputs, and route `ExecutionDone` through that same priority path so terminal runtime state remains causally after the final stream manifest.
-
-Output widget replay is not the durable record; RuntimeStateDoc is. Kernel-facing `SendCommUpdate` replay from IOPub must be non-blocking and best-effort so a full bounded work queue cannot delay later lifecycle status.
-
-`update_display_data` is transient display churn. Coalesce it by `display_id` off the IOPub hot path, but flush pending display updates after `KernelIdle` and before `ExecutionDone` so terminal runtime state still follows durable output state.
-
-### Execution references synced cell IDs
-
-Execution that belongs to notebook state should reference a synced `cell_id`. Create or edit the cell in the Automerge document, wait for sync as needed, then execute by `cell_id`. Do not bypass the document with side-channel code strings or ad hoc code payloads; otherwise peers can execute source that is not the live notebook content.
-
-## Notebook files
-
-Use MCP tools (`create_notebook`, `manage_dependencies`) for notebooks with dependency metadata — the schema is internal. Test fixtures that need deps put them at `metadata.runt.uv.dependencies`.
-
-## Desktop app
-
-`cargo xtask notebook` opens a GUI that blocks until ⌘Q. Let the human launch it from their own terminal.
+Use the notebook MCP tools to create notebooks with dependency metadata; the
+schema is internal. Test fixtures that need dependencies store them at
+`metadata.runt.uv.dependencies`.

--- a/apps/notebook/src/components/__tests__/notebook-view-stable-dom-order.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-stable-dom-order.test.ts
@@ -9,12 +9,11 @@ import { describe, expect, it } from "vite-plus/test";
  * them visually with CSS `order` inside a flex column. The invariant lives
  * in three places that must all hold together — regressing any one of them
  * silently reintroduces React `insertBefore` on reorder, which destroys
- * output iframes (white flashes, lost widget state). See CLAUDE.md
- * § "Cell list uses stable DOM order" and frontend-sync-bridge.md
- * Decision 2.
+ * output iframes (white flashes, lost widget state). See
+ * apps/notebook/src/AGENTS.md and frontend-sync-bridge.md Decision 2.
  *
  * This is a source-shape guard, not a behavior test: jsdom cannot observe
- * iframe teardown, so the load-bearing truth is pinned at the source level
+ * iframe teardown, so the required source shape is pinned at the source level
  * (same pattern as notebook-view-capabilities-source.test.ts).
  */
 describe("NotebookView stable DOM order invariant (FSB-2)", () => {

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -18,6 +18,23 @@ Scope: `crates/runtimed/**`, `crates/runt/**`, `crates/runtimed-client/**`, `cra
 
 7. **Process-isolated kernel execution.** Every kernel runs in a separate runtime agent subprocess (`runtimed runtime-agent`) connecting back as an Automerge peer. Execution is CRDT-driven — the coordinator writes execution entries (source + sequence number) to RuntimeStateDoc; the runtime agent discovers them via sync and executes in order. RPC handles lifecycle (`LaunchKernel`, `RestartKernel`, `ShutdownKernel`), interrupts, environment hot-sync (`SyncEnvironment`), completion/history queries, and ephemeral comm traffic (`SendComm`).
 
+## Lifecycle and output ordering
+
+- Stream output may use bounded, lossy periodic flushes. Ordering boundaries
+  may not lose or reorder messages.
+- Send `KernelIdle`, `ExecutionDone`, `CellError`, and `KernelDied` over the
+  reliable lifecycle channel, separate from the bounded output/work queue.
+  Drain lifecycle messages before bounded output work so output pressure cannot
+  delay interrupts or queue release.
+- Flush pending stdout and stderr through the priority commit path before
+  clearing terminal state for display or error output. Send `ExecutionDone`
+  through the same path so it follows the final stream manifest.
+- IOPub widget replay through `SendCommUpdate` is best-effort and non-blocking.
+  A full work queue must not delay later lifecycle messages. RuntimeStateDoc,
+  not widget replay, records runtime state.
+- Coalesce `update_display_data` by `display_id` away from the IOPub hot path.
+  Flush pending display updates after `KernelIdle` and before `ExecutionDone`.
+
 ## Crate boundaries
 
 | Crate | Owns | Consumers |

--- a/docs/adr/execution-pipeline.md
+++ b/docs/adr/execution-pipeline.md
@@ -312,4 +312,5 @@ If lifecycle and work shared one channel, the interrupt's `KernelIdle` would hav
 - `crates/runtimed/src/notebook_sync_server/peer_writer.rs:167-256` - `required_heads` gate.
 - `crates/runt-mcp/src/execution.rs` - MCP consumer pattern.
 - `.agents/skills/execution-pipeline/SKILL.md` - the agent-facing summary that this ADR expands.
-- `AGENTS.md` / `CLAUDE.md` "Runtime control-plane signals are not output transport" - the load-bearing paragraph this ADR is the long-form of.
+- `crates/runtimed/AGENTS.md` "Lifecycle and output ordering" - the scoped
+  summary of the rules this ADR expands.

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -403,4 +403,4 @@ machinery.
 - `apps/notebook/src/lib/project-runtime-stores.ts` - execution-view projection.
 - `packages/runtimed/src/sync-engine.ts` - the engine: `flushAndWait`, `scheduleFlush`, every `*$` Observable.
 - `apps/notebook/src/AGENTS.md` - companion frontend-architecture map (data-flow diagram).
-- `AGENTS.md` / `CLAUDE.md` - "Cell list uses stable DOM order" load-bearing invariant.
+- `apps/notebook/src/AGENTS.md` - the scoped stable DOM-order rule.


### PR DESCRIPTION
## Summary

- rewrite the root agent guide as a short operating contract instead of a subsystem directory map
- replace "load-bearing" and similar synthetic phrasing with direct nteract terminology and concrete instructions
- keep only canonical paths and commands in the root guide; agents should discover current files and read the nearest scoped guidance
- move runtime lifecycle/output ordering rules into the runtimed guide, while preserving the existing notebook stable-DOM rule in its owning scope
- keep the shared review rubric unchanged, with Kilo for workstation-triggered reviews and Pullfrog still supported for hosted PR reviews

## Kilo review

Two read-only panels used three model families and separate lenses:

- Inkling Small: reader and editorial clarity
- Gemini 3.7 Flash: information architecture and maintainability
- Kimi K2.7 Code: technical correctness and rule preservation

The final Gemini pass had no actionable findings. Kimi identified stale references to headings moved out of the root guide and one compressed stream-ordering distinction; those were fixed. Inkling repeated stale pre-edit and symlink claims, which were rejected after direct checkout verification.

## Verification

- `cargo xtask lint --fix`
- `python3 scripts/ci/check-docs-guidance.py AGENTS.md crates/runtimed/AGENTS.md docs/adr/execution-pipeline.md docs/adr/frontend-sync-bridge.md`
- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-stable-dom-order.test.ts`
- `git diff --check`
