### PR TITLE
fix(kernel-launch): satisfy Windows cross-target Clippy

### DIFF
--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -688,13 +688,13 @@ async fn download_deno_from_github(version: &str) -> Result<BootstrappedTool> {
             info!("Extracting deno to {:?}...", staging_env);
             tokio::task::spawn_blocking(move || -> Result<()> {
                 let _lease = lease;
-                let extracted_binary = extract_deno_zip(&zip_bytes, &staging_env)?;
+                let _extracted_binary = extract_deno_zip(&zip_bytes, &staging_env)?;
 
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
                     let perms = std::fs::Permissions::from_mode(0o755);
-                    std::fs::set_permissions(&extracted_binary, perms)?;
+                    std::fs::set_permissions(&_extracted_binary, perms)?;
                 }
 
                 if !staging_binary.exists() {


### PR DESCRIPTION
## Summary

- Mark the extracted Deno binary binding as intentionally platform-conditional.
- Preserve Unix executable-permission setup and Windows extraction behavior unchanged.

## Root cause

The Deno extraction result is used to set executable permissions inside a `#[cfg(unix)]` block. On the Windows GNU target, extraction still must run, but the returned path is otherwise unused, so the cross-target Clippy lane rejected the binding under `-D warnings`.

## Verification

- `cargo test -p kernel-launch` (22 passed, 1 network test ignored)
- `cargo clippy --target x86_64-pc-windows-gnu -p kernel-launch --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- Attempted the full Windows GNU workspace Clippy command; local execution is blocked by the missing `x86_64-w64-mingw32-gcc` cross-compiler when `zstd-sys` builds. The focused `kernel-launch` cross-target check passes.
