### PR TITLE
feat(release): publish notebook UI bundles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,6 +446,21 @@ jobs:
           pnpm --dir apps/notebook build
           pnpm --dir apps/elements build
 
+      - name: Test and package notebook UI release bundle
+        run: |
+          python3 -m unittest scripts/tests/test_package_notebook_ui.py
+          SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")
+          python3 scripts/package-notebook-ui.py \
+            --dist apps/notebook/dist \
+            --license LICENSE \
+            --output "$RUNNER_TEMP/notebook-ui-assets/nteract-nightly-notebook-ui.tar.gz" \
+            --channel nightly \
+            --version "pr.${GITHUB_SHA}" \
+            --commit "$GITHUB_SHA" \
+            --source-date-epoch "$SOURCE_DATE_EPOCH"
+          cd "$RUNNER_TEMP/notebook-ui-assets"
+          sha256sum --check nteract-nightly-notebook-ui.tar.gz.sha256
+
       - name: Upload UI build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -816,6 +816,28 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
+      - name: Package notebook UI for embedders
+        run: |
+          CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
+          SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")
+          python3 scripts/package-notebook-ui.py \
+            --dist apps/notebook/dist \
+            --license LICENSE \
+            --output "notebook-ui-assets/nteract-${CHANNEL}-notebook-ui.tar.gz" \
+            --channel "$CHANNEL" \
+            --version "${{ needs.compute-version.outputs.version }}" \
+            --commit "$GITHUB_SHA" \
+            --source-date-epoch "$SOURCE_DATE_EPOCH"
+          cd notebook-ui-assets
+          sha256sum --check "nteract-${CHANNEL}-notebook-ui.tar.gz.sha256"
+
+      - name: Upload notebook UI release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: nteract-notebook-ui
+          path: notebook-ui-assets/
+          if-no-files-found: error
+
       - name: Install Tauri CLI
         uses: ./.github/actions/install-tauri-cli
 
@@ -1263,6 +1285,12 @@ jobs:
           name: nteract-linux-x64
           path: ./notebook-linux-x64
 
+      - name: Download notebook UI release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: nteract-notebook-ui
+          path: ./notebook-ui
+
       - name: Report downloaded release artifact sizes
         run: |
           echo "Downloaded artifact directories:"
@@ -1271,7 +1299,8 @@ jobs:
             notebook-macos-arm64 \
             notebook-macos-x64 \
             notebook-windows-x64 \
-            notebook-linux-x64
+            notebook-linux-x64 \
+            notebook-ui
           echo ""
           echo "Downloaded artifact files:"
           find \
@@ -1280,6 +1309,7 @@ jobs:
             notebook-macos-x64 \
             notebook-windows-x64 \
             notebook-linux-x64 \
+            notebook-ui \
             -type f -printf "%12s  %p\n" | sort -nr
 
       - name: Prepare release assets
@@ -1317,6 +1347,9 @@ jobs:
           cp "notebook-macos-x64/nteract-${CHANNEL}-darwin-x64.dmg" release-assets/
           cp "notebook-windows-x64/nteract-${CHANNEL}-windows-x64.exe" release-assets/
           cp "notebook-linux-x64/nteract-${CHANNEL}-linux-x64.AppImage" release-assets/
+          # Platform-neutral production notebook frontend for embedding hosts.
+          cp "notebook-ui/nteract-${CHANNEL}-notebook-ui.tar.gz" release-assets/
+          cp "notebook-ui/nteract-${CHANNEL}-notebook-ui.tar.gz.sha256" release-assets/
           # Updater bundles + signatures
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz" release-assets/
           cp "notebook-macos-arm64/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig" release-assets/
@@ -1509,6 +1542,10 @@ jobs:
             fi
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
+            echo '### Notebook UI (embedders)'
+            echo ''
+            echo "The platform-neutral production frontend is available as \`nteract-${VERSION_SUFFIX}-notebook-ui.tar.gz\`. Verify it with the adjacent \`.sha256\` file before extracting it into an embedding host."
+            echo ''
             echo '### runtimed (Python — macOS, Linux, Windows)'
             echo ''
             echo '```bash'
@@ -1578,6 +1615,8 @@ jobs:
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-x64.app.tar.gz
             ./release-assets/nteract-${{ inputs.version_suffix }}-darwin-x64.app.tar.gz.sig
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe
+            ./release-assets/nteract-${{ inputs.version_suffix }}-notebook-ui.tar.gz
+            ./release-assets/nteract-${{ inputs.version_suffix }}-notebook-ui.tar.gz.sha256
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe.sig
             ./release-assets/latest.json
             ./wheels/*.whl

--- a/packages/notebook-host/README.md
+++ b/packages/notebook-host/README.md
@@ -15,6 +15,25 @@ The Electron adapter is split across two trust zones:
 The notebook iframe never receives `ipcRenderer`, filesystem primitives, a
 WebSocket URL, or the daemon socket path.
 
+## Published notebook UI bundle
+
+Stable and nightly GitHub releases publish the production notebook frontend as
+`nteract-stable-notebook-ui.tar.gz` and
+`nteract-nightly-notebook-ui.tar.gz`, respectively. Each archive has an
+adjacent `.sha256` file and expands into a single `nteract-notebook-ui/`
+directory containing:
+
+- the static frontend rooted at `index.html`;
+- the separately served `output-frame.html` document;
+- `nteract-notebook-ui.json`, which records the schema version, release
+  channel, nteract version, source commit, and entrypoint names; and
+- `LICENSE.nteract`.
+
+Pin a unique release tag, verify the checksum, and serve the extracted files
+from a secure origin. The archive is the same platform-neutral frontend used by
+the nteract desktop release; the embedding host still supplies the authorized
+runtime transport and host capabilities described below.
+
 ## Electron topology
 
 Create a `MessageChannelMain` in Electron main, serve one end, and transfer the

--- a/scripts/package-notebook-ui.py
+++ b/scripts/package-notebook-ui.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Package the production notebook frontend for release embedders."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import re
+import sys
+import tarfile
+from pathlib import Path
+
+BUNDLE_ROOT = "nteract-notebook-ui"
+REQUIRED_FILES = ("index.html", "output-frame.html")
+RESERVED_FILES = ("LICENSE.nteract", "nteract-notebook-ui.json")
+TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist", type=Path, required=True)
+    parser.add_argument("--license", dest="license_path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--channel", choices=("stable", "nightly"), required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--source-date-epoch", type=int, required=True)
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if not args.dist.is_dir():
+        raise ValueError(f"notebook UI directory does not exist: {args.dist}")
+    if not args.license_path.is_file():
+        raise ValueError(f"license file does not exist: {args.license_path}")
+    if not TOKEN_PATTERN.fullmatch(args.version):
+        raise ValueError("version may contain only letters, digits, dots, underscores, and hyphens")
+    if not COMMIT_PATTERN.fullmatch(args.commit):
+        raise ValueError("commit must be a lowercase 40-character Git SHA")
+    if args.source_date_epoch < 0:
+        raise ValueError("source-date-epoch must be non-negative")
+
+    for relative_path in REQUIRED_FILES:
+        if not (args.dist / relative_path).is_file():
+            raise ValueError(f"notebook UI is missing required file: {relative_path}")
+    for relative_path in RESERVED_FILES:
+        if (args.dist / relative_path).exists():
+            raise ValueError(f"notebook UI contains reserved bundle file: {relative_path}")
+
+
+def tar_info(name: str, *, size: int, mode: int, mtime: int, kind: bytes) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.size = size
+    info.mode = mode
+    info.mtime = mtime
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.type = kind
+    return info
+
+
+def add_bytes(archive: tarfile.TarFile, name: str, contents: bytes, mtime: int) -> None:
+    info = tar_info(name, size=len(contents), mode=0o644, mtime=mtime, kind=tarfile.REGTYPE)
+    archive.addfile(info, io.BytesIO(contents))
+
+
+def add_directory(archive: tarfile.TarFile, name: str, mtime: int) -> None:
+    info = tar_info(name.rstrip("/") + "/", size=0, mode=0o755, mtime=mtime, kind=tarfile.DIRTYPE)
+    archive.addfile(info)
+
+
+def iter_dist_entries(dist: Path) -> list[Path]:
+    entries = sorted(dist.rglob("*"), key=lambda path: path.relative_to(dist).as_posix())
+    for entry in entries:
+        if entry.is_symlink():
+            raise ValueError(f"notebook UI contains unsupported symlink: {entry.relative_to(dist)}")
+        if not entry.is_dir() and not entry.is_file():
+            raise ValueError(f"notebook UI contains unsupported entry: {entry.relative_to(dist)}")
+    return entries
+
+
+def create_archive(args: argparse.Namespace) -> str:
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "channel": args.channel,
+        "commit": args.commit,
+        "entrypoint": "index.html",
+        "outputDocument": "output-frame.html",
+        "schemaVersion": 1,
+        "version": args.version,
+    }
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    license_bytes = args.license_path.read_bytes()
+
+    with (
+        args.output.open("wb") as raw_output,
+        gzip.GzipFile(
+            fileobj=raw_output, mode="wb", filename="", mtime=args.source_date_epoch
+        ) as compressed,
+        tarfile.open(fileobj=compressed, mode="w", format=tarfile.GNU_FORMAT) as archive,
+    ):
+        add_directory(archive, BUNDLE_ROOT, args.source_date_epoch)
+        entries: list[tuple[str, Path | bytes]] = [
+            (entry.relative_to(args.dist).as_posix(), entry)
+            for entry in iter_dist_entries(args.dist)
+        ]
+        entries.extend(
+            [
+                ("LICENSE.nteract", license_bytes),
+                ("nteract-notebook-ui.json", manifest_bytes),
+            ]
+        )
+        for relative, entry in sorted(entries, key=lambda item: item[0]):
+            archive_name = f"{BUNDLE_ROOT}/{relative}"
+            if isinstance(entry, bytes):
+                add_bytes(archive, archive_name, entry, args.source_date_epoch)
+            elif entry.is_dir():
+                add_directory(archive, archive_name, args.source_date_epoch)
+            else:
+                add_bytes(archive, archive_name, entry.read_bytes(), args.source_date_epoch)
+
+    digest = hashlib.sha256(args.output.read_bytes()).hexdigest()
+    checksum_path = args.output.with_name(args.output.name + ".sha256")
+    checksum_path.write_text(f"{digest}  {args.output.name}\n", encoding="utf-8")
+    return digest
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        validate_args(args)
+        digest = create_archive(args)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Created {args.output} (sha256: {digest})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_package_notebook_ui.py
+++ b/scripts/tests/test_package_notebook_ui.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGER = REPO_ROOT / "scripts" / "package-notebook-ui.py"
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+class PackageNotebookUiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.dist = self.root / "dist"
+        (self.dist / "assets").mkdir(parents=True)
+        (self.dist / "index.html").write_text("<main>notebook</main>\n", encoding="utf-8")
+        (self.dist / "output-frame.html").write_text("<main>output</main>\n", encoding="utf-8")
+        (self.dist / "assets" / "main-example.js").write_text("export {};\n", encoding="utf-8")
+        self.license_path = self.root / "LICENSE"
+        self.license_path.write_text("BSD-3-Clause\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_packager(self, output: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(PACKAGER),
+                "--dist",
+                str(self.dist),
+                "--license",
+                str(self.license_path),
+                "--output",
+                str(output),
+                "--channel",
+                "nightly",
+                "--version",
+                "2.7.0-nightly.202608180909",
+                "--commit",
+                COMMIT,
+                "--source-date-epoch",
+                "1776556800",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_packages_expected_files_and_metadata_deterministically(self) -> None:
+        first = self.root / "first.tar.gz"
+        second = self.root / "second.tar.gz"
+
+        first_result = self.run_packager(first)
+        second_result = self.run_packager(second)
+        self.assertEqual(first_result.returncode, 0, first_result.stderr)
+        self.assertEqual(second_result.returncode, 0, second_result.stderr)
+        self.assertEqual(
+            hashlib.sha256(first.read_bytes()).digest(),
+            hashlib.sha256(second.read_bytes()).digest(),
+        )
+
+        with tarfile.open(first, "r:gz") as archive:
+            names = archive.getnames()
+            self.assertEqual(names, sorted(names))
+            self.assertIn("nteract-notebook-ui/index.html", names)
+            self.assertIn("nteract-notebook-ui/output-frame.html", names)
+            self.assertIn("nteract-notebook-ui/LICENSE.nteract", names)
+            manifest_file = archive.extractfile("nteract-notebook-ui/nteract-notebook-ui.json")
+            self.assertIsNotNone(manifest_file)
+            manifest = json.loads(manifest_file.read())
+            self.assertEqual(manifest["schemaVersion"], 1)
+            self.assertEqual(manifest["channel"], "nightly")
+            self.assertEqual(manifest["commit"], COMMIT)
+
+        checksum = first.with_name(first.name + ".sha256").read_text(encoding="utf-8")
+        self.assertEqual(
+            checksum, f"{hashlib.sha256(first.read_bytes()).hexdigest()}  first.tar.gz\n"
+        )
+
+    def test_rejects_an_incomplete_frontend_build(self) -> None:
+        (self.dist / "output-frame.html").unlink()
+        result = self.run_packager(self.root / "incomplete.tar.gz")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing required file: output-frame.html", result.stderr)
+
+    def test_rejects_a_reserved_bundle_file(self) -> None:
+        (self.dist / "LICENSE.nteract").write_text("unexpected\n", encoding="utf-8")
+        result = self.run_packager(self.root / "reserved.tar.gz")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains reserved bundle file: LICENSE.nteract", result.stderr)
+
+    def test_rejects_a_symbolic_link(self) -> None:
+        os.symlink(self.dist / "index.html", self.dist / "linked-index.html")
+        result = self.run_packager(self.root / "symlink.tar.gz")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains unsupported symlink: linked-index.html", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- publish a platform-neutral notebook UI archive and checksum on both stable and nightly releases
- package the existing Linux-built production frontend with release metadata and the nteract license
- document the versioned bundle contract for embedding hosts
- exercise deterministic packaging and rejection of incomplete, reserved-name, and symlinked inputs in CI

## Why

Embedding hosts need a supported way to consume the same notebook frontend shipped by nteract desktop without recreating the complete Rust, WASM, renderer, and Vite build. A release-tagged archive makes that output directly available and verifiable while keeping host-specific runtime transport and capabilities outside the bundle.

## Release assets

Each release gains:

- `nteract-stable-notebook-ui.tar.gz` or `nteract-nightly-notebook-ui.tar.gz`
- the adjacent `.sha256` checksum

The archive expands beneath `nteract-notebook-ui/` and includes `index.html`, `output-frame.html`, `LICENSE.nteract`, and a manifest recording the channel, nteract version, source commit, and entrypoint names.

## Validation

- `cargo xtask lint --fix`
- `python3 -m unittest scripts/tests/test_package_notebook_ui.py`
- `actionlint -color`
- `cargo xtask artifacts ensure runtime,sift,renderer`
- `pnpm --dir apps/notebook build`
- packaged the real production `apps/notebook/dist`, verified its checksum, extracted it, and compared it byte-for-byte with the build output
- independent Kilo correctness and operability reviews; the confirmed CI artifact-layout finding was fixed and relevant checks were rerun