### PR TITLE
feat(agent-tools): add OpenCode and Kilo runtimed plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,6 +509,11 @@ jobs:
       - name: Type-check runtimed tests
         run: pnpm --dir packages/runtimed typecheck
 
+      - name: Type-check and pack runtimed agent tools
+        run: |
+          pnpm --dir packages/runtimed-agent-tools typecheck
+          pnpm --dir packages/runtimed-agent-tools pack:dry-run
+
       # Same enforcement for the cloud viewer stores' equality manifests and
       # store typing: no other lane runs the notebook-cloud tsc pass. Its
       # wasm-ensure-runtime pretypecheck is satisfied by the artifact build

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -276,6 +276,11 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "packages/runtimed-agent-tools/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
         path: "packages/runtimed-node/npm/darwin-arm64/package.json",
         format: Format::Json,
         matches: 1,

--- a/packages/runtimed-agent-tools/README.md
+++ b/packages/runtimed-agent-tools/README.md
@@ -7,6 +7,10 @@ appends a synced code cell, executes that cell, and returns the durable executio
 identity and resolved outputs. Sessions are reused within an agent session and
 closed when that agent session is deleted.
 
+OpenCode and Kilo emit `session.deleted` during normal session cleanup, which
+closes the corresponding `@runtimed/node` handles. If a host exits without that
+event, terminating the host process closes its underlying daemon peer connection.
+
 ## OpenCode
 
 Add the npm plugin to `opencode.json`:

--- a/packages/runtimed-agent-tools/README.md
+++ b/packages/runtimed-agent-tools/README.md
@@ -51,8 +51,13 @@ success, and resolved outputs.
 pnpm --dir packages/runtimed-agent-tools typecheck
 pnpm --dir packages/runtimed-agent-tools test
 pnpm --dir packages/runtimed-agent-tools smoke:hosts
+RUNTIMED_SOCKET_PATH=/path/to/runtimed.sock pnpm --dir packages/runtimed-agent-tools smoke:live
 pnpm --dir packages/runtimed-agent-tools pack:dry-run
 ```
 
 The host smoke tests load the built local plugin through real OpenCode and Kilo
 config directories without changing the user's global configuration.
+
+The live smoke test creates a temporary notebook on the selected daemon, invokes
+the same `notebook_run_source` handler registered with both hosts, verifies its
+resolved output, and shuts the notebook down.

--- a/packages/runtimed-agent-tools/README.md
+++ b/packages/runtimed-agent-tools/README.md
@@ -1,0 +1,58 @@
+# `@runtimed/agent-tools`
+
+OpenCode and Kilo notebook tools backed directly by `@runtimed/node`.
+
+The initial `notebook_run_source` tool attaches to an active nteract notebook,
+appends a synced code cell, executes that cell, and returns the durable execution
+identity and resolved outputs. Sessions are reused within an agent session and
+closed when that agent session is deleted.
+
+## OpenCode
+
+Add the npm plugin to `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@runtimed/agent-tools@0.1.0"]
+}
+```
+
+## Kilo
+
+Install the plugin for the current project:
+
+```bash
+kilo plugin @runtimed/agent-tools@0.1.0
+```
+
+Pass `--global` to install it into the user-wide Kilo configuration instead.
+
+## Daemon selection
+
+The plugin uses the default `runtimed` socket unless `RUNTIMED_SOCKET_PATH` is
+set. Hosts such as Agentic Desktop should set this to their bundled daemon's
+socket and install a package version matched to that daemon.
+
+## Tool
+
+`notebook_run_source` accepts:
+
+- `notebook_id`: an active nteract notebook ID
+- `source`: Python source for a new synced code cell
+- `timeout_ms`: optional execution timeout
+
+It returns JSON containing `notebook_id`, `cell_id`, `execution_id`, status,
+success, and resolved outputs.
+
+## Development
+
+```bash
+pnpm --dir packages/runtimed-agent-tools typecheck
+pnpm --dir packages/runtimed-agent-tools test
+pnpm --dir packages/runtimed-agent-tools smoke:hosts
+pnpm --dir packages/runtimed-agent-tools pack:dry-run
+```
+
+The host smoke tests load the built local plugin through real OpenCode and Kilo
+config directories without changing the user's global configuration.

--- a/packages/runtimed-agent-tools/fixtures/kilo/.kilo/plugin/runtimed-agent-tools.ts
+++ b/packages/runtimed-agent-tools/fixtures/kilo/.kilo/plugin/runtimed-agent-tools.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../dist/kilo.js";

--- a/packages/runtimed-agent-tools/fixtures/opencode/.opencode/plugins/runtimed-agent-tools.ts
+++ b/packages/runtimed-agent-tools/fixtures/opencode/.opencode/plugins/runtimed-agent-tools.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../dist/opencode.js";

--- a/packages/runtimed-agent-tools/package.json
+++ b/packages/runtimed-agent-tools/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@runtimed/agent-tools",
+  "version": "0.1.0",
+  "description": "OpenCode and Kilo notebook tools backed directly by @runtimed/node.",
+  "type": "module",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nteract/nteract.git",
+    "directory": "packages/runtimed-agent-tools"
+  },
+  "homepage": "https://github.com/nteract/nteract/tree/main/packages/runtimed-agent-tools#readme",
+  "bugs": {
+    "url": "https://github.com/nteract/nteract/issues"
+  },
+  "keywords": [
+    "nteract",
+    "runtimed",
+    "opencode",
+    "kilo",
+    "notebook",
+    "jupyter",
+    "agent-tools"
+  ],
+  "main": "./dist/opencode.js",
+  "types": "./dist/opencode.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/opencode.d.ts",
+      "import": "./dist/opencode.js",
+      "default": "./dist/opencode.js"
+    },
+    "./server": {
+      "types": "./dist/kilo.d.ts",
+      "import": "./dist/kilo.js",
+      "default": "./dist/kilo.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "import": "./dist/core.js",
+      "default": "./dist/core.js"
+    }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm --dir ../.. exec vp test run packages/runtimed-agent-tools/tests",
+    "smoke:opencode": "pnpm build && node scripts/smoke-host.mjs opencode",
+    "smoke:kilo": "pnpm build && node scripts/smoke-host.mjs kilo",
+    "smoke:hosts": "pnpm smoke:opencode && pnpm smoke:kilo",
+    "prepack": "pnpm build",
+    "pack:dry-run": "pnpm pack --dry-run"
+  },
+  "dependencies": {
+    "@runtimed/node": "workspace:*",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "vite-plus": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/runtimed-agent-tools/package.json
+++ b/packages/runtimed-agent-tools/package.json
@@ -52,6 +52,7 @@
     "smoke:opencode": "pnpm build && node scripts/smoke-host.mjs opencode",
     "smoke:kilo": "pnpm build && node scripts/smoke-host.mjs kilo",
     "smoke:hosts": "pnpm smoke:opencode && pnpm smoke:kilo",
+    "smoke:live": "pnpm build && node scripts/smoke-live.mjs",
     "prepack": "pnpm build",
     "pack:dry-run": "pnpm pack --dry-run"
   },

--- a/packages/runtimed-agent-tools/scripts/smoke-host.mjs
+++ b/packages/runtimed-agent-tools/scripts/smoke-host.mjs
@@ -1,0 +1,85 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const host = process.argv[2];
+if (host !== "opencode" && host !== "kilo") {
+  throw new Error("usage: node scripts/smoke-host.mjs <opencode|kilo>");
+}
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const fixtureDirectory = join(packageRoot, "fixtures", host);
+const configHome = await mkdtemp(join(tmpdir(), `runtimed-agent-tools-${host}-`));
+const port = await availablePort();
+const output = [];
+
+const child = spawn(host, ["serve", "--hostname", "127.0.0.1", "--port", String(port)], {
+  cwd: fixtureDirectory,
+  env: { ...process.env, XDG_CONFIG_HOME: configHome },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+child.stdout.on("data", (chunk) => output.push(String(chunk)));
+child.stderr.on("data", (chunk) => output.push(String(chunk)));
+
+try {
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForServer(`${baseUrl}/config`, child, output);
+  const url = new URL(`${baseUrl}/experimental/tool/ids`);
+  url.searchParams.set("directory", fixtureDirectory);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${host} tool listing failed with HTTP ${response.status}`);
+  }
+  const toolIds = await response.json();
+  if (!Array.isArray(toolIds) || !toolIds.includes("notebook_run_source")) {
+    throw new Error(`${host} did not register notebook_run_source: ${JSON.stringify(toolIds)}`);
+  }
+  console.log(`${host} registered notebook_run_source`);
+} finally {
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(configHome, { recursive: true, force: true });
+}
+
+async function availablePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("could not reserve a smoke-test port");
+  }
+  const { port } = address;
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function waitForServer(url, child, logs) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${host} exited before startup:\n${logs.join("")}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The host has not bound the socket yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`${host} did not start within 20 seconds:\n${logs.join("")}`);
+}

--- a/packages/runtimed-agent-tools/scripts/smoke-live.mjs
+++ b/packages/runtimed-agent-tools/scripts/smoke-live.mjs
@@ -1,0 +1,50 @@
+const socketPath = process.env.RUNTIMED_SOCKET_PATH;
+if (!socketPath) {
+  throw new Error("RUNTIMED_SOCKET_PATH is required for the live smoke test");
+}
+
+const imported = await import("@runtimed/node");
+const runtimed = typeof imported.createNotebook === "function" ? imported : imported.default;
+if (typeof runtimed?.createNotebook !== "function") {
+  throw new Error("@runtimed/node did not expose createNotebook");
+}
+
+const { createAgentToolHooks } = await import("../dist/plugin.js");
+const owner = await runtimed.createNotebook({
+  socketPath,
+  workingDir: process.cwd(),
+  peerLabel: "runtimed-agent-tools:live-smoke-owner",
+  description: "@runtimed/agent-tools live smoke notebook",
+});
+const hooks = createAgentToolHooks();
+
+try {
+  const serialized = await hooks.tool.notebook_run_source.execute(
+    {
+      notebook_id: owner.notebookId,
+      source: "answer = 6 * 7\nanswer",
+      timeout_ms: 30_000,
+    },
+    { sessionID: "runtimed-agent-tools-live-smoke" },
+  );
+  const result = JSON.parse(serialized);
+  if (!result.success || !JSON.stringify(result.outputs).includes("42")) {
+    throw new Error(`unexpected live execution result: ${serialized}`);
+  }
+  console.log(`executed ${result.cell_id} as ${result.execution_id} in ${result.notebook_id}`);
+} finally {
+  console.log("closing agent-tool session");
+  await hooks.event({
+    event: {
+      type: "session.deleted",
+      properties: { info: { id: "runtimed-agent-tools-live-smoke" } },
+    },
+  });
+  console.log("shutting down smoke notebook");
+  await owner.shutdownNotebook();
+  console.log("smoke notebook shut down");
+}
+
+// OpenCode and Kilo are long-lived hosts. End this one-shot harness explicitly
+// after the same session cleanup the hosts perform.
+process.exit(0);

--- a/packages/runtimed-agent-tools/src/core.ts
+++ b/packages/runtimed-agent-tools/src/core.ts
@@ -1,0 +1,171 @@
+import type { CellResult, JsOutput, OpenNotebookOptions, Session } from "@runtimed/node";
+
+export interface RuntimeBindings {
+  openNotebook(notebookId: string, options?: OpenNotebookOptions): Promise<Session>;
+}
+
+export interface RunSourceInput {
+  agentSessionId: string;
+  notebookId: string;
+  source: string;
+  timeoutMs?: number;
+}
+
+export interface RunSourceResult {
+  notebook_id: string;
+  cell_id: string;
+  execution_id: string;
+  execution_count?: number;
+  status: string;
+  success: boolean;
+  outputs: Array<Record<string, unknown>>;
+}
+
+export interface RuntimedSessionRegistryOptions {
+  socketPath?: string;
+  peerLabelPrefix?: string;
+  loadBindings?: () => Promise<RuntimeBindings>;
+}
+
+type SessionEntry = {
+  agentSessionId: string;
+  session: Promise<Session>;
+};
+
+const DEFAULT_PEER_LABEL_PREFIX = "runtimed-agent-tools";
+
+export class RuntimedSessionRegistry {
+  readonly #socketPath?: string;
+  readonly #peerLabelPrefix: string;
+  readonly #loadBindings: () => Promise<RuntimeBindings>;
+  readonly #sessions = new Map<string, SessionEntry>();
+
+  constructor(options: RuntimedSessionRegistryOptions = {}) {
+    this.#socketPath = options.socketPath;
+    this.#peerLabelPrefix = options.peerLabelPrefix ?? DEFAULT_PEER_LABEL_PREFIX;
+    this.#loadBindings = options.loadBindings ?? loadRuntimeBindings;
+  }
+
+  async runSource(input: RunSourceInput): Promise<RunSourceResult> {
+    const agentSessionId = requiredString(input.agentSessionId, "agentSessionId");
+    const notebookId = requiredString(input.notebookId, "notebookId");
+    const source = requiredString(input.source, "source", false);
+    const session = await this.#getSession(agentSessionId, notebookId);
+    const result = await session.runCell(source, { timeoutMs: input.timeoutMs });
+    return normalizeResult(notebookId, result);
+  }
+
+  async disposeAgentSession(agentSessionId: string): Promise<void> {
+    const pending: Promise<Session>[] = [];
+    for (const [key, entry] of this.#sessions) {
+      if (entry.agentSessionId !== agentSessionId) continue;
+      this.#sessions.delete(key);
+      pending.push(entry.session);
+    }
+    await closeSessions(pending);
+  }
+
+  async disposeAll(): Promise<void> {
+    const pending = Array.from(this.#sessions.values(), (entry) => entry.session);
+    this.#sessions.clear();
+    await closeSessions(pending);
+  }
+
+  async #getSession(agentSessionId: string, notebookId: string): Promise<Session> {
+    const key = sessionKey(agentSessionId, notebookId);
+    const existing = this.#sessions.get(key);
+    if (existing) return existing.session;
+
+    const session = this.#openSession(agentSessionId, notebookId);
+    this.#sessions.set(key, { agentSessionId, session });
+    try {
+      return await session;
+    } catch (error) {
+      this.#sessions.delete(key);
+      throw error;
+    }
+  }
+
+  async #openSession(agentSessionId: string, notebookId: string): Promise<Session> {
+    const bindings = await this.#loadBindings();
+    return bindings.openNotebook(notebookId, {
+      socketPath: this.#socketPath,
+      peerLabel: `${this.#peerLabelPrefix}:${agentSessionId}`,
+      description: "OpenCode/Kilo notebook tool session",
+    });
+  }
+}
+
+export function serializeRunSourceResult(result: RunSourceResult): string {
+  return JSON.stringify(result);
+}
+
+async function loadRuntimeBindings(): Promise<RuntimeBindings> {
+  const imported = (await import("@runtimed/node")) as unknown as {
+    default?: RuntimeBindings;
+    openNotebook?: RuntimeBindings["openNotebook"];
+  };
+  if (typeof imported.openNotebook === "function") {
+    return imported as RuntimeBindings;
+  }
+  if (typeof imported.default?.openNotebook === "function") {
+    return imported.default;
+  }
+  throw new Error("@runtimed/node did not expose openNotebook");
+}
+
+function sessionKey(agentSessionId: string, notebookId: string): string {
+  return `${agentSessionId}\u0000${notebookId}`;
+}
+
+function requiredString(value: string, name: string, trim = true): string {
+  if (typeof value !== "string" || (trim ? value.trim() : value).length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return trim ? value.trim() : value;
+}
+
+function normalizeResult(notebookId: string, result: CellResult): RunSourceResult {
+  return {
+    notebook_id: notebookId,
+    cell_id: result.cellId,
+    execution_id: result.executionId,
+    ...(result.executionCount === undefined ? {} : { execution_count: result.executionCount }),
+    status: result.status,
+    success: result.success,
+    outputs: result.outputs.map(normalizeOutput),
+  };
+}
+
+function normalizeOutput(output: JsOutput): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries({
+      output_type: output.outputType,
+      name: output.name,
+      text: output.text,
+      data: parseJson(output.dataJson),
+      ename: output.ename,
+      evalue: output.evalue,
+      traceback: output.traceback,
+      execution_count: output.executionCount,
+      blob_urls: parseJson(output.blobUrlsJson),
+      blob_paths: parseJson(output.blobPathsJson),
+    }).filter(([, value]) => value !== undefined),
+  );
+}
+
+function parseJson(value: string | undefined): unknown {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+async function closeSessions(pending: Promise<Session>[]): Promise<void> {
+  const sessions = await Promise.allSettled(pending);
+  await Promise.allSettled(
+    sessions.flatMap((result) => (result.status === "fulfilled" ? [result.value.close()] : [])),
+  );
+}

--- a/packages/runtimed-agent-tools/src/kilo.ts
+++ b/packages/runtimed-agent-tools/src/kilo.ts
@@ -1,0 +1,8 @@
+import { createAgentToolHooks } from "./plugin.js";
+
+const server = async () => createAgentToolHooks();
+
+export default {
+  id: "@runtimed/agent-tools",
+  server,
+};

--- a/packages/runtimed-agent-tools/src/opencode.ts
+++ b/packages/runtimed-agent-tools/src/opencode.ts
@@ -1,0 +1,5 @@
+import { createAgentToolHooks } from "./plugin.js";
+
+export const RuntimedAgentTools = async () => createAgentToolHooks();
+
+export default RuntimedAgentTools;

--- a/packages/runtimed-agent-tools/src/plugin.ts
+++ b/packages/runtimed-agent-tools/src/plugin.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+import { RuntimedSessionRegistry, serializeRunSourceResult } from "./core.js";
+
+export interface ToolExecutionContext {
+  sessionID: string;
+}
+
+export interface SessionDeletedEvent {
+  type: string;
+  properties?: {
+    info?: {
+      id?: string;
+    };
+  };
+}
+
+export function createAgentToolHooks() {
+  const registry = new RuntimedSessionRegistry({
+    socketPath: process.env.RUNTIMED_SOCKET_PATH,
+  });
+
+  return {
+    tool: {
+      notebook_run_source: {
+        description: "Append and execute a synced code cell in an existing nteract notebook.",
+        args: {
+          notebook_id: z.string().describe("Active nteract notebook ID to attach to"),
+          source: z.string().describe("Python source for the new code cell"),
+          timeout_ms: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Optional execution timeout in milliseconds"),
+        },
+        async execute(
+          args: { notebook_id: string; source: string; timeout_ms?: number },
+          context: ToolExecutionContext,
+        ) {
+          const result = await registry.runSource({
+            agentSessionId: context.sessionID,
+            notebookId: args.notebook_id,
+            source: args.source,
+            timeoutMs: args.timeout_ms,
+          });
+          return serializeRunSourceResult(result);
+        },
+      },
+    },
+    async event({ event }: { event: SessionDeletedEvent }) {
+      const sessionId = event.properties?.info?.id;
+      if (event.type === "session.deleted" && sessionId) {
+        await registry.disposeAgentSession(sessionId);
+      }
+    },
+  };
+}

--- a/packages/runtimed-agent-tools/tests/core.test.ts
+++ b/packages/runtimed-agent-tools/tests/core.test.ts
@@ -1,0 +1,130 @@
+import type { CellResult, Session } from "@runtimed/node";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RuntimedSessionRegistry,
+  serializeRunSourceResult,
+  type RuntimeBindings,
+} from "../src/core.js";
+
+function cellResult(overrides: Partial<CellResult> = {}): CellResult {
+  return {
+    cellId: "cell-1",
+    executionId: "execution-1",
+    executionCount: 3,
+    status: "done",
+    success: true,
+    outputs: [
+      {
+        outputType: "execute_result",
+        dataJson: JSON.stringify({ "text/plain": "42" }),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function fakeRuntime() {
+  const runCell = vi.fn(async () => cellResult());
+  const close = vi.fn(async () => undefined);
+  const session = { runCell, close } as unknown as Session;
+  const openNotebook = vi.fn(async () => session);
+  const bindings: RuntimeBindings = { openNotebook };
+  return { bindings, session, runCell, close, openNotebook };
+}
+
+describe("RuntimedSessionRegistry", () => {
+  it("opens once per agent and notebook, then executes synced cells", async () => {
+    const runtime = fakeRuntime();
+    const registry = new RuntimedSessionRegistry({
+      socketPath: "/tmp/runtimed.sock",
+      loadBindings: async () => runtime.bindings,
+    });
+
+    const first = await registry.runSource({
+      agentSessionId: "agent-1",
+      notebookId: "notebook-1",
+      source: "21 * 2",
+    });
+    await registry.runSource({
+      agentSessionId: "agent-1",
+      notebookId: "notebook-1",
+      source: "6 * 7",
+      timeoutMs: 5_000,
+    });
+
+    expect(runtime.openNotebook).toHaveBeenCalledOnce();
+    expect(runtime.openNotebook).toHaveBeenCalledWith("notebook-1", {
+      socketPath: "/tmp/runtimed.sock",
+      peerLabel: "runtimed-agent-tools:agent-1",
+      description: "OpenCode/Kilo notebook tool session",
+    });
+    expect(runtime.runCell).toHaveBeenNthCalledWith(1, "21 * 2", {
+      timeoutMs: undefined,
+    });
+    expect(runtime.runCell).toHaveBeenNthCalledWith(2, "6 * 7", {
+      timeoutMs: 5_000,
+    });
+    expect(first).toEqual({
+      notebook_id: "notebook-1",
+      cell_id: "cell-1",
+      execution_id: "execution-1",
+      execution_count: 3,
+      status: "done",
+      success: true,
+      outputs: [
+        {
+          output_type: "execute_result",
+          data: { "text/plain": "42" },
+        },
+      ],
+    });
+  });
+
+  it("isolates notebooks across agent sessions and closes their handles", async () => {
+    const runtime = fakeRuntime();
+    const registry = new RuntimedSessionRegistry({
+      loadBindings: async () => runtime.bindings,
+    });
+
+    await registry.runSource({
+      agentSessionId: "agent-1",
+      notebookId: "notebook-1",
+      source: "1",
+    });
+    await registry.runSource({
+      agentSessionId: "agent-2",
+      notebookId: "notebook-1",
+      source: "2",
+    });
+    await registry.disposeAgentSession("agent-1");
+
+    expect(runtime.openNotebook).toHaveBeenCalledTimes(2);
+    expect(runtime.close).toHaveBeenCalledOnce();
+
+    await registry.disposeAll();
+    expect(runtime.close).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes a stable JSON tool response", () => {
+    expect(
+      JSON.parse(
+        serializeRunSourceResult({
+          notebook_id: "notebook-1",
+          cell_id: "cell-1",
+          execution_id: "execution-1",
+          status: "done",
+          success: true,
+          outputs: [],
+        }),
+      ),
+    ).toEqual({
+      notebook_id: "notebook-1",
+      cell_id: "cell-1",
+      execution_id: "execution-1",
+      status: "done",
+      success: true,
+      outputs: [],
+    });
+  });
+});

--- a/packages/runtimed-agent-tools/tests/hosts.test.ts
+++ b/packages/runtimed-agent-tools/tests/hosts.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import OpenCodePlugin from "../src/opencode.js";
+import KiloPlugin from "../src/kilo.js";
+
+describe("host entrypoints", () => {
+  it("exports an OpenCode plugin function", () => {
+    expect(OpenCodePlugin).toBeTypeOf("function");
+  });
+
+  it("exports a Kilo server plugin descriptor", () => {
+    expect(KiloPlugin).toMatchObject({
+      id: "@runtimed/agent-tools",
+      server: expect.any(Function),
+    });
+  });
+});

--- a/packages/runtimed-agent-tools/tsconfig.build.json
+++ b/packages/runtimed-agent-tools/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "fixtures", "dist"]
+}

--- a/packages/runtimed-agent-tools/tsconfig.json
+++ b/packages/runtimed-agent-tools/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,22 @@ importers:
         specifier: ^6.2.5
         version: 6.2.5
 
+  packages/runtimed-agent-tools:
+    dependencies:
+      '@runtimed/node':
+        specifier: workspace:*
+        version: link:../runtimed-node
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+
   packages/runtimed-node:
     dependencies:
       rxjs:


### PR DESCRIPTION
## Summary

- add a packable `@runtimed/agent-tools` package with OpenCode and Kilo plugin entrypoints
- register `notebook_run_source`, which attaches to an existing notebook and uses `@runtimed/node` to append and execute a synced code cell
- reuse notebook sessions within each agent session and close their handles when that agent session is deleted
- add isolated host fixtures and a smoke harness that verifies real OpenCode and Kilo servers register the tool

## Why

Agent harnesses can control notebooks directly through `@runtimed/node` without routing cell execution through an MCP server. This first slice exercises the native-package and host-plugin boundary with one useful tool while preserving the NotebookDoc as the source of executed cell content.

This does not depend on #4138. Its durable `getCellOutputs` API and replaying connection status remain useful follow-ups once this consumer needs reopened-notebook output reads and stronger cached-session health handling.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir packages/runtimed-agent-tools typecheck`
- `pnpm --dir packages/runtimed-agent-tools test` (5 tests)
- `pnpm --dir packages/runtimed-agent-tools smoke:hosts`
  - OpenCode 1.18.15 registered `notebook_run_source`
  - Kilo 7.4.21 registered `notebook_run_source`
- `RUNTIMED_SOCKET_PATH=... pnpm --dir packages/runtimed-agent-tools smoke:live`
  - created a real notebook on the worktree daemon
  - executed `answer = 6 * 7; answer` through the shipped tool handler
  - resolved output `42`, then closed the session and shut down the notebook
- `pnpm --dir packages/runtimed-agent-tools pack:dry-run`
- `cargo test -p xtask bump` (11 tests)
- independent Kilo panel: product, architecture, and correctness lenses
  - no blocking findings survived local verification
  - documented the reviewed session-cleanup contract

## Follow-up

- configure npm trusted publishing and wire `@runtimed/agent-tools` into the release workflow
