### PR TITLE
fix(outputs): keep HTML outputs interactive

### DIFF
--- a/apps/notebook/e2e/isolated-rich-output.spec.ts
+++ b/apps/notebook/e2e/isolated-rich-output.spec.ts
@@ -124,6 +124,43 @@ test.describe("isolated rich output rendering", () => {
     expect(logs).not.toContain("renderer-bundle-pending");
     expect(logs).not.toContain("renderer-error");
   });
+
+  test("keeps HTML output buttons clickable and inner regions scrollable", async ({ page }) => {
+    test.setTimeout(180_000);
+
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const cell = await ensureCodeCell(page);
+    await setCellSource(
+      cell,
+      [
+        "from IPython.display import HTML, display",
+        'display(HTML("""',
+        '<button id="html-action" type="button" onclick="document.getElementById(\'html-status\').textContent=\'clicked\'">Click me</button>',
+        '<span id="html-status">waiting</span>',
+        '<div id="html-scroller" style="height: 80px; overflow-y: auto">',
+        '<div style="height: 480px">Scrollable HTML content</div>',
+        "</div>",
+        '"""))',
+      ].join("\n"),
+    );
+
+    await executeCell(cell);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const frame = cell.frameLocator('[data-slot="isolated-frame"]');
+    const button = frame.getByRole("button", { name: "Click me" });
+    await expect(button).toBeVisible({ timeout: 60_000 });
+    await button.click();
+    await expect(frame.locator("#html-status")).toHaveText("clicked");
+
+    const scroller = frame.locator("#html-scroller");
+    await scroller.hover();
+    await page.mouse.wheel(0, 240);
+    await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+  });
 });
 
 function normalizeOutputText(text: string): string {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -188,6 +188,20 @@ function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
   ];
 }
 
+function makeHtmlOutput(): JupyterOutput[] {
+  return [
+    {
+      output_id: "html-output",
+      output_type: "display_data",
+      data: {
+        "text/html":
+          '<button type="button">Run</button><div style="max-height: 80px; overflow-y: auto">Rows</div>',
+      },
+      metadata: {},
+    },
+  ];
+}
+
 function makeWidgetOutput(outputId = "widget-output", modelId = "widget-model"): JupyterOutput {
   return {
     output_id: outputId,
@@ -617,6 +631,15 @@ describe("OutputArea iframe theme sync", () => {
     );
   });
 
+  it("keeps HTML iframe controls and inner scroll regions interactive by default", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeHtmlOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("true");
+  });
+
   it("releases static document iframe outputs after a plain iframe click", () => {
     const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
     const frame = getByTestId("isolated-frame");
@@ -1039,7 +1062,7 @@ describe("OutputArea iframe theme sync", () => {
 
     const frames = screen.getAllByTestId("isolated-frame");
     expect(frames).toHaveLength(1);
-    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("false");
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
@@ -1082,7 +1105,7 @@ describe("OutputArea iframe theme sync", () => {
 
     const frames = screen.getAllByTestId("isolated-frame");
     expect(frames).toHaveLength(1);
-    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("false");
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
@@ -1110,7 +1133,7 @@ describe("OutputArea iframe theme sync", () => {
 
     const frames = screen.getAllByTestId("isolated-frame");
     expect(frames).toHaveLength(1);
-    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("false");
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -176,6 +176,22 @@ describe("output lane policy", () => {
     ).toBe("interactive-frame");
   });
 
+  it("keeps HTML and JavaScript documents interactive for controls and inner scrolling", () => {
+    const outputs = [
+      displayOutput("html-output", {
+        "text/html": '<button type="button">Run</button><div style="overflow:auto">Rows</div>',
+      }),
+      displayOutput("javascript-output", {
+        "application/javascript": "document.querySelector('button')?.focus();",
+      }),
+    ];
+
+    expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([false, false]);
+    expect(splitOutputSegments(outputs).map((segment) => segment.lane)).toEqual([
+      "interactive-frame",
+    ]);
+  });
+
   it("routes Vega/Altair charts onto the click-to-engage static frame", () => {
     const output = displayOutput("vega-output", {
       "application/vnd.vegalite.v5+json": { mark: "circle" },
@@ -218,12 +234,12 @@ describe("output lane policy", () => {
     expect(outputUsesBokeh(outputs[3])).toBe(true);
     expect(outputUsesWheelOwningFrame(outputs[3])).toBe(true);
     expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
-      true,
-      true,
-      true,
-      true,
+      false,
+      false,
+      false,
+      false,
     ]);
-    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments.map((segment) => segment.lane)).toEqual(["interactive-frame"]);
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "bokeh-loading-html",
       "bokeh-load-js",
@@ -245,14 +261,14 @@ describe("output lane policy", () => {
 
     const segments = splitOutputSegments(outputs);
 
-    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments.map((segment) => segment.lane)).toEqual(["interactive-frame"]);
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "bokeh-root-html",
       "bokeh-exec-js",
     ]);
   });
 
-  it("routes native Bokeh sessions through a click-to-engage document frame", () => {
+  it("routes native Bokeh sessions through an interactive document frame", () => {
     const output = displayOutput("bokeh-session", {
       [NTERACT_BOKEH_SESSION_MIME_TYPE]: { schema_version: 1 },
       "text/plain": "fallback",
@@ -261,8 +277,8 @@ describe("output lane policy", () => {
     expect(selectedOutputMimeType(output)).toBe(NTERACT_BOKEH_SESSION_MIME_TYPE);
     expect(outputUsesBokeh(output)).toBe(true);
     expect(outputUsesWheelOwningFrame(output)).toBe(true);
-    expect(outputAllowsScrollPassthrough(output)).toBe(true);
-    expect(outputSegmentLane(output)).toBe("static-frame");
+    expect(outputAllowsScrollPassthrough(output)).toBe(false);
+    expect(outputSegmentLane(output)).toBe("interactive-frame");
   });
 
   it("keeps Panel's HTML and JavaScript display outputs in one document lane", () => {
@@ -299,13 +315,13 @@ describe("output lane policy", () => {
     expect(hasWidgetOutputs(outputs)).toBe(false);
     expect(outputUsesWheelOwningFrame(outputs[4])).toBe(true);
     expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
+      false,
+      false,
       true,
-      true,
-      true,
-      true,
-      true,
+      false,
+      false,
     ]);
-    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments.map((segment) => segment.lane)).toEqual(["interactive-frame"]);
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "panel-loading-html",
       "panel-load-js",
@@ -431,9 +447,9 @@ describe("output lane policy", () => {
 
     expect(
       segmentedOutputLanes(outputs, { isolated: true }).map((segment) => segment.lane),
-    ).toEqual(["dom", "static-frame", "sift-frame"]);
+    ).toEqual(["dom", "interactive-frame", "sift-frame"]);
     expect(
       segmentedOutputLanes(outputs, { hasCollapseControl: true }).map((segment) => segment.lane),
-    ).toEqual(["dom", "static-frame", "sift-frame"]);
+    ).toEqual(["dom", "interactive-frame", "sift-frame"]);
   });
 });

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -1,15 +1,6 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
-import {
-  BOKEHJS_EXEC_MIME_TYPE,
-  BOKEHJS_LOAD_MIME_TYPE,
-  NTERACT_BOKEH_SESSION_MIME_TYPE,
-  isBokehMimeType,
-} from "@/components/outputs/bokeh-mime";
-import {
-  PANEL_EXEC_MIME_TYPE,
-  PANEL_LOAD_MIME_TYPE,
-  isPanelMimeType,
-} from "@/components/outputs/panel-mime";
+import { isBokehMimeType } from "@/components/outputs/bokeh-mime";
+import { isPanelMimeType } from "@/components/outputs/panel-mime";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
@@ -40,20 +31,12 @@ export interface OutputSegmentationOptions {
 }
 
 const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
-  // Static document-like outputs (markdown / HTML / SVG) all behave better as
-  // click-to-engage: the page wheels through them by default, while
-  // pointer-down hands events back to the iframe.
+  // Static document-like outputs can use click-to-engage so the page wheels
+  // through them by default. HTML and JavaScript are deliberately excluded:
+  // they may contain controls or their own scroll regions, so disabling iframe
+  // pointer events would make those interactions unreachable.
   "text/markdown",
-  "text/html",
   "image/svg+xml",
-  // JavaScript display outputs often act on adjacent HTML display outputs in
-  // the same cell (Bokeh and Panel notebook loader/root pairs are common).
-  "application/javascript",
-  BOKEHJS_LOAD_MIME_TYPE,
-  BOKEHJS_EXEC_MIME_TYPE,
-  NTERACT_BOKEH_SESSION_MIME_TYPE,
-  PANEL_LOAD_MIME_TYPE,
-  PANEL_EXEC_MIME_TYPE,
   // Sift's interactive tables are also click-to-engage (see SIFT_MIME_TYPES).
   "application/vnd.apache.parquet",
   "application/vnd.apache.arrow.stream",
@@ -253,7 +236,10 @@ export function splitOutputSegments(
     const lane = outputSegmentLane(output, priority);
     const previous = segments.at(-1);
 
-    if (previous?.lane === "static-frame" && isEmptyDisplayOutput(output, priority)) {
+    if (
+      (previous?.lane === "static-frame" || previous?.lane === "interactive-frame") &&
+      isEmptyDisplayOutput(output, priority)
+    ) {
       previous.outputs.push(output);
     } else if (!laneStandsAlone(lane) && previous && previous.lane === lane) {
       previous.outputs.push(output);


### PR DESCRIPTION
## Summary

- keep HTML and JavaScript output documents pointer-interactive by default
- preserve Bokeh and Panel multi-output document grouping
- cover direct button clicks and nested HTML scrolling in browser E2E

## Problem

HTML outputs were routed through the static click-to-engage frame. The iframe started with pointer events disabled, so the first click only activated the wrapper instead of reaching an HTML control. A plain mouse-up immediately returned the frame to passthrough mode, which also made nested HTML scroll regions impractical to use.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx` (65 passed)
- `pnpm test:run` (2,849 passed, 6 skipped)
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/isolated-rich-output.spec.ts` (3 passed)
