### PR TITLE
fix(mcp): recover sessions across daemon replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7427,6 +7427,7 @@ dependencies = [
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",
+ "proptest",
  "regex",
  "repr-llm",
  "reqwest 0.12.28",

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -3,14 +3,14 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::Path;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 
 use rmcp::model::Implementation;
 use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::{async_rw::AsyncRwTransport, Transport};
 use rmcp::{ClientHandler, ServiceExt};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tracing::{info, warn};
 
 /// rmcp client role type alias.
@@ -35,6 +35,16 @@ impl ClientHandler for ChildClientHandler {
 
 /// A running child service.
 pub type RunningChild = rmcp::service::RunningService<RoleChild, ChildClientHandler>;
+
+/// Exit status observed by the task that owns and reaps the child process.
+pub type ChildExitStatus = watch::Receiver<Option<ExitStatus>>;
+
+/// An initialized MCP client plus the operating-system exit status channel for
+/// the process behind it.
+pub struct SpawnedChild {
+    pub client: RunningChild,
+    pub exit_status: ChildExitStatus,
+}
 
 /// Transport for a child MCP process whose lifecycle is owned by this proxy.
 struct ManagedChildTransport {
@@ -77,13 +87,20 @@ impl Transport<RoleChild> for ManagedChildTransport {
     }
 }
 
-async fn wait_for_child(mut child: Child, mut shutdown_rx: oneshot::Receiver<()>) {
+async fn wait_for_child(
+    mut child: Child,
+    mut shutdown_rx: oneshot::Receiver<()>,
+    exit_status_tx: watch::Sender<Option<ExitStatus>>,
+) {
     let child_id = child.id();
 
     tokio::select! {
         status = child.wait() => {
             match status {
-                Ok(status) => info!(pid = ?child_id, %status, "Child process reaped"),
+                Ok(status) => {
+                    let _ = exit_status_tx.send(Some(status));
+                    info!(pid = ?child_id, %status, "Child process reaped");
+                }
                 Err(e) => warn!(pid = ?child_id, error = %e, "Failed to wait for child process"),
             }
         }
@@ -93,7 +110,10 @@ async fn wait_for_child(mut child: Child, mut shutdown_rx: oneshot::Receiver<()>
             }
 
             match child.wait().await {
-                Ok(status) => info!(pid = ?child_id, %status, "Child process stopped and reaped"),
+                Ok(status) => {
+                    let _ = exit_status_tx.send(Some(status));
+                    info!(pid = ?child_id, %status, "Child process stopped and reaped");
+                }
                 Err(e) => warn!(pid = ?child_id, error = %e, "Failed to reap child process after shutdown"),
             }
         }
@@ -104,6 +124,7 @@ async fn wait_for_child(mut child: Child, mut shutdown_rx: oneshot::Receiver<()>
 /// discard the lifecycle handle; tests use it as an oracle.
 struct SpawnedTransport {
     transport: ManagedChildTransport,
+    exit_status: ChildExitStatus,
     /// Handle to the background `wait_for_child` task. Completes when
     /// the child has been reaped (naturally or via shutdown signal).
     lifecycle_handle: tokio::task::JoinHandle<()>,
@@ -157,13 +178,15 @@ fn spawn_managed_transport_inner(
         .ok_or_else(|| std::io::Error::other("child stdout was not piped"))?;
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let lifecycle_handle = tokio::spawn(wait_for_child(child, shutdown_rx));
+    let (exit_status_tx, exit_status) = watch::channel(None);
+    let lifecycle_handle = tokio::spawn(wait_for_child(child, shutdown_rx, exit_status_tx));
 
     Ok(SpawnedTransport {
         transport: ManagedChildTransport {
             inner: AsyncRwTransport::new(stdout, stdin),
             shutdown_tx: Some(shutdown_tx),
         },
+        exit_status,
         lifecycle_handle,
     })
 }
@@ -172,11 +195,11 @@ fn spawn_managed_transport(
     command: &Path,
     args: &[String],
     env: &HashMap<String, String>,
-) -> std::io::Result<ManagedChildTransport> {
+) -> std::io::Result<(ManagedChildTransport, ChildExitStatus)> {
     let spawned = spawn_managed_transport_inner(command, args, env)?;
     // Production path: drop the lifecycle handle (task runs detached).
     drop(spawned.lifecycle_handle);
-    Ok(spawned.transport)
+    Ok((spawned.transport, spawned.exit_status))
 }
 
 /// Spawn `runt mcp` (or similar) as a child process and return an rmcp client.
@@ -190,7 +213,7 @@ pub async fn spawn_child(
     env: &HashMap<String, String>,
     upstream_name: &str,
     upstream_title: Option<&str>,
-) -> Result<RunningChild, String> {
+) -> Result<SpawnedChild, String> {
     if !command.exists() {
         return Err(format!("Child binary not found at {}", command.display()));
     }
@@ -201,7 +224,7 @@ pub async fn spawn_child(
         args.join(" ")
     );
 
-    let transport = spawn_managed_transport(command, args, env)
+    let (transport, exit_status) = spawn_managed_transport(command, args, env)
         .map_err(|e| format!("Failed to spawn child process: {e}"))?;
 
     let handler = ChildClientHandler {
@@ -214,7 +237,10 @@ pub async fn spawn_child(
         .await
         .map_err(|e| format!("Failed to initialize child MCP client: {e}"))?;
 
-    Ok(client)
+    Ok(SpawnedChild {
+        client,
+        exit_status,
+    })
 }
 
 #[cfg(test)]
@@ -312,10 +338,14 @@ mod tests {
         let mut cmd = instant_exit_command();
         let child = cmd.spawn().expect("spawn child");
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (exit_status_tx, _exit_status) = watch::channel(None);
 
-        tokio::time::timeout(Duration::from_secs(5), wait_for_child(child, shutdown_rx))
-            .await
-            .expect("child wait should complete");
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            wait_for_child(child, shutdown_rx, exit_status_tx),
+        )
+        .await
+        .expect("child wait should complete");
     }
 
     #[tokio::test]
@@ -323,8 +353,9 @@ mod tests {
         let mut cmd = long_running_command();
         let child = cmd.spawn().expect("spawn child");
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (exit_status_tx, _exit_status) = watch::channel(None);
 
-        let task = tokio::spawn(wait_for_child(child, shutdown_rx));
+        let task = tokio::spawn(wait_for_child(child, shutdown_rx, exit_status_tx));
         shutdown_tx.send(()).expect("send shutdown");
 
         tokio::time::timeout(Duration::from_secs(5), task)
@@ -342,8 +373,9 @@ mod tests {
         let mut cmd = instant_exit_command();
         let child = cmd.spawn().expect("spawn child");
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (exit_status_tx, _exit_status) = watch::channel(None);
 
-        let task = tokio::spawn(wait_for_child(child, shutdown_rx));
+        let task = tokio::spawn(wait_for_child(child, shutdown_rx, exit_status_tx));
 
         // The instant-exit child is very likely reaped by the natural
         // `child.wait()` branch before we get here, so the shutdown
@@ -373,10 +405,19 @@ mod tests {
         };
         let child = cmd.spawn().expect("spawn child");
         let (_shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (exit_status_tx, exit_status) = watch::channel(None);
 
-        tokio::time::timeout(Duration::from_secs(5), wait_for_child(child, shutdown_rx))
-            .await
-            .expect("child with exit(75) should be reaped");
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            wait_for_child(child, shutdown_rx, exit_status_tx),
+        )
+        .await
+        .expect("child with exit(75) should be reaped");
+        assert_eq!(
+            exit_status.borrow().as_ref().and_then(ExitStatus::code),
+            Some(75),
+            "child owner must publish intentional daemon-upgrade exit status"
+        );
     }
 
     /// Rapid spawn/kill cycles must not leak tasks or panic. This exercises
@@ -387,8 +428,9 @@ mod tests {
             let mut cmd = long_running_command();
             let child = cmd.spawn().expect("spawn child");
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
+            let (exit_status_tx, _exit_status) = watch::channel(None);
 
-            let task = tokio::spawn(wait_for_child(child, shutdown_rx));
+            let task = tokio::spawn(wait_for_child(child, shutdown_rx, exit_status_tx));
             // Immediately kill
             shutdown_tx.send(()).expect("send shutdown");
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -138,8 +138,13 @@ pub struct ProxyState {
     upgrade_handoff_limiter: CircuitBreaker,
     /// Cached child tool definitions, loaded from disk at startup.
     pub cached_tools: Option<Vec<Tool>>,
-    /// Last active notebook ID for auto-rejoin after restart.
+    /// Durable active notebook target for auto-rejoin after restart. This may
+    /// be a daemon UUID, canonical file path, or hosted notebook URL.
     pub last_notebook_id: Option<String>,
+    /// Daemon/cloud notebook id corresponding to `last_notebook_id`. The
+    /// durable handoff target may instead be a path or hosted URL, so retain
+    /// both forms to recognize an explicit disconnect by notebook id.
+    last_notebook_session_id: Option<String>,
     /// Upstream MCP client name (forwarded to child).
     pub upstream_name: String,
     /// Upstream MCP client title (forwarded to child).
@@ -195,6 +200,7 @@ impl McpProxy {
                 upgrade_handoff_limiter: CircuitBreaker::new(),
                 cached_tools,
                 last_notebook_id: None,
+                last_notebook_session_id: None,
                 upstream_name: "unknown".to_string(),
                 upstream_title: None,
                 last_daemon_version: None,
@@ -933,6 +939,24 @@ impl McpProxy {
     }
 
     async fn track_session(&self, params: &CallToolRequestParams, result: &CallToolResult) {
+        if params.name.as_ref() == "disconnect_notebook" && result.is_error != Some(true) {
+            let requested_id = params
+                .arguments
+                .as_ref()
+                .and_then(|args| args.get("notebook_id"))
+                .and_then(serde_json::Value::as_str);
+            let mut state = self.state.write().await;
+            let disconnected_active = requested_id.is_none()
+                || requested_id == state.last_notebook_id.as_deref()
+                || requested_id == state.last_notebook_session_id.as_deref();
+            if disconnected_active {
+                info!("Clearing notebook handoff target after explicit disconnect");
+                state.last_notebook_id = None;
+                state.last_notebook_session_id = None;
+            }
+            return;
+        }
+
         if let Some(id) = session::extract_session_id(params, result) {
             let mut state = self.state.write().await;
             let saving_hosted_session = params.name.as_ref() == "save_notebook"
@@ -945,6 +969,9 @@ impl McpProxy {
             } else {
                 info!("Tracking active notebook session: {id}");
                 state.last_notebook_id = Some(id);
+            }
+            if let Some(notebook_id) = session::extract_notebook_id_from_result(result) {
+                state.last_notebook_session_id = Some(notebook_id);
             }
         }
     }
@@ -1673,6 +1700,59 @@ mod tests {
             proxy.state.read().await.last_notebook_id.as_deref(),
             Some(hosted_target)
         );
+    }
+
+    #[tokio::test]
+    async fn track_session_clears_handoff_after_active_disconnect() {
+        let proxy = McpProxy::new(test_config(), None);
+        {
+            let mut state = proxy.state.write().await;
+            state.last_notebook_id = Some("/tmp/analysis.ipynb".to_string());
+            state.last_notebook_session_id =
+                Some("38582ef2-a117-4ce6-83d2-20c2c45d33d7".to_string());
+        }
+        let disconnect: CallToolRequestParams = serde_json::from_value(serde_json::json!({
+            "name": "disconnect_notebook",
+            "arguments": { "notebook_id": "38582ef2-a117-4ce6-83d2-20c2c45d33d7" }
+        }))
+        .unwrap();
+
+        proxy
+            .track_session(
+                &disconnect,
+                &CallToolResult::success(vec![Content::text("ok")]),
+            )
+            .await;
+
+        let state = proxy.state.read().await;
+        assert!(state.last_notebook_id.is_none());
+        assert!(state.last_notebook_session_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn track_session_keeps_active_handoff_when_parked_session_disconnects() {
+        let proxy = McpProxy::new(test_config(), None);
+        {
+            let mut state = proxy.state.write().await;
+            state.last_notebook_id = Some("/tmp/active.ipynb".to_string());
+            state.last_notebook_session_id = Some("active-id".to_string());
+        }
+        let disconnect: CallToolRequestParams = serde_json::from_value(serde_json::json!({
+            "name": "disconnect_notebook",
+            "arguments": { "notebook_id": "parked-id" }
+        }))
+        .unwrap();
+
+        proxy
+            .track_session(
+                &disconnect,
+                &CallToolResult::success(vec![Content::text("ok")]),
+            )
+            .await;
+
+        let state = proxy.state.read().await;
+        assert_eq!(state.last_notebook_id.as_deref(), Some("/tmp/active.ipynb"));
+        assert_eq!(state.last_notebook_session_id.as_deref(), Some("active-id"));
     }
 
     #[tokio::test]

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -19,7 +19,7 @@ use rmcp::{ErrorData as McpError, ServerHandler};
 use tokio::sync::{mpsc, Mutex, Notify, RwLock};
 use tracing::{error, info, warn};
 
-use crate::child::{self, RunningChild};
+use crate::child::{self, ChildExitStatus, RunningChild};
 use crate::circuit_breaker::CircuitBreaker;
 use crate::session;
 use crate::tools::{self, ToolDivergence};
@@ -29,6 +29,40 @@ use crate::version::ReconnectionEvent;
 /// target. Must match `runt_mcp::daemon_watch::REJOIN_ENV_VAR`.
 const REJOIN_ENV_VAR: &str = "NTERACT_MCP_REJOIN_NOTEBOOK";
 const SLOW_CHILD_CALL: Duration = Duration::from_secs(30);
+const EX_TEMPFAIL: i32 = 75;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChildRestartReason {
+    /// The child deliberately asked the proxy to pick up a new daemon binary.
+    DaemonUpgrade,
+    /// A crash, closed transport without exit metadata, or an explicit restart.
+    UnexpectedOrRequested,
+}
+
+impl ChildRestartReason {
+    fn from_exit_code(exit_code: Option<i32>) -> Self {
+        if exit_code == Some(EX_TEMPFAIL) {
+            Self::DaemonUpgrade
+        } else {
+            Self::UnexpectedOrRequested
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::DaemonUpgrade => "daemon_upgrade_exit_75",
+            Self::UnexpectedOrRequested => "unexpected_or_requested",
+        }
+    }
+}
+
+fn circuit_breaker_allows_restart(
+    circuit_breaker: &mut CircuitBreaker,
+    child_was_dead: bool,
+    reason: ChildRestartReason,
+) -> bool {
+    child_was_dead || reason == ChildRestartReason::DaemonUpgrade || circuit_breaker.record_crash()
+}
 
 /// Extract the daemon version from a freshly-initialized child's MCP
 /// `ServerInfo`. `runt mcp` stamps the daemon version into
@@ -80,6 +114,8 @@ pub struct ProxyConfig {
 pub struct ProxyState {
     /// rmcp client connected to the child process.
     pub child_client: Option<RunningChild>,
+    /// OS exit status published by the task that owns the current child.
+    child_exit_status: Option<ChildExitStatus>,
     /// Monotonic generation for the child transport.
     ///
     /// Forwarded calls snapshot this with a cloned child peer so stale calls
@@ -141,6 +177,7 @@ impl McpProxy {
         Self {
             state: Arc::new(RwLock::new(ProxyState {
                 child_client: None,
+                child_exit_status: None,
                 child_generation: 0,
                 restart_count: 0,
                 circuit_breaker: CircuitBreaker::new(),
@@ -187,7 +224,7 @@ impl McpProxy {
             "Spawning child process"
         );
 
-        let client = child::spawn_child(
+        let spawned = child::spawn_child(
             &child_command,
             &self.config.child_args,
             &self.config.child_env,
@@ -200,12 +237,13 @@ impl McpProxy {
         // before we move the client into state. `runt mcp` stamps the
         // daemon version there during its startup handshake (see
         // crates/runt-mcp/src/lib.rs::get_info).
-        let daemon_version = extract_daemon_version(&client);
+        let daemon_version = extract_daemon_version(&spawned.client);
 
         let generation = {
             let mut state = self.state.write().await;
             state.child_generation = state.child_generation.wrapping_add(1);
-            state.child_client = Some(client);
+            state.child_client = Some(spawned.client);
+            state.child_exit_status = Some(spawned.exit_status);
             state.child_spawn_time = Some(Instant::now());
             state.last_daemon_version = daemon_version;
             state.child_generation
@@ -227,6 +265,10 @@ impl McpProxy {
     /// Handles circuit breaker, version detection, session rejoin, and
     /// tool divergence detection.
     pub async fn restart_child(&self) -> Result<(), String> {
+        self.restart_child_for_reason().await
+    }
+
+    async fn restart_child_for_reason(&self) -> Result<(), String> {
         // Prevent concurrent restarts (monitor task + tool call racing)
         let mut restart_lock = self.restart_in_progress.lock().await;
         if *restart_lock {
@@ -236,11 +278,19 @@ impl McpProxy {
         *restart_lock = true;
         drop(restart_lock);
 
+        let reason = self.current_child_restart_reason().await;
+        info!(
+            event = "child_restart_classified",
+            restart_reason = reason.label(),
+            "Classified child restart reason"
+        );
+
         // Phase 1: Drop old client, check circuit breaker
         let (child_was_dead, old_child) = {
             let mut state = self.state.write().await;
             let was_dead = state.child_client.is_none();
             let old_child = state.child_client.take();
+            state.child_exit_status = None;
             if old_child.is_some() {
                 state.child_generation = state.child_generation.wrapping_add(1);
             }
@@ -254,12 +304,14 @@ impl McpProxy {
                 event = "child_restart_requested",
                 restart_num = state.restart_count + 1,
                 child_was_dead = was_dead,
+                restart_reason = reason.label(),
                 uptime_secs = uptime,
                 "Restarting child process"
             );
 
-            // Skip circuit breaker if child exited on its own (daemon upgrade)
-            if !was_dead && !state.circuit_breaker.record_crash() {
+            // Exit 75 is the child's intentional handoff protocol for a
+            // daemon upgrade. It must not consume the crash budget.
+            if !circuit_breaker_allows_restart(&mut state.circuit_breaker, was_dead, reason) {
                 let msg = format!(
                     "The nteract MCP server failed after repeated restarts. \
                      Restart your Claude session so a fresh MCP connection \
@@ -279,7 +331,7 @@ impl McpProxy {
         }
 
         // Phase 2: Backoff (skip for daemon upgrade exits)
-        if !child_was_dead {
+        if !child_was_dead && reason != ChildRestartReason::DaemonUpgrade {
             tokio::time::sleep(Duration::from_secs(2)).await;
         }
 
@@ -334,15 +386,16 @@ impl McpProxy {
         )
         .await
         {
-            Ok(client) => {
+            Ok(spawned) => {
                 // Read new daemon version from the restarted child's
                 // ServerInfo.title before moving the client into state.
-                let new_version = extract_daemon_version(&client);
+                let new_version = extract_daemon_version(&spawned.client);
 
                 let (old_tools, generation) = {
                     let mut state = self.state.write().await;
                     state.child_generation = state.child_generation.wrapping_add(1);
-                    state.child_client = Some(client);
+                    state.child_client = Some(spawned.client);
+                    state.child_exit_status = Some(spawned.exit_status);
                     state.restart_count += 1;
                     state.child_spawn_time = Some(Instant::now());
                     state.last_restart_time = Some(Instant::now());
@@ -384,18 +437,20 @@ impl McpProxy {
 
                     // Session rejoin is now the child's responsibility
                     // (`daemon_watch` consumes the seeded REJOIN env var on
-                    // its first `Connected` event). We still record whether
-                    // we handed off a target so reconnection messages are
-                    // informative.
-                    let session_rejoined = rejoin_target.is_some();
+                    // its first `Connected` event). A handed-off target means
+                    // rejoin was requested, not that the asynchronous child
+                    // rejoin has completed successfully.
+                    let session_rejoin_requested = rejoin_target.is_some();
                     let reconnection_event = match (old_version.as_deref(), new_version.as_deref())
                     {
                         (Some(old), Some(new)) if old != new => ReconnectionEvent::DaemonUpgrade {
                             old_version: old.to_string(),
                             new_version: new.to_string(),
-                            session_rejoined,
+                            session_rejoin_requested,
                         },
-                        _ => ReconnectionEvent::ChildRestart { session_rejoined },
+                        _ => ReconnectionEvent::ChildRestart {
+                            session_rejoin_requested,
+                        },
                     };
                     state.reconnection_message = Some(reconnection_event.message());
                     state.tool_list_changed_tx.clone()
@@ -424,6 +479,43 @@ impl McpProxy {
                 Err(e)
             }
         }
+    }
+
+    /// Observe the process owner's exit status after the MCP transport closes.
+    /// The short wait closes the race where stdout EOF reaches rmcp just before
+    /// `Child::wait` publishes the status. A live transport is an explicit or
+    /// manual restart and does not wait here.
+    async fn current_child_restart_reason(&self) -> ChildRestartReason {
+        let mut exit_status = {
+            let state = self.state.read().await;
+            let transport_closed = state
+                .child_client
+                .as_ref()
+                .is_some_and(|child| child.is_transport_closed());
+            if !transport_closed {
+                return ChildRestartReason::UnexpectedOrRequested;
+            }
+            state.child_exit_status.clone()
+        };
+
+        let Some(ref mut exit_status) = exit_status else {
+            return ChildRestartReason::UnexpectedOrRequested;
+        };
+
+        let observed = exit_status
+            .borrow()
+            .as_ref()
+            .and_then(|status| status.code());
+        if observed.is_some() {
+            return ChildRestartReason::from_exit_code(observed);
+        }
+
+        let _ = tokio::time::timeout(Duration::from_secs(1), exit_status.changed()).await;
+        let observed = exit_status
+            .borrow()
+            .as_ref()
+            .and_then(|status| status.code());
+        ChildRestartReason::from_exit_code(observed)
     }
 
     /// Spawn a background task to monitor the child process and auto-restart on exit.
@@ -488,7 +580,7 @@ impl McpProxy {
                 );
 
                 // Attempt to restart the child
-                match proxy.restart_child().await {
+                match proxy.restart_child_for_reason().await {
                     Ok(_) => {
                         info!("Child monitor: restart successful, exiting (new monitor spawned)");
                         // Exit this monitor — restart_child() spawned a new one
@@ -755,6 +847,7 @@ impl McpProxy {
     pub async fn shutdown_child(&self) {
         let old = {
             let mut state = self.state.write().await;
+            state.child_exit_status = None;
             state.child_client.take()
         };
         if let Some(child) = old {
@@ -814,8 +907,18 @@ impl McpProxy {
 
     async fn track_session(&self, params: &CallToolRequestParams, result: &CallToolResult) {
         if let Some(id) = session::extract_session_id(params, result) {
-            info!("Tracking active notebook session: {id}");
-            self.state.write().await.last_notebook_id = Some(id);
+            let mut state = self.state.write().await;
+            let saving_hosted_session = params.name.as_ref() == "save_notebook"
+                && state
+                    .last_notebook_id
+                    .as_deref()
+                    .is_some_and(session::is_hosted_session_target);
+            if saving_hosted_session {
+                info!("Preserving hosted notebook target across save_notebook");
+            } else {
+                info!("Tracking active notebook session: {id}");
+                state.last_notebook_id = Some(id);
+            }
         }
     }
 
@@ -1288,6 +1391,50 @@ mod tests {
         }
     }
 
+    #[test]
+    fn exit_75_is_classified_as_daemon_upgrade() {
+        assert_eq!(
+            ChildRestartReason::from_exit_code(Some(75)),
+            ChildRestartReason::DaemonUpgrade
+        );
+        assert_eq!(
+            ChildRestartReason::from_exit_code(Some(1)),
+            ChildRestartReason::UnexpectedOrRequested
+        );
+        assert_eq!(
+            ChildRestartReason::from_exit_code(None),
+            ChildRestartReason::UnexpectedOrRequested
+        );
+    }
+
+    #[test]
+    fn intentional_upgrade_exits_do_not_consume_crash_budget() {
+        let mut circuit_breaker = CircuitBreaker::new();
+
+        for _ in 0..20 {
+            assert!(circuit_breaker_allows_restart(
+                &mut circuit_breaker,
+                false,
+                ChildRestartReason::DaemonUpgrade,
+            ));
+        }
+
+        // The full five-crash budget remains after any number of intentional
+        // upgrade handoffs; the sixth unexpected restart trips the breaker.
+        for _ in 0..5 {
+            assert!(circuit_breaker_allows_restart(
+                &mut circuit_breaker,
+                false,
+                ChildRestartReason::UnexpectedOrRequested,
+            ));
+        }
+        assert!(!circuit_breaker_allows_restart(
+            &mut circuit_breaker,
+            false,
+            ChildRestartReason::UnexpectedOrRequested,
+        ));
+    }
+
     // ── Reconnection message lifecycle ────────────────────────────────
 
     #[tokio::test]
@@ -1414,6 +1561,71 @@ mod tests {
         assert_eq!(
             state.last_notebook_id,
             Some("/tmp/second.ipynb".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn track_session_promotes_saved_notebook_from_uuid_to_path() {
+        let proxy = McpProxy::new(test_config(), None);
+
+        let create: CallToolRequestParams = serde_json::from_value(serde_json::json!({
+            "name": "create_notebook",
+            "arguments": {}
+        }))
+        .unwrap();
+        proxy
+            .track_session(
+                &create,
+                &CallToolResult::success(vec![Content::text(
+                    r#"{"notebook_id":"38582ef2-a117-4ce6-83d2-20c2c45d33d7"}"#,
+                )]),
+            )
+            .await;
+
+        let save: CallToolRequestParams = serde_json::from_value(serde_json::json!({
+            "name": "save_notebook",
+            "arguments": { "path": "analysis.ipynb" }
+        }))
+        .unwrap();
+        proxy
+            .track_session(
+                &save,
+                &CallToolResult::success(vec![Content::text(
+                    r#"{"path":"/tmp/analysis.ipynb","notebook_id":"38582ef2-a117-4ce6-83d2-20c2c45d33d7"}"#,
+                )]),
+            )
+            .await;
+
+        let state = proxy.state.read().await;
+        assert_eq!(
+            state.last_notebook_id,
+            Some("/tmp/analysis.ipynb".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn track_session_preserves_hosted_target_across_save() {
+        let proxy = McpProxy::new(test_config(), None);
+        let hosted_target = "https://preview.runt.run/n/01KTZA152886TK1WAHYA48G7HJ";
+        proxy.state.write().await.last_notebook_id = Some(hosted_target.to_string());
+
+        let save: CallToolRequestParams = serde_json::from_value(serde_json::json!({
+            "name": "save_notebook",
+            "arguments": { "path": "analysis.ipynb" }
+        }))
+        .unwrap();
+        proxy
+            .track_session(
+                &save,
+                &CallToolResult::success(vec![Content::text(
+                    r#"{"path":"/tmp/analysis.ipynb","notebook_id":"01KTZA152886TK1WAHYA48G7HJ"}"#,
+                )]),
+            )
+            .await;
+
+        assert_eq!(
+            proxy.state.read().await.last_notebook_id.as_deref(),
+            Some(hosted_target)
         );
     }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -58,10 +58,17 @@ impl ChildRestartReason {
 
 fn circuit_breaker_allows_restart(
     circuit_breaker: &mut CircuitBreaker,
+    upgrade_handoff_limiter: &mut CircuitBreaker,
     child_was_dead: bool,
     reason: ChildRestartReason,
 ) -> bool {
-    child_was_dead || reason == ChildRestartReason::DaemonUpgrade || circuit_breaker.record_crash()
+    if child_was_dead {
+        return true;
+    }
+    match reason {
+        ChildRestartReason::DaemonUpgrade => upgrade_handoff_limiter.record_crash(),
+        ChildRestartReason::UnexpectedOrRequested => circuit_breaker.record_crash(),
+    }
 }
 
 /// Extract the daemon version from a freshly-initialized child's MCP
@@ -125,6 +132,10 @@ pub struct ProxyState {
     pub restart_count: u32,
     /// Circuit breaker for crash detection.
     pub circuit_breaker: CircuitBreaker,
+    /// Independent rate limit for intentional upgrade handoffs. Upgrade exits
+    /// do not consume the crash budget, but a flapping installation must not
+    /// respawn children forever in a tight loop.
+    upgrade_handoff_limiter: CircuitBreaker,
     /// Cached child tool definitions, loaded from disk at startup.
     pub cached_tools: Option<Vec<Tool>>,
     /// Last active notebook ID for auto-rejoin after restart.
@@ -181,6 +192,7 @@ impl McpProxy {
                 child_generation: 0,
                 restart_count: 0,
                 circuit_breaker: CircuitBreaker::new(),
+                upgrade_handoff_limiter: CircuitBreaker::new(),
                 cached_tools,
                 last_notebook_id: None,
                 upstream_name: "unknown".to_string(),
@@ -311,7 +323,20 @@ impl McpProxy {
 
             // Exit 75 is the child's intentional handoff protocol for a
             // daemon upgrade. It must not consume the crash budget.
-            if !circuit_breaker_allows_restart(&mut state.circuit_breaker, was_dead, reason) {
+            let restart_allowed = {
+                let ProxyState {
+                    circuit_breaker,
+                    upgrade_handoff_limiter,
+                    ..
+                } = &mut *state;
+                circuit_breaker_allows_restart(
+                    circuit_breaker,
+                    upgrade_handoff_limiter,
+                    was_dead,
+                    reason,
+                )
+            };
+            if !restart_allowed {
                 let msg = format!(
                     "The nteract MCP server failed after repeated restarts. \
                      Restart your Claude session so a fresh MCP connection \
@@ -815,7 +840,9 @@ impl McpProxy {
 
     /// Reset the circuit breaker (used by supervisor after manual restart or file change).
     pub async fn reset_circuit_breaker(&self) {
-        self.state.write().await.circuit_breaker.reset();
+        let mut state = self.state.write().await;
+        state.circuit_breaker.reset();
+        state.upgrade_handoff_limiter.reset();
     }
 
     /// Get the number of child restarts since proxy creation.
@@ -1376,8 +1403,13 @@ mod tests {
             let mut state = proxy.state.write().await;
             for _ in 0..10 {
                 state.circuit_breaker.record_crash();
+                state.upgrade_handoff_limiter.record_crash();
             }
             assert!(!state.circuit_breaker.record_crash(), "should be tripped");
+            assert!(
+                !state.upgrade_handoff_limiter.record_crash(),
+                "upgrade limiter should be tripped"
+            );
         }
 
         proxy.reset_circuit_breaker().await;
@@ -1387,6 +1419,10 @@ mod tests {
             assert!(
                 state.circuit_breaker.record_crash(),
                 "should allow crashes after reset"
+            );
+            assert!(
+                state.upgrade_handoff_limiter.record_crash(),
+                "should allow upgrade handoffs after reset"
             );
         }
     }
@@ -1410,26 +1446,36 @@ mod tests {
     #[test]
     fn intentional_upgrade_exits_do_not_consume_crash_budget() {
         let mut circuit_breaker = CircuitBreaker::new();
+        let mut upgrade_handoff_limiter = CircuitBreaker::new();
 
-        for _ in 0..20 {
+        for _ in 0..5 {
             assert!(circuit_breaker_allows_restart(
                 &mut circuit_breaker,
+                &mut upgrade_handoff_limiter,
                 false,
                 ChildRestartReason::DaemonUpgrade,
             ));
         }
+        assert!(!circuit_breaker_allows_restart(
+            &mut circuit_breaker,
+            &mut upgrade_handoff_limiter,
+            false,
+            ChildRestartReason::DaemonUpgrade,
+        ));
 
-        // The full five-crash budget remains after any number of intentional
-        // upgrade handoffs; the sixth unexpected restart trips the breaker.
+        // Exhausting the independent handoff limiter leaves the full crash
+        // budget untouched; the sixth unexpected restart trips that breaker.
         for _ in 0..5 {
             assert!(circuit_breaker_allows_restart(
                 &mut circuit_breaker,
+                &mut upgrade_handoff_limiter,
                 false,
                 ChildRestartReason::UnexpectedOrRequested,
             ));
         }
         assert!(!circuit_breaker_allows_restart(
             &mut circuit_breaker,
+            &mut upgrade_handoff_limiter,
             false,
             ChildRestartReason::UnexpectedOrRequested,
         ));

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -1,15 +1,15 @@
-//! Notebook session tracking — records the notebook_id of session-establishing
-//! tool calls so that when the child is restarted, the supervisor can seed the
-//! new child's `NTERACT_MCP_REJOIN_NOTEBOOK` env var and let the child's
-//! `daemon_watch` loop re-join on its first `Connected` event.
+//! Notebook session tracking — records the durable target of session-establishing
+//! and persistence tool calls so that when the child is restarted, the supervisor
+//! can seed the new child's `NTERACT_MCP_REJOIN_NOTEBOOK` env var and let the
+//! child's `daemon_watch` loop re-join on its first `Connected` event.
 
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use serde_json::Value;
 
-/// Track notebook_id from session-establishing tool calls.
+/// Track a durable notebook target from session-establishing or persistence calls.
 ///
-/// When `connect_notebook` or `create_notebook` succeeds, returns the notebook_id
-/// to persist for seeding the next child restart.
+/// When `connect_notebook`, `create_notebook`, or `save_notebook` succeeds,
+/// returns the best target to persist for seeding the next child restart.
 ///
 /// Checks request arguments first (connect_notebook passes path/notebook_id),
 /// then falls back to parsing the response content (create_notebook returns
@@ -81,6 +81,11 @@ pub fn extract_session_id(
 
             extract_notebook_id_from_result(result)
         }
+        // Saving an ephemeral notebook promotes its durable restart identity
+        // from the daemon-scoped UUID tracked at creation time to the canonical
+        // path returned by the daemon. Without this update, an upgrade hands the
+        // stale UUID to the new daemon and the notebook cannot be recovered.
+        "save_notebook" => extract_path_from_result(result),
         _ => None,
     }
 }
@@ -98,6 +103,26 @@ fn extract_notebook_path_from_result(result: &CallToolResult) -> Option<String> 
         }
     }
     None
+}
+
+/// Parse the canonical `path` returned by `save_notebook`.
+fn extract_path_from_result(result: &CallToolResult) -> Option<String> {
+    for content in &result.content {
+        if let Some(text) = content.raw.as_text() {
+            if let Ok(json) = serde_json::from_str::<Value>(&text.text) {
+                if let Some(path) = json.get("path").and_then(Value::as_str) {
+                    return Some(path.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Whether a tracked target is a hosted notebook identity that must survive
+/// local persistence calls unchanged.
+pub(crate) fn is_hosted_session_target(target: &str) -> bool {
+    is_hosted_target(target)
 }
 
 /// Parse notebook_id from a tool result's text content (JSON response body).
@@ -409,7 +434,22 @@ mod tests {
     }
 
     #[test]
-    fn ignores_save_notebook() {
+    fn tracks_save_notebook_canonical_path_from_response() {
+        let params = make_params(
+            "save_notebook",
+            serde_json::json!({"path": "/tmp/test.ipynb"}),
+        );
+        let result = CallToolResult::success(vec![Content::text(
+            r#"{"path": "/private/tmp/test.ipynb", "notebook_id": "abc-123"}"#,
+        )]);
+        assert_eq!(
+            extract_session_id(&params, &result),
+            Some("/private/tmp/test.ipynb".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_save_notebook_without_canonical_path() {
         let params = make_params(
             "save_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -126,7 +126,7 @@ pub(crate) fn is_hosted_session_target(target: &str) -> bool {
 }
 
 /// Parse notebook_id from a tool result's text content (JSON response body).
-fn extract_notebook_id_from_result(result: &CallToolResult) -> Option<String> {
+pub(crate) fn extract_notebook_id_from_result(result: &CallToolResult) -> Option<String> {
     for content in &result.content {
         if let Some(text) = content.raw.as_text() {
             if let Ok(json) = serde_json::from_str::<Value>(&text.text) {

--- a/crates/runt-mcp-proxy/src/version.rs
+++ b/crates/runt-mcp-proxy/src/version.rs
@@ -12,10 +12,10 @@ pub enum ReconnectionEvent {
     DaemonUpgrade {
         old_version: String,
         new_version: String,
-        session_rejoined: bool,
+        session_rejoin_requested: bool,
     },
     /// Child restarted for non-upgrade reasons (crash, etc.).
-    ChildRestart { session_rejoined: bool },
+    ChildRestart { session_rejoin_requested: bool },
 }
 
 impl ReconnectionEvent {
@@ -25,18 +25,20 @@ impl ReconnectionEvent {
             ReconnectionEvent::DaemonUpgrade {
                 old_version,
                 new_version,
-                session_rejoined,
+                session_rejoin_requested,
             } => {
-                let session_msg = if *session_rejoined {
-                    ", session reconnected"
+                let session_msg = if *session_rejoin_requested {
+                    ", session reconnect requested"
                 } else {
                     ""
                 };
                 format!("Daemon upgraded ({old_version} → {new_version}){session_msg}")
             }
-            ReconnectionEvent::ChildRestart { session_rejoined } => {
-                if *session_rejoined {
-                    "MCP server restarted, session reconnected".to_string()
+            ReconnectionEvent::ChildRestart {
+                session_rejoin_requested,
+            } => {
+                if *session_rejoin_requested {
+                    "MCP server restarted, session reconnect requested".to_string()
                 } else {
                     "MCP server restarted".to_string()
                 }
@@ -54,11 +56,11 @@ mod tests {
         let event = ReconnectionEvent::DaemonUpgrade {
             old_version: "2.1.2".to_string(),
             new_version: "2.1.3".to_string(),
-            session_rejoined: true,
+            session_rejoin_requested: true,
         };
         assert_eq!(
             event.message(),
-            "Daemon upgraded (2.1.2 → 2.1.3), session reconnected"
+            "Daemon upgraded (2.1.2 → 2.1.3), session reconnect requested"
         );
     }
 
@@ -67,7 +69,7 @@ mod tests {
         let event = ReconnectionEvent::DaemonUpgrade {
             old_version: "2.1.2".to_string(),
             new_version: "2.1.3".to_string(),
-            session_rejoined: false,
+            session_rejoin_requested: false,
         };
         assert_eq!(event.message(), "Daemon upgraded (2.1.2 → 2.1.3)");
     }
@@ -75,15 +77,18 @@ mod tests {
     #[test]
     fn restart_message_with_session() {
         let event = ReconnectionEvent::ChildRestart {
-            session_rejoined: true,
+            session_rejoin_requested: true,
         };
-        assert_eq!(event.message(), "MCP server restarted, session reconnected");
+        assert_eq!(
+            event.message(),
+            "MCP server restarted, session reconnect requested"
+        );
     }
 
     #[test]
     fn restart_message_without_session() {
         let event = ReconnectionEvent::ChildRestart {
-            session_rejoined: false,
+            session_rejoin_requested: false,
         };
         assert_eq!(event.message(), "MCP server restarted");
     }
@@ -93,7 +98,7 @@ mod tests {
         let event = ReconnectionEvent::DaemonUpgrade {
             old_version: "2.1.2+abc1234".to_string(),
             new_version: "2.1.3+def5678".to_string(),
-            session_rejoined: false,
+            session_rejoin_requested: false,
         };
         assert_eq!(
             event.message(),
@@ -106,7 +111,7 @@ mod tests {
         let event = ReconnectionEvent::DaemonUpgrade {
             old_version: "1.0".to_string(),
             new_version: "2.0".to_string(),
-            session_rejoined: false,
+            session_rejoin_requested: false,
         };
         let msg = event.message();
         assert!(msg.contains('→'));
@@ -118,7 +123,7 @@ mod tests {
         let event = ReconnectionEvent::DaemonUpgrade {
             old_version: "1.0".to_string(),
             new_version: "2.0".to_string(),
-            session_rejoined: true,
+            session_rejoin_requested: true,
         };
         let cloned = event.clone();
         assert_eq!(event.message(), cloned.message());

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -36,9 +36,10 @@ fancy-regex = "0.14"
 uuid = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
-chrono = { workspace = true }
 futures-util = { workspace = true }
+proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -26,7 +26,10 @@ use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
 use crate::cloud::{self, NotebookTarget};
-use crate::session::{DaemonIncarnation, NotebookSession, SessionDropInfo, SessionDropReason};
+use crate::session::{
+    query_current_daemon_incarnation, DaemonIncarnation, NotebookSession, SessionDropInfo,
+    SessionDropReason,
+};
 use std::collections::HashMap;
 
 /// Exit code when the daemon has been upgraded and the MCP server should
@@ -345,6 +348,10 @@ fn looks_like_uuid(target: &str) -> bool {
         && uuid::Uuid::parse_str(target).is_ok()
 }
 
+fn missing_saved_rejoin_source(path: Option<&str>) -> Option<&str> {
+    path.filter(|path| !Path::new(path).is_file())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublicationResult {
     Installed,
@@ -467,21 +474,26 @@ async fn rejoin(
             info!("Automatic notebook rejoin cancelled by explicit session intent");
             return true;
         }
-        if query_daemon_info(socket_path.to_path_buf())
+        if query_current_daemon_incarnation(socket_path.to_path_buf())
             .await
-            .as_ref()
-            .map(DaemonIncarnation::from)
             .as_ref()
             != Some(&expected_incarnation)
         {
             info!("Automatic notebook rejoin cancelled because daemon incarnation changed");
             return false;
         }
-        let use_path = notebook_path
-            .as_ref()
-            .filter(|p| std::path::Path::new(p.as_str()).exists());
+        if let Some(path) = missing_saved_rejoin_source(notebook_path.as_deref()) {
+            info!(%path, "Saved notebook source is missing; cancelling automatic rejoin");
+            *last_session_drop.write().await = Some(SessionDropInfo {
+                reason: SessionDropReason::Evicted,
+                notebook_id: notebook_id.clone(),
+                notebook_path: notebook_path.clone(),
+                rejoin_target: Some(path.to_string()),
+            });
+            return true;
+        }
 
-        let result = if let Some(path) = use_path {
+        let result = if let Some(path) = notebook_path.as_ref() {
             match notebook_sync::connect::connect_open(
                 socket_path.to_path_buf(),
                 PathBuf::from(path),
@@ -533,10 +545,8 @@ async fn rejoin(
 
                 // Sample again after the entire connect/readiness operation.
                 // A mismatch leaves no local handle eligible for publication.
-                if query_daemon_info(socket_path.to_path_buf())
+                if query_current_daemon_incarnation(socket_path.to_path_buf())
                     .await
-                    .as_ref()
-                    .map(DaemonIncarnation::from)
                     .as_ref()
                     != Some(&expected_incarnation)
                 {
@@ -912,6 +922,20 @@ mod tests {
         assert!(looks_like_uuid("550e8400-e29b-41d4-a716-446655440000"));
         assert!(!looks_like_uuid("/tmp/notebook.ipynb"));
         assert!(!looks_like_uuid("relative/notebook.ipynb"));
+    }
+
+    #[test]
+    fn missing_saved_path_is_refused_before_uuid_connect_fallback() {
+        let missing = std::env::temp_dir().join(format!(
+            "nteract-missing-rejoin-{}.ipynb",
+            uuid::Uuid::new_v4()
+        ));
+
+        assert_eq!(
+            missing_saved_rejoin_source(missing.to_str()),
+            missing.to_str()
+        );
+        assert_eq!(missing_saved_rejoin_source(None), None);
     }
 
     #[test]

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use runtimed_client::daemon_connection::{DaemonConnection, DaemonEvent};
+use runtimed_client::singleton::query_daemon_info;
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
@@ -101,14 +102,6 @@ impl RecoveryState {
     }
 }
 
-fn event_live_info(event: &DaemonEvent) -> Option<&runtimed_client::singleton::DaemonInfo> {
-    match event {
-        DaemonEvent::Connected { info } => Some(info),
-        DaemonEvent::Upgraded { current, .. } => Some(current),
-        DaemonEvent::Disconnected => None,
-    }
-}
-
 async fn resync_live_info<F, Fut>(
     delivery_was_lagged: bool,
     read: F,
@@ -121,6 +114,10 @@ where
         info!("Re-reading daemon identity after lagged event delivery");
     }
     read().await
+}
+
+fn event_confirms_daemon_absence(event: Option<&DaemonEvent>) -> bool {
+    matches!(event, Some(DaemonEvent::Disconnected))
 }
 
 fn daemon_binding_matches(
@@ -274,17 +271,20 @@ pub async fn watch(resources: WatchResources) -> i32 {
             recovery.observe_explicit_intent(current_intent_epoch);
         }
 
-        if let Some(info) = event.as_ref().and_then(event_live_info) {
-            if recovery.live_version_requires_exit(&info.version) {
-                info!(version = %info.version, "Daemon version differs from MCP startup version");
-                return EXIT_DAEMON_UPGRADED;
-            }
+        // The event stream is only a wake-up signal. Query the socket for the
+        // identity used by reconciliation so a queued event cannot make a
+        // decision from the supervisor's up-to-10-second cached heartbeat.
+        // This direct read is also mandatory after Lagged.
+        let live_info =
+            resync_live_info(event.is_none(), || query_daemon_info(socket_path.clone())).await;
+        if live_info.is_none() && !event_confirms_daemon_absence(event.as_ref()) {
+            // A failed one-shot identity query is not proof that a healthy
+            // daemon disappeared. Only an explicit supervisor disconnect may
+            // reconcile local handles against absence; otherwise wait for the
+            // next event and preserve the current session.
+            warn!("Could not verify live daemon identity; deferring session reconciliation");
+            continue;
         }
-
-        // `info()` is the resynchronization authority for every event, and is
-        // mandatory after Lagged. It prevents a delayed event from making a
-        // decision about an already-replaced daemon.
-        let live_info = resync_live_info(event.is_none(), || daemon_conn.info()).await;
         if let Some(info) = live_info.as_ref() {
             if recovery.live_version_requires_exit(&info.version) {
                 info!(version = %info.version, "Live daemon version differs from MCP startup version");
@@ -319,7 +319,6 @@ pub async fn watch(resources: WatchResources) -> i32 {
         info!(%target, "Rejoining notebook against current daemon incarnation");
         if rejoin(
             RejoinResources {
-                daemon_conn: &daemon_conn,
                 socket_path: &socket_path,
                 session: &session,
                 peer_label: &peer_label,
@@ -392,7 +391,6 @@ async fn publish_rejoined_session<S>(
 /// failure or a daemon-incarnation change so the recovery target survives for
 /// the next live observation.
 struct RejoinResources<'a> {
-    daemon_conn: &'a DaemonConnection,
     socket_path: &'a Path,
     session: &'a Arc<RwLock<Option<NotebookSession>>>,
     peer_label: &'a Arc<RwLock<String>>,
@@ -407,7 +405,6 @@ async fn rejoin(
     expected_intent_epoch: u64,
 ) -> bool {
     let RejoinResources {
-        daemon_conn,
         socket_path,
         session,
         peer_label,
@@ -470,8 +467,7 @@ async fn rejoin(
             info!("Automatic notebook rejoin cancelled by explicit session intent");
             return true;
         }
-        if daemon_conn
-            .info()
+        if query_daemon_info(socket_path.to_path_buf())
             .await
             .as_ref()
             .map(DaemonIncarnation::from)
@@ -537,8 +533,7 @@ async fn rejoin(
 
                 // Sample again after the entire connect/readiness operation.
                 // A mismatch leaves no local handle eligible for publication.
-                if daemon_conn
-                    .info()
+                if query_daemon_info(socket_path.to_path_buf())
                     .await
                     .as_ref()
                     .map(DaemonIncarnation::from)
@@ -923,6 +918,14 @@ mod tests {
     fn lagged_live_version_mismatch_exits() {
         let mut state = RecoveryState::new(Some("2.7.0".to_string()), 0);
         assert!(state.live_version_requires_exit("2.7.1"));
+    }
+
+    #[test]
+    fn failed_identity_query_is_destructive_only_after_explicit_disconnect() {
+        assert!(!event_confirms_daemon_absence(None));
+        assert!(event_confirms_daemon_absence(Some(
+            &DaemonEvent::Disconnected
+        )));
     }
 
     #[test]

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -14,6 +14,7 @@
 //! `Reconnecting` while the daemon is healthy, short-circuiting every tool call.
 //! See #2000.
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -24,7 +25,7 @@ use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
 use crate::cloud::{self, NotebookTarget};
-use crate::session::{NotebookSession, SessionDropInfo, SessionDropReason};
+use crate::session::{DaemonIncarnation, NotebookSession, SessionDropInfo, SessionDropReason};
 use std::collections::HashMap;
 
 /// Exit code when the daemon has been upgraded and the MCP server should
@@ -40,321 +41,298 @@ const REJOIN_RETRY_DELAY: Duration = Duration::from_secs(1);
 const REJOIN_MAX_RETRIES: u32 = 3;
 const REJOIN_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// What the watch loop should do in response to a `DaemonEvent`.
-#[derive(Debug, PartialEq, Eq)]
-enum WatchDecision {
-    /// Exit the process with the given code (daemon upgraded).
-    Exit(i32),
-    /// Rejoin using the provided initial target (UUID or file path) from
-    /// `NTERACT_MCP_REJOIN_NOTEBOOK` — for the restarted-child case.
-    RejoinInitial(String),
-    /// Rejoin using the current session's state — for reconnect or
-    /// same-version restart while we already have a session.
-    RejoinContinuation,
-    /// Record that the daemon was lost. The watch loop uses this to
-    /// gate `RejoinContinuation` — only after a disconnect.
-    MarkDisconnected,
-    /// Nothing to do.
-    NoOp,
+#[derive(Debug)]
+struct RecoveryState {
+    startup_version: Option<String>,
+    initial_target: Option<String>,
+    recovery_target: Option<String>,
+    observed_intent_epoch: u64,
 }
 
-/// Classify a `DaemonEvent` into the action the watch loop should take.
-///
-/// `initial_target` is **not consumed** by `classify()`. The watch loop
-/// is responsible for clearing it — either after a successful rejoin, or
-/// when a tool call establishes a session first (making the handoff
-/// stale). This ensures the target survives failed rejoin attempts and
-/// can be retried on the next `Connected` event, but never overwrites a
-/// session that the user explicitly switched to.
-///
-/// `was_disconnected` tracks whether the daemon connection was lost since
-/// the last successful join. This prevents the 10-second heartbeat
-/// `Connected` events from triggering spurious rejoins — only a
-/// `Connected` event that follows an actual `Disconnected` triggers a
-/// `RejoinContinuation`. Without this, every heartbeat creates a brief
-/// 2→1 peer cycle that keeps the room alive indefinitely (#2088).
-fn classify(
-    event: &DaemonEvent,
-    initial_target: &Option<String>,
-    has_session: bool,
-    was_disconnected: bool,
-    disconnect_target: &Option<String>,
-) -> WatchDecision {
+impl RecoveryState {
+    fn new(startup_version: Option<String>, observed_intent_epoch: u64) -> Self {
+        Self {
+            startup_version,
+            initial_target: std::env::var(REJOIN_ENV_VAR).ok(),
+            recovery_target: None,
+            observed_intent_epoch,
+        }
+    }
+
+    fn observe_explicit_intent(&mut self, epoch: u64) {
+        if epoch != self.observed_intent_epoch {
+            self.observed_intent_epoch = epoch;
+            self.initial_target = None;
+            self.recovery_target = None;
+        }
+    }
+
+    fn live_version_requires_exit(&mut self, version: &str) -> bool {
+        match self.startup_version.as_deref() {
+            Some(startup) => startup != version,
+            None => {
+                self.startup_version = Some(version.to_string());
+                false
+            }
+        }
+    }
+
+    fn remember_target(&mut self, target: String) {
+        // A file path is the durable identity. Never replace one with a UUID
+        // from a later, less informative observation of the same loss.
+        let should_replace = match self.recovery_target.as_deref() {
+            None => true,
+            Some(existing) => looks_like_uuid(existing) || !looks_like_uuid(&target),
+        };
+        if should_replace {
+            self.recovery_target = Some(target);
+        }
+    }
+
+    fn target(&self) -> Option<String> {
+        self.initial_target
+            .clone()
+            .or_else(|| self.recovery_target.clone())
+    }
+
+    fn rejoin_succeeded(&mut self) {
+        self.initial_target = None;
+        self.recovery_target = None;
+    }
+}
+
+fn event_live_info(event: &DaemonEvent) -> Option<&runtimed_client::singleton::DaemonInfo> {
     match event {
-        DaemonEvent::Upgraded { previous, current } => {
-            if previous.version != current.version {
-                return WatchDecision::Exit(EXIT_DAEMON_UPGRADED);
-            }
-            // Same-version restart (new pid) always needs a rejoin —
-            // the old peer connection is dead regardless of
-            // was_disconnected (the daemon process recycled).
-            if let Some(t) = initial_target.as_ref() {
-                WatchDecision::RejoinInitial(t.clone())
-            } else if has_session {
-                WatchDecision::RejoinContinuation
-            } else if let Some(t) = disconnect_target.as_ref() {
-                // Session was cleared on disconnect to prevent tool
-                // calls from hanging on a dead DocHandle. Rejoin
-                // using the saved target.
-                WatchDecision::RejoinInitial(t.clone())
-            } else {
-                WatchDecision::NoOp
-            }
-        }
-        DaemonEvent::Connected { .. } => {
-            // Initial target always takes priority (proxy hand-off).
-            if let Some(t) = initial_target.as_ref() {
-                return WatchDecision::RejoinInitial(t.clone());
-            }
-            // Only rejoin after a real disconnect, not on routine
-            // heartbeat refreshes. DaemonConnection emits Connected
-            // every HEARTBEAT_INTERVAL (10s); without this gate the
-            // watch loop would reconnect every 10s, creating a brief
-            // 2-peer spike that resets the eviction timer (#2088).
-            if has_session && was_disconnected {
-                WatchDecision::RejoinContinuation
-            } else if !has_session && was_disconnected {
-                // Session was cleared on disconnect to prevent tool
-                // calls from hanging on a dead DocHandle. Rejoin
-                // using the saved target.
-                if let Some(t) = disconnect_target.as_ref() {
-                    WatchDecision::RejoinInitial(t.clone())
-                } else {
-                    WatchDecision::NoOp
-                }
-            } else {
-                WatchDecision::NoOp
-            }
-        }
-        DaemonEvent::Disconnected => WatchDecision::MarkDisconnected,
+        DaemonEvent::Connected { info } => Some(info),
+        DaemonEvent::Upgraded { current, .. } => Some(current),
+        DaemonEvent::Disconnected => None,
     }
 }
 
-/// Clear daemon-disconnect state when a tool-established session made it stale.
-///
-/// Hosted sessions do not depend on the local daemon, so local daemon disconnects
-/// should not stay latched while a hosted session survives. Local sessions still
-/// preserve `was_disconnected` when it came from a lagged event with no saved
-/// target; that path intentionally triggers a continuity rejoin.
-fn clear_stale_disconnect_state_for_active_session(
-    has_session: bool,
-    has_local_session: bool,
-    was_disconnected: &mut bool,
-    disconnect_target: &mut Option<String>,
+async fn resync_live_info<F, Fut>(
+    delivery_was_lagged: bool,
+    read: F,
+) -> Option<runtimed_client::singleton::DaemonInfo>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Option<runtimed_client::singleton::DaemonInfo>>,
+{
+    if delivery_was_lagged {
+        info!("Re-reading daemon identity after lagged event delivery");
+    }
+    read().await
+}
+
+fn daemon_binding_matches(
+    is_hosted: bool,
+    binding: Option<&DaemonIncarnation>,
+    live_incarnation: Option<&DaemonIncarnation>,
 ) -> bool {
-    if !has_session {
-        return false;
+    is_hosted || live_incarnation.is_some_and(|live| binding == Some(live))
+}
+
+trait RecoverySession {
+    fn hosted(&self) -> bool;
+    fn daemon_incarnation(&self) -> Option<&DaemonIncarnation>;
+    fn recovery_notebook_id(&self) -> &str;
+    fn recovery_notebook_path(&self) -> Option<&str>;
+    fn recovery_target(&self) -> String;
+}
+
+impl RecoverySession for NotebookSession {
+    fn hosted(&self) -> bool {
+        self.is_hosted()
     }
 
-    let mut cleared = false;
+    fn daemon_incarnation(&self) -> Option<&DaemonIncarnation> {
+        self.local_daemon_incarnation.as_ref()
+    }
 
-    if disconnect_target.is_some() {
-        *disconnect_target = None;
-        cleared = true;
-        if *was_disconnected {
-            *was_disconnected = false;
+    fn recovery_notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    fn recovery_notebook_path(&self) -> Option<&str> {
+        self.notebook_path.as_deref()
+    }
+
+    fn recovery_target(&self) -> String {
+        self.rejoin_target()
+    }
+}
+
+fn local_session_matches<S: RecoverySession>(
+    session: &S,
+    live_incarnation: Option<&DaemonIncarnation>,
+) -> bool {
+    daemon_binding_matches(
+        session.hosted(),
+        session.daemon_incarnation(),
+        live_incarnation,
+    )
+}
+
+/// Reconcile all local handles with the one daemon incarnation currently
+/// reported live. This contains no disconnect latch: ownership is the entire
+/// stale-session predicate.
+async fn reconcile_sessions<S: RecoverySession>(
+    live_incarnation: Option<&DaemonIncarnation>,
+    session: &Arc<RwLock<Option<S>>>,
+    parked_sessions: &Arc<RwLock<HashMap<String, S>>>,
+    last_session_drop: &Arc<RwLock<Option<SessionDropInfo>>>,
+    recovery: &mut RecoveryState,
+) {
+    let stale_active = {
+        let mut guard = session.write().await;
+        if guard
+            .as_ref()
+            .is_some_and(|active| !local_session_matches(active, live_incarnation))
+        {
+            guard.take()
+        } else {
+            None
         }
+    };
+
+    if let Some(stale) = stale_active {
+        let target = stale.recovery_target();
+        recovery.remember_target(target.clone());
+        *last_session_drop.write().await = Some(SessionDropInfo {
+            reason: SessionDropReason::Disconnected,
+            notebook_id: stale.recovery_notebook_id().to_string(),
+            notebook_path: stale.recovery_notebook_path().map(str::to_string),
+            rejoin_target: Some(target),
+        });
+        info!(
+            notebook_id = %stale.recovery_notebook_id(),
+            "Removed local session owned by a stale daemon incarnation"
+        );
     }
 
-    if !has_local_session && *was_disconnected {
-        *was_disconnected = false;
-        cleared = true;
+    let mut parked = parked_sessions.write().await;
+    let before = parked.len();
+    parked.retain(|_, parked_session| local_session_matches(parked_session, live_incarnation));
+    let removed = before.saturating_sub(parked.len());
+    if removed > 0 {
+        info!(
+            removed,
+            "Removed parked sessions owned by a stale daemon incarnation"
+        );
     }
+}
 
-    cleared
+pub struct WatchResources {
+    pub daemon_conn: Arc<DaemonConnection>,
+    pub socket_path: PathBuf,
+    pub session: Arc<RwLock<Option<NotebookSession>>>,
+    pub peer_label: Arc<RwLock<String>>,
+    pub last_session_drop: Arc<RwLock<Option<SessionDropInfo>>>,
+    pub parked_sessions: Arc<RwLock<HashMap<String, NotebookSession>>>,
+    pub session_intent_epoch: Arc<AtomicU64>,
+    pub startup_version: Option<String>,
 }
 
 /// Run the watch loop to completion. Returns the exit code the caller
 /// should use; 0 means the event stream closed cleanly.
-pub async fn watch(
-    daemon_conn: Arc<DaemonConnection>,
-    socket_path: PathBuf,
-    session: Arc<RwLock<Option<NotebookSession>>>,
-    peer_label: Arc<RwLock<String>>,
-    last_session_drop: Arc<RwLock<Option<SessionDropInfo>>>,
-    parked_sessions: Arc<RwLock<HashMap<String, NotebookSession>>>,
-    session_intent_epoch: Arc<AtomicU64>,
-) -> i32 {
+pub async fn watch(resources: WatchResources) -> i32 {
+    let WatchResources {
+        daemon_conn,
+        socket_path,
+        session,
+        peer_label,
+        last_session_drop,
+        parked_sessions,
+        session_intent_epoch,
+        startup_version,
+    } = resources;
     let mut rx = daemon_conn.subscribe();
-    let mut initial_target: Option<String> = std::env::var(REJOIN_ENV_VAR).ok();
-    if initial_target.is_some() {
+    let mut recovery = RecoveryState::new(
+        startup_version,
+        session_intent_epoch.load(Ordering::Acquire),
+    );
+    if recovery.initial_target.is_some() {
         info!("Seeded initial rejoin target from {REJOIN_ENV_VAR}");
     }
 
-    // Track whether we've been through a Disconnected state.
-    // `initial_target.is_some()` seeds this to true so the first
-    // Connected event (which always fires on supervisor startup)
-    // triggers the initial rejoin without requiring a prior disconnect.
-    let mut was_disconnected = initial_target.is_some();
-
-    // When a disconnect clears the session (to prevent tool calls from
-    // hanging on a dead DocHandle), we stash the notebook target here so
-    // the next Connected/Upgraded event can rejoin without requiring an
-    // initial_target from the proxy.
-    let mut disconnect_target: Option<String> = None;
-    let mut observed_intent_epoch = session_intent_epoch.load(Ordering::Acquire);
-
     loop {
         let event = match rx.recv().await {
-            Ok(ev) => ev,
+            Ok(event) => Some(event),
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 warn!("Daemon event stream lagged, dropped {n} events");
-                // Treat a lag as a potential disconnect — we may have
-                // missed a Disconnected event in the dropped batch.
-                was_disconnected = true;
-                continue;
+                None
             }
             Err(broadcast::error::RecvError::Closed) => return 0,
         };
 
-        let (has_session, has_local_session) = {
-            let guard = session.read().await;
-            (
-                guard.is_some(),
-                guard.as_ref().is_some_and(|session| !session.is_hosted()),
-            )
-        };
-
         let current_intent_epoch = session_intent_epoch.load(Ordering::Acquire);
-        if current_intent_epoch != observed_intent_epoch {
+        if current_intent_epoch != recovery.observed_intent_epoch {
             info!(
-                previous_epoch = observed_intent_epoch,
+                previous_epoch = recovery.observed_intent_epoch,
                 current_epoch = current_intent_epoch,
                 "Clearing automatic rejoin state after explicit session intent"
             );
-            observed_intent_epoch = current_intent_epoch;
-            initial_target = None;
-            disconnect_target = None;
-            was_disconnected = false;
+            recovery.observe_explicit_intent(current_intent_epoch);
         }
 
-        // Once a tool call (connect_notebook / create_notebook) has
-        // established a live session, the proxy's initial handoff target
-        // is stale. Without this, a pending initial_target would win over
-        // the user's active session on the next Connected/Upgraded event,
-        // overwriting or clearing whatever notebook the user switched to.
-        if has_session && initial_target.is_some() {
-            info!("Clearing stale initial rejoin target (session already active)");
-            initial_target = None;
+        if let Some(info) = event.as_ref().and_then(event_live_info) {
+            if recovery.live_version_requires_exit(&info.version) {
+                info!(version = %info.version, "Daemon version differs from MCP startup version");
+                return EXIT_DAEMON_UPGRADED;
+            }
         }
 
-        // If a tool call re-established a session after a disconnect, or
-        // a hosted session survived a local daemon disconnect, clear the
-        // stale daemon disconnect state so it cannot trigger a later
-        // continuity rejoin against a healthy tool-selected session.
-        if clear_stale_disconnect_state_for_active_session(
-            has_session,
-            has_local_session,
-            &mut was_disconnected,
-            &mut disconnect_target,
-        ) {
-            info!("Clearing stale daemon disconnect state (session already active)");
+        // `info()` is the resynchronization authority for every event, and is
+        // mandatory after Lagged. It prevents a delayed event from making a
+        // decision about an already-replaced daemon.
+        let live_info = resync_live_info(event.is_none(), || daemon_conn.info()).await;
+        if let Some(info) = live_info.as_ref() {
+            if recovery.live_version_requires_exit(&info.version) {
+                info!(version = %info.version, "Live daemon version differs from MCP startup version");
+                return EXIT_DAEMON_UPGRADED;
+            }
+        }
+        let live_incarnation = live_info.as_ref().map(DaemonIncarnation::from);
+
+        reconcile_sessions(
+            live_incarnation.as_ref(),
+            &session,
+            &parked_sessions,
+            &last_session_drop,
+            &mut recovery,
+        )
+        .await;
+
+        // Any live tool-installed session is authoritative. This also makes a
+        // same-incarnation Connected heartbeat a structural no-op.
+        if session.read().await.is_some() {
+            recovery.rejoin_succeeded();
+            continue;
         }
 
-        match classify(
-            &event,
-            &initial_target,
-            has_local_session,
-            was_disconnected,
-            &disconnect_target,
-        ) {
-            WatchDecision::Exit(code) => {
-                if let DaemonEvent::Upgraded { previous, current } = &event {
-                    info!(
-                        "Daemon upgraded ({} → {}), exiting for proxy respawn",
-                        previous.version, current.version
-                    );
-                }
-                return code;
-            }
-            WatchDecision::RejoinInitial(target) => {
-                info!("Performing initial rejoin to {target}");
-                let ok = rejoin(
-                    &socket_path,
-                    &session,
-                    &peer_label,
-                    &last_session_drop,
-                    Some(target),
-                    &session_intent_epoch,
-                    observed_intent_epoch,
-                )
-                .await;
-                // Only clear the disconnect flag and consume the initial
-                // target if rejoin succeeded or the session was explicitly
-                // cleared (room evicted). If rejoin exhausted retries,
-                // keep both was_disconnected=true and initial_target
-                // intact so the next Connected event retries.
-                if ok {
-                    was_disconnected = false;
-                    initial_target = None;
-                    disconnect_target = None;
-                }
-            }
-            WatchDecision::RejoinContinuation => {
-                info!("Daemon reachable, rejoining notebook session");
-                let ok = rejoin(
-                    &socket_path,
-                    &session,
-                    &peer_label,
-                    &last_session_drop,
-                    None,
-                    &session_intent_epoch,
-                    observed_intent_epoch,
-                )
-                .await;
-                if ok {
-                    was_disconnected = false;
-                    disconnect_target = None;
-                }
-            }
-            WatchDecision::MarkDisconnected => {
-                was_disconnected = true;
-                // Immediately clear the session to prevent tool calls from
-                // hanging on a dead DocHandle while we wait for the daemon
-                // to come back. Save the notebook target so we can rejoin
-                // when the daemon reconnects.
-                let old_session = {
-                    let mut guard = session.write().await;
-                    if guard.as_ref().is_some_and(NotebookSession::is_hosted) {
-                        None
-                    } else {
-                        guard.take().map(|session| {
-                            (session.notebook_id.clone(), session.notebook_path.clone())
-                        })
-                    }
-                };
-                if let Some((notebook_id, notebook_path)) = old_session {
-                    info!(
-                        "Clearing session for disconnected daemon (notebook: {notebook_id}); \
-                         will rejoin on reconnect"
-                    );
-                    // Stash the target for rejoin. File-backed notebooks
-                    // use the file path; ephemeral notebooks use the UUID.
-                    disconnect_target =
-                        Some(notebook_path.clone().unwrap_or_else(|| notebook_id.clone()));
-                    *last_session_drop.write().await = Some(SessionDropInfo {
-                        reason: SessionDropReason::Disconnected,
-                        notebook_id,
-                        notebook_path: notebook_path.clone(),
-                        rejoin_target: disconnect_target.clone(),
-                    });
-                }
-                // Also clear parked local sessions — their DocHandles are dead
-                // too. Hosted parked sessions do not depend on this daemon.
-                {
-                    let mut parked = parked_sessions.write().await;
-                    let before = parked.len();
-                    parked.retain(|_, session| session.is_hosted());
-                    let removed = before.saturating_sub(parked.len());
-                    if removed > 0 {
-                        info!(
-                            "Clearing {} parked local session(s) on daemon disconnect",
-                            removed
-                        );
-                    }
-                }
-            }
-            WatchDecision::NoOp => {}
+        let Some(target) = recovery.target() else {
+            continue;
+        };
+        let Some(expected_incarnation) = live_incarnation else {
+            continue;
+        };
+
+        info!(%target, "Rejoining notebook against current daemon incarnation");
+        if rejoin(
+            RejoinResources {
+                daemon_conn: &daemon_conn,
+                socket_path: &socket_path,
+                session: &session,
+                peer_label: &peer_label,
+                last_session_drop: &last_session_drop,
+                session_intent_epoch: &session_intent_epoch,
+            },
+            target,
+            expected_incarnation,
+            recovery.observed_intent_epoch,
+        )
+        .await
+        {
+            recovery.rejoin_succeeded();
         }
     }
 }
@@ -366,6 +344,30 @@ fn looks_like_uuid(target: &str) -> bool {
     path.components().count() == 1
         && path.extension().is_none()
         && uuid::Uuid::parse_str(target).is_ok()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicationResult {
+    Installed,
+    Superseded,
+    Cancelled,
+}
+
+async fn publish_rejoined_session<S>(
+    session: &Arc<RwLock<Option<S>>>,
+    new_session: S,
+    session_intent_epoch: &AtomicU64,
+    expected_intent_epoch: u64,
+) -> PublicationResult {
+    let mut guard = session.write().await;
+    if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
+        return PublicationResult::Cancelled;
+    }
+    if guard.is_some() {
+        return PublicationResult::Superseded;
+    }
+    *guard = Some(new_session);
+    PublicationResult::Installed
 }
 
 /// Re-join the active notebook session.
@@ -385,68 +387,73 @@ fn looks_like_uuid(target: &str) -> bool {
 /// and the session is cleared as `Evicted` without retries; the phantom-room
 /// guard (#2088) now lives in the daemon, not a client `list_rooms` heuristic.
 ///
-/// Returns `true` if the rejoin succeeded or the session was explicitly
-/// cleared (room evicted). Returns `false` if retries were exhausted
-/// without success — the caller should keep `was_disconnected` true so
-/// the next `Connected` event retries.
+/// Returns `true` if the rejoin succeeded, was superseded by explicit user
+/// intent, or the room was definitively evicted. Returns `false` for transient
+/// failure or a daemon-incarnation change so the recovery target survives for
+/// the next live observation.
+struct RejoinResources<'a> {
+    daemon_conn: &'a DaemonConnection,
+    socket_path: &'a Path,
+    session: &'a Arc<RwLock<Option<NotebookSession>>>,
+    peer_label: &'a Arc<RwLock<String>>,
+    last_session_drop: &'a Arc<RwLock<Option<SessionDropInfo>>>,
+    session_intent_epoch: &'a Arc<AtomicU64>,
+}
+
 async fn rejoin(
-    socket_path: &Path,
-    session: &Arc<RwLock<Option<NotebookSession>>>,
-    peer_label: &Arc<RwLock<String>>,
-    last_session_drop: &Arc<RwLock<Option<SessionDropInfo>>>,
-    override_target: Option<String>,
-    session_intent_epoch: &Arc<AtomicU64>,
+    resources: RejoinResources<'_>,
+    target: String,
+    expected_incarnation: DaemonIncarnation,
     expected_intent_epoch: u64,
 ) -> bool {
+    let RejoinResources {
+        daemon_conn,
+        socket_path,
+        session,
+        peer_label,
+        last_session_drop,
+        session_intent_epoch,
+    } = resources;
     if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
         return true;
     }
-    if let Some(target) = override_target.as_deref() {
-        match cloud::parse_connect_target(Some(target), None, None, None) {
-            Ok(NotebookTarget::Hosted {
+    match cloud::parse_connect_target(Some(&target), None, None, None) {
+        Ok(NotebookTarget::Hosted {
+            domain,
+            notebook_id,
+            ..
+        }) => {
+            return rejoin_hosted(
+                session,
+                peer_label,
+                last_session_drop,
                 domain,
                 notebook_id,
-                ..
-            }) => {
-                return rejoin_hosted(
-                    session,
-                    peer_label,
-                    last_session_drop,
-                    domain,
-                    notebook_id,
-                    session_intent_epoch,
-                    expected_intent_epoch,
-                )
-                .await;
-            }
-            Ok(NotebookTarget::LocalPath(_)) | Ok(NotebookTarget::LocalNotebookId(_)) => {}
-            Err(e) if target.starts_with("http://") || target.starts_with("https://") => {
-                warn!("Hosted rejoin target is invalid: {e}");
-                *last_session_drop.write().await = Some(SessionDropInfo {
-                    reason: SessionDropReason::Disconnected,
-                    notebook_id: target.to_string(),
-                    notebook_path: None,
-                    rejoin_target: Some(target.to_string()),
-                });
-                return false;
-            }
-            Err(_) => {}
+                session_intent_epoch,
+                expected_intent_epoch,
+            )
+            .await;
         }
+        Ok(NotebookTarget::LocalPath(_)) | Ok(NotebookTarget::LocalNotebookId(_)) => {}
+        Err(e) if target.starts_with("http://") || target.starts_with("https://") => {
+            warn!("Hosted rejoin target is invalid: {e}");
+            *last_session_drop.write().await = Some(SessionDropInfo {
+                reason: SessionDropReason::Disconnected,
+                notebook_id: target.to_string(),
+                notebook_path: None,
+                rejoin_target: Some(target.to_string()),
+            });
+            return false;
+        }
+        Err(_) => {}
     }
 
-    let (notebook_id, notebook_path) = match override_target {
-        Some(target) if looks_like_uuid(&target) => (target, None),
-        Some(target) => {
+    let (notebook_id, notebook_path) = match target {
+        target if looks_like_uuid(&target) => (target, None),
+        target => {
             // Treat as file path. We'll learn the real notebook_id from
             // connect_open's response.
             (target.clone(), Some(target))
-        }
-        None => {
-            let guard = session.read().await;
-            match guard.as_ref() {
-                Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
-                None => return true, // No session to rejoin — not a failure
-            }
         }
     };
 
@@ -462,6 +469,17 @@ async fn rejoin(
         if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
             info!("Automatic notebook rejoin cancelled by explicit session intent");
             return true;
+        }
+        if daemon_conn
+            .info()
+            .await
+            .as_ref()
+            .map(DaemonIncarnation::from)
+            .as_ref()
+            != Some(&expected_incarnation)
+        {
+            info!("Automatic notebook rejoin cancelled because daemon incarnation changed");
+            return false;
         }
         let use_path = notebook_path
             .as_ref()
@@ -517,28 +535,51 @@ async fn rejoin(
             Ok((handle, new_cell_count, new_notebook_id)) => {
                 crate::presence::announce(&handle, &label).await;
 
-                let new_session =
-                    NotebookSession::local(handle, new_notebook_id, notebook_path.clone());
+                // Sample again after the entire connect/readiness operation.
+                // A mismatch leaves no local handle eligible for publication.
+                if daemon_conn
+                    .info()
+                    .await
+                    .as_ref()
+                    .map(DaemonIncarnation::from)
+                    .as_ref()
+                    != Some(&expected_incarnation)
+                {
+                    info!("Dropping rejoin completed against a replaced daemon incarnation");
+                    return false;
+                }
+
+                let new_session = NotebookSession::local(
+                    handle,
+                    new_notebook_id,
+                    notebook_path.clone(),
+                    Some(expected_incarnation.clone()),
+                );
                 // Hold the publication lock across the check/install. Any
                 // active session is authoritative, even for the same UUID:
                 // an explicit tool activation may carry retained projection
                 // heads/generation that a background rejoin must not erase.
-                let mut guard = session.write().await;
-                if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
-                    info!("Dropping automatic rejoin superseded by explicit disconnect");
-                    return true;
-                }
-                if let Some(existing) = guard.as_ref() {
-                    info!(
-                        "Rejoin target {} superseded by active session {}; \
-                         dropping rejoined connection",
-                        new_session.notebook_id, existing.notebook_id
-                    );
-                    return true;
-                }
-                *guard = Some(new_session);
-                info!("Rejoined notebook session ({new_cell_count} cells)");
-                return true;
+                return match publish_rejoined_session(
+                    session,
+                    new_session,
+                    session_intent_epoch,
+                    expected_intent_epoch,
+                )
+                .await
+                {
+                    PublicationResult::Installed => {
+                        info!("Rejoined notebook session ({new_cell_count} cells)");
+                        true
+                    }
+                    PublicationResult::Superseded => {
+                        info!("Dropping rejoin superseded by an active tool-installed session");
+                        true
+                    }
+                    PublicationResult::Cancelled => {
+                        info!("Dropping automatic rejoin superseded by explicit disconnect");
+                        true
+                    }
+                };
             }
             Err(e) => {
                 if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
@@ -641,22 +682,27 @@ async fn rejoin_hosted(
                     notebook_id.clone(),
                     domain_config.base_url.clone(),
                 );
-                let mut guard = session.write().await;
-                if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
-                    info!("Dropping hosted rejoin superseded by explicit disconnect");
-                    return true;
-                }
-                if let Some(existing) = guard.as_ref() {
-                    info!(
-                        "Hosted rejoin target {target} superseded by active session {}; \
-                         dropping rejoined connection",
-                        existing.session_key()
-                    );
-                    return true;
-                }
-                *guard = Some(new_session);
-                info!("Rejoined hosted notebook session {target}");
-                return true;
+                return match publish_rejoined_session(
+                    session,
+                    new_session,
+                    session_intent_epoch,
+                    expected_intent_epoch,
+                )
+                .await
+                {
+                    PublicationResult::Installed => {
+                        info!("Rejoined hosted notebook session {target}");
+                        true
+                    }
+                    PublicationResult::Superseded => {
+                        info!("Dropping hosted rejoin superseded by an active session");
+                        true
+                    }
+                    PublicationResult::Cancelled => {
+                        info!("Dropping hosted rejoin superseded by explicit disconnect");
+                        true
+                    }
+                };
             }
             Err(e) => {
                 if session_intent_epoch.load(Ordering::Acquire) != expected_intent_epoch {
@@ -689,15 +735,73 @@ async fn rejoin_hosted(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use runtimed_client::singleton::DaemonInfo;
+    use chrono::{TimeZone, Utc};
+    use proptest::prelude::*;
+    use std::sync::atomic::AtomicUsize;
 
-    fn info_with(version: &str, pid: u32) -> DaemonInfo {
-        DaemonInfo {
+    fn incarnation(pid: u32) -> DaemonIncarnation {
+        DaemonIncarnation {
+            pid,
+            started_at: Utc.timestamp_opt(pid.into(), 0).single().unwrap(),
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct FakeSession {
+        id: String,
+        path: Option<String>,
+        hosted: bool,
+        incarnation: Option<DaemonIncarnation>,
+    }
+
+    impl FakeSession {
+        fn local(id: &str, path: Option<&str>, pid: u32) -> Self {
+            Self {
+                id: id.to_string(),
+                path: path.map(str::to_string),
+                hosted: false,
+                incarnation: Some(incarnation(pid)),
+            }
+        }
+
+        fn hosted(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                path: None,
+                hosted: true,
+                incarnation: None,
+            }
+        }
+    }
+
+    impl RecoverySession for FakeSession {
+        fn hosted(&self) -> bool {
+            self.hosted
+        }
+
+        fn daemon_incarnation(&self) -> Option<&DaemonIncarnation> {
+            self.incarnation.as_ref()
+        }
+
+        fn recovery_notebook_id(&self) -> &str {
+            &self.id
+        }
+
+        fn recovery_notebook_path(&self) -> Option<&str> {
+            self.path.as_deref()
+        }
+
+        fn recovery_target(&self) -> String {
+            self.path.clone().unwrap_or_else(|| self.id.clone())
+        }
+    }
+
+    fn daemon_info(version: &str, pid: u32) -> runtimed_client::singleton::DaemonInfo {
+        runtimed_client::singleton::DaemonInfo {
             endpoint: "/tmp/test.sock".to_string(),
             pid,
             version: version.to_string(),
-            started_at: Utc::now(),
+            started_at: incarnation(pid).started_at,
             blob_port: None,
             execution_store_dir: None,
             worktree_path: None,
@@ -705,410 +809,284 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum ModelSession {
+        Hosted,
+        Local(Option<u8>),
+    }
+
+    #[derive(Clone, Debug)]
+    struct LoopModel {
+        active: Option<ModelSession>,
+        parked: Vec<ModelSession>,
+        recovery_target: Option<String>,
+        startup_version: u8,
+        exited: bool,
+    }
+
+    impl LoopModel {
+        fn reconcile(&mut self, live: Option<u8>, version: u8) {
+            if version != self.startup_version {
+                self.exited = true;
+                return;
+            }
+            let active_matches = self.active.as_ref().is_none_or(|session| match session {
+                ModelSession::Hosted => true,
+                ModelSession::Local(binding) => live.is_some() && *binding == live,
+            });
+            if !active_matches {
+                self.active = None;
+                if self.recovery_target.is_none() {
+                    self.recovery_target = Some("saved.ipynb".to_string());
+                }
+            }
+            self.parked.retain(|session| match session {
+                ModelSession::Hosted => true,
+                ModelSession::Local(binding) => live.is_some() && *binding == live,
+            });
+        }
+
+        fn remember(&mut self, target: &str) {
+            let mut state = RecoveryState {
+                startup_version: Some(self.startup_version.to_string()),
+                initial_target: None,
+                recovery_target: self.recovery_target.take(),
+                observed_intent_epoch: 0,
+            };
+            state.remember_target(target.to_string());
+            self.recovery_target = state.recovery_target;
+        }
+    }
+
     #[test]
-    fn version_change_triggers_exit() {
-        let event = DaemonEvent::Upgraded {
-            previous: info_with("1.0.0", 100),
-            current: info_with("1.1.0", 200),
+    fn same_incarnation_heartbeat_is_structural_noop() {
+        let binding = incarnation(10);
+        assert!(daemon_binding_matches(
+            false,
+            Some(&binding),
+            Some(&binding)
+        ));
+        assert!(!daemon_binding_matches(
+            false,
+            Some(&binding),
+            Some(&incarnation(11))
+        ));
+        assert!(!daemon_binding_matches(false, None, Some(&binding)));
+    }
+
+    #[test]
+    fn hosted_binding_survives_local_daemon_loss() {
+        assert!(daemon_binding_matches(true, None, None));
+        assert!(daemon_binding_matches(true, None, Some(&incarnation(4))));
+    }
+
+    #[test]
+    fn saved_path_is_not_replaced_by_later_uuid_observation() {
+        let mut state = RecoveryState {
+            startup_version: Some("2.7.1".to_string()),
+            initial_target: None,
+            recovery_target: Some("/tmp/saved.ipynb".to_string()),
+            observed_intent_epoch: 0,
         };
-        let initial = None;
-        let disconnect = None;
-        // Version change exits regardless of was_disconnected.
-        assert_eq!(
-            classify(&event, &initial, false, false, &disconnect),
-            WatchDecision::Exit(EXIT_DAEMON_UPGRADED)
-        );
+        state.remember_target("550e8400-e29b-41d4-a716-446655440000".to_string());
+        assert_eq!(state.recovery_target.as_deref(), Some("/tmp/saved.ipynb"));
     }
 
     #[test]
-    fn same_version_restart_triggers_continuation_rejoin() {
-        // Upgraded (same-version) always triggers rejoin — the daemon
-        // process recycled so the old peer is dead. was_disconnected
-        // is irrelevant for Upgraded events.
-        let event = DaemonEvent::Upgraded {
-            previous: info_with("1.0.0", 100),
-            current: info_with("1.0.0", 200),
+    fn recovery_target_prefers_handoff_and_survives_until_success_or_intent() {
+        let mut state = RecoveryState {
+            startup_version: Some("2.7.1".to_string()),
+            initial_target: Some("proxy-target".to_string()),
+            recovery_target: Some("/tmp/recovery.ipynb".to_string()),
+            observed_intent_epoch: 3,
         };
-        let initial = None;
-        let disconnect = None;
-        assert_eq!(
-            classify(&event, &initial, true, false, &disconnect),
-            WatchDecision::RejoinContinuation
-        );
+        assert_eq!(state.target().as_deref(), Some("proxy-target"));
+        // A failed rejoin makes no state transition.
+        assert_eq!(state.target().as_deref(), Some("proxy-target"));
+        state.rejoin_succeeded();
+        assert!(state.target().is_none());
+
+        state.initial_target = Some("stale".to_string());
+        state.recovery_target = Some("stale-recovery".to_string());
+        state.observe_explicit_intent(4);
+        assert!(state.target().is_none());
     }
 
     #[test]
-    fn same_version_restart_without_session_is_noop() {
-        let event = DaemonEvent::Upgraded {
-            previous: info_with("1.0.0", 100),
-            current: info_with("1.0.0", 200),
-        };
-        let initial = None;
-        let disconnect = None;
-        assert_eq!(
-            classify(&event, &initial, false, false, &disconnect),
-            WatchDecision::NoOp
-        );
-    }
-
-    #[test]
-    fn connected_returns_initial_target_without_consuming() {
-        let event = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = Some("abc-uuid".to_string());
-        let disconnect = None;
-        // Initial target triggers RejoinInitial but classify() does NOT
-        // consume it — the watch loop consumes after successful rejoin.
-        assert_eq!(
-            classify(&event, &initial, false, false, &disconnect),
-            WatchDecision::RejoinInitial("abc-uuid".to_string())
-        );
-        assert!(
-            initial.is_some(),
-            "classify must not consume initial target"
-        );
-
-        // With initial_target still present, next Connected still returns
-        // RejoinInitial (retry semantics — will keep trying until the
-        // watch loop clears it after a successful rejoin).
-        assert_eq!(
-            classify(&event, &initial, false, false, &disconnect),
-            WatchDecision::RejoinInitial("abc-uuid".to_string())
-        );
-    }
-
-    #[test]
-    fn cleared_initial_target_falls_through() {
-        let event = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        // After the watch loop clears initial_target (on successful rejoin),
-        // subsequent Connected events without session/disconnect are NoOp.
-        let initial: Option<String> = None;
-        let disconnect = None;
-        assert_eq!(
-            classify(&event, &initial, false, false, &disconnect),
-            WatchDecision::NoOp
-        );
-    }
-
-    #[test]
-    fn disconnected_marks_disconnected() {
-        let initial = Some("abc".to_string());
-        let disconnect = None;
-        assert_eq!(
-            classify(
-                &DaemonEvent::Disconnected,
-                &initial,
-                true,
-                false,
-                &disconnect
-            ),
-            WatchDecision::MarkDisconnected
-        );
-        assert!(
-            initial.is_some(),
-            "disconnect must not consume initial target"
-        );
-    }
-
-    #[test]
-    fn uuid_target_detected() {
+    fn uuid_and_path_recovery_targets_are_distinct() {
         assert!(looks_like_uuid("550e8400-e29b-41d4-a716-446655440000"));
         assert!(!looks_like_uuid("/tmp/notebook.ipynb"));
-        assert!(!looks_like_uuid("notebook.ipynb"));
-        assert!(!looks_like_uuid("relative/path"));
-    }
-
-    /// Connected events that are just heartbeat refreshes (no prior
-    /// disconnect) must NOT trigger RejoinContinuation. This is the
-    /// primary fix for #2088 — without this gate, every 10s heartbeat
-    /// Connected event would create a brief 2→1 peer cycle that resets
-    /// the eviction timer, keeping the room alive indefinitely.
-    #[test]
-    fn heartbeat_connected_does_not_rejoin() {
-        let event = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let disconnect = None;
-
-        // has_session=true but was_disconnected=false (steady-state
-        // heartbeat) → must be NoOp, not RejoinContinuation.
-        assert_eq!(
-            classify(&event, &initial, true, false, &disconnect),
-            WatchDecision::NoOp,
-            "heartbeat Connected must not trigger rejoin"
-        );
-    }
-
-    /// Connected events after a lagged disconnect should trigger
-    /// RejoinContinuation because the peer connection was actually lost.
-    #[test]
-    fn lagged_connected_after_disconnect_triggers_rejoin_continuation() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let disconnect = None;
-
-        // After disconnect, Connected should trigger rejoin while the session
-        // is still live.
-        assert_eq!(
-            classify(&connected, &initial, true, true, &disconnect),
-            WatchDecision::RejoinContinuation
-        );
-    }
-
-    /// After an ephemeral notebook is evicted and the session is cleared
-    /// WITHOUT a disconnect_target, subsequent Connected/Upgraded events
-    /// should produce NoOp (not RejoinContinuation). This regression test
-    /// verifies the fix for #2088 — without clearing the session, the
-    /// watch loop would reconnect every 10s, briefly creating peers and
-    /// preventing proper room eviction.
-    #[test]
-    fn cleared_session_stops_continuation_rejoins() {
-        let event = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let disconnect = None;
-
-        // With has_session=true AND was_disconnected=true, we get
-        // RejoinContinuation.
-        assert_eq!(
-            classify(&event, &initial, true, true, &disconnect),
-            WatchDecision::RejoinContinuation
-        );
-
-        // After the session is cleared (has_session=false) and no
-        // disconnect_target, same event is NoOp even with
-        // was_disconnected=true. This is the eviction case: the room
-        // is gone, so there's nothing to rejoin.
-        assert_eq!(
-            classify(&event, &initial, false, true, &disconnect),
-            WatchDecision::NoOp
-        );
-
-        // Same for Upgraded (same-version restart).
-        let upgraded = DaemonEvent::Upgraded {
-            previous: info_with("1.0.0", 100),
-            current: info_with("1.0.0", 200),
-        };
-        assert_eq!(
-            classify(&upgraded, &initial, false, false, &disconnect),
-            WatchDecision::NoOp
-        );
-    }
-
-    /// Once a tool call (connect_notebook / create_notebook) establishes a
-    /// session, the proxy's initial handoff target becomes stale. The watch
-    /// loop clears initial_target before calling classify() when
-    /// has_session=true, so a heartbeat Connected with a stale handoff
-    /// yields RejoinContinuation (if was_disconnected) or NoOp — never
-    /// RejoinInitial that would overwrite the user's active notebook.
-    #[test]
-    fn stale_handoff_cleared_when_session_exists() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let disconnect = None;
-
-        // Simulate: proxy set initial_target, but before the first
-        // Connected event, a connect_notebook tool call established a
-        // session. The watch loop clears initial_target because
-        // has_session=true.
-        let initial_after_clear: Option<String> = None;
-
-        // With session active and was_disconnected=false (steady state),
-        // heartbeat is NoOp — does NOT rejoin to the stale target.
-        assert_eq!(
-            classify(&connected, &initial_after_clear, true, false, &disconnect),
-            WatchDecision::NoOp,
-            "stale handoff must not override active session"
-        );
-
-        // With session active and was_disconnected=true (daemon bounced),
-        // RejoinContinuation uses the current session — not the stale target.
-        assert_eq!(
-            classify(&connected, &initial_after_clear, true, true, &disconnect),
-            WatchDecision::RejoinContinuation,
-            "should rejoin current session, not stale target"
-        );
-    }
-
-    /// When rejoin fails (returns false), initial_target must survive for
-    /// retry on the next Connected event. This test simulates the classify
-    /// behavior: with initial_target present, classify always returns
-    /// RejoinInitial — it never consumes the target. The watch loop only
-    /// clears it after successful rejoin.
-    #[test]
-    fn failed_initial_rejoin_preserves_target_for_retry() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let disconnect = None;
-
-        // Simulate the watch loop's initial_target across multiple events.
-        let mut initial_target = Some("target-uuid".to_string());
-
-        // First Connected → RejoinInitial.
-        assert_eq!(
-            classify(&connected, &initial_target, false, true, &disconnect),
-            WatchDecision::RejoinInitial("target-uuid".to_string())
-        );
-
-        // Simulate rejoin failure (watch loop does NOT clear initial_target).
-        // was_disconnected stays true, initial_target stays Some.
-
-        // Second Connected → still RejoinInitial (retry).
-        assert_eq!(
-            classify(&connected, &initial_target, false, true, &disconnect),
-            WatchDecision::RejoinInitial("target-uuid".to_string())
-        );
-
-        // Simulate rejoin success (watch loop clears initial_target).
-        initial_target = None;
-
-        // Third Connected without session → NoOp.
-        assert_eq!(
-            classify(&connected, &initial_target, false, false, &disconnect),
-            WatchDecision::NoOp
-        );
-    }
-
-    /// When the session is cleared on disconnect (to prevent tool calls
-    /// from hanging on a dead DocHandle), the saved disconnect_target
-    /// enables automatic rejoin when the daemon reconnects.
-    #[test]
-    fn disconnect_target_triggers_rejoin_on_reconnect() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let disconnect_target = Some("/tmp/notebook.ipynb".to_string());
-
-        // Session cleared (has_session=false), was_disconnected=true,
-        // disconnect_target present → RejoinInitial with the saved path.
-        assert_eq!(
-            classify(&connected, &initial, false, true, &disconnect_target),
-            WatchDecision::RejoinInitial("/tmp/notebook.ipynb".to_string())
-        );
-    }
-
-    /// Same-version daemon restart with a disconnect_target (session was
-    /// cleared on disconnect) triggers RejoinInitial with the saved target.
-    #[test]
-    fn disconnect_target_triggers_rejoin_on_upgraded() {
-        let upgraded = DaemonEvent::Upgraded {
-            previous: info_with("1.0.0", 100),
-            current: info_with("1.0.0", 200),
-        };
-        let initial = None;
-        let disconnect_target = Some("some-uuid".to_string());
-
-        // Session cleared, disconnect_target present → RejoinInitial.
-        assert_eq!(
-            classify(&upgraded, &initial, false, false, &disconnect_target),
-            WatchDecision::RejoinInitial("some-uuid".to_string())
-        );
-    }
-
-    /// When both initial_target and disconnect_target are present,
-    /// initial_target takes priority (it's the proxy's handoff).
-    #[test]
-    fn initial_target_takes_priority_over_disconnect_target() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = Some("proxy-target".to_string());
-        let disconnect_target = Some("disconnect-target".to_string());
-
-        assert_eq!(
-            classify(&connected, &initial, false, true, &disconnect_target),
-            WatchDecision::RejoinInitial("proxy-target".to_string())
-        );
-    }
-
-    /// After a successful rejoin clears disconnect_target, heartbeats
-    /// should not trigger rejoins (prevents the #2088 regression).
-    #[test]
-    fn cleared_disconnect_target_prevents_spurious_rejoins() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let disconnect = None; // cleared after successful rejoin
-
-        // Session re-established (has_session=true), steady-state heartbeat.
-        assert_eq!(
-            classify(&connected, &initial, true, false, &disconnect),
-            WatchDecision::NoOp,
-            "cleared disconnect target must not trigger rejoin"
-        );
+        assert!(!looks_like_uuid("relative/notebook.ipynb"));
     }
 
     #[test]
-    fn hosted_session_clears_stale_daemon_disconnect_state() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
+    fn lagged_live_version_mismatch_exits() {
+        let mut state = RecoveryState::new(Some("2.7.0".to_string()), 0);
+        assert!(state.live_version_requires_exit("2.7.1"));
+    }
+
+    #[test]
+    fn new_incarnation_tool_install_survives_next_heartbeat() {
+        let mut model = LoopModel {
+            active: Some(ModelSession::Local(Some(1))),
+            parked: vec![],
+            recovery_target: None,
+            startup_version: 1,
+            exited: false,
         };
-        let initial = None;
-        let mut was_disconnected = true;
-        let mut disconnect_target = Some("550e8400-e29b-41d4-a716-446655440000".to_string());
+        model.reconcile(Some(2), 1);
+        assert!(model.active.is_none());
+        model.active = Some(ModelSession::Local(Some(2)));
+        let before = model.clone();
+        model.reconcile(Some(2), 1);
+        assert_eq!(model.active, before.active);
+        assert!(!model.exited);
+    }
 
-        assert!(clear_stale_disconnect_state_for_active_session(
-            true,
-            false,
-            &mut was_disconnected,
-            &mut disconnect_target,
-        ));
-        assert!(!was_disconnected);
-        assert_eq!(disconnect_target, None);
-
-        // If the user later opens a local notebook, the old daemon
-        // disconnect must not force a continuity rejoin that replaces the
-        // healthy tool-selected local peer.
-        assert_eq!(
-            classify(
-                &connected,
-                &initial,
-                true,
-                was_disconnected,
-                &disconnect_target
+    #[tokio::test]
+    async fn async_reconciliation_clears_stale_handles_and_retains_new_tool_install() {
+        let session = Arc::new(RwLock::new(Some(FakeSession::local(
+            "old",
+            Some("/tmp/saved.ipynb"),
+            1,
+        ))));
+        let parked = Arc::new(RwLock::new(HashMap::from([
+            (
+                "old-parked".to_string(),
+                FakeSession::local("old-parked", None, 1),
             ),
-            WatchDecision::NoOp
+            ("hosted".to_string(), FakeSession::hosted("hosted")),
+        ])));
+        let last_drop = Arc::new(RwLock::new(None));
+        let mut recovery = RecoveryState {
+            startup_version: Some("2.7.1".to_string()),
+            initial_target: None,
+            recovery_target: None,
+            observed_intent_epoch: 0,
+        };
+
+        reconcile_sessions(
+            Some(&incarnation(2)),
+            &session,
+            &parked,
+            &last_drop,
+            &mut recovery,
+        )
+        .await;
+        assert!(session.read().await.is_none());
+        assert_eq!(
+            recovery.recovery_target.as_deref(),
+            Some("/tmp/saved.ipynb")
+        );
+        assert_eq!(parked.read().await.len(), 1);
+        assert!(parked.read().await.contains_key("hosted"));
+
+        // A user activation published for the new incarnation is the slot
+        // authority and survives the next same-incarnation heartbeat.
+        *session.write().await = Some(FakeSession::local("new", None, 2));
+        reconcile_sessions(
+            Some(&incarnation(2)),
+            &session,
+            &parked,
+            &last_drop,
+            &mut recovery,
+        )
+        .await;
+        assert_eq!(
+            session.read().await.as_ref().map(|s| s.id.as_str()),
+            Some("new")
         );
     }
 
-    #[test]
-    fn local_session_with_disconnect_target_clears_rejoin_latch() {
-        let connected = DaemonEvent::Connected {
-            info: info_with("1.0.0", 100),
-        };
-        let initial = None;
-        let mut was_disconnected = true;
-        let mut disconnect_target = Some("/tmp/previous.ipynb".to_string());
-
-        assert!(clear_stale_disconnect_state_for_active_session(
-            true,
-            true,
-            &mut was_disconnected,
-            &mut disconnect_target,
-        ));
-        assert!(!was_disconnected);
-        assert_eq!(disconnect_target, None);
-
+    #[tokio::test]
+    async fn async_publication_never_overwrites_tool_installed_session() {
+        let session = Arc::new(RwLock::new(Some(FakeSession::local("tool", None, 2))));
+        let epoch = AtomicU64::new(4);
+        let result = publish_rejoined_session(
+            &session,
+            FakeSession::local("background", None, 2),
+            &epoch,
+            4,
+        )
+        .await;
+        assert_eq!(result, PublicationResult::Superseded);
         assert_eq!(
-            classify(
-                &connected,
-                &initial,
-                true,
-                was_disconnected,
-                &disconnect_target
-            ),
-            WatchDecision::NoOp
+            session.read().await.as_ref().map(|s| s.id.as_str()),
+            Some("tool")
         );
+
+        *session.write().await = None;
+        epoch.store(5, Ordering::Release);
+        let result = publish_rejoined_session(
+            &session,
+            FakeSession::local("background", None, 2),
+            &epoch,
+            4,
+        )
+        .await;
+        assert_eq!(result, PublicationResult::Cancelled);
+        assert!(session.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn lagged_delivery_rereads_live_info_and_detects_version_exit() {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let reads_in_provider = Arc::clone(&reads);
+        let info = resync_live_info(true, move || async move {
+            reads_in_provider.fetch_add(1, Ordering::AcqRel);
+            Some(daemon_info("2.7.2", 22))
+        })
+        .await
+        .expect("lag recovery must return the provider's current info");
+
+        assert_eq!(reads.load(Ordering::Acquire), 1);
+        let mut state = RecoveryState::new(Some("2.7.1".to_string()), 0);
+        assert!(state.live_version_requires_exit(&info.version));
+    }
+
+    proptest! {
+        /// Exercise transition sequences instead of independent classifier
+        /// inputs. Each byte selects a daemon reconciliation, explicit tool
+        /// install, hosted switch, target observation, or version replacement.
+        #[test]
+        fn transition_sequences_preserve_incarnation_invariants(ops in prop::collection::vec(any::<u8>(), 1..200)) {
+            let mut model = LoopModel {
+                active: Some(ModelSession::Local(Some(1))),
+                parked: vec![ModelSession::Local(Some(1)), ModelSession::Hosted],
+                recovery_target: Some("/tmp/original.ipynb".to_string()),
+                startup_version: 7,
+                exited: false,
+            };
+            let mut live = Some(1u8);
+
+            for op in ops {
+                if model.exited {
+                    break;
+                }
+                match op % 6 {
+                    0 => model.reconcile(live, 7),
+                    1 => {
+                        live = Some(op.wrapping_add(1));
+                        model.reconcile(live, 7);
+                    }
+                    2 => {
+                        model.active = Some(ModelSession::Local(live));
+                    }
+                    3 => model.active = Some(ModelSession::Hosted),
+                    4 => model.remember("550e8400-e29b-41d4-a716-446655440000"),
+                    _ => model.reconcile(live, 8),
+                }
+
+                if !model.exited {
+                    if let Some(ModelSession::Local(binding)) = &model.active {
+                        // A tool install may precede reconciliation, but it is
+                        // always stamped with the live incarnation.
+                        prop_assert_eq!(*binding, live);
+                    }
+                    prop_assert!(model.parked.iter().any(|s| matches!(s, ModelSession::Hosted)));
+                    prop_assert_ne!(model.recovery_target.as_deref(), Some("550e8400-e29b-41d4-a716-446655440000"));
+                }
+            }
+        }
     }
 }

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use notebook_sync::handle::DocHandle;
 use notebook_sync::status::{
     ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase,
@@ -12,6 +13,26 @@ use runtimed_client::protocol::{
 use serde::Serialize;
 
 use crate::session_activation::CanonicalNotebookTarget;
+
+/// Identity of one concrete local daemon process.
+///
+/// A PID alone can be reused by the operating system. Pairing it with the
+/// daemon's persisted start timestamp gives MCP sessions an explicit owner
+/// across disconnects and same-version restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DaemonIncarnation {
+    pub pid: u32,
+    pub started_at: DateTime<Utc>,
+}
+
+impl From<&runtimed_client::singleton::DaemonInfo> for DaemonIncarnation {
+    fn from(info: &runtimed_client::singleton::DaemonInfo) -> Self {
+        Self {
+            pid: info.pid,
+            started_at: info.started_at,
+        }
+    }
+}
 
 /// Where the active notebook document is hosted.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,6 +146,10 @@ pub struct NotebookSession {
     pub notebook_path: Option<String>,
     /// Session source. Hosted sessions do not depend on the local daemon.
     pub source: NotebookSessionSource,
+    /// The local daemon process that owns this handle. `None` means either a
+    /// hosted session or a local connection whose daemon changed while the
+    /// connection was being established. An unbound local handle is stale.
+    pub local_daemon_incarnation: Option<DaemonIncarnation>,
     /// Monotonic MCP activation generation. Daemon rejoin/create legacy paths
     /// use generation zero until they are replaced by an explicit activation.
     pub activation_generation: u64,
@@ -134,13 +159,19 @@ pub struct NotebookSession {
 }
 
 impl NotebookSession {
-    pub fn local(handle: DocHandle, notebook_id: String, notebook_path: Option<String>) -> Self {
+    pub fn local(
+        handle: DocHandle,
+        notebook_id: String,
+        notebook_path: Option<String>,
+        daemon_incarnation: Option<DaemonIncarnation>,
+    ) -> Self {
         let activation_target = format!("local:id:{notebook_id}");
         Self {
             handle,
             notebook_id,
             notebook_path,
             source: NotebookSessionSource::Local,
+            local_daemon_incarnation: daemon_incarnation,
             activation_generation: 0,
             activation_target,
             readiness_evidence: SessionReadinessEvidence::AwaitedSessionReady,
@@ -154,12 +185,14 @@ impl NotebookSession {
         activation_generation: u64,
         activation_target: CanonicalNotebookTarget,
         projection: NotebookProjection,
+        daemon_incarnation: Option<DaemonIncarnation>,
     ) -> Self {
         Self {
             handle,
             notebook_id,
             notebook_path,
             source: NotebookSessionSource::Local,
+            local_daemon_incarnation: daemon_incarnation,
             activation_generation,
             activation_target: activation_target.as_str().to_string(),
             readiness_evidence: SessionReadinessEvidence::RetainedProjection {
@@ -175,6 +208,7 @@ impl NotebookSession {
             notebook_id,
             notebook_path: None,
             source: NotebookSessionSource::Hosted { domain },
+            local_daemon_incarnation: None,
             activation_generation: 0,
             activation_target,
             readiness_evidence: SessionReadinessEvidence::HostedLegacy,
@@ -193,6 +227,7 @@ impl NotebookSession {
             notebook_id,
             notebook_path: None,
             source: NotebookSessionSource::Hosted { domain },
+            local_daemon_incarnation: None,
             activation_generation,
             activation_target: activation_target.as_str().to_string(),
             readiness_evidence: SessionReadinessEvidence::HostedLegacy,

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -1,6 +1,9 @@
 //! Notebook session state management.
 
+use std::future::Future;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use notebook_sync::handle::DocHandle;
@@ -32,6 +35,51 @@ impl From<&runtimed_client::singleton::DaemonInfo> for DaemonIncarnation {
             started_at: info.started_at,
         }
     }
+}
+
+const DAEMON_INCARNATION_SAMPLE_ATTEMPTS: usize = 3;
+const DAEMON_INCARNATION_SAMPLE_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+pub(crate) async fn sample_daemon_incarnation_with_retry<F, Fut>(
+    mut query: F,
+    retry_delay: Duration,
+) -> Option<DaemonIncarnation>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<DaemonIncarnation>>,
+{
+    for attempt in 0..DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
+        if let Some(incarnation) = query().await {
+            return Some(incarnation);
+        }
+        if attempt + 1 < DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+    None
+}
+
+/// Sample the live daemon identity with a short retry window.
+///
+/// Both explicit tool activation and automatic rejoin use this boundary so a
+/// brief socket transition cannot make one path publish while the other path
+/// cancels against a single transient miss.
+pub(crate) async fn query_current_daemon_incarnation(
+    socket_path: PathBuf,
+) -> Option<DaemonIncarnation> {
+    sample_daemon_incarnation_with_retry(
+        move || {
+            let socket_path = socket_path.clone();
+            async move {
+                runtimed_client::singleton::query_daemon_info(socket_path)
+                    .await
+                    .as_ref()
+                    .map(DaemonIncarnation::from)
+            }
+        },
+        DAEMON_INCARNATION_SAMPLE_RETRY_DELAY,
+    )
+    .await
 }
 
 /// Where the active notebook document is hosted.
@@ -610,6 +658,23 @@ pub struct SessionDropInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn daemon_incarnation_sample_retries_transient_unavailability() {
+        let expected = DaemonIncarnation {
+            pid: 42,
+            started_at: Utc::now(),
+        };
+        let mut samples = std::collections::VecDeque::from([None, None, Some(expected.clone())]);
+        let observed = sample_daemon_incarnation_with_retry(
+            || std::future::ready(samples.pop_front().unwrap()),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(observed, Some(expected));
+        assert!(samples.is_empty());
+    }
 
     #[test]
     fn stalled_local_peer_keeps_document_capabilities_closed() {

--- a/crates/runt-mcp/src/session_activation.rs
+++ b/crates/runt-mcp/src/session_activation.rs
@@ -124,6 +124,29 @@ impl SessionActivation {
             })
     }
 
+    /// Whether an already-installed session can satisfy a repeated connect.
+    /// An in-flight activation always wins; generation zero is reserved for
+    /// daemon-watch recovery outside the explicit activation flow.
+    pub fn can_reuse_installed(&self, generation: u64, target: &str) -> bool {
+        let state = self.lock_state();
+        let current_flight_active = state.current_target.as_ref().is_some_and(|current| {
+            state
+                .in_flight
+                .get(current)
+                .is_some_and(|flight| flight.generation == state.generation)
+        });
+        if current_flight_active {
+            return false;
+        }
+        generation == 0
+            || state
+                .installed
+                .as_ref()
+                .is_some_and(|(installed_generation, installed_target)| {
+                    *installed_generation == generation && installed_target.as_str() == target
+                })
+    }
+
     pub fn has_current_local_path_flight(&self) -> bool {
         let state = self.lock_state();
         state.current_target.as_ref().is_some_and(|target| {

--- a/crates/runt-mcp/src/session_activation.rs
+++ b/crates/runt-mcp/src/session_activation.rs
@@ -214,20 +214,34 @@ impl ActivationLease {
         slot: &tokio::sync::RwLock<Option<S>>,
         session: S,
     ) -> Result<Option<S>, CallToolResult> {
+        self.install_in_slot_recovering(slot, session)
+            .await
+            .map_err(|(result, _rejected)| result)
+    }
+
+    /// Variant of [`Self::install_in_slot`] that returns a rejected payload to
+    /// the caller. Hosted-session resume uses this to put a healthy parked peer
+    /// back when a newer activation wins during slot publication.
+    pub async fn install_in_slot_recovering<S>(
+        &self,
+        slot: &tokio::sync::RwLock<Option<S>>,
+        session: S,
+    ) -> Result<Option<S>, (CallToolResult, S)> {
         if !self.is_current() {
-            return Err(self.superseded_result());
+            return Err((self.superseded_result(), session));
         }
 
         let mut guard = slot.write().await;
         if !self.is_current() {
-            return Err(self.superseded_result());
+            return Err((self.superseded_result(), session));
         }
         let previous = guard.replace(session);
         if !self.mark_installed() {
-            let stale = guard.take();
+            let Some(stale) = guard.take() else {
+                unreachable!("slot contains the session installed immediately above");
+            };
             *guard = previous;
-            drop(stale);
-            return Err(self.superseded_result());
+            return Err((self.superseded_result(), stale));
         }
         Ok(previous)
     }
@@ -347,6 +361,26 @@ mod tests {
 
     fn target(value: &str) -> CanonicalNotebookTarget {
         CanonicalNotebookTarget::new(value)
+    }
+
+    #[tokio::test]
+    async fn recovering_install_returns_payload_when_superseded() {
+        let activation = Arc::new(SessionActivation::default());
+        let ActivationTicket::Leader(stale) = activation.begin(target("a")) else {
+            panic!("first activation should lead");
+        };
+        let ActivationTicket::Leader(_newer) = activation.begin(target("b")) else {
+            panic!("different target should supersede and lead");
+        };
+        let slot = tokio::sync::RwLock::new(None);
+
+        let (_result, rejected) = stale
+            .install_in_slot_recovering(&slot, "parked-peer".to_string())
+            .await
+            .expect_err("superseded install should return its payload");
+
+        assert_eq!(rejected, "parked-peer");
+        assert!(slot.read().await.is_none());
     }
 
     fn success(value: &str) -> CallToolResult {

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -1,5 +1,6 @@
 //! Session management tools: list, join, open notebooks.
 
+use std::future::Future;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -27,12 +28,43 @@ use crate::NteractMcp;
 // must be longer so the daemon can return its typed current state instead of
 // the client racing it with an unclassified timeout.
 const MCP_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(125);
+const DAEMON_INCARNATION_SAMPLE_ATTEMPTS: usize = 3;
+const DAEMON_INCARNATION_SAMPLE_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+async fn sample_daemon_incarnation_with_retry<F, Fut>(
+    mut query: F,
+    retry_delay: Duration,
+) -> Option<DaemonIncarnation>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<DaemonIncarnation>>,
+{
+    for attempt in 0..DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
+        if let Some(incarnation) = query().await {
+            return Some(incarnation);
+        }
+        if attempt + 1 < DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+    None
+}
 
 async fn current_daemon_incarnation(server: &NteractMcp) -> Option<DaemonIncarnation> {
-    runtimed_client::singleton::query_daemon_info(server.socket_path.clone())
-        .await
-        .as_ref()
-        .map(DaemonIncarnation::from)
+    let socket_path = server.socket_path.clone();
+    sample_daemon_incarnation_with_retry(
+        move || {
+            let socket_path = socket_path.clone();
+            async move {
+                runtimed_client::singleton::query_daemon_info(socket_path)
+                    .await
+                    .as_ref()
+                    .map(DaemonIncarnation::from)
+            }
+        },
+        DAEMON_INCARNATION_SAMPLE_RETRY_DELAY,
+    )
+    .await
 }
 
 fn unchanged_daemon_incarnation(
@@ -1950,6 +1982,20 @@ mod tests {
             unchanged_daemon_incarnation(None, Some(test_incarnation(42))),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn daemon_incarnation_sample_retries_transient_unavailability() {
+        let expected = test_incarnation(42);
+        let mut samples = std::collections::VecDeque::from([None, None, Some(expected.clone())]);
+        let observed = sample_daemon_incarnation_with_retry(
+            || std::future::ready(samples.pop_front().unwrap()),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(observed, Some(expected));
+        assert!(samples.is_empty());
     }
 
     #[test]

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -1,6 +1,5 @@
 //! Session management tools: list, join, open notebooks.
 
-use std::future::Future;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -16,8 +15,8 @@ use runtimed_client::protocol::{NotebookCellProjection, NotebookProjection};
 use crate::cloud::{self, CloudRegistry, NotebookTarget};
 use crate::formatting;
 use crate::session::{
-    DaemonIncarnation, NotebookSession, NotebookSessionSource, SessionDropInfo, SessionDropReason,
-    SessionRequirement,
+    query_current_daemon_incarnation, DaemonIncarnation, NotebookSession, NotebookSessionSource,
+    SessionDropInfo, SessionDropReason, SessionRequirement,
 };
 use crate::session_activation::{
     activation_error, ActivationLease, ActivationTicket, CanonicalNotebookTarget,
@@ -28,43 +27,9 @@ use crate::NteractMcp;
 // must be longer so the daemon can return its typed current state instead of
 // the client racing it with an unclassified timeout.
 const MCP_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(125);
-const DAEMON_INCARNATION_SAMPLE_ATTEMPTS: usize = 3;
-const DAEMON_INCARNATION_SAMPLE_RETRY_DELAY: Duration = Duration::from_millis(50);
-
-async fn sample_daemon_incarnation_with_retry<F, Fut>(
-    mut query: F,
-    retry_delay: Duration,
-) -> Option<DaemonIncarnation>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Option<DaemonIncarnation>>,
-{
-    for attempt in 0..DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
-        if let Some(incarnation) = query().await {
-            return Some(incarnation);
-        }
-        if attempt + 1 < DAEMON_INCARNATION_SAMPLE_ATTEMPTS {
-            tokio::time::sleep(retry_delay).await;
-        }
-    }
-    None
-}
 
 async fn current_daemon_incarnation(server: &NteractMcp) -> Option<DaemonIncarnation> {
-    let socket_path = server.socket_path.clone();
-    sample_daemon_incarnation_with_retry(
-        move || {
-            let socket_path = socket_path.clone();
-            async move {
-                runtimed_client::singleton::query_daemon_info(socket_path)
-                    .await
-                    .as_ref()
-                    .map(DaemonIncarnation::from)
-            }
-        },
-        DAEMON_INCARNATION_SAMPLE_RETRY_DELAY,
-    )
-    .await
+    query_current_daemon_incarnation(server.socket_path.clone()).await
 }
 
 fn unchanged_daemon_incarnation(
@@ -118,8 +83,9 @@ const MAX_PARKED_SESSIONS: usize = 8;
 /// Instead of dropping the old session (which would decrement the daemon's
 /// peer count and start the eviction timer), we move it into a parked
 /// sessions map. The daemon peer connection stays alive, so the room and
-/// kernel survive. When the agent switches back, the parked session is
-/// resumed without a new connection.
+/// kernel survive. Hosted sessions can reuse the parked peer when the agent
+/// switches back. Local sessions are retained only for keepalive and are
+/// rebuilt from their durable identity after daemon replacement.
 ///
 /// If parking would exceed [`MAX_PARKED_SESSIONS`], one existing parked
 /// session is evicted to keep the cache bounded.
@@ -155,7 +121,7 @@ async fn park_session(server: &NteractMcp, old: NotebookSession) {
     parked.insert(session_key, old);
 }
 
-/// Try to resume a parked session for the given notebook_id.
+/// Try to resume a parked hosted session for the given notebook URL.
 ///
 /// Returns `Some(session)` if a parked session was found and removed from
 /// the parked map. The caller should install it as the active session.
@@ -800,7 +766,9 @@ async fn install_activated_session(
     // actually publishes; failed attempts never poison the active slot.
     if !lease.is_current() {
         if let Some(old) = previous {
-            park_session(server, old).await;
+            if old.session_key() != session_key {
+                park_session(server, old).await;
+            }
         }
         return Err(superseded_result(lease));
     }
@@ -814,6 +782,27 @@ async fn install_activated_session(
     // room. Remove it only after successful generation publication.
     server.parked_sessions.write().await.remove(&session_key);
     Ok(())
+}
+
+fn add_created_notebook_recovery(mut result: CallToolResult, notebook_id: &str) -> CallToolResult {
+    let mut details = result
+        .structured_content
+        .take()
+        .unwrap_or_else(|| serde_json::json!({ "error": {} }));
+    if !details
+        .get("error")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        details["error"] = serde_json::json!({});
+    }
+    details["error"]["notebook_id"] = serde_json::json!(notebook_id);
+    details["error"]["recovery"] = serde_json::json!({
+        "tool": "connect_notebook",
+        "notebook_id": notebook_id,
+    });
+    result.content = vec![Content::text(details.to_string())];
+    result.structured_content = Some(details);
+    result
 }
 
 fn notebook_session_response(mut response: serde_json::Value, notebook_id: &str) -> CallToolResult {
@@ -1247,9 +1236,34 @@ async fn connect_hosted_notebook(
         }
 
         add_progressive_session_fields(&mut response, &parked);
-        if let Err(result) = install_activated_session(server, lease, parked).await {
-            return Ok(result);
+        let previous = match lease
+            .install_in_slot_recovering(&server.session, parked)
+            .await
+        {
+            Ok(previous) => previous,
+            Err((result, rejected)) => {
+                server
+                    .parked_sessions
+                    .write()
+                    .await
+                    .insert(session_key.clone(), rejected);
+                return Ok(result);
+            }
+        };
+        if !lease.is_current() {
+            if let Some(old) = previous {
+                if old.session_key() != session_key {
+                    park_session(server, old).await;
+                }
+            }
+            return Ok(superseded_result(lease));
         }
+        if let Some(old) = previous {
+            if old.session_key() != session_key {
+                park_session(server, old).await;
+            }
+        }
+        server.parked_sessions.write().await.remove(&session_key);
         return Ok(notebook_session_response(response, &notebook_id));
     }
 
@@ -1712,7 +1726,7 @@ pub async fn create_notebook(
                 if let Err(result) =
                     install_activated_session(server, &activation_lease, session).await
                 {
-                    return Ok(result);
+                    return Ok(add_created_notebook_recovery(result, &notebook_id));
                 }
 
                 Ok(notebook_session_response(info, &notebook_id))
@@ -1984,18 +1998,26 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn daemon_incarnation_sample_retries_transient_unavailability() {
-        let expected = test_incarnation(42);
-        let mut samples = std::collections::VecDeque::from([None, None, Some(expected.clone())]);
-        let observed = sample_daemon_incarnation_with_retry(
-            || std::future::ready(samples.pop_front().unwrap()),
-            Duration::ZERO,
-        )
-        .await;
+    #[test]
+    fn created_notebook_recovery_keeps_new_identity() {
+        let original = activation_error(
+            "daemon_replaced",
+            "retry",
+            7,
+            &CanonicalNotebookTarget::new("local:create:test"),
+        );
+        let result = add_created_notebook_recovery(original, "new-notebook-id");
+        let details = result.structured_content.expect("structured error");
 
-        assert_eq!(observed, Some(expected));
-        assert!(samples.is_empty());
+        assert_eq!(details["error"]["notebook_id"], "new-notebook-id");
+        assert_eq!(
+            details["error"]["recovery"],
+            serde_json::json!({
+                "tool": "connect_notebook",
+                "notebook_id": "new-notebook-id",
+            })
+        );
+        assert_eq!(result.is_error, Some(true));
     }
 
     #[test]

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -8,12 +8,16 @@ use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use notebook_sync::status::ConnectionState;
 use runtimed_client::client::{ClientError, PoolClient};
 use runtimed_client::protocol::{NotebookCellProjection, NotebookProjection};
 
 use crate::cloud::{self, CloudRegistry, NotebookTarget};
 use crate::formatting;
-use crate::session::{NotebookSession, SessionDropInfo, SessionDropReason};
+use crate::session::{
+    DaemonIncarnation, NotebookSession, NotebookSessionSource, SessionDropInfo, SessionDropReason,
+    SessionRequirement,
+};
 use crate::session_activation::{
     activation_error, ActivationLease, ActivationTicket, CanonicalNotebookTarget,
 };
@@ -23,6 +27,23 @@ use crate::NteractMcp;
 // must be longer so the daemon can return its typed current state instead of
 // the client racing it with an unclassified timeout.
 const MCP_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(125);
+
+async fn current_daemon_incarnation(server: &NteractMcp) -> Option<DaemonIncarnation> {
+    runtimed_client::singleton::query_daemon_info(server.socket_path.clone())
+        .await
+        .as_ref()
+        .map(DaemonIncarnation::from)
+}
+
+fn unchanged_daemon_incarnation(
+    before: Option<DaemonIncarnation>,
+    after: Option<DaemonIncarnation>,
+) -> Option<DaemonIncarnation> {
+    match (before, after) {
+        (Some(before), Some(after)) if before == after => Some(after),
+        _ => None,
+    }
+}
 
 /// Read the current session's notebook_id (if any) before replacing it.
 async fn previous_notebook_id(server: &NteractMcp) -> Option<String> {
@@ -616,11 +637,129 @@ fn superseded_result(lease: &ActivationLease) -> CallToolResult {
     lease.superseded_result()
 }
 
+fn session_matches_target(session: &NotebookSession, requested: &CanonicalNotebookTarget) -> bool {
+    if session.activation_target == requested.as_str() {
+        return true;
+    }
+
+    match &session.source {
+        NotebookSessionSource::Local => {
+            canonical_local_id_target(&session.notebook_id).is_ok_and(|target| target == *requested)
+                || session
+                    .notebook_path
+                    .as_deref()
+                    .is_some_and(|path| canonical_local_path_target(path) == *requested)
+        }
+        NotebookSessionSource::Hosted { domain } => {
+            let url = cloud::hosted_notebook_url(domain, &session.notebook_id);
+            CanonicalNotebookTarget::new(format!("hosted:{url}")) == *requested
+        }
+    }
+}
+
+fn has_reusable_replica(
+    connection: ConnectionState,
+    interactive: bool,
+    projection_ready: bool,
+) -> bool {
+    connection == ConnectionState::Connected && (interactive || projection_ready)
+}
+
+async fn reuse_active_session(
+    server: &NteractMcp,
+    requested: &CanonicalNotebookTarget,
+) -> Option<CallToolResult> {
+    // Sample the local daemon before taking the session lock. The lock is only
+    // used for synchronous validation and response construction.
+    let current_incarnation = current_daemon_incarnation(server).await;
+    let guard = server.session.read().await;
+    let session = guard.as_ref()?;
+    if !session_matches_target(session, requested)
+        || !server
+            .session_activation
+            .can_reuse_installed(session.activation_generation, &session.activation_target)
+        || (!session.is_hosted()
+            && !current_incarnation
+                .as_ref()
+                .is_some_and(|current| session.local_daemon_incarnation.as_ref() == Some(current)))
+    {
+        return None;
+    }
+
+    let readiness = session.readiness();
+    if !has_reusable_replica(
+        session.handle.status().connection,
+        readiness.interactive,
+        readiness.projection_ready,
+    ) {
+        return None;
+    }
+    let projection = if readiness.interactive {
+        None
+    } else {
+        session
+            .access(SessionRequirement::ProjectionRead)
+            .ok()
+            .and_then(|access| access.projection)
+    };
+    let (runtime, dependencies, project_context, cells) = match projection {
+        Some(projection) => (
+            projected_runtime_info(&projection),
+            projection.dependencies.clone(),
+            serde_json::to_value(&projection.runtime.project_context)
+                .unwrap_or(serde_json::Value::Null),
+            format_projected_cell_summaries(&projection.cells),
+        ),
+        None => (
+            read_runtime_info(&session.handle),
+            get_dependencies(&session.handle),
+            read_project_context(&session.handle),
+            format_cell_summaries(&session.handle),
+        ),
+    };
+
+    let mut response = serde_json::json!({
+        "notebook_id": session.notebook_id,
+        "connected": true,
+        "already_connected": true,
+        "runtime": runtime,
+        "dependencies": dependencies,
+        "project_context": project_context,
+        "cells": cells,
+    });
+    if let Some(path) = &session.notebook_path {
+        response["path"] = serde_json::json!(path);
+        response["notebook_path"] = serde_json::json!(path);
+    }
+    if let NotebookSessionSource::Hosted { domain } = &session.source {
+        response["source"] = serde_json::json!("hosted");
+        response["domain"] = serde_json::json!(domain);
+        response["target"] =
+            serde_json::json!(cloud::hosted_notebook_url(domain, &session.notebook_id));
+    }
+    add_progressive_session_fields(&mut response, session);
+    Some(notebook_session_response(response, &session.notebook_id))
+}
+
 async fn install_activated_session(
     server: &NteractMcp,
     lease: &ActivationLease,
     session: NotebookSession,
 ) -> Result<(), CallToolResult> {
+    if !session.is_hosted() {
+        let current_incarnation = current_daemon_incarnation(server).await;
+        let is_bound_to_current = current_incarnation
+            .as_ref()
+            .is_some_and(|current| session.local_daemon_incarnation.as_ref() == Some(current));
+        if !is_bound_to_current {
+            return Err(activation_error(
+                "daemon_replaced",
+                "The local daemon changed while the notebook connection was being established; retry the connection",
+                lease.generation(),
+                lease.target(),
+            ));
+        }
+    }
     let session_key = session.session_key();
     let previous = lease.install_in_slot(&server.session, session).await?;
 
@@ -1151,6 +1290,7 @@ async fn connect_local_path_progressive(
     lease: &ActivationLease,
 ) -> Result<CallToolResult, McpError> {
     let abs_path = PathBuf::from(canonicalize_local_path(&path));
+    let incarnation_before = current_daemon_incarnation(server).await;
     let result = match notebook_sync::connect::connect_open(
         server.socket_path.clone(),
         abs_path.clone(),
@@ -1178,7 +1318,6 @@ async fn connect_local_path_progressive(
     if !lease.is_current() {
         return Ok(superseded_result(lease));
     }
-
     let mut session = NotebookSession::local_with_projection(
         result.handle,
         notebook_id.clone(),
@@ -1186,6 +1325,7 @@ async fn connect_local_path_progressive(
         lease.generation(),
         lease.target().clone(),
         projection.clone(),
+        None,
     );
 
     if session.notebook_path.is_none() {
@@ -1193,6 +1333,8 @@ async fn connect_local_path_progressive(
     }
     let peer_label = server.get_peer_label().await;
     crate::presence::announce(&session.handle, &peer_label).await;
+    session.local_daemon_incarnation =
+        unchanged_daemon_incarnation(incarnation_before, current_daemon_incarnation(server).await);
 
     let mut response = serde_json::json!({
         "notebook_id": notebook_id,
@@ -1221,6 +1363,7 @@ async fn connect_local_id_progressive(
     prev: Option<String>,
     lease: &ActivationLease,
 ) -> Result<CallToolResult, McpError> {
+    let incarnation_before = current_daemon_incarnation(server).await;
     let result = match notebook_sync::connect::connect(
         server.socket_path.clone(),
         notebook_id.clone(),
@@ -1258,6 +1401,7 @@ async fn connect_local_id_progressive(
         lease.generation(),
         lease.target().clone(),
         projection.clone(),
+        None,
     );
     if session.notebook_path.is_none() {
         session.notebook_path = notebook_path.clone();
@@ -1265,6 +1409,8 @@ async fn connect_local_id_progressive(
 
     let peer_label = server.get_peer_label().await;
     crate::presence::announce(&session.handle, &peer_label).await;
+    session.local_daemon_incarnation =
+        unchanged_daemon_incarnation(incarnation_before, current_daemon_incarnation(server).await);
     let mut response = serde_json::json!({
         "notebook_id": notebook_id,
         "connected": true,
@@ -1356,6 +1502,10 @@ pub async fn open_notebook(
         }
     };
 
+    if let Some(result) = reuse_active_session(server, &canonical_target).await {
+        return Ok(result);
+    }
+
     let mut lease = match server.session_activation.begin(canonical_target) {
         ActivationTicket::Follower(follower) => return Ok(follower.wait().await),
         ActivationTicket::Leader(lease) => lease,
@@ -1434,6 +1584,7 @@ pub async fn create_notebook(
     let prev = previous_notebook_id(server).await;
 
     let outcome = async {
+        let incarnation_before = current_daemon_incarnation(server).await;
         match notebook_sync::connect::connect_create(
             server.socket_path.clone(),
             notebook_sync::connect::CreateNotebookSpec {
@@ -1484,7 +1635,8 @@ pub async fn create_notebook(
                     )
                 };
 
-                let mut session = NotebookSession::local(result.handle, notebook_id.clone(), None);
+                let mut session =
+                    NotebookSession::local(result.handle, notebook_id.clone(), None, None);
                 session.reactivate(activation_lease.generation(), activation_lease.target());
 
                 let runtime_info = collect_runtime_info(&session.handle).await;
@@ -1494,6 +1646,10 @@ pub async fn create_notebook(
                     Vec::new() // Deno: no Python deps
                 };
                 let project_context = read_project_context(&session.handle);
+                session.local_daemon_incarnation = unchanged_daemon_incarnation(
+                    incarnation_before,
+                    current_daemon_incarnation(server).await,
+                );
 
                 let mut info = serde_json::json!({
                     "notebook_id": notebook_id,
@@ -1754,6 +1910,14 @@ pub async fn show_notebook(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn test_incarnation(pid: u32) -> DaemonIncarnation {
+        DaemonIncarnation {
+            pid,
+            started_at: Utc.timestamp_opt(pid.into(), 0).single().unwrap(),
+        }
+    }
 
     fn make_request(name: &str, arguments: serde_json::Value) -> CallToolRequestParams {
         serde_json::from_value(serde_json::json!({
@@ -1769,6 +1933,47 @@ mod tests {
             .expect("tool response text")
             .text
             .as_str()
+    }
+
+    #[test]
+    fn daemon_binding_requires_equal_samples() {
+        let daemon = test_incarnation(41);
+        assert_eq!(
+            unchanged_daemon_incarnation(Some(daemon.clone()), Some(daemon.clone())),
+            Some(daemon)
+        );
+        assert_eq!(
+            unchanged_daemon_incarnation(Some(test_incarnation(41)), Some(test_incarnation(42))),
+            None
+        );
+        assert_eq!(
+            unchanged_daemon_incarnation(None, Some(test_incarnation(42))),
+            None
+        );
+    }
+
+    #[test]
+    fn reuse_requires_connected_readable_replica() {
+        assert!(has_reusable_replica(
+            ConnectionState::Connected,
+            true,
+            false
+        ));
+        assert!(has_reusable_replica(
+            ConnectionState::Connected,
+            false,
+            true
+        ));
+        assert!(!has_reusable_replica(
+            ConnectionState::Disconnected,
+            true,
+            true
+        ));
+        assert!(!has_reusable_replica(
+            ConnectionState::Connected,
+            false,
+            false
+        ));
     }
 
     /// When package_manager is explicitly provided, it takes precedence

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -814,25 +814,44 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         }
     };
 
-    tokio::select! {
+    let daemon_upgrade_exit = tokio::select! {
         result = handle.waiting() => {
             // MCP client disconnected — normal shutdown
             result?;
+            false
         }
-        exit_code = watch_handle => {
-            // Watcher returned — daemon was upgraded.
-            // Gracefully close the MCP transport so the client sees a clean
-            // EOF rather than a broken pipe, then exit with EX_TEMPFAIL (75)
-            // so the wrapper or client knows to restart us.
-            let code = exit_code.unwrap_or(runt_mcp::daemon_watch::EXIT_DAEMON_UPGRADED);
-            eprintln!("Daemon upgraded, exiting for restart (exit code {code}).");
-            cancel_token.cancel();
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-            std::process::exit(code);
+        watch_result = watch_handle => {
+            match watch_result {
+                Ok(runt_mcp::daemon_watch::EXIT_DAEMON_UPGRADED) => true,
+                Ok(0) => {
+                    tracing::info!("[mcp] Daemon watch stream closed; shutting down normally");
+                    false
+                }
+                Ok(code) => {
+                    return Err(anyhow::anyhow!(
+                        "daemon watch exited with unexpected code {code}"
+                    ));
+                }
+                Err(error) => {
+                    return Err(anyhow::anyhow!("daemon watch task failed: {error}"));
+                }
+            }
         }
         _ = sigterm => {
             tracing::info!("[mcp] Received SIGTERM, shutting down gracefully");
+            false
         }
+    };
+
+    if daemon_upgrade_exit {
+        // Gracefully close the MCP transport so the client sees a clean EOF,
+        // then use EX_TEMPFAIL so the proxy can classify the intentional
+        // daemon-upgrade handoff separately from a crash.
+        let code = runt_mcp::daemon_watch::EXIT_DAEMON_UPGRADED;
+        eprintln!("Daemon upgraded, exiting for restart (exit code {code}).");
+        cancel_token.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        std::process::exit(code);
     }
 
     // Disconnect our peer from the notebook session before the process exits.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -730,6 +730,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     .ok()
     .flatten();
     let daemon_version = daemon_info.as_ref().map(|info| info.version.clone());
+    let watch_startup_version = daemon_version.clone();
     let execution_store_path = daemon_info
         .as_ref()
         .and_then(|info| info.execution_store_dir.as_ref())
@@ -768,15 +769,16 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     );
     let watch_socket = socket_path;
     let watch_handle = tokio::spawn(async move {
-        runt_mcp::daemon_watch::watch(
+        runt_mcp::daemon_watch::watch(runt_mcp::daemon_watch::WatchResources {
             daemon_conn,
-            watch_socket,
+            socket_path: watch_socket,
             session,
             peer_label,
             last_session_drop,
             parked_sessions,
             session_intent_epoch,
-        )
+            startup_version: watch_startup_version,
+        })
         .await
     });
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -39,6 +39,43 @@ use crate::{default_blob_store_dir, is_pool_env_dir, is_within_cache_dir, EnvTyp
 use notebook_protocol::connection::{self, Handshake};
 use runtimed_client::singleton::DaemonInfo;
 
+fn existing_file_allows_write(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.permissions().readonly() => return false,
+        Ok(_) => {}
+        Err(_) => return false,
+    }
+    #[cfg(unix)]
+    {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+            return false;
+        };
+        // SAFETY: `path` is a valid NUL-terminated C string created from the
+        // OS path bytes above. `access` does not retain it.
+        unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn local_connection_scope_for_path(path: Option<&Path>) -> nteract_identity::ConnectionScope {
+    match path {
+        Some(path) if path.is_file() && !existing_file_allows_write(path) => {
+            nteract_identity::ConnectionScope::Viewer
+        }
+        _ => nteract_identity::ConnectionScope::Owner,
+    }
+}
+
+fn registry_binding_has_recovery_source(source_path: &Path, recovery_path: &Path) -> bool {
+    source_path.is_file() || recovery_path.is_file()
+}
+
 /// Configuration for the pool daemon.
 #[derive(Debug, Clone)]
 pub struct DaemonConfig {
@@ -3002,6 +3039,9 @@ impl Daemon {
                 // the resident-room cache is meant to preserve.
                 let parsed_notebook_id = uuid::Uuid::parse_str(&notebook_id).ok();
                 let (room, _room_guard) = if let Some(parsed) = parsed_notebook_id {
+                    let persisted_doc_path =
+                        docs_dir.join(crate::paths::notebook_doc_filename(&parsed.to_string()));
+                    let recovery_path = persisted_doc_path.with_extension("recovery");
                     // NotebookSync by UUID is attach-only (see the notebook crate's
                     // `Attach` intent: "attach to a room the daemon has already
                     // created. No create, no load."). Attach to a resident room, or
@@ -3014,10 +3054,62 @@ impl Daemon {
                         // reaper cannot remove it between this check and steady
                         // state (the guard is part of `found`).
                         found
-                    } else if docs_dir
-                        .join(crate::paths::notebook_doc_filename(&parsed.to_string()))
-                        .exists()
-                    {
+                    } else if let Some(canonical) = self.notebook_registry.lookup_path(parsed) {
+                        if !registry_binding_has_recovery_source(&canonical, &recovery_path) {
+                            // A registry row is an identity binding, not notebook
+                            // content. In particular, do not fall through to the
+                            // legacy UUID-keyed `.automerge` mirror for a saved
+                            // notebook whose file and causal journal are both
+                            // gone: that mirror is unvalidated and may be stale.
+                            info!(
+                                "[runtimed] NotebookSync for {parsed}: registry binding has no source file or recovery journal — refusing (gone)"
+                            );
+                            let (_reader, mut writer) = tokio::io::split(stream);
+                            send_error_response(
+                                &mut writer,
+                                format!(
+                                    "Notebook {parsed} is no longer available (not found or evicted)"
+                                ),
+                                typed_bootstrap.unwrap_or(false),
+                            )
+                            .await?;
+                            return Ok(());
+                        }
+                        // A notebook created untitled keeps its UUID when saved.
+                        // After a daemon replacement its transient DocHandle and
+                        // UUID-keyed room may be gone, but the persistent registry
+                        // still binds that UUID to the file it became. Follow the
+                        // reverse binding so UUID-only clients recover the
+                        // file-backed room instead of receiving a false eviction.
+                        match self.gate_file_claim(&canonical, parsed) {
+                            FileClaimGate::Proceed => {}
+                            FileClaimGate::ActiveElsewhere(message) => {
+                                let (_reader, mut writer) = tokio::io::split(stream);
+                                send_error_response(
+                                    &mut writer,
+                                    message,
+                                    typed_bootstrap.unwrap_or(false),
+                                )
+                                .await?;
+                                return Ok(());
+                            }
+                        }
+                        crate::notebook_sync_server::get_or_create_room_result(
+                            &self.notebook_rooms,
+                            parsed,
+                            crate::notebook_sync_server::RoomCreationOptions {
+                                path: Some(canonical),
+                                initial_load_execution_store_dir: Some(
+                                    self.config.execution_store_dir.as_path(),
+                                ),
+                                docs_dir: &docs_dir,
+                                blob_store: self.blob_store.clone(),
+                                ephemeral: false,
+                                trusted_packages: self.trusted_packages.clone(),
+                            },
+                        )
+                        .await?
+                    } else if persisted_doc_path.exists() {
                         // Not resident but recoverable: reload from the persisted doc.
                         crate::notebook_sync_server::get_or_create_room_result(
                             &self.notebook_rooms,
@@ -3153,8 +3245,14 @@ impl Daemon {
 
                 // Convert working_dir String to PathBuf
                 let working_dir_path = working_dir.map(std::path::PathBuf::from);
+                let connection_scope =
+                    local_connection_scope_for_path(room.file_binding.path().await.as_deref());
                 let connection_identity =
-                    crate::notebook_sync_server::RoomConnectionIdentity::local(operator).await?;
+                    crate::notebook_sync_server::RoomConnectionIdentity::local_with_scope(
+                        operator,
+                        connection_scope,
+                    )
+                    .await?;
                 crate::notebook_sync_server::handle_notebook_sync_connection(
                     reader,
                     writer,
@@ -3963,30 +4061,6 @@ impl Daemon {
             }
         };
 
-        fn existing_file_allows_write(path: &std::path::Path) -> bool {
-            match std::fs::metadata(path) {
-                Ok(metadata) if metadata.permissions().readonly() => return false,
-                Ok(_) => {}
-                Err(_) => return false,
-            }
-            #[cfg(unix)]
-            {
-                use std::ffi::CString;
-                use std::os::unix::ffi::OsStrExt;
-
-                let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
-                    return false;
-                };
-                // SAFETY: `path` is a valid NUL-terminated C string created
-                // from the OS path bytes above. `access` does not retain it.
-                unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
-            }
-            #[cfg(not(unix))]
-            {
-                true
-            }
-        }
-
         // Derive notebook_id from path
         // For existing files: canonicalize for stable cross-process identity
         // For new files: use absolute path (canonicalize would fail)
@@ -4013,11 +4087,7 @@ impl Daemon {
         };
 
         let connection_scope =
-            if file_exists && !existing_file_allows_write(&PathBuf::from(&notebook_id)) {
-                nteract_identity::ConnectionScope::Viewer
-            } else {
-                nteract_identity::ConnectionScope::Owner
-            };
+            local_connection_scope_for_path(file_exists.then(|| Path::new(&notebook_id)));
         let connection_identity =
             crate::notebook_sync_server::RoomConnectionIdentity::local_with_scope(
                 operator.clone(),
@@ -7675,6 +7745,44 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn registry_binding_requires_file_or_recovery_journal() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("moved.ipynb");
+        let recovery = temp_dir.path().join("room.recovery");
+
+        assert!(!registry_binding_has_recovery_source(&source, &recovery));
+
+        std::fs::write(&source, b"{}").unwrap();
+        assert!(registry_binding_has_recovery_source(&source, &recovery));
+
+        std::fs::remove_file(&source).unwrap();
+        std::fs::write(&recovery, b"journal").unwrap();
+        assert!(registry_binding_has_recovery_source(&source, &recovery));
+    }
+
+    #[test]
+    fn read_only_file_connections_use_viewer_scope() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("read-only.ipynb");
+        std::fs::write(&path, b"{}").unwrap();
+        let original_permissions = std::fs::metadata(&path).unwrap().permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&path, permissions).unwrap();
+
+        assert_eq!(
+            local_connection_scope_for_path(Some(&path)),
+            nteract_identity::ConnectionScope::Viewer
+        );
+        assert_eq!(
+            local_connection_scope_for_path(None),
+            nteract_identity::ConnectionScope::Owner
+        );
+
+        std::fs::set_permissions(&path, original_permissions).unwrap();
+    }
 
     #[test]
     fn daemon_defaults_preapprove_official_conda_sources() {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -72,8 +72,8 @@ fn local_connection_scope_for_path(path: Option<&Path>) -> nteract_identity::Con
     }
 }
 
-fn registry_binding_has_recovery_source(source_path: &Path, recovery_path: &Path) -> bool {
-    source_path.is_file() || recovery_path.is_file()
+fn registry_binding_has_source_file(source_path: &Path) -> bool {
+    source_path.is_file()
 }
 
 /// Configuration for the pool daemon.
@@ -3055,21 +3055,30 @@ impl Daemon {
                         // state (the guard is part of `found`).
                         found
                     } else if let Some(canonical) = self.notebook_registry.lookup_path(parsed) {
-                        if !registry_binding_has_recovery_source(&canonical, &recovery_path) {
+                        if !registry_binding_has_source_file(&canonical) {
                             // A registry row is an identity binding, not notebook
                             // content. In particular, do not fall through to the
                             // legacy UUID-keyed `.automerge` mirror for a saved
-                            // notebook whose file and causal journal are both
-                            // gone: that mirror is unvalidated and may be stale.
+                            // notebook whose file is gone: that mirror is
+                            // unvalidated and may be stale. A recovery journal is
+                            // preserved, but finalizing a file-backed generation
+                            // still requires the matching source bytes.
+                            let message = if recovery_path.is_file() {
+                                format!(
+                                    "Notebook {parsed} is unavailable because its saved source file is missing; the recovery journal was preserved"
+                                )
+                            } else {
+                                format!(
+                                    "Notebook {parsed} is no longer available (not found or evicted)"
+                                )
+                            };
                             info!(
-                                "[runtimed] NotebookSync for {parsed}: registry binding has no source file or recovery journal — refusing (gone)"
+                                "[runtimed] NotebookSync for {parsed}: registry binding has no source file — refusing"
                             );
                             let (_reader, mut writer) = tokio::io::split(stream);
                             send_error_response(
                                 &mut writer,
-                                format!(
-                                    "Notebook {parsed} is no longer available (not found or evicted)"
-                                ),
+                                message,
                                 typed_bootstrap.unwrap_or(false),
                             )
                             .await?;
@@ -7747,19 +7756,19 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
-    fn registry_binding_requires_file_or_recovery_journal() {
+    fn registry_binding_requires_source_file() {
         let temp_dir = TempDir::new().unwrap();
         let source = temp_dir.path().join("moved.ipynb");
         let recovery = temp_dir.path().join("room.recovery");
 
-        assert!(!registry_binding_has_recovery_source(&source, &recovery));
+        assert!(!registry_binding_has_source_file(&source));
 
         std::fs::write(&source, b"{}").unwrap();
-        assert!(registry_binding_has_recovery_source(&source, &recovery));
+        assert!(registry_binding_has_source_file(&source));
 
         std::fs::remove_file(&source).unwrap();
         std::fs::write(&recovery, b"journal").unwrap();
-        assert!(registry_binding_has_recovery_source(&source, &recovery));
+        assert!(!registry_binding_has_source_file(&source));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_registry.rs
+++ b/crates/runtimed/src/notebook_registry.rs
@@ -56,6 +56,8 @@ impl NotebookRegistry {
                 notebook_id    TEXT NOT NULL,
                 recorded_at    TEXT NOT NULL
             );
+            CREATE INDEX IF NOT EXISTS notebook_paths_by_id
+                ON notebook_paths (notebook_id);
             "#,
         )
         .with_context(|| format!("initialize notebook registry {}", path.display()))?;
@@ -106,6 +108,36 @@ impl NotebookRegistry {
                 None
             });
         stored.and_then(|s| Uuid::parse_str(&s).ok())
+    }
+
+    /// Return the current canonical path bound to `id`, or `None` if unknown /
+    /// unavailable.
+    ///
+    /// This is the reverse side of [`Self::lookup`]. It lets a client holding a
+    /// UUID for an untitled notebook follow that identity after the notebook is
+    /// saved and the daemon process is replaced. Save-as normally keeps one row
+    /// per id; ordering makes recovery deterministic if an older installation
+    /// left more than one historical row behind.
+    pub fn lookup_path(&self, id: Uuid) -> Option<PathBuf> {
+        let conn = match self.inner.as_ref() {
+            Inner::Sqlite { conn } => conn,
+            Inner::Unavailable { .. } => return None,
+        };
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        let stored: Option<String> = guard
+            .query_row(
+                "SELECT canonical_path FROM notebook_paths \
+                 WHERE notebook_id = ?1 \
+                 ORDER BY recorded_at DESC, canonical_path ASC LIMIT 1",
+                params![id.to_string()],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!("[notebook-registry] lookup_path({id}) failed: {e}");
+                None
+            });
+        stored.map(PathBuf::from)
     }
 
     /// Resolve `canonical` to its stable id, assigning and recording a fresh one
@@ -236,6 +268,23 @@ mod tests {
     }
 
     #[test]
+    fn reverse_lookup_survives_reopen() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("notebook-registry.sqlite");
+        let path = Path::new("/Users/me/saved-from-untitled.ipynb");
+        let id = Uuid::new_v4();
+
+        NotebookRegistry::open(db.clone())
+            .unwrap()
+            .record(path, id, TS);
+
+        assert_eq!(
+            NotebookRegistry::open(db).unwrap().lookup_path(id),
+            Some(path.to_path_buf())
+        );
+    }
+
+    #[test]
     fn distinct_paths_get_distinct_ids() {
         let tmp = tempfile::TempDir::new().unwrap();
         let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
@@ -298,6 +347,7 @@ mod tests {
         store.record(new, id, TS);
 
         assert_eq!(store.lookup(new), Some(id));
+        assert_eq!(store.lookup_path(id), Some(new.to_path_buf()));
         // The old path is free: a new file there gets a fresh id, not the moved one.
         let reused = store.resolve_or_assign(old, TS);
         assert_ne!(reused, id);

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -4196,6 +4196,84 @@ async fn test_notebook_sync_uuid_imports_saved_file_without_recovery_journal() {
     stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
 }
 
+/// A recovery journal is preserved when the last saved `.ipynb` disappears,
+/// but file-backed recovery cannot validate/finalize without the source bytes.
+/// UUID attach must refuse clearly instead of exposing a disconnected room.
+#[tokio::test]
+async fn test_notebook_sync_uuid_refuses_journal_without_source_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let saved_path = temp_dir.path().join("journal-only-source.ipynb");
+    write_test_ipynb(
+        &saved_path,
+        &[("saved-cell", "code", "saved_value = 1", vec![])],
+    );
+
+    let daemon = Daemon::new_for_test(config.clone()).unwrap();
+    let mut daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let opened = connect::connect_open(socket_path.clone(), saved_path.clone(), "open")
+        .await
+        .expect("saved notebook should open");
+    let notebook_id = opened.info.notebook_id.clone();
+    assert_session_ready(&opened.handle, "journal-only setup").await;
+    let cell = opened
+        .handle
+        .get_cells()
+        .into_iter()
+        .find(|cell| cell.id == "saved-cell")
+        .expect("saved cell should load");
+    opened
+        .handle
+        .update_source(&cell.id, "journal_only_value = 2")
+        .unwrap();
+    opened.handle.confirm_sync().await.unwrap();
+    drop(opened);
+    stop_daemon_for_replacement(&pool_client, &mut daemon_handle).await;
+
+    let persist_path = config
+        .notebook_docs_dir
+        .join(notebook_doc::notebook_doc_filename(&notebook_id));
+    let journal_path = persist_path.with_extension("recovery");
+    assert!(
+        journal_path.is_file(),
+        "shutdown should flush the recovery journal"
+    );
+    std::fs::remove_file(&saved_path).unwrap();
+
+    let restarted =
+        Daemon::new_for_test(replacement_config(config, &temp_dir, "journal-only")).unwrap();
+    let mut restarted_handle = tokio::spawn(async move {
+        restarted.run().await.ok();
+    });
+    let restarted_pool = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&restarted_pool).await);
+
+    match connect::connect(socket_path, notebook_id.clone(), "rejoin").await {
+        Err(notebook_sync::SyncError::NotebookUnavailable(ref message))
+            if message.contains("saved source file is missing")
+                && message.contains("recovery journal was preserved") => {}
+        Err(other) => panic!("journal-only UUID returned an unexpected error: {other:?}"),
+        Ok(_) => panic!("journal-only UUID should be refused, but it created a room"),
+    }
+    assert!(
+        journal_path.is_file(),
+        "refusal must preserve the recovery journal"
+    );
+    let rooms = restarted_pool.list_rooms().await.unwrap();
+    assert!(
+        !rooms.iter().any(|room| room.notebook_id == notebook_id),
+        "journal-only refusal must not publish a disconnected room: {rooms:?}"
+    );
+
+    stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
+}
+
 /// A UUID-keyed legacy `.automerge` mirror is not authoritative for a saved
 /// notebook. With a registry row and source file but no recovery journal, UUID
 /// attach must import the current `.ipynb` rather than silently serve the stale

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -291,6 +291,30 @@ async fn assert_session_ready(handle: &notebook_sync::DocHandle, context: &str) 
     }
 }
 
+async fn stop_daemon_for_replacement(
+    pool_client: &PoolClient,
+    daemon_handle: &mut tokio::task::JoinHandle<()>,
+) {
+    pool_client.shutdown().await.ok();
+    if tokio::time::timeout(Duration::from_secs(2), &mut *daemon_handle)
+        .await
+        .is_err()
+    {
+        daemon_handle.abort();
+        let _ = daemon_handle.await;
+    }
+}
+
+fn replacement_config(mut config: DaemonConfig, temp_dir: &TempDir, suffix: &str) -> DaemonConfig {
+    // The test binary's global shutdown callback deliberately retains the
+    // first in-process daemon. A real restart is a new process and releases
+    // these process-local locks, so give the replacement equivalent fresh
+    // lock namespaces while preserving the registry, journals, and socket.
+    config.lock_dir = Some(temp_dir.path().join(format!("restart-lock-{suffix}")));
+    config.file_claims_dir = Some(temp_dir.path().join(format!("restart-claims-{suffix}")));
+    config
+}
+
 async fn wait_for_cell_count(
     handle: &notebook_sync::DocHandle,
     expected: usize,
@@ -4019,6 +4043,372 @@ async fn test_notebook_sync_refuses_gone_uuid_without_phantom() {
         "refused NotebookSync must not mint a phantom room: {rooms:?}"
     );
 
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+/// A notebook created untitled keeps its UUID when saved. After the daemon is
+/// replaced, a client that retained only that UUID must follow the persistent
+/// registry binding to the saved path and recover the file-backed room.
+#[tokio::test]
+async fn test_notebook_sync_uuid_follows_saved_path_across_daemon_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let saved_path = temp_dir.path().join("saved-from-untitled.ipynb");
+
+    let daemon = Daemon::new_for_test(config.clone()).unwrap();
+    let mut daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let created = connect::connect_create(socket_path.clone(), create_spec("test"))
+        .await
+        .expect("untitled notebook should be created");
+    let notebook_id = created.info.notebook_id.clone();
+    assert_session_ready(&created.handle, "created notebook").await;
+    let starter = wait_for_daemon_starter_cell(&created.handle, SESSION_READY_TIMEOUT)
+        .await
+        .expect("daemon starter cell should arrive");
+    created
+        .handle
+        .update_source(&starter.id, "saved_value = 42")
+        .unwrap();
+    created.handle.confirm_sync().await.unwrap();
+
+    let save = created
+        .handle
+        .send_request(NotebookRequest::SaveNotebook {
+            format_cells: false,
+            path: Some(saved_path.to_string_lossy().into_owned()),
+        })
+        .await
+        .expect("untitled notebook should save");
+    assert!(
+        matches!(
+            save,
+            NotebookResponse::NotebookSaved { .. }
+                | NotebookResponse::NotebookAlreadyCurrent { .. }
+        ),
+        "unexpected save response: {save:?}"
+    );
+    let canonical_saved_path = std::fs::canonicalize(&saved_path).unwrap();
+    drop(created);
+    stop_daemon_for_replacement(&pool_client, &mut daemon_handle).await;
+
+    let restarted =
+        Daemon::new_for_test(replacement_config(config, &temp_dir, "saved-path")).unwrap();
+    let mut restarted_handle = tokio::spawn(async move {
+        restarted.run().await.ok();
+    });
+    let restarted_pool = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&restarted_pool).await);
+
+    let rejoined = connect::connect(socket_path, notebook_id.clone(), "rejoin")
+        .await
+        .expect("saved notebook UUID should resolve after daemon restart");
+    assert_eq!(rejoined.handle.notebook_id(), notebook_id);
+    let rejoined_room = restarted_pool
+        .list_rooms()
+        .await
+        .expect("restarted daemon should list rejoined room")
+        .into_iter()
+        .find(|room| room.notebook_id == notebook_id)
+        .expect("rejoined room should be listed");
+    assert_eq!(
+        rejoined_room.notebook_path.as_deref(),
+        Some(canonical_saved_path.to_string_lossy().as_ref())
+    );
+    assert_session_ready(&rejoined.handle, "rejoined file-backed notebook").await;
+    assert!(
+        rejoined
+            .handle
+            .get_cells()
+            .iter()
+            .any(|cell| cell.source == "saved_value = 42"),
+        "rejoined notebook should retain the saved cell"
+    );
+
+    drop(rejoined);
+    stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
+}
+
+/// UUID recovery must import the saved `.ipynb` when no recovery journal
+/// survives. The durable path registry locates content; it never substitutes
+/// for loading that content.
+#[tokio::test]
+async fn test_notebook_sync_uuid_imports_saved_file_without_recovery_journal() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let saved_path = temp_dir.path().join("existing-saved-notebook.ipynb");
+    write_test_ipynb(
+        &saved_path,
+        &[
+            ("saved-cell-0", "code", "persisted_value_0 = 0", vec![]),
+            ("saved-cell-1", "code", "persisted_value_1 = 1", vec![]),
+            ("saved-cell-2", "code", "persisted_value_2 = 2", vec![]),
+        ],
+    );
+
+    let daemon = Daemon::new_for_test(config.clone()).unwrap();
+    let mut daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let opened = connect::connect_open(socket_path.clone(), saved_path.clone(), "open")
+        .await
+        .expect("saved notebook should open");
+    let notebook_id = opened.info.notebook_id.clone();
+    assert_session_ready(&opened.handle, "initial saved notebook open").await;
+    assert_eq!(opened.handle.get_cells().len(), 3);
+    drop(opened);
+    stop_daemon_for_replacement(&pool_client, &mut daemon_handle).await;
+
+    if config.notebook_docs_dir.exists() {
+        std::fs::remove_dir_all(&config.notebook_docs_dir).unwrap();
+    }
+    std::fs::create_dir_all(&config.notebook_docs_dir).unwrap();
+
+    let restarted =
+        Daemon::new_for_test(replacement_config(config, &temp_dir, "no-journal")).unwrap();
+    let mut restarted_handle = tokio::spawn(async move {
+        restarted.run().await.ok();
+    });
+    let restarted_pool = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&restarted_pool).await);
+
+    let rejoined = connect::connect(socket_path, notebook_id, "rejoin")
+        .await
+        .expect("registry-backed UUID should reconnect without a journal");
+    assert_session_ready(&rejoined.handle, "registry-only UUID recovery").await;
+    let recovered_cells = rejoined.handle.get_cells();
+    assert_eq!(recovered_cells.len(), 3);
+    assert!(recovered_cells
+        .iter()
+        .any(|cell| cell.source == "persisted_value_2 = 2"));
+
+    drop(rejoined);
+    stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
+}
+
+/// A UUID-keyed legacy `.automerge` mirror is not authoritative for a saved
+/// notebook. With a registry row and source file but no recovery journal, UUID
+/// attach must import the current `.ipynb` rather than silently serve the stale
+/// mirror as writable state.
+#[tokio::test]
+async fn test_notebook_sync_uuid_ignores_stale_mirror_without_recovery_journal() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let saved_path = temp_dir.path().join("mirror-source.ipynb");
+    write_test_ipynb(
+        &saved_path,
+        &[("original-file", "code", "original_file = True", vec![])],
+    );
+
+    let daemon = Daemon::new_for_test(config.clone()).unwrap();
+    let mut daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let opened = connect::connect_open(socket_path.clone(), saved_path.clone(), "open")
+        .await
+        .expect("saved notebook should open");
+    let notebook_id = opened.info.notebook_id.clone();
+    assert_session_ready(&opened.handle, "stale mirror setup").await;
+    drop(opened);
+    stop_daemon_for_replacement(&pool_client, &mut daemon_handle).await;
+
+    std::fs::create_dir_all(&config.notebook_docs_dir).unwrap();
+    let persist_path = config
+        .notebook_docs_dir
+        .join(notebook_doc::notebook_doc_filename(&notebook_id));
+    let journal_path = persist_path.with_extension("recovery");
+    if journal_path.exists() {
+        std::fs::remove_file(&journal_path).unwrap();
+    }
+
+    // Fabricate the exact legacy hazard: an id-keyed Automerge mirror whose
+    // content disagrees with the current file, with no causal journal capable
+    // of validating it.
+    let mut stale_doc =
+        notebook_doc::NotebookDoc::new_with_actor(&notebook_id, "stale-mirror-writer");
+    stale_doc.add_cell(0, "stale-mirror", "code").unwrap();
+    stale_doc
+        .update_source("stale-mirror", "stale_mirror = True")
+        .unwrap();
+    std::fs::write(&persist_path, stale_doc.save()).unwrap();
+    assert!(persist_path.is_file());
+    assert!(!journal_path.exists());
+
+    write_test_ipynb(
+        &saved_path,
+        &[("current-file", "code", "current_file = True", vec![])],
+    );
+
+    let restarted =
+        Daemon::new_for_test(replacement_config(config, &temp_dir, "stale-mirror")).unwrap();
+    let mut restarted_handle = tokio::spawn(async move {
+        restarted.run().await.ok();
+    });
+    let restarted_pool = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&restarted_pool).await);
+
+    let rejoined = connect::connect(socket_path, notebook_id, "rejoin")
+        .await
+        .expect("registry-backed UUID should import the current source file");
+    assert_session_ready(&rejoined.handle, "stale mirror UUID recovery").await;
+    let recovered_cells = rejoined.handle.get_cells();
+    assert!(
+        recovered_cells
+            .iter()
+            .any(|cell| cell.source == "current_file = True"),
+        "UUID recovery should materialize the current .ipynb: {recovered_cells:?}"
+    );
+    assert!(
+        recovered_cells
+            .iter()
+            .all(|cell| cell.source != "stale_mirror = True"),
+        "UUID recovery must not silently serve the stale mirror: {recovered_cells:?}"
+    );
+
+    drop(rejoined);
+    stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
+}
+
+/// A durable UUID-to-path binding is not itself recoverable notebook content.
+/// If both the source file and recovery journal are gone after replacement,
+/// UUID attach must return the typed gone refusal without creating a phantom.
+#[tokio::test]
+async fn test_notebook_sync_refuses_stale_registry_path_without_phantom() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let notebook_path = temp_dir.path().join("removed-after-open.ipynb");
+    write_test_ipynb(
+        &notebook_path,
+        &[("saved-cell", "code", "still_here = True", vec![])],
+    );
+
+    let daemon = Daemon::new_for_test(config.clone()).unwrap();
+    let mut daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let opened = connect::connect_open(socket_path.clone(), notebook_path.clone(), "open")
+        .await
+        .expect("saved notebook should open");
+    let notebook_id = opened.info.notebook_id.clone();
+    assert_session_ready(&opened.handle, "initial stale-registry setup").await;
+    drop(opened);
+    stop_daemon_for_replacement(&pool_client, &mut daemon_handle).await;
+
+    std::fs::remove_file(&notebook_path).unwrap();
+    std::fs::create_dir_all(&config.notebook_docs_dir).unwrap();
+    let persist_path = config
+        .notebook_docs_dir
+        .join(notebook_doc::notebook_doc_filename(&notebook_id));
+    let journal_path = persist_path.with_extension("recovery");
+    if journal_path.exists() {
+        std::fs::remove_file(journal_path).unwrap();
+    }
+    let mut stale_doc =
+        notebook_doc::NotebookDoc::new_with_actor(&notebook_id, "stale-registry-mirror");
+    stale_doc.add_cell(0, "stale-cell", "code").unwrap();
+    stale_doc
+        .update_source("stale-cell", "must_not_be_served = True")
+        .unwrap();
+    std::fs::write(&persist_path, stale_doc.save()).unwrap();
+    assert!(persist_path.is_file());
+
+    let restarted =
+        Daemon::new_for_test(replacement_config(config, &temp_dir, "stale-registry")).unwrap();
+    let mut restarted_handle = tokio::spawn(async move {
+        restarted.run().await.ok();
+    });
+    let restarted_pool = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&restarted_pool).await);
+
+    match connect::connect(socket_path, notebook_id.clone(), "rejoin").await {
+        Err(notebook_sync::SyncError::NotebookUnavailable(ref message))
+            if message.contains("no longer available") => {}
+        Err(other) => panic!("stale registry UUID returned an unexpected error: {other:?}"),
+        Ok(_) => panic!("stale registry UUID should be refused, but it created a room"),
+    }
+    let rooms = restarted_pool.list_rooms().await.unwrap();
+    assert!(
+        !rooms.iter().any(|room| room.notebook_id == notebook_id),
+        "stale registry refusal must not create a phantom room: {rooms:?}"
+    );
+
+    stop_daemon_for_replacement(&restarted_pool, &mut restarted_handle).await;
+}
+
+/// UUID attach must derive the same read-only capability as OpenNotebook.
+/// Otherwise reconnecting a read-only file by its stable id silently upgrades
+/// the peer from Viewer to Owner.
+#[tokio::test]
+async fn test_notebook_sync_uuid_attach_preserves_read_only_scope() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let notebook_path = temp_dir.path().join("read-only-reattach.ipynb");
+    write_test_ipynb(
+        &notebook_path,
+        &[("saved-cell", "code", "read_only = True", vec![])],
+    );
+
+    let daemon = Daemon::new_for_test(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let opened = connect::connect_open(socket_path.clone(), notebook_path.clone(), "open")
+        .await
+        .expect("saved notebook should open");
+    let notebook_id = opened.info.notebook_id.clone();
+    assert_session_ready(&opened.handle, "read-only UUID setup").await;
+
+    let original_permissions = std::fs::metadata(&notebook_path).unwrap().permissions();
+    let mut permissions = original_permissions.clone();
+    permissions.set_readonly(true);
+    std::fs::set_permissions(&notebook_path, permissions).unwrap();
+
+    let attached = connect::connect(socket_path, notebook_id, "reattach")
+        .await
+        .expect("read-only notebook should remain readable by UUID");
+    let response = attached
+        .handle
+        .send_request(NotebookRequest::SaveNotebook {
+            format_cells: false,
+            path: None,
+        })
+        .await
+        .expect("viewer refusal should be a correlated response");
+    assert!(
+        matches!(
+            response,
+            NotebookResponse::Error { ref error }
+                if error.contains("not allowed for viewer connections")
+        ),
+        "UUID attach should retain Viewer scope, got {response:?}"
+    );
+
+    std::fs::set_permissions(&notebook_path, original_permissions).unwrap();
+
+    drop(attached);
+    drop(opened);
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -236,7 +236,7 @@ fails the connection directly.
 3. Watch loop compares the live version with its startup baseline and exits with `EX_TEMPFAIL` (75).
 4. Proxy's child monitor sees the transport close, calls `restart_child()`. Re-resolves the child binary (picks up new symlink target after upgrade), seeds `NTERACT_MCP_REJOIN_NOTEBOOK = <last_notebook_id>`, spawns the new child.
 5. New child's watch loop sees the handoff target. On the first live daemon observation it reconciles the empty slot, runs recovery against that daemon incarnation, and installs a freshly stamped `NotebookSession` if no tool activation won meanwhile.
-6. Supervisor detects the daemon-version change across the child boundary (compares `ServerInfo.title` of old vs new child) and stamps a reconnection banner. The actual string is `Daemon upgraded (2.1.2 -> 2.1.3), session reconnected` (`crates/runt-mcp-proxy/src/version.rs:35`), and it fires whenever `rejoin_target.is_some()`, before the rejoin's success is known.
+6. Supervisor detects the daemon-version change across the child boundary (compares `ServerInfo.title` of old vs new child) and stamps a reconnection banner. The banner says `Daemon upgraded (2.1.2 -> 2.1.3), session reconnect requested` when a handoff target was supplied; it intentionally reports the request rather than claiming the asynchronous rejoin already succeeded.
 7. The agent's next tool result has the banner prepended. The agent sees one message; underneath, the child has been completely replaced.
 
 ### Last peer leaves, comes back during teardown

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -1,6 +1,6 @@
 # MCP Session Lifecycle and Daemon Supervision
 
-**Status:** Accepted, 2026-07-13; supersedes Draft from 2026-05-23.
+**Status:** Accepted, 2026-07-13; amended 2026-08-20; supersedes Draft from 2026-05-23.
 
 **Neighbors:**
 - `docs/adr/room-source-lifecycle-and-file-recovery.md` - the room-owned source states, recovery journal, and progressive capability gates observed by MCP sessions.
@@ -79,99 +79,37 @@ For the stable / nightly desktop apps (the non-dev path), there is no `NTERACT_D
 
 This is a structural choice, not an oversight: the daemon doesn't know who its clients are beyond a peer label, so it cannot push "owner exited" anywhere. If we want explicit owner handoff (e.g., owner relinquishes ownership cleanly without killing the daemon), that's a feature on the daemon, not the proxy.
 
-## Decision 3: `Arc<RwLock<Option<NotebookSession>>>` is the only session truth
+## Decision 3: The active slot plus daemon incarnation are session truth
 
-The child holds exactly one place that says "the current session is X":
+The child holds one active slot:
 
 ```rust
 session: Arc<RwLock<Option<NotebookSession>>>
 ```
 
-`Option` is the load-bearing part. Three things set it to `None`:
+A local session also carries `local_daemon_incarnation: Option<DaemonIncarnation>`, where the incarnation is `pid + started_at`. The slot answers which notebook is selected; the incarnation answers whether its local `DocHandle` belongs to the daemon that is live now. A hosted session deliberately has no local incarnation.
 
-1. **Daemon disconnect.** The watch loop's `MarkDisconnected` branch clears the session immediately so tool calls don't hang on a dead `DocHandle`. The previous notebook target is stashed in `disconnect_target` for automatic rejoin on the next `Connected`.
-2. **Room eviction.** When `rejoin()` runs and `list_rooms` does not contain the target notebook UUID, the session is cleared and `SessionDropReason::Evicted` is recorded. No phantom empty room is created.
-3. **Rejoin failure after `REJOIN_MAX_RETRIES`.** The session is cleared and `SessionDropReason::Disconnected` is recorded with the original notebook id and path so the next tool call gets a meaningful error.
+A local connect samples daemon identity before and after connection/readiness. Equal samples bind the session. A missing or changed sample leaves it unbound and it is not published as an active tool session. The watch loop removes any active or parked local session whose binding does not equal the live incarnation. Hosted sessions survive local-daemon reconciliation.
 
-Three things set it to `Some(_)`:
+Tool handlers still clone the `DocHandle` under a read lock and release the lock before async work. The parked map remains a bounded cache, but parked local entries obey the same incarnation rule as the active slot.
 
-1. **A tool call** (`connect_notebook`, `create_notebook`, or the legacy `open_notebook` alias). Always wins. The user (or agent) explicitly chose this notebook.
-2. **The watch loop's `rejoin()`** after a `Disconnected`, an `Upgraded`, or the initial proxy handoff. Conditional on the session-write guard (Decision 4).
-3. **Resume from `parked_sessions`** when a tool call targets a notebook whose session was parked during a previous switch.
+## Decision 4: Tool intent and guarded publication are the convergence point
 
-**Why one optional slot and not a registry of sessions.** Because the MCP protocol itself is single-client-per-connection. The MCP client is the agent (a single conversation), and that agent has one current notebook by convention. Multi-notebook would mean every tool call carries a `notebook_id` arg; today most don't. The `parked_sessions` map is a compromise: it lets `connect_notebook` switch back and forth between a small set of notebooks without re-doing the initial sync, but it does not let *concurrent* tool calls land on different notebooks. The "current" notebook is still one slot.
+Recovery connects outside the session lock. It captures the explicit `session_intent_epoch` and expected daemon incarnation, verifies both after the async connect/readiness window, then takes the active-slot write lock. Publication occurs only if the epoch is unchanged and the slot is empty. A user tool that installs any session during recovery therefore wins, including a session for the same notebook.
 
-**Why `RwLock` and not `Mutex`.** Tool handlers clone the `DocHandle` under a read lock and drop the lock before doing any async work. Holding a write lock during async work would block every other tool call and the watch loop. `DocHandle` is cheap to clone (it's an `Arc<Mutex<SharedDocState>>` internally); the read lock is held only long enough to clone.
+A completed recovery connection may be dropped after doing useful work. Dropping its handle cleanly releases the extra peer; it is preferable to overwriting the user's selected session.
 
-This convention is enforced by the `require_handle!` macro:
+## Decision 5: Live daemon incarnation drives reconciliation
 
-```rust
-let handle = {
-    let guard = session.read().await;
-    match guard.as_ref() {
-        Some(s) => s.handle.clone(),
-        None => return no_session_error(...).await,
-    }
-};
-// guard dropped; handle owned
-handle.with_doc(|doc| { ... });
-```
+The watch loop does not infer connection state from a boolean latch. For every `DaemonEvent`, and obligatorily after `RecvError::Lagged`, it re-reads `DaemonConnection::info()`. That current info is the sole authority for local-session ownership.
 
-Tool code that doesn't use the macro and holds the lock through an `.await` is the most likely way to wedge the child. The `tokio-mutex-guard-stays-sync` rule in `AGENTS.md` / `CLAUDE.md` applies here too.
+Reconciliation removes active and parked local handles whose incarnation is missing or unequal. Removing the active handle records its best recovery target, preferring a file path and never replacing a saved path with a later UUID-only observation. With a live incarnation and an empty active slot, recovery uses the proxy handoff target first, then the preserved target.
 
-## Decision 4: The session-write guard is the convergence point
+The daemon version observed when the child starts is the version baseline. Every live event and every current `info()` result is compared with it; a mismatch exits with 75. If startup had no live daemon, the first live version establishes the baseline.
 
-The longest async window in the child is `rejoin()`. It connects to the daemon socket, sends the initial sync handshake, awaits session-ready (up to 120 s), and only then installs the new session. During that window, a tool call can land and call `connect_notebook` on a different notebook. The guard:
+## Decision 6: A same-incarnation heartbeat is structurally a no-op
 
-```rust
-{
-    let guard = session.read().await;
-    if let Some(existing) = guard.as_ref() {
-        if existing.notebook_id != new_notebook_id {
-            info!("Rejoin superseded by active session; dropping");
-            return true;
-        }
-    }
-}
-*session.write().await = Some(new_session);
-```
-
-**Invariant: user-initiated session changes always win over background rejoin.** The guard runs immediately before the write. Anything else (the proxy's seeded target, the disconnect target, the previous session's notebook id) is advisory.
-
-The guard does *not* hold the write lock across the entire rejoin. That would defeat the read-clone-drop pattern from Decision 3 and serialize every tool call behind a 120-second async window on the daemon socket.
-
-The cost: rejoin can do all the work (connect, initial sync, peer announce) and then drop the result on the floor. That's fine. The peer connection drops cleanly when the `handle` goes out of scope, the daemon decrements its peer count, and the user's chosen session is left alone. We've paid one network round trip and one initial sync we then discard. Acceptable for what would otherwise be a class of bugs where the wrong notebook silently becomes the active session.
-
-## Decision 5: `classify()` is the pure decision function; the loop is plumbing
-
-`daemon_watch::classify()` is a pure function over `(event, initial_target, has_session, was_disconnected, disconnect_target)`. It returns one of:
-
-| Decision | Trigger |
-|----------|---------|
-| `Exit(75)` | `Upgraded` with version change. Proxy will respawn with new binary. |
-| `RejoinInitial(target)` | `Connected`/`Upgraded` with `initial_target` set (proxy handoff), OR `Connected`/`Upgraded` with `disconnect_target` set (session was cleared on disconnect). |
-| `RejoinContinuation` | `Connected` after `Disconnected` with session still live, OR `Upgraded` (same version) with session still live. |
-| `MarkDisconnected` | `Disconnected` event. |
-| `NoOp` | Everything else, notably `Connected` heartbeats. |
-
-The function is pure so the watch loop's interleavings are testable in isolation: the heartbeat-not-rejoin invariant (Decision 6), the proxy-handoff-clears-after-success rule, the disconnect-target priority, all live in the table.
-
-**The watch loop does the side effects.** It clears `initial_target` only after `rejoin()` returns `true` (success, including "session cleared because room was evicted"). It bumps `was_disconnected` to true on lag (`broadcast::error::RecvError::Lagged`) because a dropped batch may have contained the `Disconnected`. It stamps `last_session_drop` and clears `parked_sessions` when the daemon goes away (their `DocHandle`s are dead too).
-
-The classify/act split is the same pattern as our other state machines (cell execution, room teardown), and it's there for the same reason: every interleaving is a unit test, none of the side effects need an async runtime.
-
-## Decision 6: Daemon `Connected` is a heartbeat, not a reconnect signal
-
-`DaemonConnection` (in `runtimed-client`) emits `Connected` every ~10 s as a liveness ping. Without gating, every heartbeat would trigger a `rejoin()`, which would:
-
-1. Open a fresh peer connection to the daemon.
-2. Bump the room's `active_peers` from 1 to 2.
-3. Drop the old peer connection.
-4. Decrement `active_peers` from 2 to 1.
-
-That sequence resets the room's eviction timer (the daemon zeroes `last_kernel_torn_down_at` on any peer count increase). With heartbeats every 10 s, an idle agent connection keeps a room alive forever. The fix (#2088) is the `was_disconnected` flag: a `Connected` only triggers a continuation rejoin if we previously saw a `Disconnected`.
-
-This is structurally a workaround for `DaemonConnection`'s API conflating "I'm still here" with "I just came back." A cleaner shape would be a separate `Heartbeat` event variant, but the cost of the workaround is one boolean and a regression test.
+`Connected` may be emitted as a routine liveness refresh. When its live incarnation equals the active and parked local bindings, reconciliation changes nothing and has no recovery target to act on. No separate `was_disconnected` gate is required. A same-version daemon restart has a different `pid + started_at`, so the same reconciliation removes the old handles and recovers them against the new incarnation.
 
 ## Decision 7: Room is the durable entity; sessions and kernels are not
 
@@ -295,9 +233,9 @@ fails the connection directly.
 
 1. User upgrades the nteract desktop app. The installed daemon restarts; the new binary has version 2.1.3 (old was 2.1.2).
 2. Child's `DaemonConnection` detects the daemon version change and emits `DaemonEvent::Upgraded { previous: 2.1.2, current: 2.1.3 }`.
-3. Watch loop classifies as `Exit(75)`. Process exits with `EX_TEMPFAIL`.
+3. Watch loop compares the live version with its startup baseline and exits with `EX_TEMPFAIL` (75).
 4. Proxy's child monitor sees the transport close, calls `restart_child()`. Re-resolves the child binary (picks up new symlink target after upgrade), seeds `NTERACT_MCP_REJOIN_NOTEBOOK = <last_notebook_id>`, spawns the new child.
-5. New child's watch loop sees `initial_target = Some(<id>)`. On first `Connected`, classifies as `RejoinInitial`, runs `rejoin()`, installs new `NotebookSession`. Same `notebook_id`, fresh `DocHandle`.
+5. New child's watch loop sees the handoff target. On the first live daemon observation it reconciles the empty slot, runs recovery against that daemon incarnation, and installs a freshly stamped `NotebookSession` if no tool activation won meanwhile.
 6. Supervisor detects the daemon-version change across the child boundary (compares `ServerInfo.title` of old vs new child) and stamps a reconnection banner. The actual string is `Daemon upgraded (2.1.2 -> 2.1.3), session reconnected` (`crates/runt-mcp-proxy/src/version.rs:35`), and it fires whenever `rejoin_target.is_some()`, before the rejoin's success is known.
 7. The agent's next tool result has the banner prepended. The agent sees one message; underneath, the child has been completely replaced.
 
@@ -311,17 +249,11 @@ fails the connection directly.
 
 ### Daemon goes away mid-execution
 
-1. Agent calls `execute_cell`. Tool dispatch clones the handle, sends the
-   request, then polls `RuntimeStateDoc` until the execution reaches a terminal
-   state, with the execution pipeline's output-sync grace applied before
-   returning outputs.
-2. Daemon process is killed (SIGKILL from `runt daemon stop`, or a crash). Watch loop receives `DaemonEvent::Disconnected`, classifies as `MarkDisconnected`. Stashes `disconnect_target = "/tmp/foo.ipynb"`, sets `session = None`, sets `last_session_drop = Disconnected`. Also drains `parked_sessions` (their handles are dead).
-3. In-flight `execute_cell` tool call's `DocHandle` is now connected to a
-   closed socket. Whatever it was awaiting (RPC response or RuntimeStateDoc
-   convergence) errors out. Tool returns failure to the agent.
-4. Daemon comes back (launchd respawn, or user restart). Child's `DaemonConnection` reconnects; emits `Connected`.
-5. Watch loop classifies as `RejoinInitial("/tmp/foo.ipynb")` because `disconnect_target` is set and `was_disconnected = true`. Runs `rejoin()` via `connect_open`, installs new session.
-6. Next tool call from the agent lands on a fresh `DocHandle` for the same notebook. Cells the agent had already authored before the disconnect are restored from the matching recovery journal and `.ipynb` checkpoint; cells authored during the disconnect window (there are none, because the agent's tool call failed) are not lost.
+1. The tool call owns a cloned local handle stamped with daemon incarnation A.
+2. When the daemon disappears, the watch loop re-reads no live daemon info. Reconciliation removes active and parked local handles, preserves the active session's path when available, and records `SessionDropReason::Disconnected`. Hosted handles remain installed.
+3. The in-flight tool's cloned handle observes the closed socket and returns failure; no session lock is held across that await.
+4. When daemon incarnation B becomes live, reconciliation still cannot retain any handle from A. With an empty active slot it reconnects using the preserved path (or UUID for recoverable untitled notebooks).
+5. Recovery verifies incarnation B again after readiness, then publishes only if explicit tool intent has not advanced and the slot is still empty. A tool-installed session for B wins the race and is retained.
 
 ### Two MCP clients, attach mode
 
@@ -330,6 +262,43 @@ fails the connection directly.
 3. Both children have their own `NotebookSession` slots. Both can call `connect_notebook` on the same notebook; each becomes a separate peer on the room, with `active_peers` going from 1 to 2.
 4. One agent calls `execute_cell`; the other agent sees the cell-state changes via Automerge sync. There is no per-client routing, no per-client identity, no per-client scope (Decision 5 in `identity-and-trust.md` will eventually change this).
 5. If Claude Code exits, its child closes the socket, daemon decrements `active_peers` to 1. The daemon does *not* tear down because Codex is still connected. The daemon is now orphan-owned (Claude Code started it, Codex is using it). If Codex also exits, `active_peers` goes to 0 and the kernel-teardown timer starts.
+
+## 2026-08-20 implementation note
+
+Decisions 3 through 6 use daemon incarnation rather than disconnect latches as
+the authority for whether a local `DocHandle` is usable.
+
+Every local `NotebookSession` is stamped with a `DaemonIncarnation` consisting
+of the daemon PID and `started_at`. The connect path samples daemon identity
+before and after establishing the peer. Only an unchanged pair binds the
+session; a missing or changed sample produces an unbound local session, which
+is stale by definition. Hosted sessions have no local incarnation.
+
+On every daemon event, and after a lagged broadcast receiver, the watch loop
+reads `DaemonConnection::info()` and reconciles the active slot and parked map
+under their locks. A local session survives exactly when its incarnation equals
+the live incarnation. Hosted sessions always survive local-daemon events. Thus
+a same-incarnation `Connected` heartbeat makes no state change, while a
+same-version restart with a new incarnation removes old handles without a
+separate disconnect latch. Parked local handles follow the same rule.
+
+When reconciliation removes the active local session it preserves the path,
+when known, as the recovery target; a later UUID-only observation cannot
+replace that path. Recovery connects outside the session lock, samples the
+expected incarnation again after readiness, and publishes only if the explicit
+`session_intent_epoch` is unchanged and no tool-installed session occupies the
+slot. Explicit tool activation therefore remains authoritative.
+
+The child records the daemon version observed at startup. Every live event and
+every post-lag `info()` sample is compared with that baseline. A mismatch exits
+with `EX_TEMPFAIL` (75), even if the event stream dropped the original upgrade
+event. If no daemon was reachable at startup, the first live version becomes
+the baseline.
+
+Repeated `connect_notebook` calls may reuse the active same-target replica only
+when its peer is connected, its document or retained projection is readable,
+and (for local sessions) its incarnation equals the current daemon. Reuse of a
+stale but locally readable replica is forbidden.
 
 ## Open Questions
 
@@ -341,7 +310,10 @@ These are the architectural gaps surfaced while writing this ADR. None block the
 
 3. **Daemon ownership across attach/owner boundaries.** Attach-mode children do not know who owns the daemon. If the owner exits cleanly, the daemon may or may not exit too depending on whether anyone else is connected. There is no protocol-level "I am the owner, I am exiting now" signal. Today this is fine because the user is responsible for noticing. As we ship more agents that auto-spawn MCP clients, the implicit "first wins, others attach" rule will get racy.
 
-4. **`disconnect_target` precision after a real `Disconnected`.** When the daemon disappears, the child stashes the *last known* notebook target. But the daemon could have been gone for hours; the room may have been reaped during that window. The current `rejoin()` does the right thing for ephemeral notebooks when daemon attach refuses the room and clears the session with `Evicted`, but the agent gets a confusing trail: first `Disconnected`, then `Evicted` on the next tool call.
+4. **Recovery-target precision after a daemon replacement.** The child retains
+   the removed session's best target, preferring a path over a UUID. The daemon
+   can still refuse an ephemeral UUID that is no longer recoverable, producing
+   a `Disconnected` then `Evicted` trail for the agent.
 
 5. **`parked_sessions` lifetime.** Capped at `MAX_PARKED_SESSIONS` with arbitrary HashMap-iteration eviction. Every parked session holds a live peer connection to the daemon, which means the daemon's `active_peers` for those rooms stays at 1 even when the agent is not actively using them. That keeps the kernel alive (good if the agent comes back), but it also disables the eviction timer for any notebook the agent has touched in the recent past. Open question: is the kernel-keep-alive the intended cost, or do we want parked sessions to drop the peer connection and rebuild on resume?
 
@@ -357,7 +329,7 @@ These are the architectural gaps surfaced while writing this ADR. None block the
 
 ## References
 
-- `crates/runt-mcp/src/daemon_watch.rs` - `classify`, `watch`, `rejoin`, all the watch-loop tests.
+- `crates/runt-mcp/src/daemon_watch.rs` - incarnation reconciliation, `watch`, `rejoin`, and transition-sequence tests.
 - `crates/runt-mcp/src/session.rs` - `NotebookSession`, `SessionDropReason`, `SessionDropInfo`.
 - `crates/runt-mcp/src/lib.rs` - `NteractMcp` server, `require_handle!` macro, tool dispatch.
 - `crates/runt-mcp/src/tools/session.rs` - `connect_notebook`, `create_notebook`, parking, `disconnect_previous_session`.


### PR DESCRIPTION
## Summary

- Recover a saved notebook by its persistent UUID-to-path binding after the daemon process is replaced, while refusing stale identities that have no notebook file or recovery journal.
- Hand the proxy a durable path after `save_notebook`, preserve hosted targets, and distinguish intentional exit-75 upgrade handoffs from crashes.
- Bind local MCP sessions to the exact daemon incarnation (`pid` + `started_at`) so stale active and parked handles are reconciled without disconnect latches; lagged daemon events re-read live info before acting.

This replaces the narrower approach in #4167. It is motivated by a stable-channel report where a previously saved notebook lost its active MCP session across a 2.7.0 to 2.7.1 daemon upgrade and recovered after restarting the daemon.

## Test plan

- `cargo test -p runt-mcp-proxy` — 113 passed
- `cargo test -p runt-mcp` — 211 passed, including async race harnesses and a transition-sequence proptest
- `cargo test -p runt` — 30 passed
- Focused runtimed restart/recovery integrations — 6 passed
- `cargo test -p runtimed --test tokio_mutex_lint` — 2 passed
- `cargo xtask lint --fix`
- `cargo xtask clippy`

A broader `cargo test -p runtimed --lib` run reached 1263 passed and 2 ignored, with one unrelated environment-sensitive failure: `shell_env_overlay::tests::capture_returns_at_least_path` received no entries from the spawned shell startup environment.

## Independent review

- Fable reviewed the architecture and live/cached daemon authority boundaries. Its findings around transient identity queries, exit-75 flapping, journal-only recovery, and ADR accuracy are resolved.
- Opus performed the bounded confirmation pass. Its findings around explicit disconnect handoff state, missing saved paths, watcher exit classification, same-room parking, hosted parked-peer races, shared identity sampling, and created-notebook recovery details are resolved.
- No further model-review loop is planned; CI and human review are the remaining gates.

This is ready for human review and CI.
