### PR TITLE
fix(notebook): render ANSI in notices

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "runtimed": "workspace:*",
+    "strip-ansi": "^7.2.0",
     "tailwind-merge": "^3.4.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       runtimed:
         specifier: workspace:*
         version: link:packages/runtimed
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, Check, Copy, RotateCw, WifiOff } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import {
   NotebookNotice,
@@ -91,15 +91,16 @@ export function KernelLaunchErrorBanner({
   onDismiss,
 }: KernelLaunchErrorBannerProps) {
   const [copied, setCopied] = useState(false);
+  const plainErrorDetails = useMemo(() => ansiToPlainText(errorDetails), [errorDetails]);
 
   useEffect(() => {
     setCopied(false);
   }, [errorDetails]);
 
   const copyDetails = useCallback(async () => {
-    await navigator.clipboard.writeText(ansiToPlainText(errorDetails));
+    await navigator.clipboard.writeText(plainErrorDetails);
     setCopied(true);
-  }, [errorDetails]);
+  }, [plainErrorDetails]);
 
   return (
     <NotebookNotice
@@ -112,13 +113,15 @@ export function KernelLaunchErrorBanner({
       }
       actions={
         <>
-          <NotebookNoticeAction
-            onClick={copyDetails}
-            icon={copied ? <Check /> : <Copy />}
-            data-testid="copy-kernel-launch-error"
-          >
-            {copied ? "Copied" : "Copy"}
-          </NotebookNoticeAction>
+          {plainErrorDetails.trim() ? (
+            <NotebookNoticeAction
+              onClick={copyDetails}
+              icon={copied ? <Check /> : <Copy />}
+              data-testid="copy-kernel-launch-error"
+            >
+              {copied ? "Copied" : "Copy"}
+            </NotebookNoticeAction>
+          ) : null}
           <NotebookNoticeAction onClick={onRetry} icon={<RotateCw />}>
             Retry
           </NotebookNoticeAction>

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -92,6 +92,7 @@ export function KernelLaunchErrorBanner({
 }: KernelLaunchErrorBannerProps) {
   const [copied, setCopied] = useState(false);
   const plainErrorDetails = useMemo(() => ansiToPlainText(errorDetails), [errorDetails]);
+  const hasDiagnosticDetails = plainErrorDetails.trim().length > 0;
 
   useEffect(() => {
     setCopied(false);
@@ -109,11 +110,13 @@ export function KernelLaunchErrorBanner({
       title="Kernel failed to start"
       onDismiss={onDismiss}
       details={
-        <NotebookNoticeDetails label="Show error details">{errorDetails}</NotebookNoticeDetails>
+        hasDiagnosticDetails ? (
+          <NotebookNoticeDetails label="Show error details">{errorDetails}</NotebookNoticeDetails>
+        ) : null
       }
       actions={
         <>
-          {plainErrorDetails.trim() ? (
+          {hasDiagnosticDetails ? (
             <NotebookNoticeAction
               onClick={copyDetails}
               icon={copied ? <Check /> : <Copy />}
@@ -127,7 +130,9 @@ export function KernelLaunchErrorBanner({
           </NotebookNoticeAction>
         </>
       }
-    />
+    >
+      {hasDiagnosticDetails ? null : "No diagnostic output was captured."}
+    </NotebookNotice>
   );
 }
 

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -6,6 +6,7 @@ import {
   NotebookNoticeAction,
   NotebookNoticeDetails,
 } from "@/components/notebook/NotebookNotice";
+import { ansiToPlainText } from "@/components/outputs/ansi-output";
 
 const RUNTIME_PEER_DISCONNECTED_ERROR_PREFIX = "runtime peer disconnected:";
 
@@ -96,7 +97,7 @@ export function KernelLaunchErrorBanner({
   }, [errorDetails]);
 
   const copyDetails = useCallback(async () => {
-    await navigator.clipboard.writeText(errorDetails);
+    await navigator.clipboard.writeText(ansiToPlainText(errorDetails));
     setCopied(true);
   }, [errorDetails]);
 

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Bug, CheckCircle2, ChevronRight, Info, XCircle, X } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { AnsiText } from "@/components/outputs/ansi-output";
 import { cn } from "@/lib/utils";
 
 export type NotebookNoticeTone = "info" | "warning" | "error" | "success" | "debug";
@@ -193,7 +194,7 @@ export function NotebookNoticeDetails({
         {label}
       </summary>
       <pre className="mt-1.5 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded bg-current/5 px-2 py-1.5 font-mono text-[11px] leading-snug">
-        {children}
+        <AnsiText>{children}</AnsiText>
       </pre>
     </details>
   );

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -194,7 +194,7 @@ export function NotebookNoticeDetails({
         {label}
       </summary>
       <pre className="mt-1.5 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded bg-current/5 px-2 py-1.5 font-mono text-[11px] leading-snug">
-        <AnsiText>{children}</AnsiText>
+        <AnsiText fallback="No further details reported.">{children}</AnsiText>
       </pre>
     </details>
   );

--- a/src/components/notebook/PoolErrorBanner.tsx
+++ b/src/components/notebook/PoolErrorBanner.tsx
@@ -50,7 +50,7 @@ function PoolErrorItem({ envType, error, onDismiss, onOpenSettings }: PoolErrorI
     <NotebookNotice
       tone="warning"
       icon={isTimeout ? <Clock /> : <AlertTriangle />}
-      title={<AnsiText>{error.message}</AnsiText>}
+      title={<AnsiText fallback={`${envType} environment warmup failed`}>{error.message}</AnsiText>}
       onDismiss={onDismiss}
       actions={
         showSettingsButton(error) && onOpenSettings ? (

--- a/src/components/notebook/PoolErrorBanner.tsx
+++ b/src/components/notebook/PoolErrorBanner.tsx
@@ -4,6 +4,7 @@ import {
   NotebookNoticeAction,
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
+import { AnsiText } from "@/components/outputs/ansi-output";
 
 export interface PoolErrorDetails {
   message: string;
@@ -49,7 +50,7 @@ function PoolErrorItem({ envType, error, onDismiss, onOpenSettings }: PoolErrorI
     <NotebookNotice
       tone="warning"
       icon={isTimeout ? <Clock /> : <AlertTriangle />}
-      title={error.message}
+      title={<AnsiText>{error.message}</AnsiText>}
       onDismiss={onDismiss}
       actions={
         showSettingsButton(error) && onOpenSettings ? (

--- a/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
@@ -97,6 +97,8 @@ describe("KernelLaunchErrorBanner", () => {
     );
 
     expect(screen.queryByTestId("copy-kernel-launch-error")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show error details")).not.toBeInTheDocument();
+    expect(screen.getByText("No diagnostic output was captured.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 

--- a/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
@@ -68,6 +68,7 @@ describe("KernelLaunchErrorBanner", () => {
   it("copies the launch details", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
+    const ansiDetails = `\x1b[31m${STDERR_TAIL}\x1b[0m\nSee \x1b]8;;https://example.com\x07documentation\x1b]8;;\x07`;
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText },
       configurable: true,
@@ -75,14 +76,14 @@ describe("KernelLaunchErrorBanner", () => {
 
     render(
       <KernelLaunchErrorBanner
-        errorDetails={STDERR_TAIL}
+        errorDetails={ansiDetails}
         onRetry={() => {}}
         onDismiss={() => {}}
       />,
     );
 
     await user.click(screen.getByTestId("copy-kernel-launch-error"));
-    expect(writeText).toHaveBeenCalledWith(STDERR_TAIL);
+    expect(writeText).toHaveBeenCalledWith(`${STDERR_TAIL}\nSee documentation`);
     expect(screen.getByText("Copied")).toBeInTheDocument();
   });
 

--- a/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/KernelLaunchErrorBanner.test.tsx
@@ -87,6 +87,19 @@ describe("KernelLaunchErrorBanner", () => {
     expect(screen.getByText("Copied")).toBeInTheDocument();
   });
 
+  it("hides Copy when ANSI controls contain no diagnostic text", () => {
+    render(
+      <KernelLaunchErrorBanner
+        errorDetails={"\x1b[2K\x1b[1G"}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("copy-kernel-launch-error")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
   it("invokes onDismiss when the X is clicked", async () => {
     const user = userEvent.setup();
     const onDismiss = vi.fn();

--- a/src/components/notebook/__tests__/NotebookNotice.test.tsx
+++ b/src/components/notebook/__tests__/NotebookNotice.test.tsx
@@ -78,4 +78,15 @@ describe("NotebookNotice", () => {
     expect(details?.textContent).not.toContain("\x1b");
     expect(details?.querySelector(".ansi-red-fg")).toHaveTextContent("failed");
   });
+
+  it("provides a fallback when details contain only ANSI controls", () => {
+    render(
+      <NotebookNotice
+        title="Runtime unavailable"
+        details={<NotebookNoticeDetails>{"\x1b[2K\x1b[1G"}</NotebookNoticeDetails>}
+      />,
+    );
+
+    expect(screen.getByText("No further details reported.")).toBeInTheDocument();
+  });
 });

--- a/src/components/notebook/__tests__/NotebookNotice.test.tsx
+++ b/src/components/notebook/__tests__/NotebookNotice.test.tsx
@@ -2,7 +2,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AlertTriangle } from "lucide-react";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { NotebookNotice, NotebookNoticeAction, NotebookNoticeStack } from "../NotebookNotice";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeDetails,
+  NotebookNoticeStack,
+} from "../NotebookNotice";
 
 describe("NotebookNotice", () => {
   it("renders shared title, body, details, tone, and icon slots", () => {
@@ -58,5 +63,19 @@ describe("NotebookNotice", () => {
     expect(stack).toContainElement(
       screen.getByText("Auth needs attention").closest("[data-slot='notebook-notice']"),
     );
+  });
+
+  it("renders ANSI details without literal escape bytes", () => {
+    const { container } = render(
+      <NotebookNotice
+        title="Runtime unavailable"
+        details={<NotebookNoticeDetails>{"stderr: \x1b[31mfailed\x1b[0m"}</NotebookNoticeDetails>}
+      />,
+    );
+
+    const details = container.querySelector("pre");
+    expect(details?.textContent).toBe("stderr: failed");
+    expect(details?.textContent).not.toContain("\x1b");
+    expect(details?.querySelector(".ansi-red-fg")).toHaveTextContent("failed");
   });
 });

--- a/src/components/notebook/__tests__/PoolErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/PoolErrorBanner.test.tsx
@@ -95,4 +95,25 @@ describe("PoolErrorBanner", () => {
     expect(title?.textContent).not.toContain("\x1b");
     expect(styledTitle).toHaveClass("ansi-yellow-fg");
   });
+
+  it("provides a title when a pool error contains only ANSI controls", () => {
+    render(
+      <PoolErrorBanner
+        uvError={{
+          message: "\x1b[2K\x1b[1G",
+          error_kind: "setup_failed",
+          consecutive_failures: 1,
+          retry_in_secs: 60,
+          receivedAt: Date.now(),
+        }}
+        condaError={null}
+        pixiError={null}
+        onDismissUv={() => {}}
+        onDismissConda={() => {}}
+        onDismissPixi={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("UV environment warmup failed")).toBeInTheDocument();
+  });
 });

--- a/src/components/notebook/__tests__/PoolErrorBanner.test.tsx
+++ b/src/components/notebook/__tests__/PoolErrorBanner.test.tsx
@@ -70,4 +70,29 @@ describe("PoolErrorBanner", () => {
 
     expect(screen.queryByText("Settings")).not.toBeInTheDocument();
   });
+
+  it("renders ANSI in pool error titles without literal escape bytes", () => {
+    render(
+      <PoolErrorBanner
+        uvError={null}
+        condaError={{
+          message: "Environment warmup \x1b[33mtimed out\x1b[0m",
+          error_kind: "timeout",
+          consecutive_failures: 1,
+          retry_in_secs: 60,
+          receivedAt: Date.now(),
+        }}
+        pixiError={null}
+        onDismissUv={() => {}}
+        onDismissConda={() => {}}
+        onDismissPixi={() => {}}
+      />,
+    );
+
+    const styledTitle = screen.getByText("timed out");
+    const title = styledTitle.parentElement;
+    expect(title?.textContent).toBe("Environment warmup timed out");
+    expect(title?.textContent).not.toContain("\x1b");
+    expect(styledTitle).toHaveClass("ansi-yellow-fg");
+  });
 });

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -7,7 +7,7 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
-import { AnsiErrorOutput, AnsiOutput, AnsiStreamOutput } from "../ansi-output";
+import { AnsiErrorOutput, AnsiOutput, AnsiStreamOutput, AnsiText } from "../ansi-output";
 
 // Helper to get styles from rendered spans
 function getSpanStyles(container: HTMLElement) {
@@ -18,6 +18,27 @@ function getSpanStyles(container: HTMLElement) {
     style: span.getAttribute("style"),
   }));
 }
+
+describe("AnsiText", () => {
+  it("renders ANSI text inline without literal escape bytes", () => {
+    const { container } = render(
+      <p>
+        Status: <AnsiText>{"\x1b[31mfailed\x1b[0m"}</AnsiText>
+      </p>,
+    );
+
+    const styledText = screen.getByText("failed");
+    expect(styledText).toHaveClass("ansi-red-fg");
+    expect(styledText.parentElement?.tagName).toBe("P");
+    expect(styledText.parentElement?.textContent).toBe("Status: failed");
+    expect(container.textContent).not.toContain("\x1b");
+  });
+
+  it("preserves plain text", () => {
+    render(<AnsiText>Plain notice</AnsiText>);
+    expect(screen.getByText("Plain notice")).toBeInTheDocument();
+  });
+});
 
 describe("AnsiOutput", () => {
   describe("plain text", () => {

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -50,6 +50,24 @@ describe("AnsiText", () => {
     expect(container.textContent).not.toContain("\x07");
     expect(container.textContent).not.toContain("https://example.com");
   });
+
+  it("removes residual controls from truncated ANSI sequences", () => {
+    const { container } = render(
+      <AnsiText>{"8;;https://example.com\x07documentation \x1b]8;;https://ex"}</AnsiText>,
+    );
+
+    expect(container.textContent).not.toContain("\x1b");
+    expect(container.textContent).not.toContain("\x07");
+  });
+
+  it("keeps concealed inline text perceivable", () => {
+    const { container } = render(<AnsiText>{"\x1b[8mFailure details\x1b[0m"}</AnsiText>);
+
+    const text = screen.getByText("Failure details");
+    expect(text).toBeVisible();
+    expect(text).not.toHaveStyle({ visibility: "hidden" });
+    expect(container.textContent).toBe("Failure details");
+  });
 });
 
 describe("AnsiOutput", () => {
@@ -206,6 +224,12 @@ describe("AnsiOutput", () => {
       expect(combinedSpan?.style).toContain("font-weight: bold");
       expect(combinedSpan?.style).toContain("font-style: italic");
       expect(combinedSpan?.style).toContain("text-decoration: underline");
+    });
+
+    it("preserves terminal conceal styling", () => {
+      const { container } = render(<AnsiOutput>{"\x1b[8mHidden\x1b[0m"}</AnsiOutput>);
+      const hiddenSpan = getSpanStyles(container).find((span) => span.text === "Hidden");
+      expect(hiddenSpan?.style).toContain("visibility: hidden");
     });
   });
 

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -53,11 +53,10 @@ describe("AnsiText", () => {
 
   it("removes residual controls from truncated ANSI sequences", () => {
     const { container } = render(
-      <AnsiText>{"8;;https://example.com\x07documentation \x1b]8;;https://ex"}</AnsiText>,
+      <AnsiText>{"8;;https://example.com\x07documentation\x1b]8;;https://ex"}</AnsiText>,
     );
 
-    expect(container.textContent).not.toContain("\x1b");
-    expect(container.textContent).not.toContain("\x07");
+    expect(container.textContent).toBe("documentation");
   });
 
   it("keeps concealed inline text perceivable", () => {

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -53,10 +53,20 @@ describe("AnsiText", () => {
 
   it("removes residual controls from truncated ANSI sequences", () => {
     const { container } = render(
-      <AnsiText>{"8;;https://example.com\x07documentation\x1b]8;;https://ex"}</AnsiText>,
+      <AnsiText>
+        {"warm-env failed; stderr: 8;;https://example.com\x07documentation\x1b]8;;https://ex"}
+      </AnsiText>,
     );
 
-    expect(container.textContent).toBe("documentation");
+    expect(container.textContent).toBe("warm-env failed; stderr: documentation");
+  });
+
+  it("preserves later lines after an unterminated OSC sequence", () => {
+    const { container } = render(
+      <AnsiText>{"message \x1b]8;;https://example.com\nactual failure"}</AnsiText>,
+    );
+
+    expect(container.textContent).toBe("message \nactual failure");
   });
 
   it("keeps concealed inline text perceivable", () => {
@@ -65,6 +75,15 @@ describe("AnsiText", () => {
     const text = screen.getByText("Failure details");
     expect(text).toBeVisible();
     expect(text).not.toHaveStyle({ visibility: "hidden" });
+    expect(container.textContent).toBe("Failure details");
+  });
+
+  it("keeps terminal-only dim and background styles out of inline text", () => {
+    const { container } = render(<AnsiText>{"\x1b[2;41mFailure details\x1b[0m"}</AnsiText>);
+
+    const text = screen.getByText("Failure details");
+    expect(text).not.toHaveStyle({ opacity: 0.5 });
+    expect(text).not.toHaveClass("ansi-red-bg");
     expect(container.textContent).toBe("Failure details");
   });
 });

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -35,8 +35,20 @@ describe("AnsiText", () => {
   });
 
   it("preserves plain text", () => {
-    render(<AnsiText>Plain notice</AnsiText>);
-    expect(screen.getByText("Plain notice")).toBeInTheDocument();
+    const { container } = render(<AnsiText>Plain notice</AnsiText>);
+    expect(container.textContent).toBe("Plain notice");
+    expect(container.querySelectorAll("span")).toHaveLength(1);
+  });
+
+  it("removes unsupported ANSI controls while preserving visible text", () => {
+    const { container } = render(
+      <AnsiText>{"See \x1b]8;;https://example.com\x07documentation\x1b]8;;\x07"}</AnsiText>,
+    );
+
+    expect(container.textContent).toBe("See documentation");
+    expect(container.textContent).not.toContain("\x1b");
+    expect(container.textContent).not.toContain("\x07");
+    expect(container.textContent).not.toContain("https://example.com");
   });
 });
 

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -77,16 +77,21 @@ function paletteIndexToRgb(index: number): string {
  */
 function resolveAnsiStyle(
   entry: Anser.AnserJsonEntry,
-  preserveConceal: boolean,
+  terminalFidelity: boolean,
 ): {
   style: CSSProperties;
   className: string;
 } {
   const style: CSSProperties = {};
   const classes: string[] = [];
+  const isInverted = (
+    entry as Anser.AnserJsonEntry & {
+      isInverted?: boolean;
+    }
+  ).isInverted;
 
   // Foreground
-  if (entry.fg) {
+  if (entry.fg && (terminalFidelity || !isInverted)) {
     if (isStandardColor(entry.fg)) {
       // Use CSS variable via class: .ansi-red-fg { color: var(--ansi-red) }
       classes.push(`${entry.fg}-fg`);
@@ -99,7 +104,7 @@ function resolveAnsiStyle(
   }
 
   // Background
-  if (entry.bg) {
+  if (entry.bg && terminalFidelity) {
     if (isStandardColor(entry.bg)) {
       classes.push(`${entry.bg}-bg`);
     } else if (entry.bg === "ansi-truecolor" && entry.bg_truecolor) {
@@ -117,13 +122,15 @@ function resolveAnsiStyle(
         style.fontWeight = "bold";
         break;
       case "dim":
-        style.opacity = 0.5;
+        if (terminalFidelity) {
+          style.opacity = 0.5;
+        }
         break;
       case "italic":
         style.fontStyle = "italic";
         break;
       case "hidden":
-        if (preserveConceal) {
+        if (terminalFidelity) {
           style.visibility = "hidden";
         }
         break;
@@ -177,14 +184,14 @@ const INVISIBLE_CONTROL_CHARACTERS = new RegExp(
 );
 const OSC_SEQUENCE = new RegExp(
   // eslint-disable-next-line no-control-regex -- strip complete or tail-truncated OSC sequences
-  "(?:\\u001B\\]|\\u009D)[\\s\\S]*?(?:\\u0007|\\u001B\\\\|\\u009C|$)",
+  "(?:\\u001B\\]|\\u009D)[^\\n]*?(?:\\u0007|\\u001B\\\\|\\u009C|(?=\\n)|$)",
   "g",
 );
 // eslint-disable-next-line no-control-regex -- strip a head-truncated OSC 8 opener through BEL
-const TRUNCATED_OSC_8_PREFIX = new RegExp("^8;;[^\\u0007\\n]*(?:\\u0007|$)");
+const TRUNCATED_OSC_8_SEQUENCE = new RegExp("8;;[^\\u0007\\n]*\\u0007", "g");
 
 function sanitizeAnsiContent(content: string): string {
-  const withoutOsc = content.replace(OSC_SEQUENCE, "").replace(TRUNCATED_OSC_8_PREFIX, "");
+  const withoutOsc = content.replace(OSC_SEQUENCE, "").replace(TRUNCATED_OSC_8_SEQUENCE, "");
   return stripAnsi(withoutOsc).replace(INVISIBLE_CONTROL_CHARACTERS, "");
 }
 
@@ -192,9 +199,12 @@ function ansiEntriesToPlainText(entries: Anser.AnserJsonEntry[]): string {
   return entries.map((entry) => sanitizeAnsiContent(entry.content)).join("");
 }
 
-function renderAnsiEntries(entries: Anser.AnserJsonEntry[], preserveConceal: boolean): ReactNode[] {
+function renderAnsiEntries(
+  entries: Anser.AnserJsonEntry[],
+  terminalFidelity: boolean,
+): ReactNode[] {
   return entries.map((entry, i) => {
-    const { style, className } = resolveAnsiStyle(entry, preserveConceal);
+    const { style, className } = resolveAnsiStyle(entry, terminalFidelity);
     const hasStyle = Object.keys(style).length > 0;
     const hasClass = className.length > 0;
     const content = sanitizeAnsiContent(entry.content);
@@ -222,7 +232,7 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[], preserveConceal: boo
 interface AnsiTextProps {
   children: string;
   fallback?: ReactNode;
-  preserveConceal?: boolean;
+  terminalFidelity?: boolean;
 }
 
 /** Convert ANSI terminal text to normalized, copyable plain text. */
@@ -237,7 +247,7 @@ export function ansiToPlainText(input: string): string {
 /**
  * Render ANSI text inline, inheriting layout and typography from its parent.
  */
-export function AnsiText({ children, fallback, preserveConceal = false }: AnsiTextProps) {
+export function AnsiText({ children, fallback, terminalFidelity = false }: AnsiTextProps) {
   const entries = useMemo(
     () => (children && typeof children === "string" ? ansiToJson(children) : []),
     [children],
@@ -251,7 +261,7 @@ export function AnsiText({ children, fallback, preserveConceal = false }: AnsiTe
     return null;
   }
 
-  return <>{renderAnsiEntries(entries, preserveConceal)}</>;
+  return <>{renderAnsiEntries(entries, terminalFidelity)}</>;
 }
 
 interface AnsiOutputProps {
@@ -281,7 +291,7 @@ export function AnsiOutput({ children, className = "", isError = false }: AnsiOu
       )}
     >
       <code>
-        <AnsiText preserveConceal>{children}</AnsiText>
+        <AnsiText terminalFidelity>{children}</AnsiText>
       </code>
     </div>
   );

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -2,6 +2,7 @@ import Anser from "anser";
 import { escapeCarriageReturn } from "escape-carriage";
 import { X } from "lucide-react";
 import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import stripAnsi from "strip-ansi";
 import { cn } from "@/lib/utils";
 
 /**
@@ -169,9 +170,10 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
     const { style, className } = resolveAnsiStyle(entry);
     const hasStyle = Object.keys(style).length > 0;
     const hasClass = className.length > 0;
+    const content = stripAnsi(entry.content);
 
     if (!hasStyle && !hasClass) {
-      return <span key={i}>{entry.content}</span>;
+      return <span key={i}>{content}</span>;
     }
 
     return (
@@ -180,7 +182,7 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
         style={hasStyle ? style : undefined}
         className={hasClass ? className : undefined}
       >
-        {entry.content}
+        {content}
       </span>
     );
   });
@@ -192,6 +194,17 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
 
 interface AnsiTextProps {
   children: string;
+}
+
+/** Convert ANSI terminal text to normalized, copyable plain text. */
+export function ansiToPlainText(input: string): string {
+  if (!input || typeof input !== "string") {
+    return "";
+  }
+
+  return ansiToJson(input)
+    .map((entry) => stripAnsi(entry.content))
+    .join("");
 }
 
 /**

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -190,6 +190,21 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
 // Public components
 // ---------------------------------------------------------------------------
 
+interface AnsiTextProps {
+  children: string;
+}
+
+/**
+ * Render ANSI text inline, inheriting layout and typography from its parent.
+ */
+export function AnsiText({ children }: AnsiTextProps) {
+  if (!children || typeof children !== "string") {
+    return null;
+  }
+
+  return <>{renderAnsiEntries(ansiToJson(children))}</>;
+}
+
 interface AnsiOutputProps {
   children: string;
   className?: string;
@@ -207,8 +222,6 @@ export function AnsiOutput({ children, className = "", isError = false }: AnsiOu
     return null;
   }
 
-  const entries = ansiToJson(children);
-
   return (
     <div
       data-slot="ansi-output"
@@ -218,7 +231,9 @@ export function AnsiOutput({ children, className = "", isError = false }: AnsiOu
         className,
       )}
     >
-      <code>{renderAnsiEntries(entries)}</code>
+      <code>
+        <AnsiText>{children}</AnsiText>
+      </code>
     </div>
   );
 }

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -75,7 +75,10 @@ function paletteIndexToRgb(index: number): string {
 /**
  * Parse an anser JSON entry's color fields into a React style + className.
  */
-function resolveAnsiStyle(entry: Anser.AnserJsonEntry): {
+function resolveAnsiStyle(
+  entry: Anser.AnserJsonEntry,
+  preserveConceal: boolean,
+): {
   style: CSSProperties;
   className: string;
 } {
@@ -120,7 +123,9 @@ function resolveAnsiStyle(entry: Anser.AnserJsonEntry): {
         style.fontStyle = "italic";
         break;
       case "hidden":
-        style.visibility = "hidden";
+        if (preserveConceal) {
+          style.visibility = "hidden";
+        }
         break;
       case "strikethrough":
         style.textDecoration =
@@ -165,12 +170,26 @@ function ansiToJson(input: string): Anser.AnserJsonEntry[] {
 /**
  * Render parsed ANSI entries to React spans.
  */
-function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
+const INVISIBLE_CONTROL_CHARACTERS = new RegExp(
+  // eslint-disable-next-line no-control-regex -- remove residual C0/C1 controls except tab/newline
+  "[\\u0000-\\u0008\\u000B-\\u001F\\u007F-\\u009F]",
+  "g",
+);
+
+function sanitizeAnsiContent(content: string): string {
+  return stripAnsi(content).replace(INVISIBLE_CONTROL_CHARACTERS, "");
+}
+
+function ansiEntriesToPlainText(entries: Anser.AnserJsonEntry[]): string {
+  return entries.map((entry) => sanitizeAnsiContent(entry.content)).join("");
+}
+
+function renderAnsiEntries(entries: Anser.AnserJsonEntry[], preserveConceal: boolean): ReactNode[] {
   return entries.map((entry, i) => {
-    const { style, className } = resolveAnsiStyle(entry);
+    const { style, className } = resolveAnsiStyle(entry, preserveConceal);
     const hasStyle = Object.keys(style).length > 0;
     const hasClass = className.length > 0;
-    const content = stripAnsi(entry.content);
+    const content = sanitizeAnsiContent(entry.content);
 
     if (!hasStyle && !hasClass) {
       return <span key={i}>{content}</span>;
@@ -194,6 +213,8 @@ function renderAnsiEntries(entries: Anser.AnserJsonEntry[]): ReactNode[] {
 
 interface AnsiTextProps {
   children: string;
+  fallback?: ReactNode;
+  preserveConceal?: boolean;
 }
 
 /** Convert ANSI terminal text to normalized, copyable plain text. */
@@ -202,20 +223,27 @@ export function ansiToPlainText(input: string): string {
     return "";
   }
 
-  return ansiToJson(input)
-    .map((entry) => stripAnsi(entry.content))
-    .join("");
+  return ansiEntriesToPlainText(ansiToJson(input));
 }
 
 /**
  * Render ANSI text inline, inheriting layout and typography from its parent.
  */
-export function AnsiText({ children }: AnsiTextProps) {
-  if (!children || typeof children !== "string") {
+export function AnsiText({ children, fallback, preserveConceal = false }: AnsiTextProps) {
+  const entries = useMemo(
+    () => (children && typeof children === "string" ? ansiToJson(children) : []),
+    [children],
+  );
+
+  if (fallback !== undefined && ansiEntriesToPlainText(entries).trim().length === 0) {
+    return <>{fallback}</>;
+  }
+
+  if (entries.length === 0) {
     return null;
   }
 
-  return <>{renderAnsiEntries(ansiToJson(children))}</>;
+  return <>{renderAnsiEntries(entries, preserveConceal)}</>;
 }
 
 interface AnsiOutputProps {
@@ -245,7 +273,7 @@ export function AnsiOutput({ children, className = "", isError = false }: AnsiOu
       )}
     >
       <code>
-        <AnsiText>{children}</AnsiText>
+        <AnsiText preserveConceal>{children}</AnsiText>
       </code>
     </div>
   );

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -175,9 +175,17 @@ const INVISIBLE_CONTROL_CHARACTERS = new RegExp(
   "[\\u0000-\\u0008\\u000B-\\u001F\\u007F-\\u009F]",
   "g",
 );
+const OSC_SEQUENCE = new RegExp(
+  // eslint-disable-next-line no-control-regex -- strip complete or tail-truncated OSC sequences
+  "(?:\\u001B\\]|\\u009D)[\\s\\S]*?(?:\\u0007|\\u001B\\\\|\\u009C|$)",
+  "g",
+);
+// eslint-disable-next-line no-control-regex -- strip a head-truncated OSC 8 opener through BEL
+const TRUNCATED_OSC_8_PREFIX = new RegExp("^8;;[^\\u0007\\n]*(?:\\u0007|$)");
 
 function sanitizeAnsiContent(content: string): string {
-  return stripAnsi(content).replace(INVISIBLE_CONTROL_CHARACTERS, "");
+  const withoutOsc = content.replace(OSC_SEQUENCE, "").replace(TRUNCATED_OSC_8_PREFIX, "");
+  return stripAnsi(withoutOsc).replace(INVISIBLE_CONTROL_CHARACTERS, "");
 }
 
 function ansiEntriesToPlainText(entries: Anser.AnserJsonEntry[]): string {


### PR DESCRIPTION
## Summary

- add a shared inline `AnsiText` primitive and compose the existing block `AnsiOutput` from it
- interpret ANSI styling in pool-error notice titles and shared notebook notice details
- strip unsupported, complete, and truncated ANSI controls from rendered and explicitly copied notice text
- keep semantic notice text perceivable by omitting terminal-only background, dim, reverse, and conceal effects
- provide readable fallbacks and suppress empty detail/copy affordances when sanitization leaves no diagnostic text
- cover plain text, escape-byte removal, ANSI class rendering, truncation, fallback, conceal, and clipboard output in focused tests

## Scope

Frontend-only. This does not include runtime warmup or process-tree changes.

## Testing

- `cargo xtask lint --fix`
- `pnpm test:run` (2,862 passed, 6 skipped)
- `pnpm --dir apps/notebook build`

## Review

Source-read-only Kilo correctness and UX panels were run with different model families. The final post-fix panel (`kilo/google/gemini-3.7-flash` and `kilo/openai/gpt-5.6-sol`) reported no actionable findings.
