### PR TITLE
fix(runtimed): clean up timed-out warm env process trees

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -7516,21 +7516,32 @@ impl Daemon {
         let config_json = serde_json::to_string(&config)
             .map_err(|e| format!("Failed to serialize warm-env config: {e}"))?;
 
-        let mut child = tokio::process::Command::new(&exe)
+        let mut command = tokio::process::Command::new(&exe);
+        command
             .arg("warm-env")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
+            .kill_on_drop(true);
+        crate::warm_env::configure_process_tree(&mut command);
+
+        let mut child = command
             .spawn()
             .map_err(|e| format!("Failed to spawn warm-env: {e}"))?;
+        let mut process_tree = match crate::warm_env::own_process_tree(&child) {
+            Ok(process_tree) => process_tree,
+            Err(error) => {
+                let _ = child.kill().await;
+                return Err(format!("Failed to own warm-env process tree: {error}"));
+            }
+        };
 
         // Drain the child's stderr into the daemon log. Retain the tail so a
         // failure result with no `error` field (e.g. the child was killed by a
         // native loader error before it could emit one) can still surface a
         // real message instead of a generic placeholder.
         let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-        let stderr_task = child.stderr.take().map(|stderr| {
+        let mut stderr_task = child.stderr.take().map(|stderr| {
             let type_str = type_str.to_string();
             let stderr_tail = stderr_tail.clone();
             tokio::spawn(async move {
@@ -7580,7 +7591,7 @@ impl Daemon {
         let mut last_result: Option<crate::warm_env::WarmEnvResult> = None;
 
         let timeout = warm_env_timeout();
-        let read_result = tokio::time::timeout(timeout, async {
+        let operation = tokio::time::timeout(timeout, async {
             while let Ok(Some(line)) = lines.next_line().await {
                 match serde_json::from_str::<crate::warm_env::WarmEnvEvent>(&line) {
                     Ok(crate::warm_env::WarmEnvEvent::Progress { phase, detail }) => {
@@ -7594,30 +7605,43 @@ impl Daemon {
                     }
                 }
             }
+
+            let status = child.wait().await;
+            // Include stderr EOF in the same overall timeout. Descendants can
+            // inherit this pipe even after the direct child exits.
+            if let Some(task) = stderr_task.as_mut() {
+                let _ = task.await;
+            }
+            status
         })
         .await;
 
-        if read_result.is_err() {
-            // Kill before waiting — don't block on a wedged child.
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            if let Some(task) = stderr_task {
+        let status = match operation {
+            Ok(status) => status,
+            Err(_) => {
+                // Stop the pipe reader before teardown so a descendant that
+                // inherited stderr cannot keep this timeout path blocked.
+                if let Some(task) = stderr_task.take() {
+                    task.abort();
+                    let _ = task.await;
+                }
+                crate::warm_env::reap_timed_out_child(&mut child, &mut process_tree).await;
+                let tail = drain_stderr_tail(&stderr_tail);
+                return Err(format!(
+                    "warm-env subprocess timed out after {}s{}",
+                    timeout.as_secs(),
+                    tail.map(|t| format!("; last stderr: {t}"))
+                        .unwrap_or_default()
+                ));
+            }
+        };
+
+        // The task was awaited inside the timeout, but take the completed
+        // handle so no detached reader remains on any return path.
+        if let Some(task) = stderr_task.take() {
+            if !task.is_finished() {
                 let _ = task.await;
             }
-            let tail = drain_stderr_tail(&stderr_tail);
-            return Err(format!(
-                "warm-env subprocess timed out after {}s{}",
-                timeout.as_secs(),
-                tail.map(|t| format!("; last stderr: {t}"))
-                    .unwrap_or_default()
-            ));
-        }
-
-        let status = child.wait().await;
-        // The stderr drain finishes once the pipe closes on child exit; await
-        // it so the tail buffer is complete before we read it for diagnostics.
-        if let Some(task) = stderr_task {
-            let _ = task.await;
         }
 
         if let Some(mut result) = last_result {

--- a/crates/runtimed/src/runtime_agent_manifest.rs
+++ b/crates/runtimed/src/runtime_agent_manifest.rs
@@ -406,6 +406,16 @@ pub fn create_windows_job_for_process(
     runtime_agent_id: &str,
     process_handle: std::os::windows::io::RawHandle,
 ) -> Result<(String, WindowsJob)> {
+    let job_name = windows_job_name(runtime_agent_id);
+    let job = create_windows_kill_on_close_job_for_process(&job_name, process_handle)?;
+    Ok((job_name, job))
+}
+
+#[cfg(windows)]
+pub(crate) fn create_windows_kill_on_close_job_for_process(
+    job_name: &str,
+    process_handle: std::os::windows::io::RawHandle,
+) -> Result<WindowsJob> {
     use std::mem::{size_of, zeroed};
     use std::ptr::null;
     use windows_sys::Win32::Foundation::{GetLastError, HANDLE};
@@ -415,8 +425,7 @@ pub fn create_windows_job_for_process(
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
     };
 
-    let job_name = windows_job_name(runtime_agent_id);
-    let wide_name = wide_null(&job_name);
+    let wide_name = wide_null(job_name);
     let job = unsafe { CreateJobObjectW(null(), wide_name.as_ptr()) };
     if job == 0 {
         anyhow::bail!("CreateJobObjectW({job_name}) failed: {}", unsafe {
@@ -450,7 +459,7 @@ pub fn create_windows_job_for_process(
         });
     }
 
-    Ok((job_name, job_handle))
+    Ok(job_handle)
 }
 
 #[cfg(windows)]

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -234,24 +234,24 @@ where
 }
 
 #[cfg(unix)]
-struct ChildProcessTree {
+pub(crate) struct ChildProcessTree {
     pgid: i32,
 }
 
 #[cfg(windows)]
-struct ChildProcessTree {
+pub(crate) struct ChildProcessTree {
     job: Option<crate::runtime_agent_manifest::WindowsJob>,
 }
 
 #[cfg(not(any(unix, windows)))]
-struct ChildProcessTree;
+pub(crate) struct ChildProcessTree;
 
-fn configure_process_tree(command: &mut tokio::process::Command) {
+pub(crate) fn configure_process_tree(command: &mut tokio::process::Command) {
     #[cfg(unix)]
     command.process_group(0);
 }
 
-fn own_process_tree(child: &tokio::process::Child) -> io::Result<ChildProcessTree> {
+pub(crate) fn own_process_tree(child: &tokio::process::Child) -> io::Result<ChildProcessTree> {
     #[cfg(unix)]
     {
         let pgid = child
@@ -317,7 +317,7 @@ fn terminate_process_tree(process_tree: &mut ChildProcessTree) {
     }
 }
 
-async fn reap_timed_out_child(
+pub(crate) async fn reap_timed_out_child(
     child: &mut tokio::process::Child,
     process_tree: &mut ChildProcessTree,
 ) {

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -1111,6 +1111,7 @@ mod tests {
 
     #[test]
     #[ignore = "subprocess helper invoked by the process-tree regression test"]
+    #[allow(clippy::zombie_processes)] // Parent must exit while its descendant keeps the pipes open.
     fn run_output_with_timeout_inherited_pipe_helper() {
         match std::env::var(INHERITED_PIPE_HELPER_MODE).as_deref() {
             Ok("parent") => {

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -180,6 +180,7 @@ const UV_OFFLINE_INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
 const UV_ONLINE_INSTALL_TIMEOUT: Duration = Duration::from_secs(180);
 const UV_VENV_TIMEOUT: Duration = Duration::from_secs(60);
 const PYTHON_RUNTIME_VALIDATION_TIMEOUT: Duration = Duration::from_secs(60);
+const PROCESS_TREE_REAP_TIMEOUT: Duration = Duration::from_secs(5);
 // Keep optional warming below the daemon's 120s pool-take wait. Long compileall
 // runs should not keep a validated environment out of the pool.
 const PYTHON_WARMUP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -232,12 +233,105 @@ where
     Ok(output)
 }
 
-async fn collect_reader(
-    handle: tokio::task::JoinHandle<io::Result<Vec<u8>>>,
-) -> io::Result<Vec<u8>> {
-    handle
-        .await
-        .map_err(|error| io::Error::other(format!("failed to join child output reader: {error}")))?
+#[cfg(unix)]
+struct ChildProcessTree {
+    pgid: i32,
+}
+
+#[cfg(windows)]
+struct ChildProcessTree {
+    job: Option<crate::runtime_agent_manifest::WindowsJob>,
+}
+
+#[cfg(not(any(unix, windows)))]
+struct ChildProcessTree;
+
+fn configure_process_tree(command: &mut tokio::process::Command) {
+    #[cfg(unix)]
+    command.process_group(0);
+}
+
+fn own_process_tree(child: &tokio::process::Child) -> io::Result<ChildProcessTree> {
+    #[cfg(unix)]
+    {
+        let pgid = child
+            .id()
+            .ok_or_else(|| io::Error::other("spawned child has no process id"))?
+            as i32;
+        Ok(ChildProcessTree { pgid })
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::RawHandle;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| io::Error::other("spawned child has no process id"))?;
+        let process_handle = child
+            .raw_handle()
+            .ok_or_else(|| io::Error::other("spawned child has no process handle"))?
+            as RawHandle;
+        let job_name = format!("nteract-warm-env-command-{pid}");
+        let job = crate::runtime_agent_manifest::create_windows_kill_on_close_job_for_process(
+            &job_name,
+            process_handle,
+        )
+        .map_err(|error| io::Error::other(error.to_string()))?;
+        Ok(ChildProcessTree { job: Some(job) })
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = child;
+        Ok(ChildProcessTree)
+    }
+}
+
+fn terminate_process_tree(process_tree: &mut ChildProcessTree) {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{killpg, Signal};
+        use nix::unistd::Pid;
+
+        if let Err(error) = killpg(Pid::from_raw(process_tree.pgid), Signal::SIGKILL) {
+            if error != nix::errno::Errno::ESRCH {
+                warn!(
+                    "[warm-env] Failed to terminate subprocess group {}: {error}",
+                    process_tree.pgid
+                );
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        // The job uses JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so dropping the
+        // final handle terminates the child and every process it spawned.
+        process_tree.job.take();
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = process_tree;
+    }
+}
+
+async fn reap_timed_out_child(
+    child: &mut tokio::process::Child,
+    process_tree: &mut ChildProcessTree,
+) {
+    terminate_process_tree(process_tree);
+    let _ = child.start_kill();
+
+    match tokio::time::timeout(PROCESS_TREE_REAP_TIMEOUT, child.wait()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => warn!("[warm-env] Failed to reap timed-out subprocess: {error}"),
+        Err(_) => warn!(
+            "[warm-env] Timed-out subprocess did not exit within {} seconds of tree termination",
+            PROCESS_TREE_REAP_TIMEOUT.as_secs()
+        ),
+    }
 }
 
 async fn run_output_with_timeout(
@@ -248,61 +342,58 @@ async fn run_output_with_timeout(
         .kill_on_drop(true)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    configure_process_tree(&mut command);
 
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => return TimedResult::Failed(error),
     };
 
-    let stdout = child
-        .stdout
-        .take()
-        .map(|pipe| tokio::spawn(read_pipe_to_end(pipe)));
-    let stderr = child
-        .stderr
-        .take()
-        .map(|pipe| tokio::spawn(read_pipe_to_end(pipe)));
-
-    let status = match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => status,
-        Ok(Err(error)) => return TimedResult::Failed(error),
-        Err(_) => {
-            // Dropping `Command::output()` on timeout can leave the spawned
-            // process running. Keep ownership of the child handle and kill it
-            // before reporting the timeout so warmup retries do not accumulate
-            // orphaned Python processes.
+    let mut process_tree = match own_process_tree(&child) {
+        Ok(process_tree) => process_tree,
+        Err(error) => {
             let _ = child.kill().await;
-            let _ = child.wait().await;
-            if let Some(stdout) = stdout {
-                let _ = collect_reader(stdout).await;
-            }
-            if let Some(stderr) = stderr {
-                let _ = collect_reader(stderr).await;
-            }
-            return TimedResult::TimedOut;
+            return TimedResult::Failed(error);
         }
     };
 
-    let stdout = match stdout {
-        Some(stdout) => match collect_reader(stdout).await {
-            Ok(output) => output,
-            Err(error) => return TimedResult::Failed(error),
-        },
-        None => Vec::new(),
-    };
-    let stderr = match stderr {
-        Some(stderr) => match collect_reader(stderr).await {
-            Ok(output) => output,
-            Err(error) => return TimedResult::Failed(error),
-        },
-        None => Vec::new(),
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let collect_output = async {
+        let status = child.wait();
+        let stdout = async {
+            match stdout {
+                Some(pipe) => read_pipe_to_end(pipe).await,
+                None => Ok(Vec::new()),
+            }
+        };
+        let stderr = async {
+            match stderr {
+                Some(pipe) => read_pipe_to_end(pipe).await,
+                None => Ok(Vec::new()),
+            }
+        };
+        let (status, stdout, stderr) = tokio::join!(status, stdout, stderr);
+
+        Ok(Output {
+            status: status?,
+            stdout: stdout?,
+            stderr: stderr?,
+        })
     };
 
-    TimedResult::Completed(Output {
-        status,
-        stdout,
-        stderr,
-    })
+    match tokio::time::timeout(timeout, collect_output).await {
+        Ok(Ok(output)) => TimedResult::Completed(output),
+        Ok(Err(error)) => TimedResult::Failed(error),
+        Err(_) => {
+            // The collection future owns the pipe readers, so timing it out
+            // drops both read ends before teardown. This prevents descendants
+            // that inherited stdout/stderr from keeping cleanup blocked.
+            reap_timed_out_child(&mut child, &mut process_tree).await;
+            TimedResult::TimedOut
+        }
+    }
 }
 
 fn stderr_excerpt(output: &Output) -> String {
@@ -1011,6 +1102,117 @@ mod tests {
         let result = run_output_with_timeout(command, Duration::from_millis(25)).await;
 
         assert!(matches!(result, TimedResult::TimedOut));
+    }
+
+    const INHERITED_PIPE_HELPER_MODE: &str = "NTERACT_WARM_ENV_PIPE_HELPER_MODE";
+    const INHERITED_PIPE_HELPER_PID_FILE: &str = "NTERACT_WARM_ENV_PIPE_HELPER_PID_FILE";
+    const INHERITED_PIPE_HELPER_TEST: &str =
+        "warm_env::tests::run_output_with_timeout_inherited_pipe_helper";
+
+    #[test]
+    #[ignore = "subprocess helper invoked by the process-tree regression test"]
+    fn run_output_with_timeout_inherited_pipe_helper() {
+        match std::env::var(INHERITED_PIPE_HELPER_MODE).as_deref() {
+            Ok("parent") => {
+                // Give the outer process time to establish its Windows Job
+                // Object before this helper creates the inherited descendant.
+                std::thread::sleep(Duration::from_millis(250));
+
+                let child = std::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        INHERITED_PIPE_HELPER_TEST,
+                        "--exact",
+                        "--ignored",
+                        "--nocapture",
+                    ])
+                    .env(INHERITED_PIPE_HELPER_MODE, "descendant")
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .spawn()
+                    .unwrap();
+
+                std::fs::write(
+                    std::env::var(INHERITED_PIPE_HELPER_PID_FILE).unwrap(),
+                    child.id().to_string(),
+                )
+                .unwrap();
+            }
+            Ok("descendant") => std::thread::sleep(Duration::from_secs(30)),
+            _ => panic!("process-tree helper invoked without a mode"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn process_is_alive(pid: u32) -> bool {
+        let result = unsafe { libc::kill(pid as i32, 0) };
+        result == 0 || io::Error::last_os_error().kind() == io::ErrorKind::PermissionDenied
+    }
+
+    #[cfg(windows)]
+    fn process_is_alive(pid: u32) -> bool {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process == 0 {
+            return false;
+        }
+
+        let mut exit_code = 0;
+        let ok = unsafe { GetExitCodeProcess(process, &mut exit_code) };
+        unsafe { CloseHandle(process) };
+        ok != 0 && exit_code == 259 // STILL_ACTIVE
+    }
+
+    #[cfg(any(unix, windows))]
+    async fn wait_for_process_exit(pid: u32) -> bool {
+        for _ in 0..100 {
+            if !process_is_alive(pid) {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        false
+    }
+
+    #[cfg(any(unix, windows))]
+    #[tokio::test]
+    async fn run_output_with_timeout_kills_descendant_holding_output_pipes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let mut command = tokio::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                INHERITED_PIPE_HELPER_TEST,
+                "--exact",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env(INHERITED_PIPE_HELPER_MODE, "parent")
+            .env(INHERITED_PIPE_HELPER_PID_FILE, &pid_file);
+
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(8),
+            run_output_with_timeout(command, Duration::from_secs(1)),
+        )
+        .await
+        .expect("subprocess cleanup must return within its bounded reap window");
+
+        assert!(matches!(result, TimedResult::TimedOut));
+        assert!(started.elapsed() < Duration::from_secs(8));
+
+        let descendant_pid: u32 = std::fs::read_to_string(&pid_file)
+            .expect("helper must record its descendant pid before the timeout")
+            .parse()
+            .unwrap();
+        assert!(
+            wait_for_process_exit(descendant_pid).await,
+            "descendant {descendant_pid} survived process-tree cleanup"
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -246,9 +246,9 @@ pub(crate) struct ChildProcessTree {
 #[cfg(not(any(unix, windows)))]
 pub(crate) struct ChildProcessTree;
 
-pub(crate) fn configure_process_tree(command: &mut tokio::process::Command) {
+pub(crate) fn configure_process_tree(_command: &mut tokio::process::Command) {
     #[cfg(unix)]
-    command.process_group(0);
+    _command.process_group(0);
 }
 
 pub(crate) fn own_process_tree(child: &tokio::process::Child) -> io::Result<ChildProcessTree> {

--- a/python/prewarm/src/prewarm/__init__.py
+++ b/python/prewarm/src/prewarm/__init__.py
@@ -138,7 +138,7 @@ def normalize_module_name(spec: str) -> str | None:
 
 def _compile_site_packages(path: str) -> None:
     """Pre-compile all .py files in site-packages to .pyc."""
-    compileall.compile_dir(path, quiet=2, workers=0)
+    compileall.compile_dir(path, quiet=2, workers=1)
 
 
 def _collect_modules(extra: list[str], *, include_conda: bool = False) -> list[str]:
@@ -207,7 +207,7 @@ def build_warmup_script(
     # Phase 1: compileall (always import, conditionally run)
     lines.append("import compileall")
     if site_packages:
-        lines.append(f"compileall.compile_dir({site_packages!r}, quiet=2, workers=0)")
+        lines.append(f"compileall.compile_dir({site_packages!r}, quiet=2, workers=1)")
 
     # Phase 2: critical imports — these MUST succeed or the script exits non-zero,
     # preventing a broken environment from being admitted to the pool.

--- a/python/prewarm/src/prewarm/__init__.py
+++ b/python/prewarm/src/prewarm/__init__.py
@@ -138,6 +138,8 @@ def normalize_module_name(spec: str) -> str | None:
 
 def _compile_site_packages(path: str) -> None:
     """Pre-compile all .py files in site-packages to .pyc."""
+    # Keep optional warming single-process so one timeout cannot fan out into
+    # a CPU-sized multiprocessing pool that competes with environment setup.
     compileall.compile_dir(path, quiet=2, workers=1)
 
 
@@ -207,6 +209,8 @@ def build_warmup_script(
     # Phase 1: compileall (always import, conditionally run)
     lines.append("import compileall")
     if site_packages:
+        # Match _compile_site_packages: warming is background optimization,
+        # not a reason to fan out across every CPU in the pool subprocess.
         lines.append(f"compileall.compile_dir({site_packages!r}, quiet=2, workers=1)")
 
     # Phase 2: critical imports — these MUST succeed or the script exits non-zero,

--- a/python/prewarm/tests/test_prewarm.py
+++ b/python/prewarm/tests/test_prewarm.py
@@ -134,7 +134,7 @@ def test_build_warmup_script_with_site_packages():
     from prewarm import build_warmup_script
 
     script = build_warmup_script([], include_conda=False, site_packages="/fake/path")
-    assert "compileall" in script
+    assert "compileall.compile_dir('/fake/path', quiet=2, workers=1)" in script
     assert "/fake/path" in script
 
 


### PR DESCRIPTION
## Summary

- isolate both the outer `runtimed warm-env` subprocess and each command it launches in a Unix process group or Windows kill-on-close Job Object
- apply inner and outer timeouts to process exit and stdout/stderr EOF together, then drop or abort pipe readers and perform bounded process-tree teardown
- add a cross-platform regression helper whose parent exits while a long-lived descendant retains both output pipes
- run `compileall` with one worker so optional `.pyc` warming cannot fan out across every CPU

## Context

Nightly UV pool replenishment timed out while running `compileall.compile_dir(..., workers=0)`. Killing only the direct Python process left its multiprocessing workers reparented and holding stdout/stderr open, so `run_output_with_timeout` waited indefinitely for its reader tasks and only returned at the outer 900-second timeout.

This keeps the fix in the background pool lifecycle. It does not change notebook-kernel execution or frontend output rendering.

## Verification

- `cargo xtask lint --fix`
- `cargo check -p runtimed`
- `cargo clippy -p runtimed --tests -- -D warnings`
- `cargo test -p runtimed warm_env::tests::run_output_with_timeout -- --nocapture`
- `cargo test -p kernel-env warmup`
- `cargo test -p runtimed -p kernel-env -- --test-threads=1`
- `uv run --directory python/prewarm pytest tests/test_prewarm.py -q`
- `cargo xtask artifacts verify sift,renderer`
- GitHub PR Build workflow: passed on `842c09a49`
- Windows GNU compile/Clippy cross-check: passed on `842c09a49`

A source-read-only Kilo panel reviewed the final diff with correctness and operability lenses using different model families. Correctness reported no actionable findings. Operability flagged the Pixi path's reliance on the repaired outer timeout, pre-handshake Unix setup returns, and the known post-spawn Windows Job Object assignment race. The first two remain bounded or cannot spawn descendants in the cited state; the Windows race is a limitation of the existing ownership pattern reused here. Earlier confirmed findings, including the outer timeout gap and Windows-only Clippy failure, were fixed and the affected checks were rerun.

Local process-tree execution was verified on macOS. A local Windows cross-check was attempted but stopped in `zstd-sys` because this macOS host lacks Windows C/SDK headers. The repository's Windows GNU compile/Clippy cross-check passed; no native Windows runtime execution is claimed.
