### PR TITLE
ci: restore portable post-merge checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,10 @@ apps/notebook/src/renderer-plugins/leaflet.css filter=lfs diff=lfs merge=lfs -te
 # each time we regenerate them for a schema change.
 packages/runtimed/tests/fixtures/**/*.bin filter=lfs diff=lfs merge=lfs -text
 
+# Recovery manifests fingerprint notebook fixture bytes. Keep those fixtures
+# LF-stable so Windows checkouts validate the same content as macOS and Linux.
+crates/runtimed/tests/fixtures/**/*.ipynb text eol=lf
+
 # Docs catalog static copy of the Sift WASM runtime. This lets apps/elements
 # exercise @nteract/sift URL loading without depending on ignored local
 # wasm-pack outputs at build time.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1060,7 +1060,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Enable corepack
         run: corepack enable


### PR DESCRIPTION
## Summary

- keep recovery notebook fixtures LF-stable across Windows, macOS, and Linux checkouts
- run native desktop E2E setup on Node 22, which supports the repository's pnpm 11 toolchain

## Why

The post-merge Build workflow was failing on the current `main` commit even though the release build succeeded:

- Windows changed fixture bytes during checkout, invalidating exact recovery-manifest fingerprints
- native E2E jobs used Node 20, while pnpm 11 requires Node 22.13 or newer

## Verification

- `cargo test -p runtimed --test integration test_undead_room_4065_fixture -- --nocapture`
- `actionlint .github/workflows/build.yml`
- `git check-attr text eol -- crates/runtimed/tests/fixtures/undead-room-4065/tinker1.ipynb`
- `cargo xtask lint --fix`

This intentionally changes test checkout and CI runtime configuration only; application behavior is unchanged.
