### PR TITLE
fix(runtimed): bound recovery manifest history

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -5654,7 +5654,7 @@ impl Daemon {
             source_generation: manifest.source_generation,
             durable_head_count: manifest.durable_heads.len(),
             exported_head_count: manifest.exported_heads.len(),
-            peer_change_count: manifest.peer_change_hashes.len(),
+            peer_change_count: usize::try_from(manifest.peer_change_count).unwrap_or(usize::MAX),
             file_save_sequence: manifest.file_save_sequence,
             full_head_coverage: manifest.file_checkpoint_covers_durable_heads(),
             source_fingerprint_hex: manifest.source_fingerprint.to_hex(),

--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -6,7 +6,6 @@
 //! an acknowledgement/broadcast. The append-only journal is authoritative;
 //! the watch state makes durable-head barriers and degradation observable.
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -421,11 +420,8 @@ impl RoomDurability {
                 .checked_add(1)
                 .ok_or(RoomDurabilityError::SequenceExhausted)?;
             promoted_manifest.source_phase = RecoverySourcePhase::Ready;
-            promoted_manifest.staged_change_hashes = durable
-                .get_changes(&[])
-                .iter()
-                .map(|change| change.hash().0)
-                .collect();
+            promoted_manifest.staged_change_count =
+                u64::try_from(durable.get_changes(&[]).len()).unwrap_or(u64::MAX);
         }
 
         if let Err(error) = journal.append(&promoted_manifest, &state.durable_snapshot) {
@@ -1021,7 +1017,8 @@ impl RoomDurability {
             source_generation,
         );
         manifest.source_phase = RecoverySourcePhase::DurablyStaged;
-        manifest.staged_change_hashes = replacement_change_hashes;
+        manifest.staged_change_count =
+            u64::try_from(replacement_change_hashes.len()).unwrap_or(u64::MAX);
         manifest.durable_heads = durable_heads.clone();
         manifest.exported_heads = durable_heads;
         manifest.file_save_sequence = Some(save_sequence);
@@ -1061,23 +1058,19 @@ impl RoomDurability {
         let mut state = self.lock_state();
         let mut durable = AutoCommit::load(&state.durable_snapshot)
             .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
-        let peer_hashes = changes
-            .iter()
-            .map(|change| change.hash().0)
-            .collect::<Vec<_>>();
         let missing = changes
             .into_iter()
             .filter(|change| durable.get_change_by_hash(&change.hash()).is_none())
             .collect::<Vec<_>>();
-        if missing.is_empty()
-            && peer_hashes
-                .iter()
-                .all(|hash| state.manifest.peer_change_hashes.contains(hash))
-        {
+        if missing.is_empty() {
             return Ok(DurableCommitOutcome::AlreadyDurable(status_from_state(
                 &state,
             )));
         }
+        let peer_hashes = missing
+            .iter()
+            .map(|change| change.hash().0)
+            .collect::<Vec<_>>();
         durable
             .apply_changes(missing)
             .map_err(|error| RoomDurabilityError::InvalidSnapshot(error.to_string()))?;
@@ -1173,7 +1166,7 @@ impl RoomDurability {
         manifest.source_generation = generation;
         manifest.source_phase = RecoverySourcePhase::DurablyStaged;
         manifest.source_fingerprint = observed_source;
-        manifest.staged_change_hashes = source_hashes;
+        manifest.staged_change_count = u64::try_from(source_hashes.len()).unwrap_or(u64::MAX);
         manifest.durable_heads = durable_heads.clone();
         manifest.exported_heads = durable_heads;
         manifest.canonical_path = Some(canonical_path);
@@ -1283,7 +1276,7 @@ fn status_from_state(state: &DurabilityState) -> RoomDurabilityStatus {
         source_generation: state.manifest.source_generation,
         source_phase: state.manifest.source_phase,
         source_fingerprint: state.manifest.source_fingerprint,
-        has_peer_changes: !state.manifest.peer_change_hashes.is_empty(),
+        has_peer_changes: state.manifest.peer_change_count > 0,
         degraded: state.degraded.clone(),
     }
 }
@@ -1330,19 +1323,13 @@ fn apply_mutation_to_manifest(manifest: &mut RecoveryManifest, mutation: Durable
             manifest.source_generation = generation;
             manifest.source_fingerprint = fingerprint;
             manifest.source_phase = RecoverySourcePhase::DurablyStaged;
-            manifest.staged_change_hashes = staged_change_hashes;
+            manifest.staged_change_count =
+                u64::try_from(staged_change_hashes.len()).unwrap_or(u64::MAX);
         }
         DurableMutation::Peer { change_hashes } => {
-            let mut seen = manifest
-                .peer_change_hashes
-                .iter()
-                .copied()
-                .collect::<HashSet<_>>();
-            for hash in change_hashes {
-                if seen.insert(hash) {
-                    manifest.peer_change_hashes.push(hash);
-                }
-            }
+            manifest.peer_change_count = manifest
+                .peer_change_count
+                .saturating_add(u64::try_from(change_hashes.len()).unwrap_or(u64::MAX));
         }
         DurableMutation::SourceReady { generation } => {
             manifest.source_generation = generation;
@@ -1378,11 +1365,13 @@ fn mutation_is_already_reflected(manifest: &RecoveryManifest, mutation: &Durable
         } => {
             manifest.source_generation == *generation
                 && manifest.source_fingerprint == *fingerprint
-                && manifest.staged_change_hashes == *staged_change_hashes
+                && manifest.staged_change_count
+                    == u64::try_from(staged_change_hashes.len()).unwrap_or(u64::MAX)
         }
-        DurableMutation::Peer { change_hashes } => change_hashes
-            .iter()
-            .all(|hash| manifest.peer_change_hashes.contains(hash)),
+        // The caller also requires exact durable-head equality. Equal heads
+        // prove these peer changes are already represented by the snapshot;
+        // the persisted count is diagnostic evidence, not a causal index.
+        DurableMutation::Peer { .. } => true,
         DurableMutation::SourceReady { generation } => {
             manifest.source_generation == *generation
                 && manifest.source_phase == RecoverySourcePhase::Ready
@@ -1504,10 +1493,7 @@ mod tests {
             RecoveryLoadOutcome::Match(recovered) => recovered,
             other => panic!("expected matching recovery, got {other:?}"),
         };
-        assert_eq!(
-            recovered.record.manifest.peer_change_hashes,
-            vec![change_hash]
-        );
+        assert_eq!(recovered.record.manifest.peer_change_count, 1);
         assert_eq!(recovered.record.automerge_snapshot, snapshot);
     }
 
@@ -1930,6 +1916,55 @@ mod tests {
             Some(2)
         );
         assert_eq!(durability.status().durable_heads, after_peer.durable_heads);
+    }
+
+    #[test]
+    fn recovered_large_peer_count_accepts_the_next_edit() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source = source_fingerprint(b"");
+        let mut document = AutoCommit::new();
+        document.put(ROOT, "existing", 1).unwrap();
+        let durable_heads = document.get_heads();
+        let durable_snapshot = document.save();
+        let mut manifest = RecoveryManifest::new(
+            2_251,
+            Uuid::new_v4(),
+            None,
+            notebook_doc::SCHEMA_VERSION,
+            source,
+            0,
+        );
+        manifest.peer_change_count = 2_251;
+        manifest.durable_heads = durable_heads.iter().map(|head| head.0).collect();
+        let durability = RoomDurability::recovered(
+            journal.clone(),
+            RecoveredJournalRecord {
+                record: super::super::recovery::RecoveryRecord {
+                    manifest,
+                    automerge_snapshot: durable_snapshot.clone(),
+                },
+                ignored_tail: None,
+            },
+        );
+
+        let mut peer = AutoCommit::load(&durable_snapshot).unwrap();
+        let baseline = peer.get_heads();
+        peer.put(ROOT, "next", 2).unwrap();
+        durability
+            .commit_peer_changes(peer.get_changes(&baseline))
+            .unwrap();
+
+        assert_eq!(durability.manifest().peer_change_count, 2_252);
+        let latest = match journal.latest_record().unwrap() {
+            super::super::recovery::RecoveryLatestOutcome::Recovered(recovered) => recovered,
+            other => panic!("expected committed recovery record, got {other:?}"),
+        };
+        assert_eq!(latest.record.manifest.peer_change_count, 2_252);
+        assert_eq!(
+            latest.record.manifest.version,
+            super::super::recovery::RECOVERY_MANIFEST_VERSION
+        );
     }
 
     #[test]
@@ -2438,10 +2473,10 @@ mod tests {
             other => panic!("expected selected active recovery, got {other:?}"),
         };
         assert_eq!(
-            active.record.manifest.staged_change_hashes,
-            replacement_hashes
+            active.record.manifest.staged_change_count,
+            u64::try_from(replacement_hashes.len()).unwrap()
         );
-        assert!(active.record.manifest.peer_change_hashes.is_empty());
+        assert_eq!(active.record.manifest.peer_change_count, 0);
         assert_eq!(active.record.manifest.durable_heads, selected_heads);
         assert_eq!(active.record.manifest.exported_heads, selected_heads);
         assert_eq!(active.record.manifest.file_save_sequence, Some(12));
@@ -2451,10 +2486,7 @@ mod tests {
             RecoveryLoadOutcome::Match(recovered) => recovered,
             other => panic!("expected preserved archived recovery, got {other:?}"),
         };
-        assert_eq!(
-            archived_record.record.manifest.peer_change_hashes,
-            vec![peer_hash]
-        );
+        assert_eq!(archived_record.record.manifest.peer_change_count, 1);
         assert_eq!(
             archived_record.record.automerge_snapshot,
             recovered_snapshot

--- a/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability/property_tests.rs
@@ -112,7 +112,7 @@ fn classify(manifest: &RecoveryManifest) -> RecoveryCase {
         RecoverySourcePhase::Pending | RecoverySourcePhase::Failed => {
             if manifest.pending_file_checkpoint.is_some() {
                 RecoveryCase::ResolvableIntent
-            } else if manifest.peer_change_hashes.is_empty() {
+            } else if manifest.peer_change_count == 0 {
                 RecoveryCase::Regenerable
             } else {
                 RecoveryCase::NeedsReconciliation
@@ -624,7 +624,7 @@ impl Runner {
             );
         }
         if case == RecoveryCase::NeedsReconciliation {
-            assert!(!manifest.peer_change_hashes.is_empty());
+            assert!(manifest.peer_change_count > 0);
             assert_ne!(
                 sorted(&manifest.durable_heads),
                 sorted(&manifest.exported_heads),
@@ -669,10 +669,7 @@ impl Runner {
             manifest.pending_file_checkpoint.is_some(),
             self.model.pending.is_some()
         );
-        assert_eq!(
-            !manifest.peer_change_hashes.is_empty(),
-            self.model.has_peer_changes
-        );
+        assert_eq!(manifest.peer_change_count > 0, self.model.has_peer_changes);
         self.assert_coverage_matches_model(&manifest);
         assert!(!self.durability.status().is_degraded());
     }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1075,11 +1075,13 @@ pub(crate) async fn finalize_recovered_source(
 
     let (cell_count, document_heads) = {
         let mut doc = room.doc.write().await;
-        for raw_hash in &manifest.staged_change_hashes {
+        // A staged frontier proves all of its causal ancestors are present;
+        // version 2 no longer persists every historical staged change hash.
+        for raw_hash in &manifest.exported_heads {
             let hash = automerge::ChangeHash(*raw_hash);
             if doc.doc_mut().get_change_by_hash(&hash).is_none() {
                 return Err(format!(
-                    "source_degraded: recovered document is missing staged change {hash}"
+                    "source_degraded: recovered document is missing staged head {hash}"
                 ));
             }
         }

--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -239,7 +239,7 @@ struct RecoveryManifestHeader {
 }
 
 enum DecodedRecoveryManifest {
-    Supported(RecoveryManifest),
+    Supported(Box<RecoveryManifest>),
     Unsupported(u16),
 }
 
@@ -248,10 +248,11 @@ fn decode_manifest(bytes: &[u8]) -> Result<DecodedRecoveryManifest, serde_json::
     match header.version {
         LEGACY_RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes)
             .map(LegacyRecoveryManifestV1::into)
+            .map(Box::new)
             .map(DecodedRecoveryManifest::Supported),
-        RECOVERY_MANIFEST_VERSION => {
-            serde_json::from_slice(bytes).map(DecodedRecoveryManifest::Supported)
-        }
+        RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes)
+            .map(Box::new)
+            .map(DecodedRecoveryManifest::Supported),
         version => Ok(DecodedRecoveryManifest::Unsupported(version)),
     }
 }
@@ -1104,7 +1105,7 @@ fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
         }
 
         let manifest = match decode_manifest(&manifest_bytes) {
-            Ok(DecodedRecoveryManifest::Supported(manifest)) => manifest,
+            Ok(DecodedRecoveryManifest::Supported(manifest)) => *manifest,
             Ok(DecodedRecoveryManifest::Unsupported(version)) => {
                 ignored_tail =
                     Some(JournalTailIssue::UnsupportedManifestVersion { offset, version });

--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -20,11 +20,15 @@ use crate::paths::notebook_doc_filename;
 
 const RECORD_MAGIC: [u8; 8] = *b"NTRJNL01";
 const RECORD_FORMAT_VERSION: u16 = 1;
-pub(crate) const RECOVERY_MANIFEST_VERSION: u16 = 1;
+const LEGACY_RECOVERY_MANIFEST_VERSION: u16 = 1;
+pub(crate) const RECOVERY_MANIFEST_VERSION: u16 = 2;
 
 const HEADER_PREFIX_LEN: usize = 8 + 2 + 4 + 8;
 const CHECKSUM_LEN: usize = 32;
 const HEADER_LEN: usize = HEADER_PREFIX_LEN + CHECKSUM_LEN;
+/// Bound causal metadata independently from the document snapshot so a corrupt
+/// record cannot request an unbounded allocation while scanning recovery data.
+/// Normal edit history must be summarized before it reaches this boundary.
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 const MAX_AUTOMERGE_SNAPSHOT_BYTES: usize = 256 * 1024 * 1024;
 const MAX_RECORD_BYTES: usize = HEADER_LEN + MAX_MANIFEST_BYTES + MAX_AUTOMERGE_SNAPSHOT_BYTES;
@@ -110,12 +114,15 @@ pub(crate) struct RecoveryManifest {
     pub(crate) source_generation: u64,
     #[serde(default)]
     pub(crate) source_phase: RecoverySourcePhase,
-    pub(crate) staged_change_hashes: Vec<[u8; 32]>,
+    /// Number of changes in the staged source generation. Exact causal
+    /// coverage is represented by `exported_heads`; retaining every ancestor
+    /// hash made this metadata grow without bound.
+    pub(crate) staged_change_count: u64,
     /// Peer-authored changes durably accepted after (or concurrently with)
     /// source publication. Recovery uses this evidence to forbid implicit
     /// source regeneration over collaborative work.
     #[serde(default)]
-    pub(crate) peer_change_hashes: Vec<[u8; 32]>,
+    pub(crate) peer_change_count: u64,
     pub(crate) durable_heads: Vec<[u8; 32]>,
     pub(crate) exported_heads: Vec<[u8; 32]>,
     #[serde(default)]
@@ -142,8 +149,8 @@ impl RecoveryManifest {
             source_fingerprint,
             source_generation,
             source_phase: RecoverySourcePhase::Pending,
-            staged_change_hashes: Vec::new(),
-            peer_change_hashes: Vec::new(),
+            staged_change_count: 0,
+            peer_change_count: 0,
             durable_heads: Vec::new(),
             exported_heads: Vec::new(),
             file_save_sequence: None,
@@ -175,6 +182,77 @@ impl RecoveryManifest {
         exported.sort_unstable();
         durable.sort_unstable();
         exported == durable
+    }
+}
+
+/// Version 1 retained every staged and peer-authored change hash. Long-lived
+/// untitled notebooks eventually filled the fixed-size manifest with ordinary
+/// edit history. Decode it only as a migration source; all new records use the
+/// bounded version 2 representation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct LegacyRecoveryManifestV1 {
+    version: u16,
+    sequence: u64,
+    notebook_id: Uuid,
+    canonical_path: Option<PathBuf>,
+    notebook_schema_version: u64,
+    source_fingerprint: SourceFingerprint,
+    source_generation: u64,
+    #[serde(default)]
+    source_phase: RecoverySourcePhase,
+    staged_change_hashes: Vec<[u8; 32]>,
+    #[serde(default)]
+    peer_change_hashes: Vec<[u8; 32]>,
+    durable_heads: Vec<[u8; 32]>,
+    exported_heads: Vec<[u8; 32]>,
+    #[serde(default)]
+    file_save_sequence: Option<u64>,
+    #[serde(default)]
+    pending_file_checkpoint: Option<PendingFileCheckpoint>,
+}
+
+impl From<LegacyRecoveryManifestV1> for RecoveryManifest {
+    fn from(legacy: LegacyRecoveryManifestV1) -> Self {
+        Self {
+            version: RECOVERY_MANIFEST_VERSION,
+            sequence: legacy.sequence,
+            notebook_id: legacy.notebook_id,
+            canonical_path: legacy.canonical_path,
+            notebook_schema_version: legacy.notebook_schema_version,
+            source_fingerprint: legacy.source_fingerprint,
+            source_generation: legacy.source_generation,
+            source_phase: legacy.source_phase,
+            staged_change_count: u64::try_from(legacy.staged_change_hashes.len())
+                .unwrap_or(u64::MAX),
+            peer_change_count: u64::try_from(legacy.peer_change_hashes.len()).unwrap_or(u64::MAX),
+            durable_heads: legacy.durable_heads,
+            exported_heads: legacy.exported_heads,
+            file_save_sequence: legacy.file_save_sequence,
+            pending_file_checkpoint: legacy.pending_file_checkpoint,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RecoveryManifestHeader {
+    version: u16,
+}
+
+enum DecodedRecoveryManifest {
+    Supported(RecoveryManifest),
+    Unsupported(u16),
+}
+
+fn decode_manifest(bytes: &[u8]) -> Result<DecodedRecoveryManifest, serde_json::Error> {
+    let header: RecoveryManifestHeader = serde_json::from_slice(bytes)?;
+    match header.version {
+        LEGACY_RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes)
+            .map(LegacyRecoveryManifestV1::into)
+            .map(DecodedRecoveryManifest::Supported),
+        RECOVERY_MANIFEST_VERSION => {
+            serde_json::from_slice(bytes).map(DecodedRecoveryManifest::Supported)
+        }
+        version => Ok(DecodedRecoveryManifest::Unsupported(version)),
     }
 }
 
@@ -1025,8 +1103,13 @@ fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
             break;
         }
 
-        let manifest: RecoveryManifest = match serde_json::from_slice(&manifest_bytes) {
-            Ok(manifest) => manifest,
+        let manifest = match decode_manifest(&manifest_bytes) {
+            Ok(DecodedRecoveryManifest::Supported(manifest)) => manifest,
+            Ok(DecodedRecoveryManifest::Unsupported(version)) => {
+                ignored_tail =
+                    Some(JournalTailIssue::UnsupportedManifestVersion { offset, version });
+                break;
+            }
             Err(error) => {
                 ignored_tail = Some(JournalTailIssue::InvalidManifest {
                     offset,
@@ -1035,14 +1118,6 @@ fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
                 break;
             }
         };
-        if manifest.version != RECOVERY_MANIFEST_VERSION {
-            ignored_tail = Some(JournalTailIssue::UnsupportedManifestVersion {
-                offset,
-                version: manifest.version,
-            });
-            break;
-        }
-
         let record_len = HEADER_LEN as u64 + payload_len;
         last_valid_end = offset + record_len;
         offset = last_valid_end;
@@ -1303,7 +1378,7 @@ mod tests {
             source_fingerprint(source),
             7,
         );
-        manifest.staged_change_hashes = vec![[sequence as u8; 32]];
+        manifest.staged_change_count = 1;
         manifest.durable_heads = vec![[(sequence + 1) as u8; 32]];
         manifest.exported_heads = vec![[(sequence + 2) as u8; 32]];
         manifest
@@ -1314,6 +1389,29 @@ mod tests {
             RecoveryLoadOutcome::Match(recovery) => recovery,
             other => panic!("expected matching recovery record, got {other:?}"),
         }
+    }
+
+    fn encode_legacy_record(
+        manifest: &LegacyRecoveryManifestV1,
+        automerge_snapshot: &[u8],
+    ) -> Vec<u8> {
+        let manifest_bytes = serde_json::to_vec(manifest).unwrap();
+        assert!(manifest_bytes.len() <= MAX_MANIFEST_BYTES);
+        let mut prefix = Vec::with_capacity(HEADER_PREFIX_LEN);
+        prefix.extend_from_slice(&RECORD_MAGIC);
+        prefix.extend_from_slice(&RECORD_FORMAT_VERSION.to_le_bytes());
+        prefix.extend_from_slice(&u32::try_from(manifest_bytes.len()).unwrap().to_le_bytes());
+        prefix.extend_from_slice(
+            &u64::try_from(automerge_snapshot.len())
+                .unwrap()
+                .to_le_bytes(),
+        );
+        let checksum = record_checksum(&prefix, &manifest_bytes, automerge_snapshot);
+        let mut bytes = prefix;
+        bytes.extend_from_slice(&checksum);
+        bytes.extend_from_slice(&manifest_bytes);
+        bytes.extend_from_slice(automerge_snapshot);
+        bytes
     }
 
     #[test]
@@ -1339,6 +1437,79 @@ mod tests {
 
         assert_eq!(recovered.record.manifest.version, RECOVERY_MANIFEST_VERSION);
         assert_eq!(recovered.record.manifest.notebook_schema_version, 42);
+    }
+
+    #[test]
+    fn legacy_manifest_near_cap_migrates_to_bounded_summary() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = RecoveryJournal::new(directory.path().join("room.recovery"));
+        let source = b"source";
+        let snapshot = snapshot("long editing session");
+        let mut document = AutoCommit::load(&snapshot).unwrap();
+        let heads = document.get_heads().iter().map(|head| head.0).collect();
+        let candidate_hashes = (0_u64..3_000)
+            .map(|index| Sha256::digest(index.to_le_bytes()).into())
+            .collect::<Vec<[u8; 32]>>();
+        let mut legacy = LegacyRecoveryManifestV1 {
+            version: LEGACY_RECOVERY_MANIFEST_VERSION,
+            sequence: 2_251,
+            notebook_id: Uuid::new_v4(),
+            canonical_path: None,
+            notebook_schema_version: notebook_doc::SCHEMA_VERSION,
+            source_fingerprint: source_fingerprint(source),
+            source_generation: 0,
+            source_phase: RecoverySourcePhase::Pending,
+            staged_change_hashes: Vec::new(),
+            peer_change_hashes: Vec::new(),
+            durable_heads: heads,
+            exported_heads: Vec::new(),
+            file_save_sequence: None,
+            pending_file_checkpoint: None,
+        };
+
+        let (mut low, mut high) = (0_usize, candidate_hashes.len());
+        while low < high {
+            let mid = low + (high - low).div_ceil(2);
+            legacy.peer_change_hashes = candidate_hashes[..mid].to_vec();
+            if serde_json::to_vec(&legacy).unwrap().len() <= MAX_MANIFEST_BYTES {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        legacy.peer_change_hashes = candidate_hashes[..low].to_vec();
+        let legacy_size = serde_json::to_vec(&legacy).unwrap().len();
+        assert!(legacy_size > MAX_MANIFEST_BYTES - 256);
+        std::fs::write(journal.path(), encode_legacy_record(&legacy, &snapshot)).unwrap();
+
+        let recovered = match journal.latest_record().unwrap() {
+            RecoveryLatestOutcome::Recovered(recovered) => *recovered,
+            other => panic!("expected migrated recovery record, got {other:?}"),
+        };
+        assert_eq!(recovered.record.manifest.version, RECOVERY_MANIFEST_VERSION);
+        assert_eq!(
+            recovered.record.manifest.peer_change_count,
+            u64::try_from(low).unwrap()
+        );
+        assert!(
+            serde_json::to_vec(&recovered.record.manifest)
+                .unwrap()
+                .len()
+                < 1_024
+        );
+
+        let mut next = recovered.record.manifest;
+        next.sequence += 1;
+        next.peer_change_count += 1;
+        journal
+            .append(&next, &recovered.record.automerge_snapshot)
+            .unwrap();
+        let latest = match journal.latest_record().unwrap() {
+            RecoveryLatestOutcome::Recovered(recovered) => recovered,
+            other => panic!("expected version 2 recovery record, got {other:?}"),
+        };
+        assert_eq!(latest.record.manifest, next);
+        assert!(latest.ignored_tail.is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1744,11 +1744,11 @@ impl NotebookRoom {
                     }
                     super::recovery::RecoverySourcePhase::Pending
                     | super::recovery::RecoverySourcePhase::Failed
-                        if !manifest.peer_change_hashes.is_empty() =>
+                        if manifest.peer_change_count > 0 =>
                     {
                         let reason = format!(
                             "source_degraded: recovery contains {} peer changes but no durably staged source generation",
-                            manifest.peer_change_hashes.len()
+                            manifest.peer_change_count
                         );
                         state.with_doc(|runtime| {
                             runtime.set_file_source_issue(Some(


### PR DESCRIPTION
## Summary

- keep the 256 KiB recovery-manifest limit as a defensive record/allocation boundary
- replace unbounded staged and peer change-hash histories with fixed-width diagnostic counts; causal coverage remains represented by Automerge frontiers
- migrate version 1 recovery manifests on read and write all new records as version 2

## Incident

A long-lived untitled notebook in the 2.7.3 stable release accumulated 2,251 peer change hashes in its recovery manifest. The last valid manifest was 262,060 bytes; acknowledging the next ordinary edit required 262,178 bytes, exceeding the 262,144-byte limit. The durability boundary correctly refused to acknowledge an edit it could not journal, but the room then remained degraded and reconnect attempts repeatedly relaunched and evicted kernels.

The size limit is still valuable: recovery scanning must reject corrupt length fields before allocating arbitrary amounts of memory, independently of the much larger Automerge snapshot bound. The failure was using that bounded metadata area as an append-only causal index.

## Fix

Recovery manifest v2 stores:

- `durable_heads` and `exported_heads` as the bounded causal frontiers used for coverage checks
- `peer_change_count` and `staged_change_count` as fixed-width diagnostic evidence

Version 1 records are decoded through an explicit legacy schema and migrated in memory. The next journal write emits version 2. Unsupported future versions remain rejected. Older binaries will stop at a v2 record rather than silently interpreting the new schema; a v1 record earlier in the append-only journal remains their last readable recovery point.

Peer commit idempotence now checks the durable Automerge snapshot directly. Staged-source verification checks the exported frontier: if every exported head is present, Automerge guarantees its causal ancestors are present as well.

## Validation

- `cargo xtask lint --fix`
- `cargo test -p runtimed legacy_manifest_near_cap_migrates_to_bounded_summary --no-fail-fast`
- `cargo test -p runtimed recovered_large_peer_count_accepts_the_next_edit --no-fail-fast`
- `cargo clippy -p runtimed --lib -- -D warnings`
- `cargo test -p runtimed --no-fail-fast` (all recovery, durability, integration, and lint targets passed; one unrelated shell-startup environment smoke test failed once, then passed immediately when rerun alone)
- `cargo xtask build --rust-only --skip-tauri`

The captured 2.7.3 incident journal was copied into an isolated worktree daemon. The patched daemon recovered all 23 cells and exported a valid notebook. After the first v2 write, the manifest was 763 bytes, retained the 2,251 peer-change count and identical Automerge frontier, and no longer approached the cap.

Independent Kilo correctness and operability reviews found the migration, downgrade, idempotence, and frontier checks sound. The operability pass caught a CI-blocking `large_enum_variant` warning in the initial commit; the follow-up commit boxes the decoded manifest and the exact clippy command now passes. A third architecture pass was discarded because it inspected the wrong repository history despite the runner's source-integrity check.
