### PR TITLE
test(runtimed): remove Bloom-dependent sync fixtures

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs
@@ -242,18 +242,31 @@ mod tests {
             .generate_sync_message_recovering(room_peer_state, "comments-test-initial")
             .unwrap()
             .expect("initial comments sync message");
+        let room_heads = initial_message.heads.clone();
         sender
             .receive_sync_message_with_changes(sender_state, initial_message)
             .expect("client receives initial comments sync");
         create_sender_thread(sender, body);
-        let message = sender
-            .generate_sync_message(sender_state)
-            .expect("sender sync message");
-        assert!(
-            !message.changes.is_empty(),
-            "client payload should carry comment changes"
-        );
-        message.encode()
+        let heads = sender.get_heads();
+        // Include the sender's actor-authored schema branch as well as the new
+        // thread; the room heads are the exact history the receiver already has.
+        let changes = sender.doc_mut().get_changes(&room_heads);
+        assert!(!changes.is_empty(), "fixture must author comment changes");
+        // Avoid the normal sync exchange's approximate `have` Bloom filter:
+        // these authorization tests require an exact changes-bearing frame.
+        sync::Message {
+            heads,
+            need: Vec::new(),
+            have: Vec::new(),
+            changes: changes
+                .iter()
+                .map(|change| change.raw_bytes().to_vec())
+                .collect::<Vec<_>>()
+                .into(),
+            flags: None,
+            version: sync::MessageVersion::V1,
+        }
+        .encode()
     }
 
     async fn read_comments_frame<R>(reader: &mut R) -> Vec<u8>

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -1178,6 +1178,7 @@ mod tests {
         client_doc
             .receive_sync_message_recovering(&mut client_state, initial, "test-failed-load-client")
             .unwrap();
+        let mut initial_sync_converged = false;
         for round in 0..32 {
             let from_client = client_doc
                 .generate_sync_message_recovering(
@@ -1195,6 +1196,7 @@ mod tests {
                 )
                 .unwrap();
             if from_client.is_none() && from_room.is_none() {
+                initial_sync_converged = true;
                 break;
             }
             if let Some(message) = from_client {
@@ -1218,6 +1220,10 @@ mod tests {
                     .unwrap();
             }
         }
+        assert!(
+            initial_sync_converged,
+            "initial sync must converge before authoring the deferred change"
+        );
 
         client_doc
             .update_source("progressive-cell", "edited before source failure")

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2734,8 +2734,6 @@ async fn notebook_change_frame(
 ) -> (Vec<u8>, sync::State) {
     let server_snapshot = room.doc.write().await.save();
     let mut client = NotebookDoc::load_with_actor(&server_snapshot, actor_label).unwrap();
-    client.add_cell(0, cell_id, "code").unwrap();
-    client.update_source(cell_id, "peer_value = 1").unwrap();
     let mut client_state = sync::State::new();
     let mut server_peer_state = sync::State::new();
     let initial_server_message = room
@@ -2752,15 +2750,28 @@ async fn notebook_change_frame(
             "test-peer-initial-receive",
         )
         .unwrap();
-    let payload = client
-        .generate_sync_message_recovering(&mut client_state, "test-peer-change")
-        .unwrap()
-        .expect("peer should produce a changes-bearing message")
-        .encode();
-    assert!(
-        !sync::Message::decode(&payload).unwrap().changes.is_empty(),
-        "the test frame must carry peer changes"
-    );
+    let initial_heads = client.get_heads();
+    client.add_cell(0, cell_id, "code").unwrap();
+    client.update_source(cell_id, "peer_value = 1").unwrap();
+    let heads = client.get_heads();
+    let changes = client.doc_mut().get_changes(&initial_heads);
+    assert!(!changes.is_empty(), "the fixture must author peer changes");
+    // The normal sync exchange uses an approximate `have` Bloom filter, which
+    // can legally omit a newly authored change. This fixture must exercise a
+    // changes-bearing admission frame on every platform.
+    let payload = sync::Message {
+        heads,
+        need: Vec::new(),
+        have: Vec::new(),
+        changes: changes
+            .iter()
+            .map(|change| change.raw_bytes().to_vec())
+            .collect::<Vec<_>>()
+            .into(),
+        flags: None,
+        version: sync::MessageVersion::V1,
+    }
+    .encode();
     (payload, server_peer_state)
 }
 


### PR DESCRIPTION
## Summary

- make NotebookDoc peer-admission fixtures construct exact changes-bearing Automerge V1 frames
- include the complete sender-authored CommentsDoc causal branch in comments authorization fixtures
- assert reciprocal initial sync reaches quiescence before testing buffered peer edits

## Why

PR #4185 removed a Bloom-filter-dependent runtime-agent fixture after it failed on Windows. The post-merge `main` build then exposed the same test-fixture pattern on macOS in `peer_journal_failure_rolls_back_document_and_sync_ack` (workflow run `32923737676`, job `98043247917`).

Automerge sync `have` entries use an intentionally approximate Bloom filter. A false positive may legally produce a heads-only frame instead of carrying a newly authored change, so tests that require a changes-bearing admission frame must not depend on normal message generation. Production sync behavior is unchanged.

## Verification

- `cargo test -p runtimed peer_journal_failure_rolls_back_document_and_sync_ack`
- `cargo test -p runtimed foreign_actor_changes_never_reach_durability`
- `cargo test -p runtimed viewer_changes_never_reach_durability`
- `cargo test -p runtimed notebook_sync_server::peer_comments_sync::tests::`
- `cargo test -p runtimed failed_generation_preserves_journaled_peer_changes_before_terminal_status`
- `cargo test -p runtimed`
- `cargo xtask lint --fix`
- `git diff --check`

Independent protocol review confirmed the explicit frames retain complete causal history and preserve foreign-actor rejection, viewer/runtime stripping, editor persistence, and fanout semantics.
