### PR TITLE
test(runtimed): make buffered peer edit deterministic

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -1225,17 +1225,28 @@ mod tests {
             "initial sync must converge before authoring the deferred change"
         );
 
+        let before_edit_heads = client_doc.get_heads();
         client_doc
             .update_source("progressive-cell", "edited before source failure")
             .unwrap();
-        let peer_edit = client_doc
-            .generate_sync_message_recovering(&mut client_state, "test-failed-load-edit")
-            .unwrap()
-            .expect("client edit should produce a sync message");
-        assert!(
-            !peer_edit.changes.is_empty(),
-            "regression requires a change-bearing frame deferred by bootstrap"
-        );
+        let edit_heads = client_doc.get_heads();
+        let edit_changes = client_doc.doc_mut().get_changes(&before_edit_heads);
+        assert!(!edit_changes.is_empty(), "fixture must author a peer edit");
+        // This regression requires an edit-bearing frame followed by a
+        // causally-later empty ACK. Normal sync generation uses an approximate
+        // `have` Bloom filter and may legally produce a heads-only edit frame.
+        let peer_edit = sync::Message {
+            heads: edit_heads,
+            need: Vec::new(),
+            have: Vec::new(),
+            changes: edit_changes
+                .iter()
+                .map(|change| change.raw_bytes().to_vec())
+                .collect::<Vec<_>>()
+                .into(),
+            flags: None,
+            version: sync::MessageVersion::V1,
+        };
         let empty_ack = sync::Message {
             heads: peer_edit.heads.clone(),
             need: peer_edit.need.clone(),


### PR DESCRIPTION
## Summary

- construct the buffered peer edit as an exact Automerge V1 changes frame
- preserve the realistic initial handshake and the edit-then-empty-ACK ordering
- remove the final Bloom-filter-dependent assertion from the peer sync fixtures

## Why

The post-merge `main` Build for #4186 failed on macOS in `failed_generation_preserves_journaled_peer_changes_before_terminal_status` (workflow run `32927530581`). Initial sync had converged, but the client retained a non-empty peer `have` Bloom from an earlier exchange. A legal false positive then produced a frame with the new heads and no changes.

That is safe protocol behavior—the receiver can request the missing head on another round—but this regression fixture intentionally prebuffers exactly two frames: a changes-bearing edit and a causally later empty ACK. It must construct that edit frame deterministically.

This is test-only. Production sync, authorization, journaling, and recovery behavior are unchanged.

## Verification

- `cargo test -p runtimed failed_generation_preserves_journaled_peer_changes_before_terminal_status`
- `cargo test -p runtimed`
- `cargo xtask lint --fix`
- `git diff --check`
- focused source-read-only Kilo correctness review with `kilo/anthropic/claude-opus-5`: no actionable findings

The independent review confirmed complete causal closure, byte-equivalent Automerge V1 change encoding, preserved edit-before-ACK semantics, and retained authorization plus real durability coverage.
