### PR TITLE
fix(kernel): preserve Python IOPub output under pressure

### DIFF
--- a/crates/kernel-env/src/launcher.rs
+++ b/crates/kernel-env/src/launcher.rs
@@ -40,6 +40,12 @@ pub const LAUNCHER_FILES: &[(&str, &str)] = &[
         include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/app.py"),
     ),
     (
+        "transport.py",
+        include_str!(
+            "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/transport.py"
+        ),
+    ),
+    (
         "_bootstrap.py",
         include_str!(
             "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py"
@@ -260,6 +266,13 @@ mod tests {
             LAUNCHER_FILES.iter().map(|(name, _)| *name).collect();
         assert!(names.contains("_bokeh_session.py"));
         assert!(names.contains("_panel.py"));
+    }
+
+    #[test]
+    fn launcher_ships_reliable_transport_policy() {
+        let names: std::collections::HashSet<&str> =
+            LAUNCHER_FILES.iter().map(|(name, _)| *name).collect();
+        assert!(names.contains("transport.py"));
     }
 
     #[tokio::test]

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/app.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/app.py
@@ -42,6 +42,7 @@ from nteract_kernel_launcher._bokeh_session import (
     StaleBokehRevisionError,
     session_registry,
 )
+from nteract_kernel_launcher.transport import ReliableIOPubMixin
 
 _BOKEH_PATCH_REQUEST = "nteract_bokeh_patch_request"
 _BOKEH_PATCH_REPLY = "nteract_bokeh_patch_reply"
@@ -440,7 +441,7 @@ class NteractKernel(IPythonKernel):
         _send_bokeh_reply(self, stream, ident, _BOKEH_CLOSE_REPLY, reply)
 
 
-class NteractKernelApp(IPKernelApp):
+class NteractKernelApp(ReliableIOPubMixin, IPKernelApp):
     """Kernel-app subclass. Activates the full ``Nteract*`` cascade and
     auto-loads the bootstrap extension before any user code runs.
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/transport.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/transport.py
@@ -1,0 +1,45 @@
+"""Reliable transport policy for nteract's Python kernel entry point.
+
+ZeroMQ PUB sockets normally report successful sends after silently dropping a
+subscriber whose per-peer send queue reached its high-water mark.  Notebook
+output is durable application state, so nteract keeps the finite queue but
+asks libzmq to backpressure the IOPub worker instead of discarding messages.
+This intentionally makes a slow daemon delay output publication; shell,
+control, and interrupt traffic use separate channels. Users who select the
+legacy IPython launcher retain upstream's lossy transport behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import zmq
+
+
+class ReliableIOPubMixin:
+    """Enable lossless PUB/XPUB behavior before ipykernel binds IOPub."""
+
+    def _bind_socket(self, s: Any, port: int) -> Any:
+        socket_type = s.getsockopt(zmq.TYPE)
+        if socket_type in (zmq.PUB, zmq.XPUB):
+            # ipykernel 6 uses PUB and ipykernel 7 uses XPUB. libzmq's PUB
+            # implementation accepts the XPUB_NODROP policy as well.
+            no_drop = getattr(zmq, "XPUB_NODROP", None)
+            if no_drop is None:
+                self.log.warning(
+                    "ZeroMQ does not expose XPUB_NODROP; IOPub may lose output under pressure"
+                )
+            else:
+                try:
+                    s.setsockopt(no_drop, 1)
+                    self.log.debug("Enabled lossless IOPub delivery")
+                except zmq.ZMQError as exc:
+                    # Keep older user-managed Python environments launchable.
+                    # Their libzmq may predate XPUB_NODROP even when pyzmq
+                    # exposes the constant.
+                    self.log.warning(
+                        "Could not enable lossless IOPub delivery; output may be lost under "
+                        "pressure: %s",
+                        exc,
+                    )
+        return super()._bind_socket(s, port)

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "ipykernel>=6.0",
+    "pyzmq>=17",
 ]
 
 [build-system]

--- a/python/nteract-kernel-launcher/tests/test_transport.py
+++ b/python/nteract-kernel-launcher/tests/test_transport.py
@@ -1,0 +1,208 @@
+"""Tests for nteract's reliable Python IOPub transport policy."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import zmq
+from nteract_kernel_launcher.transport import ReliableIOPubMixin
+
+
+class _BindRecorder:
+    def _bind_socket(self, s: Any, port: int) -> Any:
+        s.calls.append(("bind", port))
+        return port
+
+
+class _TestApp(ReliableIOPubMixin, _BindRecorder):
+    def __init__(self) -> None:
+        self.log = SimpleNamespace(
+            debug=lambda *args: self.debugs.append(args),
+            warning=lambda *args: self.warnings.append(args),
+        )
+        self.debugs: list[tuple[Any, ...]] = []
+        self.warnings: list[tuple[Any, ...]] = []
+
+
+class _SocketSpy:
+    def __init__(self, socket_type: int) -> None:
+        self.socket_type = socket_type
+        self.calls: list[tuple[Any, ...]] = []
+
+    def getsockopt(self, option: int) -> int:
+        assert option == zmq.TYPE
+        return self.socket_type
+
+    def setsockopt(self, option: int, value: int) -> None:
+        self.calls.append(("setsockopt", option, value))
+
+
+@pytest.mark.parametrize("socket_type", [zmq.PUB, zmq.XPUB])
+def test_publisher_nodrop_is_set_before_bind(socket_type: int) -> None:
+    socket = _SocketSpy(socket_type)
+
+    assert _TestApp()._bind_socket(socket, 42) == 42
+
+    assert socket.calls == [
+        ("setsockopt", zmq.XPUB_NODROP, 1),
+        ("bind", 42),
+    ]
+
+
+def test_nonpublisher_socket_is_unchanged() -> None:
+    socket = _SocketSpy(zmq.ROUTER)
+
+    assert _TestApp()._bind_socket(socket, 42) == 42
+
+    assert socket.calls == [("bind", 42)]
+
+
+def test_unsupported_nodrop_warns_and_still_binds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(zmq, "XPUB_NODROP")
+    app = _TestApp()
+    socket = _SocketSpy(zmq.XPUB)
+
+    assert app._bind_socket(socket, 42) == 42
+
+    assert socket.calls == [("bind", 42)]
+    assert len(app.warnings) == 1
+
+
+def test_rejected_nodrop_warns_and_still_binds() -> None:
+    class RejectingSocket(_SocketSpy):
+        def setsockopt(self, option: int, value: int) -> None:
+            raise zmq.ZMQError(zmq.EINVAL)
+
+    app = _TestApp()
+    socket = RejectingSocket(zmq.XPUB)
+
+    assert app._bind_socket(socket, 42) == 42
+
+    assert socket.calls == [("bind", 42)]
+    assert len(app.warnings) == 1
+
+
+def test_rich_entrypoint_uses_reliable_transport_policy() -> None:
+    from ipykernel.kernelapp import IPKernelApp
+    from nteract_kernel_launcher.app import NteractKernelApp
+
+    assert issubclass(NteractKernelApp, ReliableIOPubMixin)
+    assert NteractKernelApp._bind_socket is ReliableIOPubMixin._bind_socket
+    assert hasattr(IPKernelApp, "_bind_socket")
+
+
+def _connected_xpub_pair(*, no_drop: bool) -> tuple[zmq.Context[Any], Any, Any]:
+    context = zmq.Context()
+    publisher = context.socket(zmq.XPUB)
+    publisher.sndhwm = 2
+    if no_drop:
+        publisher.setsockopt(zmq.XPUB_NODROP, 1)
+    endpoint = f"inproc://nteract-iopub-{id(publisher)}"
+    publisher.bind(endpoint)
+
+    subscriber = context.socket(zmq.SUB)
+    subscriber.rcvhwm = 2
+    subscriber.setsockopt(zmq.SUBSCRIBE, b"")
+    subscriber.connect(endpoint)
+
+    assert publisher.poll(1_000, zmq.POLLIN)
+    assert publisher.recv() == b"\x01"
+    return context, publisher, subscriber
+
+
+def test_nodrop_turns_silent_loss_into_backpressure() -> None:
+    lossy_context, lossy_publisher, lossy_subscriber = _connected_xpub_pair(no_drop=False)
+    reliable_context, reliable_publisher, reliable_subscriber = _connected_xpub_pair(no_drop=True)
+    payload = b"x" * 10_000
+    try:
+        for _ in range(100):
+            # Lossy XPUB reports every nonblocking send as successful even
+            # after its subscriber is removed from the active set.
+            lossy_publisher.send(payload, zmq.NOBLOCK)
+
+        lossy_received = 0
+        while lossy_subscriber.poll(10, zmq.POLLIN):
+            lossy_subscriber.recv()
+            lossy_received += 1
+        assert lossy_received < 100
+
+        accepted = 0
+        with pytest.raises(zmq.Again):
+            for _ in range(10_000):
+                reliable_publisher.send(payload, zmq.NOBLOCK)
+                accepted += 1
+        assert accepted < 10_000
+    finally:
+        lossy_publisher.close(linger=0)
+        lossy_subscriber.close(linger=0)
+        lossy_context.term()
+        reliable_publisher.close(linger=0)
+        reliable_subscriber.close(linger=0)
+        reliable_context.term()
+
+
+def test_blocking_nodrop_preserves_order_after_reader_resumes() -> None:
+    context = zmq.Context()
+    endpoint = f"inproc://nteract-iopub-blocking-{id(context)}"
+    publisher_ready = threading.Event()
+    subscription_ready = threading.Event()
+    publisher_finished = threading.Event()
+    publisher_errors: list[BaseException] = []
+    message_count = 100
+    padding = b"x" * 10_000
+
+    def publish() -> None:
+        publisher = context.socket(zmq.XPUB)
+        publisher.sndhwm = 2
+        # Test-only timeout: a transport regression must fail this test rather
+        # than leave its publisher thread blocked forever.
+        publisher.sndtimeo = 1_000
+        publisher.setsockopt(zmq.XPUB_NODROP, 1)
+        publisher.bind(endpoint)
+        publisher_ready.set()
+        try:
+            if not publisher.poll(1_000, zmq.POLLIN):
+                raise AssertionError("subscriber did not register")
+            assert publisher.recv() == b"\x01"
+            subscription_ready.set()
+            for sequence in range(message_count):
+                publisher.send_multipart([sequence.to_bytes(4, "big"), padding])
+        except BaseException as exc:  # noqa: BLE001 - propagated to the test thread
+            publisher_errors.append(exc)
+            subscription_ready.set()
+        finally:
+            publisher.close(linger=0)
+            publisher_finished.set()
+
+    publisher_thread = threading.Thread(target=publish, daemon=True)
+    publisher_thread.start()
+    assert publisher_ready.wait(1)
+
+    subscriber = context.socket(zmq.SUB)
+    subscriber.rcvhwm = 2
+    subscriber.setsockopt(zmq.SUBSCRIBE, b"")
+    subscriber.connect(endpoint)
+    try:
+        assert subscription_ready.wait(1)
+        assert not publisher_finished.wait(0.05), "publisher should backpressure"
+
+        for expected in range(message_count):
+            assert subscriber.poll(1_000, zmq.POLLIN)
+            sequence, received_padding = subscriber.recv_multipart()
+            assert int.from_bytes(sequence, "big") == expected
+            assert received_padding == padding
+
+        assert publisher_finished.wait(1)
+        assert publisher_errors == []
+    finally:
+        subscriber.close(linger=0)
+        publisher_thread.join(timeout=2)
+        publisher_stuck = publisher_thread.is_alive()
+        if publisher_stuck:
+            context.destroy(linger=0)
+        else:
+            context.term()
+        assert not publisher_stuck, "publisher thread did not shut down"


### PR DESCRIPTION
## Summary

- enable ZeroMQ `XPUB_NODROP` on the nteract Python kernel's IOPub publisher before bind
- retain the finite send high-water mark, turning transient pressure into backpressure instead of silent notebook-output loss
- fail open with diagnostics on older ZeroMQ builds and preserve the direct legacy `ipykernel_launcher` escape hatch
- embed the new transport policy in the daemon-vendored launcher package

## Why

The post-merge `main` build exposed a real output-integrity failure: a 2,000-line, individually flushed stream returned both `chunk-0` and `chunk-1999` but only 1,780 total chunks. The final RuntimeState manifest is causally ordered before execution completion, so this was not stale Automerge state.

ipykernel 7.3 publishes through a lossy XPUB socket with ZeroMQ's default 1,000-message per-peer send high-water mark. When runtimed temporarily falls behind, libzmq silently removes that subscriber from the active set, reports sends as successful, and later resumes delivery. That exactly permits a missing interior range with the first and last messages present.

`XPUB_NODROP` preserves the existing finite memory bound but makes the publisher wait for runtimed to drain instead of discarding output. Shell, control, and interrupt traffic use separate channels. Users who explicitly select the legacy IPython launcher retain upstream's lossy behavior as a compatibility escape hatch.

## Verification

- `cargo xtask lint --fix`
- `uv run --project python/nteract-kernel-launcher pytest python/nteract-kernel-launcher/tests -q` — 140 passed
- transport tests repeated five times — 8 passed each run
- `cargo test -p kernel-env launcher` — 9 unit tests and launcher vendoring E2E passed
- `cargo build -p runtimed`
- patched-binary `test_noisy_stdout_final_output_reconciles` — exact 2,000 chunks passed
- independent correctness and maintainability reviews; follow-up review reported no actionable findings
