### PR TITLE
test: remove sync and token timing flakes

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -230,6 +230,11 @@ where
         )
         .await
         .expect("daemon should send a NotebookDoc sync reply");
+        if decode_sync_status(&frame).is_some_and(|status| {
+            status.notebook_doc == notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
+        }) {
+            panic!("daemon advertised NotebookDoc Interactive before its sync reply");
+        }
         if frame.frame_type == NotebookFrameType::AutomergeSync {
             return frame.payload;
         }
@@ -360,40 +365,71 @@ async fn notebook_doc_interactive_waits_for_initial_sync_convergence() {
     .await
     .unwrap();
 
-    let changes_reply = recv_notebook_sync_reply(&mut client_reader).await;
-    let mut premature_interactive = false;
-    while let Some(frame) = recv_typed_frame_or_timeout(
-        &mut client_reader,
-        std::time::Duration::from_millis(150),
-        "post-reply drain",
-    )
-    .await
-    {
-        if decode_sync_status(&frame).is_some_and(|status| {
-            status.notebook_doc == notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
-        }) {
-            premature_interactive = true;
+    let mut final_ack = None;
+    // Automerge's `have` Bloom filter may produce a false positive for an
+    // ancestor of the requested head. The receiver queues that orphan and
+    // requests the missing dependency on the next round, so drive the real
+    // handshake to convergence instead of requiring a particular packet to
+    // contain the room cells. Upstream Automerge uses the same 10-round bound.
+    for round in 0..10 {
+        let sync_reply = recv_notebook_sync_reply(&mut client_reader).await;
+        let mut premature_interactive = false;
+        while let Some(frame) = recv_typed_frame_or_timeout(
+            &mut client_reader,
+            std::time::Duration::from_millis(150),
+            "post-reply drain",
+        )
+        .await
+        {
+            if decode_sync_status(&frame).is_some_and(|status| {
+                status.notebook_doc
+                    == notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
+            }) {
+                premature_interactive = true;
+                break;
+            }
+            assert_ne!(
+                frame.frame_type,
+                NotebookFrameType::AutomergeSync,
+                "daemon sent another NotebookDoc sync reply before the client acknowledged round {round}"
+            );
+        }
+        assert!(
+            !premature_interactive,
+            "daemon advertised NotebookDoc Interactive before the joiner acknowledged sync round {round}"
+        );
+
+        let sync_message = sync::Message::decode(&sync_reply).expect("valid sync reply");
+        client_doc
+            .receive_sync_message_recovering(
+                &mut client_state,
+                sync_message,
+                "test-initial-sync-round",
+            )
+            .unwrap();
+        let client_reply = client_doc
+            .generate_sync_message_recovering(&mut client_state, "test-initial-sync-reply")
+            .unwrap()
+            .expect("client should continue the initial sync handshake");
+
+        if client_doc.cell_count() == 2 {
+            final_ack = Some(client_reply);
             break;
         }
-    }
-    assert!(
-        !premature_interactive,
-        "daemon advertised NotebookDoc Interactive before the joiner acknowledged the changes-bearing initial sync reply"
-    );
+        assert!(
+            !client_reply.need.is_empty(),
+            "extra initial sync round {round} must request a missing dependency"
+        );
 
-    let changes_message = sync::Message::decode(&changes_reply).expect("valid changes reply");
-    client_doc
-        .receive_sync_message_recovering(&mut client_state, changes_message, "test-changes-sync")
+        connection::send_typed_frame(
+            &mut client_writer,
+            NotebookFrameType::AutomergeSync,
+            &client_reply.encode(),
+        )
+        .await
         .unwrap();
-    assert_eq!(
-        client_doc.cell_count(),
-        2,
-        "the changes-bearing reply must deliver the existing room cells"
-    );
-    let final_ack = client_doc
-        .generate_sync_message_recovering(&mut client_state, "test-final-ack")
-        .unwrap()
-        .expect("client should acknowledge the changes-bearing reply");
+    }
+    let final_ack = final_ack.expect("initial sync must deliver the existing room cells");
     connection::send_typed_frame(
         &mut client_writer,
         NotebookFrameType::AutomergeSync,

--- a/packages/local-oidc/tests/issuer.test.ts
+++ b/packages/local-oidc/tests/issuer.test.ts
@@ -340,13 +340,17 @@ describe("createLocalOidcIssuer", () => {
   });
 
   it("honors a per-call ttl override in mintToken", async () => {
+    const overrideTtlSeconds = 60;
     const issuer = makeIssuer({ defaultTokenTtlSeconds: 3600 });
-    const token = await issuer.mintToken({ sub: "svc", email: "svc@localhost" }, { ttlSeconds: 1 });
+    const token = await issuer.mintToken(
+      { sub: "svc", email: "svc@localhost" },
+      { ttlSeconds: overrideTtlSeconds },
+    );
     const { payload } = await jose.jwtVerify(token, await verifierFor(issuer), {
       issuer: ISSUER_URL,
       audience: CLIENT_ID,
     });
-    expect((payload.exp ?? 0) - (payload.iat ?? 0)).toBe(1);
+    expect((payload.exp ?? 0) - (payload.iat ?? 0)).toBe(overrideTtlSeconds);
   });
 
   it("mintToken signs a token that verifies against the published JWKS", async () => {


### PR DESCRIPTION
## Summary

- drive the real Automerge initial sync exchange to convergence instead of assuming the first daemon reply contains every ancestor
- tolerate legal `have` Bloom-filter false positives only when the client requests a missing dependency
- keep the NotebookDoc readiness barrier strict across every round, including frame ordering before and after each daemon reply
- keep the local OIDC per-call TTL assertion exact without racing a one-second real-time expiry during the full JS suite

## Why

The post-merge Linux Rust suite exposed a rare legal Automerge exchange: a Bloom false positive can omit an ancestor of the requested head, so the receiver queues the orphan and requests the dependency on the next round. Production remains in `Syncing`, but the regression test incorrectly required both cells after exactly one daemon reply.

The first PR CI run then exposed an independent JS test race: it minted a one-second JWT and verified it after enough suite scheduling delay for the token to expire. A 60-second override still proves the per-call value wins over the 3,600-second default while removing wall-clock expiry from that assertion.

## Verification

- `cargo xtask lint --fix`
- targeted convergence test passed
- targeted test passed 200 repeated runs before the final stricter frame assertions
- `cargo test -p runtimed` (1,288 unit, 72 integration, lifecycle/RPC/safety checks)
- `cargo test -p runtimed --lib` after the final reviewer fixes (1,288 passed, 3 ignored)
- local OIDC issuer tests passed 20 repeated runs (27 tests each)
- independent Automerge protocol analysis and Kilo correctness review
