### PR TITLE
fix(runtimed): serialize concurrent kernel launches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,6 +4056,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "nix 0.31.2",
  "reqwest 0.12.28",
  "runt-workspace",
  "serde",
@@ -4064,6 +4065,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "windows-sys 0.52.0",
  "zip 8.5.1",
 ]
 

--- a/apps/notebook/src/lib/__tests__/notebook-action-policy.test.tsx
+++ b/apps/notebook/src/lib/__tests__/notebook-action-policy.test.tsx
@@ -182,4 +182,58 @@ describe("useNotebookActionPolicy", () => {
     expect(events.slice(0, 2)).toEqual(["reset-dismissed", "approve-environment"]);
     expect(options.showEnvBuildDialog).not.toHaveBeenCalled();
   });
+
+  it("shuts down before switching a running kernel to the project environment", async () => {
+    const events: string[] = [];
+    const options = createPolicyOptions({
+      shutdownKernel: vi.fn(async () => {
+        events.push("shutdown");
+        return response("kernel_shutting_down");
+      }),
+      launchKernel: vi.fn(async () => {
+        events.push("launch-project");
+        return response("kernel_launched");
+      }),
+    });
+    const { result } = renderHook(() => useNotebookActionPolicy(options));
+
+    await act(async () => {
+      await result.current.handleStartKernelWithPyproject();
+    });
+
+    expect(events).toEqual(["shutdown", "launch-project"]);
+    expect(options.launchKernel).toHaveBeenCalledWith("python", "uv:pyproject");
+  });
+
+  it("retries the project switch when it first joins a different auto-launched environment", async () => {
+    const events: string[] = [];
+    const options = createPolicyOptions({
+      shutdownKernel: vi.fn(async () => {
+        events.push("shutdown");
+        return response("kernel_shutting_down");
+      }),
+      launchKernel: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          events.push("join-auto");
+          return {
+            result: "kernel_already_running",
+            kernel_type: "python",
+            env_source: "uv:prewarmed",
+            launched_config: {},
+          } as NotebookResponse;
+        })
+        .mockImplementationOnce(async () => {
+          events.push("launch-project");
+          return response("kernel_launched");
+        }),
+    });
+    const { result } = renderHook(() => useNotebookActionPolicy(options));
+
+    await act(async () => {
+      await result.current.handleStartKernelWithPyproject();
+    });
+
+    expect(events).toEqual(["shutdown", "join-auto", "shutdown", "launch-project"]);
+  });
 });

--- a/apps/notebook/src/lib/notebook-action-policy.ts
+++ b/apps/notebook/src/lib/notebook-action-policy.ts
@@ -553,7 +553,19 @@ export function useNotebookActionPolicy({
       );
       return;
     }
-    const response = await launchKernel("python", "uv:pyproject");
+    // LaunchKernel is idempotent by protocol: an already-running kernel is
+    // returned unchanged. This action explicitly switches environments, so
+    // preserve that intent with the same shutdown-then-launch sequence used
+    // by Restart Kernel.
+    await shutdownKernel();
+    let response = await launchKernel("python", "uv:pyproject");
+    // If an auto-launch was already preparing an environment, the first call
+    // joins it rather than starting duplicate work. Once that launch finishes,
+    // replace it if it was not the requested project environment.
+    if (response.result === "kernel_already_running" && response.env_source !== "uv:pyproject") {
+      await shutdownKernel();
+      response = await launchKernel("python", "uv:pyproject");
+    }
     if (response.result === "error") {
       logger.error(
         "[notebook-action-policy] handleStartKernelWithPyproject: daemon error",
@@ -562,7 +574,7 @@ export function useNotebookActionPolicy({
     } else if (response.result === "guard_rejected") {
       setTrustActionNotice(response.reason);
     }
-  }, [canExecute, launchKernel, sessionReady]);
+  }, [canExecute, launchKernel, sessionReady, shutdownKernel]);
 
   const handleExecuteCell = useCallback(
     async (cellId: string) => {

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -22,6 +22,7 @@ use std::time::Instant;
 use crate::{
     channels::parse_channels,
     progress::{EnvProgressPhase, ProgressHandler, RattlerReporter},
+    CommandOutputExt,
 };
 
 /// Conda dependency specification.
@@ -877,7 +878,7 @@ pub async fn warmup_environment(env: &CondaEnvironment) -> Result<()> {
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])
-        .output()
+        .output_owned()
         .await?;
 
     if !output.status.success() {

--- a/crates/kernel-env/src/launcher.rs
+++ b/crates/kernel-env/src/launcher.rs
@@ -16,6 +16,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
+use crate::CommandOutputExt;
+
 /// Canonical name of the launcher package directory inside site-packages.
 pub const LAUNCHER_PKG: &str = "nteract_kernel_launcher";
 
@@ -116,7 +118,7 @@ pub async fn purelib_for(python: &Path) -> Result<PathBuf> {
             "-c",
             "import sysconfig; print(sysconfig.get_path('purelib'))",
         ])
-        .output()
+        .output_owned()
         .await
         .with_context(|| format!("failed to spawn {python:?} for sysconfig lookup"))?;
     if !output.status.success() {

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -33,12 +33,15 @@ mod channels;
 pub mod conda;
 #[cfg(feature = "runtime")]
 pub mod gc;
+#[cfg(feature = "runtime")]
 pub mod launcher;
 #[cfg(feature = "runtime")]
 pub mod lock;
 #[cfg(feature = "runtime")]
 pub mod pixi;
 pub mod progress;
+#[cfg(feature = "runtime")]
+pub use kernel_launch::CommandOutputExt;
 #[cfg(feature = "runtime")]
 pub mod repodata;
 #[cfg(feature = "runtime")]
@@ -169,7 +172,26 @@ struct IpykernelProbe {
 ///
 #[cfg(feature = "runtime")]
 pub fn diagnose_ipykernel(python_path: &std::path::Path) -> IpykernelDiagnostic {
-    let probe = match probe_ipykernel(python_path) {
+    diagnose_ipykernel_from_probe(python_path, probe_ipykernel(python_path))
+}
+
+/// Async, cancellation-safe form of [`diagnose_ipykernel`] for launch paths.
+///
+/// The interpreter is owned as a process tree and bounded independently of
+/// the caller. Dropping this future kills and reaps that tree before returning,
+/// so a cancelled launch cannot leave an import probe holding its generation
+/// gate or mutating the environment behind a replacement kernel.
+#[cfg(feature = "runtime")]
+pub async fn diagnose_ipykernel_async(python_path: &std::path::Path) -> IpykernelDiagnostic {
+    diagnose_ipykernel_from_probe(python_path, probe_ipykernel_async(python_path).await)
+}
+
+#[cfg(feature = "runtime")]
+fn diagnose_ipykernel_from_probe(
+    python_path: &std::path::Path,
+    probe: Result<IpykernelProbe, String>,
+) -> IpykernelDiagnostic {
+    let probe = match probe {
         Ok(probe) => probe,
         Err(message) => {
             return IpykernelDiagnostic::InterpreterProbeFailed {
@@ -213,9 +235,27 @@ pub fn venv_has_ipykernel(python_path: &std::path::Path) -> bool {
 #[cfg(feature = "runtime")]
 fn probe_ipykernel(python_path: &std::path::Path) -> Result<IpykernelProbe, String> {
     let output = std::process::Command::new(python_path)
-        .args([
-            "-c",
-            r#"import json, sysconfig
+        .args(["-c", IPYKERNEL_PROBE_SCRIPT])
+        .output()
+        .map_err(|e| e.to_string())?;
+    parse_ipykernel_probe_output(output)
+}
+
+#[cfg(feature = "runtime")]
+async fn probe_ipykernel_async(python_path: &std::path::Path) -> Result<IpykernelProbe, String> {
+    const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+    let mut command = tokio::process::Command::new(python_path);
+    command.args(["-c", IPYKERNEL_PROBE_SCRIPT]);
+    let output = tokio::time::timeout(PROBE_TIMEOUT, command.output_owned())
+        .await
+        .map_err(|_| format!("interpreter probe timed out after {PROBE_TIMEOUT:?}"))?
+        .map_err(|e| e.to_string())?;
+    parse_ipykernel_probe_output(output)
+}
+
+#[cfg(feature = "runtime")]
+const IPYKERNEL_PROBE_SCRIPT: &str = r#"import json, sysconfig
 try:
     import ipykernel  # noqa: F401
     import_ok = True
@@ -227,10 +267,10 @@ print(json.dumps({
     "purelib": sysconfig.get_paths().get("purelib", ""),
     "import_ok": import_ok,
     "error": error,
-}))"#,
-        ])
-        .output()
-        .map_err(|e| e.to_string())?;
+}))"#;
+
+#[cfg(feature = "runtime")]
+fn parse_ipykernel_probe_output(output: std::process::Output) -> Result<IpykernelProbe, String> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         return Err(if stderr.is_empty() {
@@ -446,6 +486,40 @@ mod site_packages_has_ipykernel_tests {
         assert!(!venv_has_ipykernel(std::path::Path::new(
             "/definitely/not/a/python/interpreter"
         )));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelling_async_probe_prevents_late_interpreter_mutation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let interpreter = tmp.path().join("hanging-python");
+        let late_mutation = tmp.path().join("late-mutation");
+        std::fs::write(
+            &interpreter,
+            format!(
+                "#!/bin/sh\nsleep 0.2\ntouch '{}'\n",
+                late_mutation.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&interpreter, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            diagnose_ipykernel_async(&interpreter),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "probe fixture should reach outer cancellation"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(
+            !late_mutation.exists(),
+            "cancelled interpreter survived long enough to mutate state"
+        );
     }
 
     #[test]

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -27,6 +27,7 @@ use std::time::Instant;
 use crate::{
     channels::parse_channels,
     progress::{EnvProgressPhase, ProgressHandler, RattlerReporter},
+    CommandOutputExt,
 };
 
 /// A resolved pixi environment on disk.
@@ -358,7 +359,7 @@ pub async fn warmup_environment(env: &PixiEnvironment, extra_modules: &[String])
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])
-        .output()
+        .output_owned()
         .await?;
 
     if !output.status.success() {

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+
+use crate::CommandOutputExt;
 use std::sync::Arc;
 
 use crate::progress::{EnvProgressPhase, ProgressHandler};
@@ -269,7 +271,7 @@ pub async fn prepare_environment_in(
     let venv_output = venv_cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if !venv_output.status.success() {
@@ -321,7 +323,7 @@ pub async fn prepare_environment_in(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if offline_output.status.success() {
@@ -359,7 +361,7 @@ pub async fn prepare_environment_in(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     // If install failed, retry once with --refresh to bypass stale index cache.
@@ -379,7 +381,7 @@ pub async fn prepare_environment_in(
             .current_dir(cache_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .output()
+            .output_owned()
             .await?
     } else {
         install_output
@@ -529,7 +531,7 @@ async fn prepare_environment_unified_inner(
     let venv_output = venv_cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if !venv_output.status.success() {
@@ -579,7 +581,7 @@ async fn prepare_environment_unified_inner(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if offline_output.status.success() {
@@ -615,7 +617,7 @@ async fn prepare_environment_unified_inner(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     let install_output = if !install_output.status.success() {
@@ -631,7 +633,7 @@ async fn prepare_environment_unified_inner(
             .current_dir(cache_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .output()
+            .output_owned()
             .await?
     } else {
         install_output
@@ -715,7 +717,7 @@ pub async fn sync_dependencies(
     let offline_output = tokio::process::Command::new(&uv_path)
         .args(&offline_args)
         .current_dir(cwd)
-        .output()
+        .output_owned()
         .await?;
 
     if offline_output.status.success() {
@@ -739,7 +741,7 @@ pub async fn sync_dependencies(
     let output = tokio::process::Command::new(&uv_path)
         .args(&install_args)
         .current_dir(cwd)
-        .output()
+        .output_owned()
         .await?;
 
     if !output.status.success() {
@@ -802,7 +804,7 @@ pub async fn create_prewarmed_environment_in(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if !venv_output.status.success() {
@@ -847,7 +849,7 @@ pub async fn create_prewarmed_environment_in(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if offline_output.status.success() {
@@ -889,7 +891,7 @@ pub async fn create_prewarmed_environment_in(
         .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .output_owned()
         .await?;
 
     if !install_output.status.success() {
@@ -1060,7 +1062,7 @@ pub async fn warmup_environment(env: &UvEnvironment) -> Result<()> {
 
     let output = tokio::process::Command::new(&env.python_path)
         .args(["-c", &warmup_script])
-        .output()
+        .output_owned()
         .await?;
 
     if !output.status.success() {

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -28,3 +28,9 @@ serde_json = { workspace = true }
 
 # GitHub release downloads
 reqwest = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/crates/kernel-launch/src/lib.rs
+++ b/crates/kernel-launch/src/lib.rs
@@ -26,7 +26,10 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod process;
 pub mod tools;
+
+pub use process::CommandOutputExt;
 
 // Re-export commonly used items
 pub use tools::{get_deno_path, get_ruff_path, get_uv_path, BootstrappedTool};

--- a/crates/kernel-launch/src/process.rs
+++ b/crates/kernel-launch/src/process.rs
@@ -49,9 +49,7 @@ impl CommandOutputExt for tokio::process::Command {
             windows,
         };
         #[cfg(windows)]
-        if let Err(error) = process_tree.windows.resume() {
-            return Err(error);
-        }
+        process_tree.windows.resume()?;
         match child.wait_with_output().await {
             Ok(output) => {
                 process_tree.armed = false;
@@ -332,37 +330,39 @@ impl WindowsProcessTree {
         // additionally fences every descendant before launch completion can
         // reopen the generation gate.
         let deadline = std::time::Instant::now() + TERMINATION_FENCE_TIMEOUT;
-        while self.job != 0 {
-            let mut accounting: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { zeroed() };
-            let query_ok = unsafe {
-                QueryInformationJobObject(
-                    self.job,
-                    JobObjectBasicAccountingInformation,
-                    &mut accounting as *mut _ as *mut _,
-                    size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
-                    std::ptr::null_mut(),
-                )
-            };
-            if query_ok == 0 {
-                log::warn!(
-                    "failed to query cancelled package-manager job completion: {}",
-                    unsafe { GetLastError() }
-                );
-                break;
+        if self.job != 0 {
+            loop {
+                let mut accounting: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { zeroed() };
+                let query_ok = unsafe {
+                    QueryInformationJobObject(
+                        self.job,
+                        JobObjectBasicAccountingInformation,
+                        &mut accounting as *mut _ as *mut _,
+                        size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                        std::ptr::null_mut(),
+                    )
+                };
+                if query_ok == 0 {
+                    log::warn!(
+                        "failed to query cancelled package-manager job completion: {}",
+                        unsafe { GetLastError() }
+                    );
+                    break;
+                }
+                if accounting.ActiveProcesses == 0 {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    log::warn!(
+                        "cancelled package-manager job for process {} retained {} process(es) after {:?}",
+                        self.pid,
+                        accounting.ActiveProcesses,
+                        TERMINATION_FENCE_TIMEOUT
+                    );
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
             }
-            if accounting.ActiveProcesses == 0 {
-                break;
-            }
-            if std::time::Instant::now() >= deadline {
-                log::warn!(
-                    "cancelled package-manager job for process {} retained {} process(es) after {:?}",
-                    self.pid,
-                    accounting.ActiveProcesses,
-                    TERMINATION_FENCE_TIMEOUT
-                );
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(1));
         }
     }
 }

--- a/crates/kernel-launch/src/process.rs
+++ b/crates/kernel-launch/src/process.rs
@@ -1,0 +1,463 @@
+use std::future::Future;
+use std::io;
+use std::process::{Output, Stdio};
+
+const TERMINATION_FENCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Cancellation-safe output collection for package-manager subprocesses.
+///
+/// Tokio leaves children running when an `output()` future is dropped unless
+/// kill-on-drop is enabled. Package managers may also spawn build helpers, so
+/// Unix commands own a fresh process group and Windows commands are terminated
+/// as a tree. A room-owned launch task can therefore be aborted without an
+/// orphan continuing to mutate its environment after the launch gate reopens.
+pub trait CommandOutputExt {
+    fn output_owned(&mut self) -> impl Future<Output = io::Result<Output>> + Send;
+}
+
+impl CommandOutputExt for tokio::process::Command {
+    async fn output_owned(&mut self) -> io::Result<Output> {
+        self.stdout(Stdio::piped()).stderr(Stdio::piped());
+        #[cfg(unix)]
+        self.process_group(0);
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+
+            self.creation_flags(CREATE_SUSPENDED);
+        }
+
+        let child = self.spawn()?;
+        #[cfg(unix)]
+        let pid = child
+            .id()
+            .ok_or_else(|| io::Error::other("spawned package-manager child has no process id"))?;
+        #[cfg(windows)]
+        let windows = match WindowsProcessTree::assign(&child) {
+            Ok(windows) => windows,
+            Err(error) => {
+                terminate_suspended_child(&child);
+                drop(child);
+                return Err(error);
+            }
+        };
+        let mut process_tree = ProcessTreeGuard {
+            #[cfg(unix)]
+            pid,
+            armed: true,
+            #[cfg(windows)]
+            windows,
+        };
+        #[cfg(windows)]
+        if let Err(error) = process_tree.windows.resume() {
+            return Err(error);
+        }
+        match child.wait_with_output().await {
+            Ok(output) => {
+                process_tree.armed = false;
+                Ok(output)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+struct ProcessTreeGuard {
+    #[cfg(unix)]
+    pid: u32,
+    armed: bool,
+    #[cfg(windows)]
+    windows: WindowsProcessTree,
+}
+
+impl Drop for ProcessTreeGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        run_blocking_cleanup(|| self.terminate_and_reap());
+    }
+}
+
+impl ProcessTreeGuard {
+    fn terminate_and_reap(&mut self) {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{killpg, Signal};
+            use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+            use nix::unistd::Pid;
+
+            let pid = Pid::from_raw(self.pid as i32);
+            if let Err(error) = killpg(pid, Signal::SIGKILL) {
+                if error != nix::errno::Errno::ESRCH {
+                    log::warn!(
+                        "failed to terminate cancelled package-manager process group {}: {}",
+                        self.pid,
+                        error
+                    );
+                }
+            }
+
+            // Task abortion drops this guard immediately before the launch
+            // attempt records completion. Reap the process leader here so
+            // completion cannot reopen the launch gate while that command is
+            // still able to mutate a project file or environment.
+            let deadline = std::time::Instant::now() + TERMINATION_FENCE_TIMEOUT;
+            loop {
+                match waitpid(pid, Some(WaitPidFlag::WNOHANG)) {
+                    Ok(WaitStatus::Exited(..) | WaitStatus::Signaled(..))
+                    | Err(nix::errno::Errno::ECHILD) => break,
+                    Err(nix::errno::Errno::EINTR) => continue,
+                    Ok(WaitStatus::StillAlive) if std::time::Instant::now() < deadline => {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    Ok(WaitStatus::StillAlive) => {
+                        log::warn!(
+                            "cancelled package-manager process {} did not reap within {:?}",
+                            self.pid,
+                            TERMINATION_FENCE_TIMEOUT
+                        );
+                        break;
+                    }
+                    Ok(status) => {
+                        log::warn!(
+                            "cancelled package-manager process {} returned unexpected wait status {:?}",
+                            self.pid,
+                            status
+                        );
+                        break;
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "failed to reap cancelled package-manager process {}: {}",
+                            self.pid,
+                            error
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            self.windows.terminate_and_wait();
+        }
+    }
+}
+
+fn run_blocking_cleanup(cleanup: impl FnOnce()) {
+    if tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+    {
+        tokio::task::block_in_place(cleanup);
+    } else {
+        cleanup();
+    }
+}
+
+#[cfg(windows)]
+struct WindowsProcessTree {
+    job: windows_sys::Win32::Foundation::HANDLE,
+    process: windows_sys::Win32::Foundation::HANDLE,
+    pid: u32,
+}
+
+#[cfg(windows)]
+impl WindowsProcessTree {
+    fn assign(child: &tokio::process::Child) -> io::Result<Self> {
+        use std::mem::{size_of, zeroed};
+        use std::os::windows::io::RawHandle;
+        use std::ptr::null;
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, DuplicateHandle, GetLastError, DUPLICATE_SAME_ACCESS, HANDLE,
+        };
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+        use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| io::Error::other("spawned package-manager child has no process id"))?;
+        let raw_process = child.raw_handle().ok_or_else(|| {
+            io::Error::other("spawned package-manager child has no process handle")
+        })? as RawHandle as HANDLE;
+        let job = unsafe { CreateJobObjectW(null(), null()) };
+        if job == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let set_ok = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const _,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if set_ok == 0 {
+            let error = unsafe { GetLastError() };
+            unsafe { CloseHandle(job) };
+            return Err(io::Error::from_raw_os_error(error as i32));
+        }
+
+        let current = unsafe { GetCurrentProcess() };
+        let mut process = 0;
+        let duplicate_ok = unsafe {
+            DuplicateHandle(
+                current,
+                raw_process,
+                current,
+                &mut process,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        if duplicate_ok == 0 {
+            let error = unsafe { GetLastError() };
+            unsafe { CloseHandle(job) };
+            return Err(io::Error::from_raw_os_error(error as i32));
+        }
+
+        let assign_ok = unsafe { AssignProcessToJobObject(job, raw_process) };
+        if assign_ok == 0 {
+            let error = unsafe { GetLastError() };
+            unsafe {
+                CloseHandle(process);
+                CloseHandle(job);
+            }
+            return Err(io::Error::from_raw_os_error(error as i32));
+        }
+
+        Ok(Self { job, process, pid })
+    }
+
+    fn resume(&self) -> io::Result<()> {
+        use std::mem::{size_of, zeroed};
+        use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+        };
+        use windows_sys::Win32::System::Threading::{
+            OpenThread, ResumeThread, THREAD_SUSPEND_RESUME,
+        };
+
+        let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut entry: THREADENTRY32 = unsafe { zeroed() };
+        entry.dwSize = size_of::<THREADENTRY32>() as u32;
+        let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+        while has_entry {
+            if entry.th32OwnerProcessID == self.pid {
+                let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+                if thread == 0 {
+                    let error = unsafe { GetLastError() };
+                    unsafe { CloseHandle(snapshot) };
+                    return Err(io::Error::from_raw_os_error(error as i32));
+                }
+                let resume_result = unsafe { ResumeThread(thread) };
+                let error = unsafe { GetLastError() };
+                unsafe {
+                    CloseHandle(thread);
+                    CloseHandle(snapshot);
+                }
+                if resume_result == u32::MAX {
+                    return Err(io::Error::from_raw_os_error(error as i32));
+                }
+                return Ok(());
+            }
+            has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+        }
+
+        unsafe { CloseHandle(snapshot) };
+        Err(io::Error::other(format!(
+            "suspended package-manager process {} had no resumable thread",
+            self.pid
+        )))
+    }
+
+    fn terminate_and_wait(&mut self) {
+        use std::mem::{size_of, zeroed};
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, GetLastError, WAIT_OBJECT_0, WAIT_TIMEOUT,
+        };
+        use windows_sys::Win32::System::JobObjects::{
+            JobObjectBasicAccountingInformation, QueryInformationJobObject, TerminateJobObject,
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+        };
+        use windows_sys::Win32::System::Threading::{TerminateProcess, WaitForSingleObject};
+
+        if unsafe { TerminateJobObject(self.job, 1) } == 0 {
+            log::warn!(
+                "failed to terminate cancelled package-manager job for process {}: {}",
+                self.pid,
+                unsafe { GetLastError() }
+            );
+            // Closing the final kill-on-close job handle is the strongest
+            // available tree fallback. Terminate the duplicated leader too,
+            // then use its handle as the bounded completion fence below.
+            unsafe {
+                CloseHandle(self.job);
+                TerminateProcess(self.process, 1);
+            }
+            self.job = 0;
+        }
+        let wait_ms = TERMINATION_FENCE_TIMEOUT.as_millis() as u32;
+        match unsafe { WaitForSingleObject(self.process, wait_ms) } {
+            WAIT_OBJECT_0 => {}
+            WAIT_TIMEOUT => log::warn!(
+                "cancelled package-manager process {} did not exit within {:?}",
+                self.pid,
+                TERMINATION_FENCE_TIMEOUT
+            ),
+            _ => log::warn!(
+                "failed waiting for cancelled package-manager process {}: {}",
+                self.pid,
+                unsafe { GetLastError() }
+            ),
+        }
+
+        // TerminateJobObject initiates termination for the whole job. The
+        // duplicated leader handle above fences the direct process; this loop
+        // additionally fences every descendant before launch completion can
+        // reopen the generation gate.
+        let deadline = std::time::Instant::now() + TERMINATION_FENCE_TIMEOUT;
+        while self.job != 0 {
+            let mut accounting: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { zeroed() };
+            let query_ok = unsafe {
+                QueryInformationJobObject(
+                    self.job,
+                    JobObjectBasicAccountingInformation,
+                    &mut accounting as *mut _ as *mut _,
+                    size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                    std::ptr::null_mut(),
+                )
+            };
+            if query_ok == 0 {
+                log::warn!(
+                    "failed to query cancelled package-manager job completion: {}",
+                    unsafe { GetLastError() }
+                );
+                break;
+            }
+            if accounting.ActiveProcesses == 0 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                log::warn!(
+                    "cancelled package-manager job for process {} retained {} process(es) after {:?}",
+                    self.pid,
+                    accounting.ActiveProcesses,
+                    TERMINATION_FENCE_TIMEOUT
+                );
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+}
+
+#[cfg(windows)]
+fn terminate_suspended_child(child: &tokio::process::Child) {
+    use std::os::windows::io::RawHandle;
+    use windows_sys::Win32::Foundation::{GetLastError, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{TerminateProcess, WaitForSingleObject};
+
+    if let Some(raw_handle) = child.raw_handle() {
+        let process = raw_handle as RawHandle as HANDLE;
+        let pid = child.id().unwrap_or_default();
+        if unsafe { TerminateProcess(process, 1) } == 0 {
+            log::warn!(
+                "failed to terminate suspended package-manager process {}: {}",
+                pid,
+                unsafe { GetLastError() }
+            );
+        }
+        match unsafe { WaitForSingleObject(process, TERMINATION_FENCE_TIMEOUT.as_millis() as u32) }
+        {
+            WAIT_OBJECT_0 => {}
+            WAIT_TIMEOUT => log::warn!(
+                "suspended package-manager process {} did not exit within {:?}",
+                pid,
+                TERMINATION_FENCE_TIMEOUT
+            ),
+            _ => log::warn!(
+                "failed waiting for suspended package-manager process {}: {}",
+                pid,
+                unsafe { GetLastError() }
+            ),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsProcessTree {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        unsafe {
+            CloseHandle(self.process);
+            if self.job != 0 {
+                CloseHandle(self.job);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::CommandOutputExt;
+
+    #[tokio::test]
+    async fn cancelling_output_terminates_the_owned_process_group_before_returning() {
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let pid_file = temp.path().join("pids");
+        let mutation_file = temp.path().join("late-mutation");
+        let script = format!(
+            "echo $$ > '{}'; (sleep 0.2; touch '{}') & echo $! >> '{}'; wait",
+            pid_file.display(),
+            mutation_file.display(),
+            pid_file.display()
+        );
+        let mut command = tokio::process::Command::new("sh");
+        command.args(["-c", &script]);
+        let task = tokio::spawn(async move { command.output_owned().await });
+
+        let pids = loop {
+            if let Ok(contents) = tokio::fs::read_to_string(&pid_file).await {
+                let pids: Vec<i32> = contents
+                    .lines()
+                    .filter_map(|line| line.parse().ok())
+                    .collect();
+                if pids.len() == 2 {
+                    break pids;
+                }
+            }
+            tokio::task::yield_now().await;
+        };
+
+        task.abort();
+        let _ = task.await;
+        assert!(
+            kill(Pid::from_raw(pids[0]), None).is_err(),
+            "process leader remained alive after cancellation completed"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(
+            !mutation_file.exists(),
+            "cancelled process tree mutated state after cancellation completed"
+        );
+    }
+}

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -17,6 +17,8 @@ use std::sync::{
 use tokio::sync::OnceCell;
 use zip::ZipArchive;
 
+use crate::CommandOutputExt;
+
 /// Target Deno version for GitHub download.
 pub const DENO_TARGET_VERSION: &str = "2.7.1";
 
@@ -485,7 +487,7 @@ pub async fn get_ruff_path() -> Result<PathBuf> {
             // First, check if ruff is on PATH
             if let Ok(output) = tokio::process::Command::new("ruff")
                 .arg("--version")
-                .output()
+                .output_owned()
                 .await
             {
                 if output.status.success() {
@@ -530,7 +532,7 @@ pub async fn check_deno_available_without_bootstrap() -> bool {
     // Check for acceptable system deno (2.x+)
     if let Ok(output) = tokio::process::Command::new("deno")
         .arg("--version")
-        .output()
+        .output_owned()
         .await
     {
         if output.status.success() {
@@ -566,7 +568,7 @@ fn parse_deno_major_version(version_output: &str) -> Option<u32> {
 async fn check_system_deno_acceptable() -> Option<PathBuf> {
     let output = tokio::process::Command::new("deno")
         .arg("--version")
-        .output()
+        .output_owned()
         .await
         .ok()?;
 
@@ -947,7 +949,7 @@ pub async fn get_uv_path() -> Result<PathBuf> {
             //    (which may be overridden by per-launch env_vars).
             if let Ok(output) = tokio::process::Command::new("uv")
                 .arg("--version")
-                .output()
+                .output_owned()
                 .await
             {
                 if output.status.success() {
@@ -1090,7 +1092,7 @@ pub async fn get_pixi_path() -> Result<PathBuf> {
             //    PATH (see `get_uv_path` for rationale).
             if let Ok(output) = tokio::process::Command::new("pixi")
                 .arg("--version")
-                .output()
+                .output_owned()
                 .await
             {
                 if output.status.success() {
@@ -1242,7 +1244,7 @@ pub async fn get_nono_path() -> Result<PathBuf> {
         .get_or_init(|| async {
             if let Ok(output) = tokio::process::Command::new("nono")
                 .arg("--version")
-                .output()
+                .output_owned()
                 .await
             {
                 if output.status.success() {
@@ -1346,7 +1348,7 @@ pub async fn pixi_info(manifest_path: &std::path::Path) -> Result<PixiInfoResult
     let output = tokio::process::Command::new(&pixi_path)
         .args(["info", "--json", "--manifest-path"])
         .arg(manifest_path)
-        .output()
+        .output_owned()
         .await
         .map_err(|e| anyhow!("failed to run pixi info: {}", e))?;
 
@@ -1385,7 +1387,7 @@ pub async fn pixi_shell_hook(
     }
 
     let output = cmd
-        .output()
+        .output_owned()
         .await
         .map_err(|e| anyhow!("failed to run pixi shell-hook: {}", e))?;
 
@@ -2002,7 +2004,7 @@ mod tests {
                 // Sanity: running `nono --version` should succeed.
                 let output = tokio::process::Command::new(&tool.binary_path)
                     .arg("--version")
-                    .output()
+                    .output_owned()
                     .await
                     .expect("should be able to run nono --version");
                 assert!(

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -51,6 +51,7 @@ pub struct PreparedEnv {
 pub struct RuntimeDocProgressHandler {
     state: RuntimeStateHandle,
     crdt_write_state: Mutex<CrdtProgressWriteState>,
+    launch_cancel_rx: Option<tokio::sync::watch::Receiver<bool>>,
 }
 
 impl RuntimeDocProgressHandler {
@@ -58,6 +59,18 @@ impl RuntimeDocProgressHandler {
         Self {
             state,
             crdt_write_state: Mutex::default(),
+            launch_cancel_rx: None,
+        }
+    }
+
+    pub fn new_for_launch(
+        state: RuntimeStateHandle,
+        launch_cancel_rx: Option<tokio::sync::watch::Receiver<bool>>,
+    ) -> Self {
+        Self {
+            state,
+            crdt_write_state: Mutex::default(),
+            launch_cancel_rx,
         }
     }
 
@@ -95,6 +108,14 @@ impl ProgressHandler for RuntimeDocProgressHandler {
         // Log all phases
         kernel_env::LogHandler.on_progress(env_type, phase.clone());
 
+        if self
+            .launch_cancel_rx
+            .as_ref()
+            .is_some_and(|cancel_rx| *cancel_rx.borrow())
+        {
+            return;
+        }
+
         let should_write = self.should_write_crdt_progress(&phase)
             || self
                 .state
@@ -106,10 +127,20 @@ impl ProgressHandler for RuntimeDocProgressHandler {
 
         match serde_json::to_value(&phase) {
             Ok(value) => {
-                if let Err(e) = self
-                    .state
-                    .with_doc(|sd| sd.set_env_progress(env_type, &value))
-                {
+                if let Err(e) = self.state.with_doc(|sd| {
+                    // Re-check while holding the RuntimeStateDoc lock. If
+                    // cancellation raced the optimistic check above, the
+                    // terminal shutdown commit either clears progress
+                    // after this write or has already made this check true.
+                    if self
+                        .launch_cancel_rx
+                        .as_ref()
+                        .is_some_and(|cancel_rx| *cancel_rx.borrow())
+                    {
+                        return Ok(());
+                    }
+                    sd.set_env_progress(env_type, &value)
+                }) {
                     tracing::warn!("[runtime-state] failed to write env progress: {}", e);
                 }
             }
@@ -753,6 +784,21 @@ mod tests {
                 "phase": "offline_hit",
             }))
         );
+    }
+
+    #[test]
+    fn cancelled_launch_progress_handler_cannot_repopulate_progress() {
+        let state = runtime_state_handle();
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let handler = RuntimeDocProgressHandler::new_for_launch(state.clone(), Some(cancel_rx));
+        cancel_tx.send(true).unwrap();
+
+        handler.on_progress("uv", EnvProgressPhase::OfflineHit);
+
+        assert!(state
+            .read(|doc| doc.read_state().env.progress)
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
+use kernel_launch::CommandOutputExt;
 use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle, TrustRuntimeState};
 
 pub struct TrustState {
@@ -1798,11 +1799,18 @@ pub(crate) async fn rebuild_captured_environment(
     room: &NotebookRoom,
     captured: &CapturedEnv,
 ) -> anyhow::Result<crate::PooledEnv> {
-    room.state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))?;
+    if let Some(result) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+    }) {
+        result?;
+    }
 
     let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
-        crate::inline_env::RuntimeDocProgressHandler::new(room.state.clone()),
+        crate::inline_env::RuntimeDocProgressHandler::new_for_launch(
+            room.state.clone(),
+            room.current_launch_cancellation_receiver(),
+        ),
     );
 
     let env = match captured {
@@ -1846,8 +1854,12 @@ pub(crate) async fn rebuild_captured_environment(
     // The runtime agent repeats this transition when it accepts the request,
     // but publish it before the retry send so the rebuild's PreparingEnv state
     // cannot remain visible during transport handoff.
-    room.state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))?;
+    if let Some(result) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    }) {
+        result?;
+    }
 
     Ok(env)
 }
@@ -2132,7 +2144,10 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
         }
     };
     let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
-        crate::inline_env::RuntimeDocProgressHandler::new(room.state.clone()),
+        crate::inline_env::RuntimeDocProgressHandler::new_for_launch(
+            room.state.clone(),
+            room.current_launch_cancellation_receiver(),
+        ),
     );
 
     // Reopen/repair path: if the notebook has an env_id and the unified-hash
@@ -2466,26 +2481,51 @@ pub(crate) async fn reset_starting_state_with_outcome<'a>(
         None
     };
 
+    // Success and disconnect both consult this identity while holding the
+    // launch gate. Clearing it here makes a reset an authoritative fence even
+    // if a launch owner is already waiting to publish Running.
+    room.invalidate_runtime_agent_connection();
+
+    if let Some(expected) = expected_runtime_agent_id {
+        room.clear_active_kernel_launch_if_agent(expected);
+    }
+
     // state handle uses std::sync::Mutex - no lock ordering concern
     // with runtime_agent_handle (tokio::sync::Mutex).
-    if let Err(e) = room.state.with_doc(|sd| {
-        match outcome {
-            ResetOutcome::NotStarted => {
-                sd.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
-            }
-            ResetOutcome::Error { reason, details } => {
-                sd.set_lifecycle_with_error_details(
-                    &RuntimeLifecycle::Error,
-                    reason,
-                    Some(details),
-                )?;
+    // A ShutdownKernel that cancelled the admitted generation owns the
+    // terminal projection. Launch error/abort cleanup still tears down agent
+    // resources below, but must not overwrite Shutdown with NotStarted/Error.
+    {
+        let launch_gate_state = room.kernel_launch_gate.lock_state();
+        let launch_is_cancelled =
+            launch_gate_state
+                .in_flight_generation
+                .is_some_and(|generation| {
+                    launch_gate_state
+                        .cancelled_generations
+                        .contains(&generation)
+                });
+        if !launch_is_cancelled {
+            if let Err(e) = room.state.with_doc(|sd| {
+                match outcome {
+                    ResetOutcome::NotStarted => {
+                        sd.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
+                    }
+                    ResetOutcome::Error { reason, details } => {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::Error,
+                            reason,
+                            Some(details),
+                        )?;
+                    }
+                }
+                sd.set_prewarmed_packages(&[])?;
+                sd.clear_env_progress()?;
+                Ok(())
+            }) {
+                warn!("[runtime-state] {}", e);
             }
         }
-        sd.set_prewarmed_packages(&[])?;
-        sd.clear_env_progress()?;
-        Ok(())
-    }) {
-        warn!("[runtime-state] {}", e);
     }
 
     // Clear stale runtime agent handle so auto-launch can retry.
@@ -2560,19 +2600,22 @@ pub(crate) fn publish_environment_launch_error(
     reason: Option<KernelErrorReason>,
     details: &str,
 ) {
-    if let Err(e) = room.state.with_doc(|sd| {
-        sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
-        sd.set_kernel_info("python", "python", env_source)?;
-        sd.clear_env_progress()?;
-        // This is the coordinator's terminal launch-error publish on the
-        // authoritative room doc. Resolve any cells still queued against the
-        // launch that just failed: with no kernel they can never run, so
-        // "queued" → "cancelled" (and any stray "running" → "error"). Catches
-        // executions the runtime agent's own abort missed because they were
-        // queued room-side during the launch and never synced to the agent.
-        sd.abort_inflight_executions()?;
-        Ok(())
-    }) {
+    let published = room.commit_unless_launch_cancelled(|| {
+        room.state.with_doc(|sd| {
+            sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
+            sd.set_kernel_info("python", "python", env_source)?;
+            sd.clear_env_progress()?;
+            // This is the coordinator's terminal launch-error publish on the
+            // authoritative room doc. Resolve any cells still queued against the
+            // launch that just failed: with no kernel they can never run, so
+            // "queued" → "cancelled" (and any stray "running" → "error"). Catches
+            // executions the runtime agent's own abort missed because they were
+            // queued room-side during the launch and never synced to the agent.
+            sd.abort_inflight_executions()?;
+            Ok(())
+        })
+    });
+    if let Some(Err(e)) = published {
         error!(
             "[runtime-state] failed to publish environment launch error: {}",
             e
@@ -2954,7 +2997,7 @@ pub(crate) async fn auto_launch_kernel(
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
-    attempt: super::room::AutoLaunchAttempt,
+    attempt: super::room::KernelLaunchAttempt,
 ) {
     let mut attempt = attempt;
     loop {
@@ -2978,10 +3021,10 @@ pub(crate) async fn auto_launch_kernel(
         // The abort reset lifecycle to NotStarted; restore Resolving to
         // mirror what the connect path writes after admission, so the
         // reconnected peer never sits on stale NotStarted.
-        if let Err(e) = room
-            .state
-            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
-        {
+        if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+            room.state
+                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        }) {
             warn!("[runtime-state] {}", e);
         }
     }
@@ -2989,39 +3032,24 @@ pub(crate) async fn auto_launch_kernel(
 
 /// Benign no-peers abort for an in-flight auto-launch attempt.
 ///
-/// Releases the single-flight token, then re-checks active peers only after
-/// the release. The order is load-bearing: a connect that lands during the
-/// abort window is refused admission (`InFlight`) and has no retry trigger of
-/// its own, so a peers check taken before the release could see 0, release
-/// the gate, and strand the reconnected peer at `NotStarted` with nobody left
-/// to launch. Checking after the release closes that window: either this
-/// call sees the peer and re-admits on its behalf, or the connect itself got
-/// admitted after the release and owns the next attempt.
+/// After reset, atomically releases the generation and checks active peers
+/// while still holding the launch gate. A connect that already observed
+/// `InFlight` is re-admitted on its behalf; a later connect admits itself.
+/// Shutdown cancellation contends on that same lock and therefore cannot land
+/// between release and the successor decision.
 ///
 /// Returns a fresh token when the caller should retry the launch; `None`
 /// when the abort stands or another caller won re-admission.
 pub(crate) async fn release_attempt_and_readmit_if_peer_waiting(
     room: &std::sync::Arc<NotebookRoom>,
-    attempt: super::room::AutoLaunchAttempt,
-) -> Option<super::room::AutoLaunchAttempt> {
-    reset_starting_state(room, None).await;
-    attempt.release_without_cooldown();
-    if room
-        .connections
-        .active_peers
-        .load(std::sync::atomic::Ordering::Relaxed)
-        == 0
-    {
+    attempt: super::room::KernelLaunchAttempt,
+) -> Option<super::room::KernelLaunchAttempt> {
+    if attempt.is_cancelled() {
+        drop(attempt);
         return None;
     }
-    match room.try_begin_auto_launch() {
-        super::room::AutoLaunchAdmission::Admitted(next) => Some(next),
-        // InFlight: the racing connect was admitted after the release and
-        // owns the retry. CoolingDown: a concurrent failed attempt armed
-        // the gate between release and re-check; its Error lifecycle is
-        // the signal the connected peer observes.
-        _ => None,
-    }
+    reset_starting_state(room, None).await;
+    attempt.release_and_readmit_auto_if_peer_waiting()
 }
 
 /// One admitted auto-launch attempt, owned end to end.
@@ -3040,8 +3068,13 @@ async fn auto_launch_kernel_attempt(
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
-    attempt: super::room::AutoLaunchAttempt,
-) -> Option<super::room::AutoLaunchAttempt> {
+    attempt: super::room::KernelLaunchAttempt,
+) -> Option<super::room::KernelLaunchAttempt> {
+    if attempt.is_cancelled() {
+        debug!("[notebook-sync] Auto-launch cancelled before environment resolution");
+        return None;
+    }
+
     // Check if room still has peers (protect against race condition where client disconnects
     // before we finish launching)
     if room
@@ -3271,12 +3304,14 @@ async fn auto_launch_kernel_attempt(
             } else {
                 let details = format_conda_env_yml_build_details(&decision);
                 warn!("[notebook-sync] {}", details);
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::AwaitingEnvBuild,
-                        Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
-                        Some(&details),
-                    )
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::AwaitingEnvBuild,
+                            Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
+                            Some(&details),
+                        )
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -3476,13 +3511,15 @@ async fn auto_launch_kernel_attempt(
                     "[notebook-sync] pixi.toml at {:?} does not declare ipykernel — cannot launch kernel",
                     detected.path
                 );
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::MissingIpykernel),
-                    )?;
-                    sd.set_kernel_info("python", "python", env_source.as_str())?;
-                    Ok(())
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error(
+                            &RuntimeLifecycle::Error,
+                            Some(KernelErrorReason::MissingIpykernel),
+                        )?;
+                        sd.set_kernel_info("python", "python", env_source.as_str())?;
+                        Ok(())
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -3492,16 +3529,19 @@ async fn auto_launch_kernel_attempt(
     }
 
     // Transition to PreparingEnv now that runtime/env has been resolved.
-    if let Err(e) = room
-        .state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
-    {
+    if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+    }) {
         warn!("[runtime-state] {}", e);
     }
 
     // For inline deps, prepare a cached environment with rich progress
     let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
-        crate::inline_env::RuntimeDocProgressHandler::new(room.state.clone()),
+        crate::inline_env::RuntimeDocProgressHandler::new_for_launch(
+            room.state.clone(),
+            room.current_launch_cancellation_receiver(),
+        ),
     );
 
     // Fetch feature flags now so inline cache hits can refresh vendored
@@ -3817,12 +3857,14 @@ async fn auto_launch_kernel_attempt(
             } else {
                 let details = format_conda_env_yml_build_details(&decision);
                 warn!("[notebook-sync] {}", details);
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::AwaitingEnvBuild,
-                        Some(KernelErrorReason::CondaEnvYmlMissing),
-                        Some(&details),
-                    )
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::AwaitingEnvBuild,
+                            Some(KernelErrorReason::CondaEnvYmlMissing),
+                            Some(&details),
+                        )
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -4206,7 +4248,7 @@ async fn auto_launch_kernel_attempt(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            let diagnostic = kernel_env::diagnose_ipykernel(&env.python_path);
+            let diagnostic = kernel_env::diagnose_ipykernel_async(&env.python_path).await;
             if !diagnostic.is_present() {
                 warn!(
                     "[notebook-sync] prepared env at {:?} ({}) cannot import ipykernel: {:?}",
@@ -4228,14 +4270,16 @@ async fn auto_launch_kernel_attempt(
                 // marker) is a follow-up; for now we surface the typed
                 // error and let the user edit deps to bump the hash.
                 let env_source_label = env_source.as_str().to_string();
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(reason),
-                        Some(&details),
-                    )?;
-                    sd.set_kernel_info("python", "python", &env_source_label)?;
-                    Ok(())
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::Error,
+                            Some(reason),
+                            Some(&details),
+                        )?;
+                        sd.set_kernel_info("python", "python", &env_source_label)?;
+                        Ok(())
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -4295,11 +4339,16 @@ async fn auto_launch_kernel_attempt(
         captured_for_config,
     );
 
+    if attempt.is_cancelled() {
+        debug!("[notebook-sync] Auto-launch cancelled before runtime agent spawn");
+        return None;
+    }
+
     // Transition to "launching" phase before starting the kernel process
-    if let Err(e) = room
-        .state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
-    {
+    if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    }) {
         warn!("[runtime-state] {}", e);
     }
     let redact_env_values_in_outputs = daemon.redact_env_values_in_outputs().await;
@@ -4325,9 +4374,19 @@ async fn auto_launch_kernel_attempt(
         // connect.
         //
         // Ordering: provenance → generation → oneshot → spawn
-        {
+        let agent_expected = {
             let mut id = room.current_runtime_agent_id.write().await;
-            *id = Some(runtime_agent_id.clone());
+            if attempt.expect_runtime_agent(&runtime_agent_id) {
+                *id = Some(runtime_agent_id.clone());
+                true
+            } else {
+                false
+            }
+        };
+        if !agent_expected || attempt.is_cancelled() {
+            debug!("[notebook-sync] Auto-launch cancelled before runtime agent provenance install");
+            reset_starting_state(room, None).await;
+            return None;
         }
         room.runtime_agent_generation
             .fetch_add(1, Ordering::Release);
@@ -4338,37 +4397,59 @@ async fn auto_launch_kernel_attempt(
             rx
         };
 
-        match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
-            nb_id,
-            runtime_agent_id.clone(),
-            room.blob_store.root().to_path_buf(),
-            socket_path,
-            daemon.config.runtime_agent_exe.clone(),
-        )
-        .await
-        {
+        let spawn_result = tokio::select! {
+            biased;
+            _ = wait_for_kernel_launch_cancellation(attempt.cancellation_receiver()) => {
+                debug!("[notebook-sync] Auto-launch cancelled while spawning runtime agent");
+                attempt.discard_cancelled_runtime_agent(&runtime_agent_id).await;
+                return None;
+            }
+            result = crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
+                nb_id,
+                runtime_agent_id.clone(),
+                room.blob_store.root().to_path_buf(),
+                socket_path,
+                daemon.config.runtime_agent_exe.clone(),
+            ) => result,
+        };
+
+        match spawn_result {
             Ok(ra) => {
                 // Store handle after spawn succeeds.
                 {
                     let mut ra_guard = room.runtime_agent_handle.lock().await;
                     *ra_guard = Some(ra);
                 }
+                if attempt.is_cancelled() {
+                    debug!("[notebook-sync] Auto-launch cancelled after runtime agent spawn");
+                    attempt
+                        .discard_cancelled_runtime_agent(&runtime_agent_id)
+                        .await;
+                    return None;
+                }
 
                 // Connecting lifecycle — fills the gap between spawn and connect
-                if let Err(e) = room
-                    .state
-                    .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
-                {
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state
+                        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
+                }) {
                     warn!("[runtime-state] {}", e);
                 }
 
                 // Wait for THIS runtime agent to establish its sync connection
-                match recv_oneshot_with_timeout(
-                    runtime_agent_connect_rx,
-                    std::time::Duration::from_secs(30),
-                )
-                .await
-                {
+                let connect_result = tokio::select! {
+                    biased;
+                    _ = wait_for_kernel_launch_cancellation(attempt.cancellation_receiver()) => {
+                        debug!("[notebook-sync] Auto-launch cancelled while waiting for runtime agent connection");
+                        attempt.discard_cancelled_runtime_agent(&runtime_agent_id).await;
+                        return None;
+                    }
+                    result = recv_oneshot_with_timeout(
+                        runtime_agent_connect_rx,
+                        std::time::Duration::from_secs(30),
+                    ) => result,
+                };
+                match connect_result {
                     TimedOneShot::Received(()) => {
                         info!("[notebook-sync] Agent connected, sending LaunchKernel");
                     }
@@ -4386,6 +4467,14 @@ async fn auto_launch_kernel_attempt(
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return None;
                     }
+                }
+
+                if attempt.is_cancelled() {
+                    debug!("[notebook-sync] Auto-launch cancelled before LaunchKernel RPC");
+                    attempt
+                        .discard_cancelled_runtime_agent(&runtime_agent_id)
+                        .await;
+                    return None;
                 }
 
                 // Send LaunchKernel RPC via the runtime agent's sync connection.
@@ -4510,59 +4599,63 @@ pub(crate) async fn finish_auto_launch_success(
     env_source_label: &str,
     runtime_agent_id: &str,
     launched_config: LaunchedEnvConfig,
-    attempt: super::room::AutoLaunchAttempt,
+    attempt: super::room::KernelLaunchAttempt,
 ) {
-    // Store launched config for env sync drift detection
-    {
-        let mut lc = room.runtime_agent_launched_config.write().await;
-        *lc = Some(launched_config);
+    let env_source = notebook_protocol::connection::EnvSource::parse(env_source_label);
+    let commit_result = {
+        let (mut config, mut presence_state) = tokio::join!(
+            room.runtime_agent_launched_config.write(),
+            room.broadcasts.presence.write()
+        );
+        attempt.succeed_with_agent(runtime_agent_id, || {
+            *config = Some(launched_config.clone());
+            update_kernel_presence_locked(
+                &mut presence_state,
+                &room.broadcasts.presence_tx,
+                presence::KernelStatus::Idle,
+                env_source_label,
+            );
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+                sd.set_kernel_info(kernel_type, kernel_type, env_source_label)?;
+                sd.set_runtime_agent_id(runtime_agent_id)?;
+                sd.set_env_sync(true, &[], &[], false, false)?;
+                Ok(())
+            }) {
+                warn!("[runtime-state] {}", e);
+            }
+            room.set_active_kernel_launch(
+                runtime_agent_id.to_string(),
+                kernel_type.to_string(),
+                env_source.clone(),
+            );
+        })
+    };
+
+    match commit_result {
+        Ok(()) => info!(
+            "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
+            kernel_type, env_source_label
+        ),
+        Err((cancelled_attempt, KernelLaunchCommitRejection::Cancelled)) => {
+            // Shutdown won before success was linearized. Hold the token
+            // until the just-started kernel is stopped so a successor cannot
+            // race cleanup.
+            let _ = crate::requests::shutdown_kernel::handle(room).await;
+            cancelled_attempt.finish_cancelled();
+        }
+        Err((superseded_attempt, KernelLaunchCommitRejection::AgentUnavailable)) => {
+            warn!(
+                "[notebook-sync] Auto-launch succeeded for superseded runtime agent {}; discarding completion",
+                runtime_agent_id
+            );
+            superseded_attempt.release_without_cooldown();
+        }
     }
-
-    publish_kernel_state_presence(room, presence::KernelStatus::Idle, env_source_label).await;
-
-    // Write Running(Idle) + kernel info to RuntimeStateDoc
-    // so frontends see "idle" via CRDT sync.
-    if let Err(e) = room.state.with_doc(|sd| {
-        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-        sd.set_kernel_info(kernel_type, kernel_type, env_source_label)?;
-        sd.set_runtime_agent_id(runtime_agent_id)?;
-        // Fresh kernel is in sync with its launched config
-        sd.set_env_sync(true, &[], &[], false, false)?;
-        Ok(())
-    }) {
-        warn!("[runtime-state] {}", e);
-    }
-
-    info!(
-        "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
-        kernel_type, env_source_label
-    );
-
-    attempt.succeed();
 }
 
-/// Publish the daemon's `KernelState` presence so late-joining peers
-/// receive kernel status in their `PresenceSnapshot`.
-pub(crate) async fn publish_kernel_state_presence(
-    room: &NotebookRoom,
-    status: presence::KernelStatus,
-    env_source: &str,
-) {
-    update_kernel_presence(
-        &room.broadcasts.presence,
-        &room.broadcasts.presence_tx,
-        status,
-        env_source,
-    )
-    .await;
-}
-
-/// Update kernel state in the shared presence state and relay to all peers.
-///
-/// Factored out so spawned tasks (which only hold cloned Arcs) can call it
-/// without needing a full `&NotebookRoom` reference.
-pub(crate) async fn update_kernel_presence(
-    presence_state: &Arc<RwLock<PresenceState>>,
+pub(crate) fn update_kernel_presence_locked(
+    presence_state: &mut PresenceState,
     presence_tx: &broadcast::Sender<(String, Vec<u8>)>,
     status: presence::KernelStatus,
     env_source: &str,
@@ -4575,7 +4668,7 @@ pub(crate) async fn update_kernel_presence(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64;
-    presence_state.write().await.update_peer(
+    presence_state.update_peer(
         "daemon",
         "daemon",
         None,
@@ -4591,6 +4684,17 @@ pub(crate) async fn update_kernel_presence(
             e
         ),
     }
+}
+
+#[cfg(test)]
+pub(crate) async fn update_kernel_presence(
+    presence_state: &Arc<RwLock<PresenceState>>,
+    presence_tx: &broadcast::Sender<(String, Vec<u8>)>,
+    status: presence::KernelStatus,
+    env_source: &str,
+) {
+    let mut state = presence_state.write().await;
+    update_kernel_presence_locked(&mut state, presence_tx, status, env_source);
 }
 
 /// Promote inline deps from CRDT metadata to a project file.
@@ -4794,7 +4898,7 @@ pub(crate) async fn promote_inline_deps_to_project(
             match tokio::process::Command::new(&pixi_path)
                 .args(["add", dep, "--manifest-path"])
                 .arg(pixi_toml_path)
-                .output()
+                .output_owned()
                 .await
             {
                 Ok(output) if output.status.success() => {
@@ -4960,7 +5064,7 @@ pub(crate) async fn promote_inline_deps_to_project(
             match tokio::process::Command::new(&uv_path)
                 .args(["add", dep, "--project"])
                 .arg(project_dir)
-                .output()
+                .output_owned()
                 .await
             {
                 Ok(output) if output.status.success() => {

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -41,6 +41,150 @@ impl PeerConnectionContext {
     }
 }
 
+fn spawn_auto_launch_attempt(
+    room: Arc<NotebookRoom>,
+    notebook_id: String,
+    default_runtime: crate::runtime::Runtime,
+    default_python_env: crate::settings_doc::PythonEnvType,
+    daemon: Arc<crate::daemon::Daemon>,
+    attempt: KernelLaunchAttempt,
+) {
+    if let Some(Err(error)) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|state| state.set_lifecycle(&RuntimeLifecycle::Resolving))
+    }) {
+        warn!("[runtime-state] {error}");
+    }
+    let generation = attempt.generation();
+    let launch_room = Arc::clone(&room);
+    let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+    let task = spawn_supervised(
+        "auto-launch-kernel",
+        async move {
+            if start_rx.await.is_err() {
+                return;
+            }
+            auto_launch_kernel(
+                &launch_room,
+                &notebook_id,
+                default_runtime,
+                default_python_env,
+                daemon,
+                attempt,
+            )
+            .await;
+        },
+        move |panic| {
+            tracing::error!(
+                "[notebook-sync] {} panicked; launch-token cleanup owns terminalization: {}",
+                panic.label,
+                panic.message
+            );
+        },
+    );
+    if !room.register_launch_abort_handle(generation, task.abort_handle()) {
+        task.abort();
+        return;
+    }
+    let _ = start_tx.send(());
+}
+
+async fn wait_for_retryable_auto_launch(
+    room: &Arc<NotebookRoom>,
+    generation: u64,
+) -> Option<KernelLaunchAttempt> {
+    const TEARDOWN_LATCH_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + TEARDOWN_LATCH_WAIT_TIMEOUT;
+    while room
+        .connections
+        .kernel_teardown_destructive
+        .load(Ordering::Acquire)
+    {
+        if tokio::time::Instant::now() >= deadline {
+            warn!(
+                "[notebook-sync] Auto-launch retry for generation {} timed out after {:?} waiting for teardown",
+                generation,
+                TEARDOWN_LATCH_WAIT_TIMEOUT
+            );
+            return None;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    if room.connections.active_peers.load(Ordering::Acquire) == 0
+        || room.is_hosted()
+        || room.has_kernel().await
+    {
+        return None;
+    }
+    let trust_status = room.trust_state.read().await.status.clone();
+    if !matches!(
+        trust_status,
+        runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
+    ) {
+        return None;
+    }
+
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(attempt) => Some(attempt),
+        AutoLaunchAdmission::InFlight { .. } | AutoLaunchAdmission::CoolingDown { .. } => None,
+    }
+}
+
+fn spawn_auto_launch_retry(
+    room: Arc<NotebookRoom>,
+    notebook_id: String,
+    default_runtime: crate::runtime::Runtime,
+    default_python_env: crate::settings_doc::PythonEnvType,
+    daemon: Arc<crate::daemon::Daemon>,
+    generation: u64,
+) {
+    if !room.connections.try_claim_auto_launch_retry(generation) {
+        debug!(
+            "[notebook-sync] Auto-launch retry for generation {} already has a follower",
+            generation
+        );
+        return;
+    }
+
+    struct RetryClaim {
+        room: Arc<NotebookRoom>,
+        generation: u64,
+    }
+    impl Drop for RetryClaim {
+        fn drop(&mut self) {
+            self.room
+                .connections
+                .release_auto_launch_retry(self.generation);
+        }
+    }
+
+    spawn_best_effort("auto-launch-after-in-flight", async move {
+        let _claim = RetryClaim {
+            room: Arc::clone(&room),
+            generation,
+        };
+        while room.launch_completion(generation).is_none() {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let Some(attempt) = wait_for_retryable_auto_launch(&room, generation).await else {
+            return;
+        };
+        info!(
+            "[notebook-sync] Retrying auto-launch for {} after generation {} completed",
+            notebook_id, generation
+        );
+        spawn_auto_launch_attempt(
+            room,
+            notebook_id,
+            default_runtime,
+            default_python_env,
+            daemon,
+            attempt,
+        );
+    });
+}
+
 /// Handle a single notebook sync client connection.
 ///
 /// The caller has already consumed the handshake frame and resolved the room.
@@ -250,55 +394,27 @@ where
                         "[notebook-sync] Auto-launching kernel for notebook {} (trust: {:?}, new: {})",
                         notebook_id, trust_status, is_new_notebook
                     );
-                    // Write Resolving immediately so clients never see stale NotStarted
-                    if let Err(e) = room
-                        .state
-                        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
-                    {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    // Spawn auto-launch in background so we don't block sync
-                    let room_clone = room.clone();
-                    let panic_room = room.clone();
-                    let notebook_id_clone = notebook_id.to_string();
-                    let daemon_clone = ctx.daemon.clone();
-                    let default_runtime = ctx.default_runtime.clone();
-                    let default_python_env = ctx.default_python_env.clone();
-                    spawn_supervised(
-                        "auto-launch-kernel",
-                        async move {
-                            auto_launch_kernel(
-                                &room_clone,
-                                &notebook_id_clone,
-                                default_runtime,
-                                default_python_env,
-                                daemon_clone,
-                                attempt,
-                            )
-                            .await;
-                        },
-                        move |_| {
-                            let r = panic_room;
-                            // with_doc is sync (std::sync::Mutex), so no need for tokio::spawn
-                            // to acquire the lock. But spawn_supervised's panic handler runs
-                            // outside async context, so we still need spawn for the closure.
-                            tokio::spawn(async move {
-                                // Auto-launch panic, no specific typed reason. Clear
-                                // any stale error_reason so the frontend prompt isn't
-                                // stuck on an earlier missing_ipykernel, etc.
-                                if let Err(e) = r.state.with_doc(|sd| {
-                                    sd.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)
-                                }) {
-                                    tracing::warn!("[runtime-state] {}", e);
-                                }
-                            });
-                        },
+                    spawn_auto_launch_attempt(
+                        Arc::clone(room),
+                        notebook_id.to_string(),
+                        ctx.default_runtime.clone(),
+                        ctx.default_python_env.clone(),
+                        Arc::clone(&ctx.daemon),
+                        attempt,
                     );
                 }
-                super::room::AutoLaunchAdmission::InFlight => {
+                super::room::AutoLaunchAdmission::InFlight { generation } => {
                     debug!(
-                        "[notebook-sync] Auto-launch skipped for {}: attempt already in flight",
-                        notebook_id
+                        "[notebook-sync] Auto-launch for {} is following in-flight generation {}",
+                        notebook_id, generation
+                    );
+                    spawn_auto_launch_retry(
+                        Arc::clone(room),
+                        notebook_id.to_string(),
+                        ctx.default_runtime.clone(),
+                        ctx.default_python_env.clone(),
+                        Arc::clone(&ctx.daemon),
+                        generation,
                     );
                 }
                 super::room::AutoLaunchAdmission::CoolingDown { remaining } => {
@@ -380,4 +496,102 @@ where
     .await;
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob_store::BlobStore;
+
+    #[tokio::test]
+    async fn reconnect_retry_follower_is_single_flight_per_generation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        );
+
+        assert!(room.connections.try_claim_auto_launch_retry(7));
+        assert!(!room.connections.try_claim_auto_launch_retry(7));
+        assert!(!room.connections.try_claim_auto_launch_retry(8));
+        room.connections.release_auto_launch_retry(7);
+        assert!(room.connections.try_claim_auto_launch_retry(8));
+        room.connections.release_auto_launch_retry(8);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_retries_after_teardown_cancels_in_flight_generation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        room.connections.active_peers.store(1, Ordering::Release);
+        room.connections
+            .kernel_teardown_destructive
+            .store(true, Ordering::Release);
+        let owner = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("first launch should be admitted"),
+        };
+        let retry = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_retryable_auto_launch(&room, 1).await }
+        });
+
+        assert_eq!(room.cancel_launch_and_mark_teardown_with(|| {}), Some(1));
+        owner.finish_cancelled();
+        tokio::task::yield_now().await;
+        assert!(
+            !retry.is_finished(),
+            "replacement must wait until destructive teardown releases its latch"
+        );
+
+        room.connections
+            .kernel_teardown_destructive
+            .store(false, Ordering::Release);
+        tokio::time::advance(std::time::Duration::from_millis(26)).await;
+        let replacement = retry
+            .await
+            .unwrap()
+            .expect("connected peer should own the replacement generation");
+        replacement.release_without_cooldown();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_retry_stops_after_bounded_teardown_wait() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        room.connections.active_peers.store(1, Ordering::Release);
+        room.connections
+            .kernel_teardown_destructive
+            .store(true, Ordering::Release);
+
+        let retry = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_retryable_auto_launch(&room, 9).await }
+        });
+        tokio::time::advance(std::time::Duration::from_secs(11)).await;
+
+        assert!(retry.await.unwrap().is_none());
+        assert!(
+            room.kernel_launch_gate
+                .lock_state()
+                .in_flight_generation
+                .is_none(),
+            "timed-out follower must not admit a replacement generation"
+        );
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -18,6 +18,27 @@ use super::{
 /// materialization itself: a large but progressing load remains room-owned.
 const LAST_PEER_NOTEBOOK_WRITE_SETTLE_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(120);
+const CANCELLED_LAUNCH_SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const ABORTED_LAUNCH_SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+async fn begin_last_peer_kernel_teardown(room: &NotebookRoom) -> Option<u64> {
+    let cancelled_launch = crate::requests::shutdown_kernel::begin_teardown(room).await;
+    // Last-peer teardown owns the room's runtime generation. Clear provenance
+    // before dropping the handle so the ensuing socket disconnect is stale and
+    // cannot replace Shutdown with Error.
+    *room.current_runtime_agent_id.write().await = None;
+    cancelled_launch
+}
+
+async fn wait_for_cancelled_launch_completion(room: &NotebookRoom, generation: u64) -> bool {
+    tokio::time::timeout(CANCELLED_LAUNCH_SETTLE_TIMEOUT, async {
+        while room.launch_completion(generation).is_none() {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
 
 async fn wait_for_initial_load_before_notebook_writes(
     initial_load: &RoomInitialLoad,
@@ -311,6 +332,7 @@ pub(super) async fn handle_peer_disconnect(
                 );
                 return;
             }
+            let cancelled_launch = begin_last_peer_kernel_teardown(&room_for_teardown).await;
             {
                 let has_runtime_agent = room_for_teardown
                     .runtime_agent_request_tx
@@ -346,6 +368,40 @@ pub(super) async fn handle_peer_disconnect(
                     {
                         let mut tx = room_for_teardown.runtime_agent_request_tx.lock().await;
                         *tx = None;
+                    }
+                }
+            }
+            if let Some(generation) = cancelled_launch {
+                // The cancelled owner keeps the gate fenced until it reaches
+                // a cancellation-safe checkpoint and finishes agent cleanup.
+                // Do not clear the destructive latch or touch its environment
+                // while that owner can still be preparing or launching.
+                if !wait_for_cancelled_launch_completion(&room_for_teardown, generation).await {
+                    warn!(
+                        "[notebook-sync] Cancelled launch generation {} did not settle within {:?} for {}; aborting the room-owned launch task",
+                        generation,
+                        CANCELLED_LAUNCH_SETTLE_TIMEOUT,
+                        notebook_id_for_teardown
+                    );
+                    let aborted = room_for_teardown.abort_launch_owner(generation);
+                    let settled_after_abort =
+                        tokio::time::timeout(ABORTED_LAUNCH_SETTLE_TIMEOUT, async {
+                            while room_for_teardown.launch_completion(generation).is_none() {
+                                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                            }
+                        })
+                        .await
+                        .is_ok();
+                    if !settled_after_abort {
+                        warn!(
+                            "[notebook-sync] Launch generation {} for {} remained unsettled after abort attempt (registered owner: {}); retaining teardown ownership until cleanup completes",
+                            generation,
+                            notebook_id_for_teardown,
+                            aborted
+                        );
+                        while room_for_teardown.launch_completion(generation).is_none() {
+                            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        }
                     }
                 }
             }
@@ -637,6 +693,7 @@ pub(super) async fn handle_peer_disconnect(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blob_store::BlobStore;
 
     fn empty_projection(generation: u64) -> Arc<runtimed_client::protocol::NotebookProjection> {
         Arc::new(runtimed_client::protocol::NotebookProjection {
@@ -671,6 +728,135 @@ mod tests {
             runtime_state_heads: Vec::new(),
             captured_at: chrono::Utc::now(),
         })
+    }
+
+    #[tokio::test]
+    async fn last_peer_teardown_atomically_cancels_launch_and_fences_agent_disconnect() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        *room.current_runtime_agent_id.write().await = Some("agent-pre-spawn".to_string());
+        room.expect_runtime_agent("agent-pre-spawn");
+        assert!(room.mark_runtime_agent_connected("agent-pre-spawn"));
+        let (request_tx, _request_rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(request_tx);
+        let attempt = match room.try_begin_manual_launch() {
+            crate::notebook_sync_server::ManualLaunchAdmission::Admitted(attempt) => attempt,
+            crate::notebook_sync_server::ManualLaunchAdmission::InFlight { .. } => {
+                panic!("launch should be admitted")
+            }
+        };
+
+        assert_eq!(begin_last_peer_kernel_teardown(&room).await, Some(1));
+        assert!(attempt.is_cancelled());
+        assert!(room.current_runtime_agent_id.read().await.is_none());
+        assert!(room.runtime_agent_request_tx.lock().await.is_some());
+        assert!(
+            !room.disconnect_runtime_agent_and_commit_terminal(
+                "agent-pre-spawn",
+                || panic!("teardown must fence the disconnect presence projection"),
+                |_| panic!("teardown must fence the disconnect lifecycle projection"),
+            ),
+            "the ensuing socket disconnect must already be stale"
+        );
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            runtime_doc::RuntimeLifecycle::Shutdown
+        );
+        let presence_state = room.broadcasts.presence.read().await;
+        let daemon = presence_state.peers().get("daemon").unwrap();
+        match daemon
+            .channels
+            .get(&notebook_doc::presence::Channel::KernelState)
+        {
+            Some(notebook_doc::presence::ChannelData::KernelState(data)) => {
+                assert_eq!(data.status, notebook_doc::presence::KernelStatus::Shutdown)
+            }
+            other => panic!("expected shutdown kernel presence, got {other:?}"),
+        }
+        drop(presence_state);
+        attempt.finish_cancelled();
+        assert_eq!(
+            room.launch_completion(1),
+            Some(crate::notebook_sync_server::KernelLaunchCompletion::Cancelled)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_launch_settle_wait_is_bounded() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        let attempt = match room.try_begin_auto_launch() {
+            crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("launch should be admitted"),
+        };
+        assert_eq!(room.cancel_in_flight_launch(), Some(1));
+
+        let settled = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_cancelled_launch_completion(&room, 1).await }
+        });
+        tokio::time::advance(CANCELLED_LAUNCH_SETTLE_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(!settled.await.unwrap());
+
+        attempt.finish_cancelled();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_room_owned_launch_is_aborted_after_settle_deadline() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        let attempt = match room.try_begin_auto_launch() {
+            crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("launch should be admitted"),
+        };
+        let generation = attempt.generation();
+        let owner = tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            drop(attempt);
+        });
+        assert!(room.register_launch_abort_handle(generation, owner.abort_handle()));
+        assert_eq!(room.cancel_in_flight_launch(), Some(generation));
+
+        let settled = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_cancelled_launch_completion(&room, generation).await }
+        });
+        tokio::time::advance(CANCELLED_LAUNCH_SETTLE_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(!settled.await.unwrap());
+
+        assert!(room.abort_launch_owner(generation));
+        for _ in 0..20 {
+            if room.launch_completion(generation).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            room.launch_completion(generation),
+            Some(crate::notebook_sync_server::KernelLaunchCompletion::Cancelled)
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use automerge::SaveOptions;
+use notebook_doc::presence;
 use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
 use notebook_protocol::protocol::{NotebookBroadcast, RuntimeAgentResponse};
 use tracing::{debug, info, warn};
@@ -11,8 +12,8 @@ use crate::async_outcome::{flatten_joined_result, JoinedResult};
 use super::peer_runtime_sync::{persist_terminal_execution_records, runtime_file_save_fingerprint};
 use super::peer_writer::spawn_peer_writer;
 use super::{
-    admit_trusted_notebook_changes, NotebookRoom, RuntimeAgentMessage, TrustedNotebookChangeSource,
-    STATE_SYNC_COMPACT_THRESHOLD,
+    admit_trusted_notebook_changes, update_kernel_presence_locked, NotebookRoom,
+    RuntimeAgentMessage, TrustedNotebookChangeSource, STATE_SYNC_COMPACT_THRESHOLD,
 };
 
 /// Apply one NotebookDoc sync frame from the runtime agent.
@@ -313,6 +314,13 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let (ra_tx, mut ra_rx) = tokio::sync::mpsc::channel::<RuntimeAgentMessage>(16);
     {
         let mut tx_guard = room.runtime_agent_request_tx.lock().await;
+        if !room.mark_runtime_agent_connected(&runtime_agent_id) {
+            warn!(
+                "[notebook-sync] Rejecting runtime agent {} after initial sync (launch provenance changed)",
+                runtime_agent_id
+            );
+            return;
+        }
         *tx_guard = Some(ra_tx);
     }
 
@@ -677,16 +685,55 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // A stale runtime agent disconnecting after a new one connected must not
     // clobber the new runtime agent's channel.
     //
-    // Scope the id read guard so it drops before acquiring other locks
-    // (deadlock prevention: no lock held across `.await`).
+    cleanup_runtime_agent_disconnect(&room, &runtime_agent_id).await;
+    info!(
+        "[notebook-sync] Runtime agent sync connection closed: {}",
+        runtime_agent_id
+    );
+}
+
+async fn cleanup_runtime_agent_disconnect(room: &NotebookRoom, runtime_agent_id: &str) -> bool {
+    let disconnect_generation = room
+        .runtime_agent_generation
+        .load(std::sync::atomic::Ordering::Acquire);
+    let env_source = room
+        .active_kernel_launch()
+        .map(|launch| launch.env_source.as_str().to_string())
+        .unwrap_or_default();
     let is_current = {
-        let expected = room.current_runtime_agent_id.read().await;
-        expected.as_deref() == Some(&runtime_agent_id)
+        let (mut presence_state, mut request_tx) = tokio::join!(
+            room.broadcasts.presence.write(),
+            room.runtime_agent_request_tx.lock()
+        );
+        let disconnected = room.disconnect_runtime_agent_and_commit_terminal(
+            runtime_agent_id,
+            || {
+                update_kernel_presence_locked(
+                    &mut presence_state,
+                    &room.broadcasts.presence_tx,
+                    presence::KernelStatus::Errored,
+                    &env_source,
+                );
+            },
+            |sd| {
+                sd.set_lifecycle_with_error_details(
+                    &runtime_doc::RuntimeLifecycle::Error,
+                    None,
+                    Some("Runtime agent disconnected"),
+                )
+            },
+        );
+        if disconnected {
+            *request_tx = None;
+        }
+        disconnected
     };
     if is_current {
         {
-            let mut tx_guard = room.runtime_agent_request_tx.lock().await;
-            *tx_guard = None;
+            let mut current = room.current_runtime_agent_id.write().await;
+            if current.as_deref() == Some(runtime_agent_id) {
+                *current = None;
+            }
         }
         // No need to signal "disconnected" — the oneshot was consumed on
         // connect. If the runtime agent dies before connecting, the oneshot
@@ -695,12 +742,15 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         //
         // Clear runtime_agent_handle so LaunchKernel spawns a new runtime agent
         let mut guard = room.runtime_agent_handle.lock().await;
-        *guard = None;
+        if room
+            .runtime_agent_generation
+            .load(std::sync::atomic::Ordering::Acquire)
+            == disconnect_generation
+        {
+            *guard = None;
+        }
     }
-    info!(
-        "[notebook-sync] Runtime agent sync connection closed: {}",
-        runtime_agent_id
-    );
+    is_current
 }
 
 fn forward_runtime_agent_broadcast(
@@ -757,6 +807,7 @@ mod tests {
     use automerge::{transaction::Transactable, ReadDoc, ROOT};
 
     use crate::blob_store::BlobStore;
+    use crate::notebook_sync_server::KernelLaunchCommitRejection;
 
     fn test_file_backed_room(tmp: &tempfile::TempDir) -> (uuid::Uuid, PathBuf, Arc<NotebookRoom>) {
         let notebook_id = uuid::Uuid::new_v4();
@@ -811,6 +862,68 @@ mod tests {
             version: automerge::sync::MessageVersion::V1,
         }
         .encode()
+    }
+
+    #[tokio::test]
+    async fn current_runtime_agent_disconnect_fences_in_flight_success_projection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (_, _, room) = test_file_backed_room(&tmp);
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        room.expect_runtime_agent("agent-1");
+        assert!(room.mark_runtime_agent_connected("agent-1"));
+        let (request_tx, _request_rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(request_tx);
+        let attempt = match room.try_begin_auto_launch() {
+            crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("launch should be admitted"),
+        };
+
+        assert!(cleanup_runtime_agent_disconnect(&room, "agent-1").await);
+        assert!(room.current_runtime_agent_id.read().await.is_none());
+        assert!(room.runtime_agent_request_tx.lock().await.is_none());
+
+        let projection_ran = std::cell::Cell::new(false);
+        let cancelled_attempt =
+            match attempt.succeed_with_agent("agent-1", || projection_ran.set(true)) {
+                Err((attempt, KernelLaunchCommitRejection::Cancelled)) => attempt,
+                Err((_, rejection)) => panic!("expected cancellation, got {rejection:?}"),
+                Ok(()) => panic!("disconnect must fence launch success"),
+            };
+        assert!(!projection_ran.get());
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            runtime_doc::RuntimeLifecycle::Error
+        );
+        let presence_state = room.broadcasts.presence.read().await;
+        let daemon = presence_state.peers().get("daemon").unwrap();
+        match daemon.channels.get(&presence::Channel::KernelState) {
+            Some(presence::ChannelData::KernelState(data)) => {
+                assert_eq!(data.status, presence::KernelStatus::Errored)
+            }
+            other => panic!("expected errored kernel presence, got {other:?}"),
+        }
+        drop(presence_state);
+        cancelled_attempt.finish_cancelled();
+    }
+
+    #[tokio::test]
+    async fn stale_runtime_agent_disconnect_preserves_replacement_channel() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let (_, _, room) = test_file_backed_room(&tmp);
+        *room.current_runtime_agent_id.write().await = Some("replacement".to_string());
+        room.expect_runtime_agent("replacement");
+        assert!(room.mark_runtime_agent_connected("replacement"));
+        let (request_tx, _request_rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(request_tx);
+
+        assert!(!cleanup_runtime_agent_disconnect(&room, "stale").await);
+        assert_eq!(
+            room.current_runtime_agent_id.read().await.as_deref(),
+            Some("replacement")
+        );
+        assert!(room.runtime_agent_request_tx.lock().await.is_some());
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -843,6 +843,11 @@ pub struct RoomConnections {
     pub had_peers: AtomicBool,
     pub last_kernel_torn_down_at: AtomicU64,
     pub connection_generation: AtomicU64,
+    /// Exact launch generation currently followed by the reconnect-driven
+    /// auto-launch retry task. Zero means no follower. This keeps rapid
+    /// disconnect/reconnect churn from accumulating detached pollers for the
+    /// same stuck owner generation.
+    pub auto_launch_retry_generation: AtomicU64,
     /// `true` while the kernel-teardown task is in the destructive
     /// section (ShutdownKernel RPC plus handle/request-tx clear). A
     /// peer that joined during this window saw `has_kernel = true` but
@@ -867,6 +872,7 @@ impl Default for RoomConnections {
             had_peers: AtomicBool::new(false),
             last_kernel_torn_down_at: AtomicU64::new(0),
             connection_generation: AtomicU64::new(0),
+            auto_launch_retry_generation: AtomicU64::new(0),
             kernel_teardown_destructive: AtomicBool::new(false),
             reservations: AtomicUsize::new(0),
         }
@@ -874,6 +880,23 @@ impl Default for RoomConnections {
 }
 
 impl RoomConnections {
+    pub(crate) fn try_claim_auto_launch_retry(&self, generation: u64) -> bool {
+        generation != 0
+            && self
+                .auto_launch_retry_generation
+                .compare_exchange(0, generation, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+    }
+
+    pub(crate) fn release_auto_launch_retry(&self, generation: u64) {
+        let _ = self.auto_launch_retry_generation.compare_exchange(
+            generation,
+            0,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
     /// Unix-epoch seconds when the room last finished kernel teardown with
     /// no peers, or `None` if the room is currently active or has never had
     /// kernel teardown.
@@ -1060,6 +1083,19 @@ pub(crate) struct SourceReconciliationClaim {
     room: Arc<NotebookRoom>,
 }
 
+/// Daemon-local description of the kernel that currently owns this room.
+///
+/// RuntimeStateDoc remains the client-facing projection, but concurrent
+/// Automerge lifecycle values cannot safely answer the daemon's idempotent
+/// `LaunchKernel` RPC. This record is written only after launch succeeds and
+/// is cleared when that kernel is shut down or its launch state is reset.
+#[derive(Clone)]
+pub(crate) struct ActiveKernelLaunch {
+    pub runtime_agent_id: String,
+    pub kernel_type: String,
+    pub env_source: notebook_protocol::connection::EnvSource,
+}
+
 impl Drop for SourceReconciliationClaim {
     fn drop(&mut self) {
         self.room
@@ -1074,34 +1110,39 @@ impl Drop for SourceReconciliationClaim {
 pub(crate) const AUTO_LAUNCH_FAILURE_COOLDOWN: std::time::Duration =
     std::time::Duration::from_secs(5);
 
-/// Per-room single-flight gate for kernel auto-launch.
+/// Per-room single-flight gate for all kernel launches.
 ///
-/// At most one auto-launch attempt runs per room at a time; connects that
-/// arrive while an attempt is in flight observe that attempt through
-/// RuntimeStateDoc instead of spawning another agent. A failed attempt closes
-/// the gate for [`AUTO_LAUNCH_FAILURE_COOLDOWN`] so a reconnect loop cannot
-/// turn connect frequency into agent spawn frequency.
+/// Auto-launch and explicit `LaunchKernel` requests share this authority.
+/// Callers that lose admission join the exact daemon-local generation instead
+/// of inferring completion from RuntimeStateDoc. A failed attempt closes the
+/// auto-launch gate for [`AUTO_LAUNCH_FAILURE_COOLDOWN`] so a reconnect loop
+/// cannot turn connect frequency into agent spawn frequency; explicit requests
+/// may retry immediately.
 ///
 /// Sync-only state behind `std::sync::Mutex`; never hold the lock across an
 /// `.await`.
 #[derive(Default)]
-pub(crate) struct AutoLaunchGate {
-    state: std::sync::Mutex<AutoLaunchGateState>,
+pub(crate) struct KernelLaunchGate {
+    state: std::sync::Mutex<KernelLaunchGateState>,
 }
 
 #[derive(Default)]
-struct AutoLaunchGateState {
-    in_flight: bool,
+pub(super) struct KernelLaunchGateState {
+    pub(super) in_flight_generation: Option<u64>,
+    in_flight_cancel_tx: Option<tokio::sync::watch::Sender<bool>>,
+    in_flight_abort_handle: Option<tokio::task::AbortHandle>,
     cooldown_until: Option<tokio::time::Instant>,
     admitted_count: u64,
+    completed_outcomes: std::collections::BTreeMap<u64, KernelLaunchCompletion>,
+    pub(super) cancelled_generations: std::collections::BTreeSet<u64>,
+    expected_runtime_agent_id: Option<String>,
+    connected_runtime_agent_id: Option<String>,
 }
 
-impl AutoLaunchGate {
-    fn lock_state(&self) -> std::sync::MutexGuard<'_, AutoLaunchGateState> {
-        // Recover from poisoning: the guarded state is two plain fields and
-        // every critical section is trivially panic-free, so a poisoned lock
-        // carries no torn invariant. Recovering also keeps the token's Drop
-        // from double-panicking during unwind.
+impl KernelLaunchGate {
+    pub(super) fn lock_state(&self) -> std::sync::MutexGuard<'_, KernelLaunchGateState> {
+        // Critical sections only mutate plain in-memory bookkeeping. Recovering
+        // also keeps the token's Drop from double-panicking during unwind.
         self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1111,16 +1152,26 @@ impl AutoLaunchGate {
 /// Outcome of asking the gate for permission to auto-launch.
 pub(crate) enum AutoLaunchAdmission {
     /// Caller owns the attempt; the gate stays closed until the token drops.
-    Admitted(AutoLaunchAttempt),
-    /// Another attempt is in flight; observe it via RuntimeStateDoc.
-    InFlight,
+    Admitted(KernelLaunchAttempt),
+    /// Another attempt is in flight; observe its exact daemon-local
+    /// generation so a reconnect can retry after teardown releases it.
+    InFlight { generation: u64 },
     /// A recent attempt failed; the gate reopens after `remaining`.
     CoolingDown { remaining: std::time::Duration },
 }
 
-enum AutoLaunchOutcome {
+pub(crate) enum ManualLaunchAdmission {
+    Admitted(KernelLaunchAttempt),
+    InFlight {
+        generation: u64,
+        cancel_rx: tokio::sync::watch::Receiver<bool>,
+    },
+}
+
+enum KernelLaunchOutcome {
     /// Default: any drop without an explicit outcome (early return, panic
-    /// unwind, launch error) counts as a failure and arms the cooldown.
+    /// unwind, launch error) counts as a failure. Auto-launch failures arm
+    /// the reconnect cooldown; explicit launch failures do not.
     Failed,
     /// Kernel launched; reopen the gate immediately.
     Succeeded,
@@ -1129,31 +1180,311 @@ enum AutoLaunchOutcome {
     Released,
 }
 
-/// Owned token for one auto-launch attempt. Dropping it reopens the gate;
-/// the drop path is where the failure cooldown is armed, so every early
-/// return and panic in the launch flow is covered without per-site calls.
-pub(crate) struct AutoLaunchAttempt {
-    room: Arc<NotebookRoom>,
-    outcome: AutoLaunchOutcome,
+#[derive(Clone, Copy)]
+enum KernelLaunchSource {
+    Auto,
+    Manual,
 }
 
-impl AutoLaunchAttempt {
-    /// Mark the attempt successful: reopen the gate with no cooldown.
-    pub(crate) fn succeed(mut self) {
-        self.outcome = AutoLaunchOutcome::Succeeded;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KernelLaunchCompletion {
+    Failed,
+    Succeeded,
+    Released,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KernelLaunchCommitRejection {
+    Cancelled,
+    AgentUnavailable,
+}
+
+pub(crate) async fn wait_for_kernel_launch_cancellation(
+    mut cancel_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    if *cancel_rx.borrow() {
+        return;
+    }
+    loop {
+        match cancel_rx.changed().await {
+            Ok(()) if *cancel_rx.borrow() => return,
+            Ok(()) => continue,
+            Err(_) => std::future::pending::<()>().await,
+        }
+    }
+}
+
+/// Owned token for one auto or manual launch attempt. Dropping it reopens the
+/// gate and records an exact-generation completion. The drop path arms the
+/// cooldown only for auto-launch failures, so every early return and panic in
+/// that flow is covered without throttling explicit requests.
+pub(crate) struct KernelLaunchAttempt {
+    room: Arc<NotebookRoom>,
+    generation: u64,
+    outcome: KernelLaunchOutcome,
+    source: KernelLaunchSource,
+    finished: bool,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+}
+
+impl KernelLaunchAttempt {
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Whether `ShutdownKernel` cancelled this generation while it was
+    /// running. Owners check this before starting a subprocess and again at
+    /// the success linearization point.
+    pub(crate) fn is_cancelled(&self) -> bool {
+        *self.cancel_rx.borrow()
+    }
+
+    /// Install the runtime-agent identity only while this exact generation
+    /// still owns the gate. Teardown can therefore cancel the generation or
+    /// install its identity, never land between two independent authorities.
+    pub(crate) fn expect_runtime_agent(&self, runtime_agent_id: &str) -> bool {
+        let mut state = self.room.kernel_launch_gate.lock_state();
+        if state.in_flight_generation != Some(self.generation)
+            || state.cancelled_generations.contains(&self.generation)
+        {
+            return false;
+        }
+        state.expected_runtime_agent_id = Some(runtime_agent_id.to_string());
+        state.connected_runtime_agent_id = None;
+        true
+    }
+
+    pub(crate) fn cancellation_receiver(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.cancel_rx.clone()
+    }
+
+    /// Remove subprocess and connection state installed by this launch after
+    /// teardown cancelled its generation. The launch token still owns the
+    /// single-flight gate, so no successor can install newer agent resources
+    /// while these fields are cleared. Unlike the general reset helper, this
+    /// deliberately does not require provenance to remain installed: teardown
+    /// clears provenance first, and may otherwise race between subprocess
+    /// spawn and handle publication.
+    pub(crate) async fn discard_cancelled_runtime_agent(&self, runtime_agent_id: &str) {
+        {
+            let mut current = self.room.current_runtime_agent_id.write().await;
+            if current.as_deref() == Some(runtime_agent_id) {
+                *current = None;
+            }
+        }
+        {
+            let mut state = self.room.kernel_launch_gate.lock_state();
+            if state.expected_runtime_agent_id.as_deref() == Some(runtime_agent_id) {
+                state.expected_runtime_agent_id = None;
+            }
+            if state.connected_runtime_agent_id.as_deref() == Some(runtime_agent_id) {
+                state.connected_runtime_agent_id = None;
+            }
+        }
+        self.room
+            .clear_active_kernel_launch_if_agent(runtime_agent_id);
+        *self.room.runtime_agent_handle.lock().await = None;
+        *self.room.runtime_agent_request_tx.lock().await = None;
+        *self.room.pending_runtime_agent_connect_tx.lock().await = None;
+    }
+
+    /// Atomically publish success and release the gate. A concurrent
+    /// `ShutdownKernel` wins if it marked this generation first; the token is
+    /// returned so the owner can tear down any kernel that just started before
+    /// recording the cancelled completion.
+    #[cfg(test)]
+    pub(crate) fn succeed(self) -> Result<(), Self> {
+        self.succeed_with(|| {})
+    }
+
+    /// Commit the daemon-local identity and client-facing success projection
+    /// at the same linearization point as gate completion. The closure must be
+    /// synchronous and follow the gate -> projection lock order.
+    #[cfg(test)]
+    pub(crate) fn succeed_with(mut self, commit: impl FnOnce()) -> Result<(), Self> {
+        let cancelled = {
+            let mut st = self.room.kernel_launch_gate.lock_state();
+            if st.cancelled_generations.contains(&self.generation) {
+                true
+            } else {
+                self.outcome = KernelLaunchOutcome::Succeeded;
+                commit();
+                st.completed_outcomes
+                    .insert(self.generation, KernelLaunchCompletion::Succeeded);
+                if self.generation > 1024 {
+                    st.completed_outcomes.remove(&(self.generation - 1024));
+                }
+                if st.in_flight_generation == Some(self.generation) {
+                    st.in_flight_generation = None;
+                    st.in_flight_cancel_tx = None;
+                    st.in_flight_abort_handle = None;
+                }
+                self.finished = true;
+                false
+            }
+        };
+        if cancelled {
+            Err(self)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn succeed_with_agent(
+        mut self,
+        runtime_agent_id: &str,
+        commit: impl FnOnce(),
+    ) -> Result<(), (Self, KernelLaunchCommitRejection)> {
+        let rejection = {
+            let mut state = self.room.kernel_launch_gate.lock_state();
+            if state.cancelled_generations.contains(&self.generation) {
+                Some(KernelLaunchCommitRejection::Cancelled)
+            } else if state.connected_runtime_agent_id.as_deref() != Some(runtime_agent_id) {
+                Some(KernelLaunchCommitRejection::AgentUnavailable)
+            } else {
+                self.outcome = KernelLaunchOutcome::Succeeded;
+                commit();
+                state
+                    .completed_outcomes
+                    .insert(self.generation, KernelLaunchCompletion::Succeeded);
+                if self.generation > 1024 {
+                    state.completed_outcomes.remove(&(self.generation - 1024));
+                }
+                if state.in_flight_generation == Some(self.generation) {
+                    state.in_flight_generation = None;
+                    state.in_flight_cancel_tx = None;
+                    state.in_flight_abort_handle = None;
+                }
+                self.finished = true;
+                None
+            }
+        };
+        match rejection {
+            Some(rejection) => Err((self, rejection)),
+            None => Ok(()),
+        }
     }
 
     /// Mark the attempt a benign no-op: reopen the gate with no cooldown.
     pub(crate) fn release_without_cooldown(mut self) {
-        self.outcome = AutoLaunchOutcome::Released;
+        self.outcome = KernelLaunchOutcome::Released;
+    }
+
+    /// Atomically finish a pre-spawn no-peer abort and, if a reconnect raced
+    /// it, admit the successor on that peer's behalf. Shutdown cancellation
+    /// and readmission contend on the same gate lock, eliminating the gap
+    /// between token release and the successor decision.
+    pub(crate) fn release_and_readmit_auto_if_peer_waiting(mut self) -> Option<Self> {
+        let next = {
+            let mut state = self.room.kernel_launch_gate.lock_state();
+            let owner_abort_handle = state.in_flight_abort_handle.take();
+            let cancelled = state.cancelled_generations.remove(&self.generation);
+            state.completed_outcomes.insert(
+                self.generation,
+                if cancelled {
+                    KernelLaunchCompletion::Cancelled
+                } else {
+                    KernelLaunchCompletion::Released
+                },
+            );
+            if self.generation > 1024 {
+                state.completed_outcomes.remove(&(self.generation - 1024));
+            }
+            if state.in_flight_generation == Some(self.generation) {
+                state.in_flight_generation = None;
+                state.in_flight_cancel_tx = None;
+            }
+
+            if cancelled
+                || self
+                    .room
+                    .connections
+                    .active_peers
+                    .load(std::sync::atomic::Ordering::Acquire)
+                    == 0
+            {
+                None
+            } else {
+                state.admitted_count = state.admitted_count.saturating_add(1);
+                let generation = state.admitted_count;
+                let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+                state.in_flight_generation = Some(generation);
+                state.in_flight_cancel_tx = Some(cancel_tx);
+                state.in_flight_abort_handle = owner_abort_handle;
+                Some((generation, cancel_rx))
+            }
+        };
+        self.finished = true;
+        next.map(|(generation, cancel_rx)| Self {
+            room: Arc::clone(&self.room),
+            generation,
+            outcome: KernelLaunchOutcome::Failed,
+            source: KernelLaunchSource::Auto,
+            finished: false,
+            cancel_rx,
+        })
+    }
+
+    /// Complete a cancelled generation after its owner has finished async
+    /// kernel/agent cleanup.
+    pub(crate) fn finish_cancelled(mut self) {
+        self.room.finish_cancelled_launch(self.generation);
+        self.finished = true;
     }
 }
 
-impl Drop for AutoLaunchAttempt {
+impl Drop for KernelLaunchAttempt {
     fn drop(&mut self) {
-        let mut st = self.room.auto_launch_gate.lock_state();
-        st.in_flight = false;
-        if matches!(self.outcome, AutoLaunchOutcome::Failed) {
+        if self.finished {
+            return;
+        }
+        if self.is_cancelled() || matches!(self.outcome, KernelLaunchOutcome::Failed) {
+            // A request worker can be aborted at any await when its peer
+            // disconnects, including after agent provenance, a subprocess, or
+            // connect channels have been installed. Keep the generation
+            // fenced and clear those room-owned resources before recording
+            // either cancellation or failure. Terminal projections are left
+            // alone: Shutdown and agent-disconnect Error were already
+            // committed by the authority that cancelled the generation.
+            self.finished = true;
+            let room = Arc::clone(&self.room);
+            let generation = self.generation;
+            let source = self.source;
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    room.cleanup_abandoned_launch(generation, source).await;
+                });
+                return;
+            }
+            // Launch attempts are runtime-owned in production. Preserve gate
+            // liveness in the defensive no-runtime case; no async-installed
+            // Tokio resources can be live here.
+            self.room
+                .finish_abandoned_launch(self.generation, self.source);
+            return;
+        }
+        let mut st = self.room.kernel_launch_gate.lock_state();
+        let completion = match self.outcome {
+            KernelLaunchOutcome::Failed => KernelLaunchCompletion::Failed,
+            KernelLaunchOutcome::Succeeded => KernelLaunchCompletion::Succeeded,
+            KernelLaunchOutcome::Released => KernelLaunchCompletion::Released,
+        };
+        st.completed_outcomes.insert(self.generation, completion);
+        // Waiters time out after 60 seconds and failed attempts have a
+        // five-second cooldown. Retaining a generous fixed window keeps exact
+        // generation results available without growing with room lifetime.
+        if self.generation > 1024 {
+            st.completed_outcomes.remove(&(self.generation - 1024));
+        }
+        if st.in_flight_generation == Some(self.generation) {
+            st.in_flight_generation = None;
+            st.in_flight_cancel_tx = None;
+            st.in_flight_abort_handle = None;
+        }
+        if completion == KernelLaunchCompletion::Failed
+            && matches!(self.source, KernelLaunchSource::Auto)
+        {
             st.cooldown_until = Some(tokio::time::Instant::now() + AUTO_LAUNCH_FAILURE_COOLDOWN);
         }
     }
@@ -1232,6 +1563,8 @@ pub struct NotebookRoom {
     /// check_and_broadcast_sync_state can detect dependency drift
     /// without accessing the runtime agent's kernel directly.
     pub runtime_agent_launched_config: Arc<RwLock<Option<LaunchedEnvConfig>>>,
+    /// Daemon-local authority for idempotent `LaunchKernel` responses.
+    pub(crate) active_kernel_launch: std::sync::Mutex<Option<ActiveKernelLaunch>>,
     /// Channel for sending RPC requests (LaunchKernel, Interrupt, etc.) to the
     /// runtime agent's sync connection. Set when runtime agent connects via
     /// socket, cleared on disconnect.
@@ -1255,12 +1588,137 @@ pub struct NotebookRoom {
     /// sync handler to validate connections and prevent stale cleanup from
     /// clobbering state.
     pub current_runtime_agent_id: Arc<RwLock<Option<String>>>,
-    /// Single-flight gate for kernel auto-launch. All auto-launch admission
-    /// goes through [`NotebookRoom::try_begin_auto_launch`].
-    pub(crate) auto_launch_gate: AutoLaunchGate,
+    /// Single-flight authority shared by reconnect-driven and explicit kernel
+    /// launches, plus shutdown cancellation.
+    pub(crate) kernel_launch_gate: KernelLaunchGate,
 }
 
 impl NotebookRoom {
+    /// Linearize a client-facing launch projection with shutdown and agent
+    /// disconnect cancellation. The launch token remains owned by the caller,
+    /// so a different generation cannot legitimately publish from that task;
+    /// this guard prevents the current cancelled generation from regressing a
+    /// terminal Shutdown/Error state after an await.
+    pub(crate) fn commit_unless_launch_cancelled<R>(
+        &self,
+        commit: impl FnOnce() -> R,
+    ) -> Option<R> {
+        let state = self.kernel_launch_gate.lock_state();
+        if state
+            .in_flight_generation
+            .is_some_and(|generation| state.cancelled_generations.contains(&generation))
+        {
+            return None;
+        }
+        Some(commit())
+    }
+
+    pub(crate) fn register_launch_abort_handle(
+        &self,
+        generation: u64,
+        abort_handle: tokio::task::AbortHandle,
+    ) -> bool {
+        let mut state = self.kernel_launch_gate.lock_state();
+        if state.in_flight_generation != Some(generation) {
+            return false;
+        }
+        state.in_flight_abort_handle = Some(abort_handle);
+        true
+    }
+
+    pub(crate) fn abort_launch_owner(&self, generation: u64) -> bool {
+        let abort_handle = {
+            let state = self.kernel_launch_gate.lock_state();
+            if state.in_flight_generation != Some(generation) {
+                return false;
+            }
+            state.in_flight_abort_handle.clone()
+        };
+        if let Some(abort_handle) = abort_handle {
+            abort_handle.abort();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn current_launch_cancellation_receiver(
+        &self,
+    ) -> Option<tokio::sync::watch::Receiver<bool>> {
+        self.kernel_launch_gate
+            .lock_state()
+            .in_flight_cancel_tx
+            .as_ref()
+            .map(tokio::sync::watch::Sender::subscribe)
+    }
+
+    async fn cleanup_abandoned_launch(&self, generation: u64, source: KernelLaunchSource) {
+        {
+            let mut state = self.kernel_launch_gate.lock_state();
+            if state.in_flight_generation != Some(generation) {
+                return;
+            }
+            state.expected_runtime_agent_id = None;
+            state.connected_runtime_agent_id = None;
+        }
+        *self.current_runtime_agent_id.write().await = None;
+        self.clear_active_kernel_launch();
+        *self.runtime_agent_handle.lock().await = None;
+        *self.runtime_agent_request_tx.lock().await = None;
+        *self.pending_runtime_agent_connect_tx.lock().await = None;
+        self.finish_abandoned_launch(generation, source);
+    }
+
+    fn finish_abandoned_launch(&self, generation: u64, source: KernelLaunchSource) {
+        let mut state = self.kernel_launch_gate.lock_state();
+        if state.in_flight_generation != Some(generation) {
+            return;
+        }
+        let cancelled = state.cancelled_generations.remove(&generation);
+        let completion = if cancelled {
+            KernelLaunchCompletion::Cancelled
+        } else {
+            KernelLaunchCompletion::Failed
+        };
+
+        // Only an unprojected abrupt failure gets a generic Error. Normal
+        // failure paths have already moved to Error or NotStarted; cancelled
+        // paths have already committed Shutdown or disconnect Error.
+        if !cancelled {
+            if let Err(error) = self.state.with_doc(|doc| {
+                if matches!(
+                    doc.read_state().kernel.lifecycle,
+                    runtime_doc::RuntimeLifecycle::Resolving
+                        | runtime_doc::RuntimeLifecycle::PreparingEnv
+                        | runtime_doc::RuntimeLifecycle::Launching
+                        | runtime_doc::RuntimeLifecycle::Connecting
+                ) {
+                    doc.set_lifecycle_with_error_details(
+                        &runtime_doc::RuntimeLifecycle::Error,
+                        None,
+                        Some("Kernel launch stopped before completion"),
+                    )?;
+                }
+                Ok(())
+            }) {
+                tracing::warn!("[runtime-state] {error}");
+            }
+        }
+
+        state.completed_outcomes.insert(generation, completion);
+        if generation > 1024 {
+            state.completed_outcomes.remove(&(generation - 1024));
+        }
+        state.in_flight_generation = None;
+        state.in_flight_cancel_tx = None;
+        state.in_flight_abort_handle = None;
+        if completion == KernelLaunchCompletion::Failed
+            && matches!(source, KernelLaunchSource::Auto)
+        {
+            state.cooldown_until = Some(tokio::time::Instant::now() + AUTO_LAUNCH_FAILURE_COOLDOWN);
+        }
+    }
+
     pub(crate) fn try_claim_source_reconciliation(
         self: &Arc<Self>,
     ) -> Option<SourceReconciliationClaim> {
@@ -1802,12 +2260,13 @@ impl NotebookRoom {
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
+            active_kernel_launch: std::sync::Mutex::new(None),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
             pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
             runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
-            auto_launch_gate: AutoLaunchGate::default(),
+            kernel_launch_gate: KernelLaunchGate::default(),
         })
     }
 
@@ -1816,14 +2275,14 @@ impl NotebookRoom {
     /// Returns `Admitted` with an owned token when no attempt is in flight
     /// and no failure cooldown is active. The token must accompany the
     /// attempt end to end: dropping it without calling
-    /// [`AutoLaunchAttempt::succeed`] or
-    /// [`AutoLaunchAttempt::release_without_cooldown`] counts as a failure
+    /// [`KernelLaunchAttempt::succeed`] or
+    /// [`KernelLaunchAttempt::release_without_cooldown`] counts as a failure
     /// and arms [`AUTO_LAUNCH_FAILURE_COOLDOWN`].
     pub(crate) fn try_begin_auto_launch(self: &Arc<Self>) -> AutoLaunchAdmission {
         let now = tokio::time::Instant::now();
-        let mut st = self.auto_launch_gate.lock_state();
-        if st.in_flight {
-            return AutoLaunchAdmission::InFlight;
+        let mut st = self.kernel_launch_gate.lock_state();
+        if let Some(generation) = st.in_flight_generation {
+            return AutoLaunchAdmission::InFlight { generation };
         }
         if let Some(until) = st.cooldown_until {
             if now < until {
@@ -1832,19 +2291,294 @@ impl NotebookRoom {
                 };
             }
         }
-        st.in_flight = true;
         st.cooldown_until = None;
         st.admitted_count = st.admitted_count.saturating_add(1);
-        AutoLaunchAdmission::Admitted(AutoLaunchAttempt {
+        let generation = st.admitted_count;
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        st.in_flight_generation = Some(generation);
+        st.in_flight_cancel_tx = Some(cancel_tx);
+        st.in_flight_abort_handle = None;
+        AutoLaunchAdmission::Admitted(KernelLaunchAttempt {
             room: Arc::clone(self),
-            outcome: AutoLaunchOutcome::Failed,
+            generation,
+            outcome: KernelLaunchOutcome::Failed,
+            source: KernelLaunchSource::Auto,
+            finished: false,
+            cancel_rx,
         })
+    }
+
+    pub(crate) fn try_begin_manual_launch(self: &Arc<Self>) -> ManualLaunchAdmission {
+        let mut state = self.kernel_launch_gate.lock_state();
+        if let Some(generation) = state.in_flight_generation {
+            let cancel_rx = state
+                .in_flight_cancel_tx
+                .as_ref()
+                .expect("in-flight launch must own a cancellation sender")
+                .subscribe();
+            return ManualLaunchAdmission::InFlight {
+                generation,
+                cancel_rx,
+            };
+        }
+        // Explicit user requests may retry immediately after an auto-launch
+        // failure, but do not erase the reconnect-only cooldown. A successful
+        // manual launch makes it irrelevant while the kernel is present; if
+        // that request also fails, reconnects remain throttled for the
+        // original auto-launch window.
+        state.admitted_count = state.admitted_count.saturating_add(1);
+        let generation = state.admitted_count;
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        state.in_flight_generation = Some(generation);
+        state.in_flight_cancel_tx = Some(cancel_tx);
+        state.in_flight_abort_handle = None;
+        ManualLaunchAdmission::Admitted(KernelLaunchAttempt {
+            room: Arc::clone(self),
+            generation,
+            outcome: KernelLaunchOutcome::Failed,
+            source: KernelLaunchSource::Manual,
+            finished: false,
+            cancel_rx,
+        })
+    }
+
+    /// Cancel the currently admitted generation, if any. The owner retains
+    /// the gate until it has stopped any subprocess or kernel it started, so
+    /// a successor cannot race the cleanup.
+    #[cfg(test)]
+    pub(crate) fn cancel_in_flight_launch(&self) -> Option<u64> {
+        let mut state = self.kernel_launch_gate.lock_state();
+        let generation = state.in_flight_generation?;
+        state.cancelled_generations.insert(generation);
+        if let Some(cancel_tx) = state.in_flight_cancel_tx.as_ref() {
+            let _ = cancel_tx.send(true);
+        }
+        Some(generation)
+    }
+
+    /// Atomically cancel the admitted generation and publish the terminal
+    /// RuntimeStateDoc projection. Reset paths take the same gate lock before
+    /// mutating that projection, so an accepted shutdown cannot be overwritten
+    /// by a late launch error or abort.
+    pub(crate) fn cancel_launch_and_mark_shutdown_with(
+        &self,
+        commit_presence: impl FnOnce(),
+    ) -> Option<u64> {
+        self.cancel_launch_and_commit_terminal(false, commit_presence, |sd| {
+            sd.set_lifecycle(&runtime_doc::RuntimeLifecycle::Shutdown)
+        })
+    }
+
+    /// Last-peer teardown owns the runtime-agent generation as well as the
+    /// kernel. Revoke the agent identity in the same gate transaction as the
+    /// Shutdown projection so its socket cleanup cannot replace Shutdown with
+    /// Error in between two otherwise-correct commits.
+    pub(crate) fn cancel_launch_and_mark_teardown_with(
+        &self,
+        commit_presence: impl FnOnce(),
+    ) -> Option<u64> {
+        self.cancel_launch_and_commit_terminal(true, commit_presence, |sd| {
+            sd.set_lifecycle(&runtime_doc::RuntimeLifecycle::Shutdown)
+        })
+    }
+
+    pub(crate) fn cancel_launch_and_commit_terminal(
+        &self,
+        invalidate_runtime_agent: bool,
+        commit_presence: impl FnOnce(),
+        commit_state: impl FnOnce(
+            &mut runtime_doc::RuntimeStateDoc,
+        ) -> Result<(), runtime_doc::RuntimeStateError>,
+    ) -> Option<u64> {
+        let mut state = self.kernel_launch_gate.lock_state();
+        let cancelled = state.in_flight_generation.inspect(|generation| {
+            state.cancelled_generations.insert(*generation);
+            if let Some(cancel_tx) = state.in_flight_cancel_tx.as_ref() {
+                let _ = cancel_tx.send(true);
+            }
+        });
+        if invalidate_runtime_agent {
+            state.expected_runtime_agent_id = None;
+            state.connected_runtime_agent_id = None;
+        }
+        self.clear_active_kernel_launch();
+        commit_presence();
+        if let Err(e) = self.state.with_doc(|sd| {
+            commit_state(sd)?;
+            sd.clear_env_progress()?;
+            sd.abort_inflight_executions()?;
+            sd.set_queue(None, &[])?;
+            Ok(())
+        }) {
+            tracing::warn!("[runtime-state] {}", e);
+        }
+        cancelled
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expect_runtime_agent(&self, runtime_agent_id: &str) {
+        let mut state = self.kernel_launch_gate.lock_state();
+        state.expected_runtime_agent_id = Some(runtime_agent_id.to_string());
+        state.connected_runtime_agent_id = None;
+    }
+
+    pub(crate) fn mark_runtime_agent_connected(&self, runtime_agent_id: &str) -> bool {
+        let mut state = self.kernel_launch_gate.lock_state();
+        if state.expected_runtime_agent_id.as_deref() != Some(runtime_agent_id) {
+            return false;
+        }
+        state.connected_runtime_agent_id = Some(runtime_agent_id.to_string());
+        true
+    }
+
+    pub(crate) fn invalidate_runtime_agent_connection(&self) {
+        let mut state = self.kernel_launch_gate.lock_state();
+        state.expected_runtime_agent_id = None;
+        state.connected_runtime_agent_id = None;
+    }
+
+    pub(crate) fn disconnect_runtime_agent_and_commit_terminal(
+        &self,
+        runtime_agent_id: &str,
+        commit_presence: impl FnOnce(),
+        commit_state: impl FnOnce(
+            &mut runtime_doc::RuntimeStateDoc,
+        ) -> Result<(), runtime_doc::RuntimeStateError>,
+    ) -> bool {
+        let mut state = self.kernel_launch_gate.lock_state();
+        if state.connected_runtime_agent_id.as_deref() != Some(runtime_agent_id) {
+            return false;
+        }
+        state.expected_runtime_agent_id = None;
+        state.connected_runtime_agent_id = None;
+        if let Some(generation) = state.in_flight_generation {
+            state.cancelled_generations.insert(generation);
+            if let Some(cancel_tx) = state.in_flight_cancel_tx.as_ref() {
+                let _ = cancel_tx.send(true);
+            }
+        }
+        self.clear_active_kernel_launch();
+        commit_presence();
+        if let Err(e) = self.state.with_doc(|sd| {
+            commit_state(sd)?;
+            sd.clear_env_progress()?;
+            sd.abort_inflight_executions()?;
+            sd.set_queue(None, &[])?;
+            Ok(())
+        }) {
+            tracing::warn!("[runtime-state] {}", e);
+        }
+        true
+    }
+
+    fn finish_cancelled_launch(&self, generation: u64) {
+        let mut state = self.kernel_launch_gate.lock_state();
+        state.cancelled_generations.remove(&generation);
+        state
+            .completed_outcomes
+            .insert(generation, KernelLaunchCompletion::Cancelled);
+        if generation > 1024 {
+            state.completed_outcomes.remove(&(generation - 1024));
+        }
+        if state.in_flight_generation == Some(generation) {
+            state.in_flight_generation = None;
+            state.in_flight_cancel_tx = None;
+            state.in_flight_abort_handle = None;
+        }
+    }
+
+    /// Whether the requested auto-launch attempt launched a kernel.
+    /// Completion is generation-scoped so a later attempt cannot overwrite
+    /// the result a manual launch request is joining.
+    pub(crate) fn launch_completion(&self, generation: u64) -> Option<KernelLaunchCompletion> {
+        self.kernel_launch_gate
+            .lock_state()
+            .completed_outcomes
+            .get(&generation)
+            .copied()
+    }
+
+    pub(crate) fn launch_successor_generation(&self, generation: u64) -> Option<u64> {
+        let state = self.kernel_launch_gate.lock_state();
+        (state.admitted_count > generation).then_some(generation.saturating_add(1))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn record_active_kernel_launch_if_current(
+        &self,
+        runtime_agent_id: String,
+        kernel_type: String,
+        env_source: notebook_protocol::connection::EnvSource,
+    ) -> bool {
+        let current = self.current_runtime_agent_id.read().await;
+        if current.as_deref() != Some(runtime_agent_id.as_str()) {
+            return false;
+        }
+        let mut active = self
+            .active_kernel_launch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *active = Some(ActiveKernelLaunch {
+            runtime_agent_id,
+            kernel_type,
+            env_source,
+        });
+        true
+    }
+
+    pub(crate) async fn is_current_runtime_agent(&self, runtime_agent_id: &str) -> bool {
+        self.current_runtime_agent_id.read().await.as_deref() == Some(runtime_agent_id)
+    }
+
+    pub(crate) fn active_kernel_launch(&self) -> Option<ActiveKernelLaunch> {
+        self.active_kernel_launch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    pub(crate) fn clear_active_kernel_launch(&self) {
+        let mut active = self
+            .active_kernel_launch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *active = None;
+    }
+
+    pub(crate) fn set_active_kernel_launch(
+        &self,
+        runtime_agent_id: String,
+        kernel_type: String,
+        env_source: notebook_protocol::connection::EnvSource,
+    ) {
+        let mut active = self
+            .active_kernel_launch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *active = Some(ActiveKernelLaunch {
+            runtime_agent_id,
+            kernel_type,
+            env_source,
+        });
+    }
+
+    pub(crate) fn clear_active_kernel_launch_if_agent(&self, runtime_agent_id: &str) {
+        let mut active = self
+            .active_kernel_launch
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if active
+            .as_ref()
+            .is_some_and(|launch| launch.runtime_agent_id == runtime_agent_id)
+        {
+            *active = None;
+        }
     }
 
     /// Test helper for integration coverage of the connection path.
     #[doc(hidden)]
     pub fn test_auto_launch_admissions(&self) -> u64 {
-        self.auto_launch_gate.lock_state().admitted_count
+        self.kernel_launch_gate.lock_state().admitted_count
     }
 
     /// Check if this room has an active kernel.

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -2311,15 +2311,18 @@ impl NotebookRoom {
     pub(crate) fn try_begin_manual_launch(self: &Arc<Self>) -> ManualLaunchAdmission {
         let mut state = self.kernel_launch_gate.lock_state();
         if let Some(generation) = state.in_flight_generation {
-            let cancel_rx = state
-                .in_flight_cancel_tx
-                .as_ref()
-                .expect("in-flight launch must own a cancellation sender")
-                .subscribe();
-            return ManualLaunchAdmission::InFlight {
+            if let Some(cancel_tx) = state.in_flight_cancel_tx.as_ref() {
+                return ManualLaunchAdmission::InFlight {
+                    generation,
+                    cancel_rx: cancel_tx.subscribe(),
+                };
+            }
+            warn!(
                 generation,
-                cancel_rx,
-            };
+                "clearing inconsistent in-flight launch without cancellation sender"
+            );
+            state.in_flight_generation = None;
+            state.in_flight_abort_handle = None;
         }
         // Explicit user requests may retry immediately after an auto-launch
         // failure, but do not erase the reconnect-only cooldown. A successful

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2575,12 +2575,13 @@ fn test_room_with_path_and_store(
         runtime_agent_handle: Arc::new(Mutex::new(None)),
         runtime_agent_env_path: Arc::new(RwLock::new(None)),
         runtime_agent_launched_config: Arc::new(RwLock::new(None)),
+        active_kernel_launch: std::sync::Mutex::new(None),
         runtime_agent_request_tx: Arc::new(Mutex::new(None)),
         pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
         runtime_agent_generation: Arc::new(AtomicU64::new(0)),
         next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         current_runtime_agent_id: Arc::new(RwLock::new(None)),
-        auto_launch_gate: AutoLaunchGate::default(),
+        kernel_launch_gate: KernelLaunchGate::default(),
     };
 
     (room, notebook_path)
@@ -13304,11 +13305,14 @@ async fn auto_launch_gate_second_request_joins_in_flight_attempt() {
         _ => panic!("first request must be admitted"),
     };
     assert!(
-        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        matches!(
+            room.try_begin_auto_launch(),
+            AutoLaunchAdmission::InFlight { generation: 1 }
+        ),
         "second request must observe the in-flight attempt"
     );
 
-    attempt.succeed();
+    assert!(attempt.succeed().is_ok());
 }
 
 /// A failed attempt closes the gate for the cooldown window, then a retry is
@@ -13324,6 +13328,9 @@ async fn auto_launch_gate_failure_arms_cooldown_then_readmits() {
     // Dropping without an explicit outcome is the failure path (covers early
     // returns and panics in auto_launch_kernel).
     drop(attempt);
+    while room.launch_completion(1).is_none() {
+        tokio::task::yield_now().await;
+    }
 
     match room.try_begin_auto_launch() {
         AutoLaunchAdmission::CoolingDown { remaining } => {
@@ -13343,7 +13350,7 @@ async fn auto_launch_gate_failure_arms_cooldown_then_readmits() {
     // Past the deadline the next attempt is admitted.
     tokio::time::advance(std::time::Duration::from_millis(2)).await;
     match room.try_begin_auto_launch() {
-        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        AutoLaunchAdmission::Admitted(a) => assert!(a.succeed().is_ok()),
         _ => panic!("retry after the cooldown must be admitted"),
     }
 }
@@ -13355,7 +13362,7 @@ async fn auto_launch_gate_success_reopens_without_cooldown() {
     let (_tmp, room) = gate_test_room();
 
     match room.try_begin_auto_launch() {
-        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        AutoLaunchAdmission::Admitted(a) => assert!(a.succeed().is_ok()),
         _ => panic!("first request must be admitted"),
     }
     assert!(matches!(
@@ -13390,9 +13397,12 @@ async fn auto_launch_gate_admission_clears_stale_cooldown() {
         AutoLaunchAdmission::Admitted(a) => drop(a),
         _ => panic!("first request must be admitted"),
     }
+    while room.launch_completion(1).is_none() {
+        tokio::task::yield_now().await;
+    }
     tokio::time::advance(AUTO_LAUNCH_FAILURE_COOLDOWN + std::time::Duration::from_millis(1)).await;
     match room.try_begin_auto_launch() {
-        AutoLaunchAdmission::Admitted(a) => a.succeed(),
+        AutoLaunchAdmission::Admitted(a) => assert!(a.succeed().is_ok()),
         _ => panic!("post-cooldown request must be admitted"),
     }
     assert!(
@@ -13402,6 +13412,28 @@ async fn auto_launch_gate_admission_clears_stale_cooldown() {
         ),
         "success must not inherit the earlier failure's cooldown"
     );
+}
+
+#[tokio::test]
+async fn same_task_auto_readmission_transfers_abort_ownership() {
+    let (_tmp, room) = gate_test_room();
+    room.connections
+        .active_peers
+        .store(1, std::sync::atomic::Ordering::Release);
+    let first = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(attempt) => attempt,
+        _ => panic!("first request must be admitted"),
+    };
+    let owner = tokio::spawn(std::future::pending::<()>());
+    assert!(room.register_launch_abort_handle(1, owner.abort_handle()));
+
+    let successor = first
+        .release_and_readmit_auto_if_peer_waiting()
+        .expect("connected peer should be readmitted in the same owner task");
+    assert_eq!(successor.generation(), 2);
+    assert!(room.abort_launch_owner(2));
+    assert!(owner.await.unwrap_err().is_cancelled());
+    successor.release_without_cooldown();
 }
 
 /// A launch attempt with zero peers aborts benignly through the real
@@ -13453,7 +13485,7 @@ async fn auto_launch_no_peers_abort_resets_lifecycle_and_reopens_gate() {
     // with no failure cooldown from the benign abort.
     match room.try_begin_auto_launch() {
         AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
-        AutoLaunchAdmission::InFlight => panic!("benign abort must release the gate"),
+        AutoLaunchAdmission::InFlight { .. } => panic!("benign abort must release the gate"),
         AutoLaunchAdmission::CoolingDown { .. } => {
             panic!("benign abort must not arm the failure cooldown")
         }
@@ -13481,7 +13513,10 @@ async fn auto_launch_no_peers_abort_readmits_reconnect_that_raced_the_abort() {
         .active_peers
         .store(1, std::sync::atomic::Ordering::Relaxed);
     assert!(
-        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        matches!(
+            room.try_begin_auto_launch(),
+            AutoLaunchAdmission::InFlight { .. }
+        ),
         "the racing connect is refused while the abort is in progress"
     );
 
@@ -13491,10 +13526,71 @@ async fn auto_launch_no_peers_abort_readmits_reconnect_that_raced_the_abort() {
 
     // The re-admitted token holds the gate for the retry.
     assert!(
-        matches!(room.try_begin_auto_launch(), AutoLaunchAdmission::InFlight),
+        matches!(
+            room.try_begin_auto_launch(),
+            AutoLaunchAdmission::InFlight { .. }
+        ),
         "the retry token must hold the gate"
     );
     next.release_without_cooldown();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_launch_no_peers_abort_does_not_readmit_after_shutdown_during_reset() {
+    let (_tmp, room) = gate_test_room();
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(attempt) => attempt,
+        _ => panic!("first request must be admitted"),
+    };
+    room.connections
+        .active_peers
+        .store(1, std::sync::atomic::Ordering::Relaxed);
+
+    // Hold the handle lock that reset_starting_state awaits after updating its
+    // projection. This opens the exact interleaving where Shutdown arrives
+    // during the abort's awaited reset rather than before its first check.
+    let abort = {
+        let _handle_guard = room.runtime_agent_handle.try_lock().unwrap();
+        let abort = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { release_attempt_and_readmit_if_peer_waiting(&room, attempt).await }
+        });
+        let mut reached_blocked_reset = false;
+        for _ in 0..10_000 {
+            if room
+                .state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap()
+                == RuntimeLifecycle::NotStarted
+            {
+                reached_blocked_reset = true;
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert!(
+            reached_blocked_reset,
+            "abort must reach the handle-clear await before cancellation"
+        );
+        assert_eq!(room.cancel_in_flight_launch(), Some(1));
+        abort
+    };
+
+    assert!(
+        abort.await.unwrap().is_none(),
+        "accepted shutdown must suppress the reconnect-driven successor"
+    );
+    for _ in 0..20 {
+        if room.launch_completion(1).is_some() {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(room.test_auto_launch_admissions(), 1);
+    assert_eq!(
+        room.launch_completion(1),
+        Some(KernelLaunchCompletion::Cancelled)
+    );
 }
 
 /// When no peer raced the abort, the no-peers release stands: no retry
@@ -13528,6 +13624,9 @@ async fn auto_launch_success_disposition_reopens_gate_immediately() {
         AutoLaunchAdmission::Admitted(a) => a,
         _ => panic!("first request must be admitted"),
     };
+    *room.current_runtime_agent_id.write().await = Some("runtime-agent:test".to_string());
+    room.expect_runtime_agent("runtime-agent:test");
+    assert!(room.mark_runtime_agent_connected("runtime-agent:test"));
 
     finish_auto_launch_success(
         &room,
@@ -13538,6 +13637,8 @@ async fn auto_launch_success_disposition_reopens_gate_immediately() {
         attempt,
     )
     .await;
+
+    assert!(room.runtime_agent_launched_config.read().await.is_some());
 
     let lifecycle = room
         .state
@@ -13550,9 +13651,54 @@ async fn auto_launch_success_disposition_reopens_gate_immediately() {
     );
     match room.try_begin_auto_launch() {
         AutoLaunchAdmission::Admitted(a) => a.release_without_cooldown(),
-        AutoLaunchAdmission::InFlight => panic!("success must release the gate"),
+        AutoLaunchAdmission::InFlight { .. } => panic!("success must release the gate"),
         AutoLaunchAdmission::CoolingDown { .. } => {
             panic!("success must not arm the failure cooldown")
+        }
+    }
+}
+
+#[tokio::test]
+async fn cancelled_auto_launch_success_is_stopped_before_gate_reopens() {
+    let (_tmp, room) = gate_test_room();
+    let attempt = match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(attempt) => attempt,
+        _ => panic!("first request must be admitted"),
+    };
+    *room.current_runtime_agent_id.write().await = Some("runtime-agent:test".to_string());
+    assert_eq!(room.cancel_in_flight_launch(), Some(1));
+
+    finish_auto_launch_success(
+        &room,
+        "python",
+        "uv",
+        "runtime-agent:test",
+        LaunchedEnvConfig::default(),
+        attempt,
+    )
+    .await;
+
+    assert!(
+        room.runtime_agent_launched_config.read().await.is_none(),
+        "a cancelled launch must not publish configuration for a kernel that never committed"
+    );
+
+    assert_eq!(
+        room.state
+            .read(|sd| sd.read_state().kernel.lifecycle)
+            .unwrap(),
+        RuntimeLifecycle::Shutdown
+    );
+    assert!(room.active_kernel_launch().is_none());
+    assert_eq!(
+        room.launch_completion(1),
+        Some(KernelLaunchCompletion::Cancelled)
+    );
+    match room.try_begin_auto_launch() {
+        AutoLaunchAdmission::Admitted(attempt) => attempt.release_without_cooldown(),
+        AutoLaunchAdmission::InFlight { .. } => panic!("cancel cleanup must release the gate"),
+        AutoLaunchAdmission::CoolingDown { .. } => {
+            panic!("cancelled auto-launch must not arm the failure cooldown")
         }
     }
 }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -127,9 +127,11 @@ async fn complete_manual_launch(
     env_source: &EnvSource,
     launched_config: &notebook_protocol::protocol::LaunchedEnvConfig,
 ) -> Result<(), NotebookResponse> {
-    let attempt = launch_attempt
-        .take()
-        .expect("manual launch attempt must be owned");
+    let Some(attempt) = launch_attempt.take() else {
+        return Err(NotebookResponse::Error {
+            error: "Kernel launch lost its manual launch ownership".to_string(),
+        });
+    };
     let env_source_label = env_source.as_str().to_string();
     let commit_result = {
         let (mut config, mut presence_state) = tokio::join!(
@@ -1822,20 +1824,27 @@ pub(crate) async fn handle(
             *guard = Some(tx);
             rx
         };
+        let Some(spawn_cancel_rx) = launch_attempt
+            .as_ref()
+            .map(KernelLaunchAttempt::cancellation_receiver)
+        else {
+            reset_starting_state(room, Some(&runtime_agent_id)).await;
+            return NotebookResponse::Error {
+                error: "Kernel launch lost its manual launch ownership before agent spawn"
+                    .to_string(),
+            };
+        };
 
         let spawn_result = tokio::select! {
             biased;
             _ = crate::notebook_sync_server::wait_for_kernel_launch_cancellation(
-                launch_attempt
-                    .as_ref()
-                    .expect("manual launch attempt must be owned")
-                    .cancellation_receiver(),
+                spawn_cancel_rx,
             ) => {
-                launch_attempt
-                    .as_ref()
-                    .expect("manual launch attempt must be owned")
-                    .discard_cancelled_runtime_agent(&runtime_agent_id)
-                    .await;
+                if let Some(attempt) = launch_attempt.as_ref() {
+                    attempt
+                        .discard_cancelled_runtime_agent(&runtime_agent_id)
+                        .await;
+                }
                 return NotebookResponse::Error {
                     error: "Kernel launch cancelled while spawning runtime agent".to_string(),
                 };
@@ -1859,11 +1868,11 @@ pub(crate) async fn handle(
                     .as_ref()
                     .is_some_and(KernelLaunchAttempt::is_cancelled)
                 {
-                    launch_attempt
-                        .as_ref()
-                        .expect("manual launch attempt must be owned")
-                        .discard_cancelled_runtime_agent(&runtime_agent_id)
-                        .await;
+                    if let Some(attempt) = launch_attempt.as_ref() {
+                        attempt
+                            .discard_cancelled_runtime_agent(&runtime_agent_id)
+                            .await;
+                    }
                     return NotebookResponse::Error {
                         error: "Kernel launch cancelled after runtime agent spawn".to_string(),
                     };
@@ -1878,19 +1887,27 @@ pub(crate) async fn handle(
                 }
 
                 // Wait for THIS runtime agent to connect back via socket
+                let Some(connect_cancel_rx) = launch_attempt
+                    .as_ref()
+                    .map(KernelLaunchAttempt::cancellation_receiver)
+                else {
+                    reset_starting_state(room, Some(&runtime_agent_id)).await;
+                    return NotebookResponse::Error {
+                        error:
+                            "Kernel launch lost its manual launch ownership before agent connection"
+                                .to_string(),
+                    };
+                };
                 let connect_result = tokio::select! {
                     biased;
                     _ = crate::notebook_sync_server::wait_for_kernel_launch_cancellation(
-                        launch_attempt
-                            .as_ref()
-                            .expect("manual launch attempt must be owned")
-                            .cancellation_receiver(),
+                        connect_cancel_rx,
                     ) => {
-                        launch_attempt
-                            .as_ref()
-                            .expect("manual launch attempt must be owned")
-                            .discard_cancelled_runtime_agent(&runtime_agent_id)
-                            .await;
+                        if let Some(attempt) = launch_attempt.as_ref() {
+                            attempt
+                                .discard_cancelled_runtime_agent(&runtime_agent_id)
+                                .await;
+                        }
                         return NotebookResponse::Error {
                             error: "Kernel launch cancelled while waiting for runtime agent connection".to_string(),
                         };
@@ -1921,11 +1938,11 @@ pub(crate) async fn handle(
                     .as_ref()
                     .is_some_and(KernelLaunchAttempt::is_cancelled)
                 {
-                    launch_attempt
-                        .as_ref()
-                        .expect("manual launch attempt must be owned")
-                        .discard_cancelled_runtime_agent(&runtime_agent_id)
-                        .await;
+                    if let Some(attempt) = launch_attempt.as_ref() {
+                        attempt
+                            .discard_cancelled_runtime_agent(&runtime_agent_id)
+                            .await;
+                    }
                     return NotebookResponse::Error {
                         error: "Kernel launch cancelled before LaunchKernel RPC".to_string(),
                     };

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -32,13 +32,168 @@ use crate::notebook_sync_server::{
     get_inline_conda_channels, get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps,
     get_inline_uv_prerelease, get_inline_uv_requires_python, missing_conda_env_yml_decision,
     project_environment_build_approved, promote_inline_deps_to_project,
-    publish_environment_launch_error, publish_kernel_state_presence, reset_starting_state,
-    reset_starting_state_with_outcome, resolve_metadata_snapshot,
-    send_runtime_agent_request_with_captured_env_repair, try_conda_pool_for_inline_deps,
-    try_uv_pool_for_inline_deps, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
+    publish_environment_launch_error, reset_starting_state, reset_starting_state_with_outcome,
+    resolve_metadata_snapshot, send_runtime_agent_request_with_captured_env_repair,
+    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, update_kernel_presence_locked,
+    CapturedEnvRuntime, KernelLaunchAttempt, KernelLaunchCommitRejection, KernelLaunchCompletion,
+    ManualLaunchAdmission, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
+
+async fn wait_for_launch_generation(
+    room: &NotebookRoom,
+    generation: u64,
+) -> KernelLaunchCompletion {
+    let mut generation = generation;
+    loop {
+        if let Some(completion) = room.launch_completion(generation) {
+            match completion {
+                KernelLaunchCompletion::Released => {
+                    if let Some(successor) = room.launch_successor_generation(generation) {
+                        generation = successor;
+                        continue;
+                    }
+                    return KernelLaunchCompletion::Released;
+                }
+                terminal => return terminal,
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_joined_launch(
+    room: &NotebookRoom,
+    generation: u64,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+) -> Result<KernelLaunchCompletion, ()> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+    let completion = wait_for_launch_generation(room, generation);
+    tokio::pin!(completion);
+    tokio::select! {
+        biased;
+        result = &mut completion => Ok(result),
+        _ = crate::notebook_sync_server::wait_for_kernel_launch_cancellation(cancel_rx) => {
+            // The owner remains independently fenced until its cancellation-
+            // safe checkpoint, but a joined request must retain its transport
+            // budget. Wait only for the remainder of the original deadline.
+            tokio::time::timeout_at(deadline, completion)
+                .await
+                .map_err(|_| ())
+        }
+        _ = tokio::time::sleep_until(deadline) => Err(()),
+    }
+}
+
+async fn existing_kernel_response(room: &NotebookRoom) -> Option<NotebookResponse> {
+    let active = room.active_kernel_launch()?;
+    let lifecycle = room
+        .state
+        .read(|sd| sd.read_state().kernel.lifecycle)
+        .unwrap_or(RuntimeLifecycle::NotStarted);
+    if !matches!(
+        lifecycle,
+        RuntimeLifecycle::Running(_)
+            | RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::PreparingEnv
+            | RuntimeLifecycle::Launching
+            | RuntimeLifecycle::Connecting
+    ) {
+        return None;
+    }
+
+    let current_agent_id = room.current_runtime_agent_id.read().await.clone();
+    if current_agent_id.as_deref() != Some(&active.runtime_agent_id)
+        || room.runtime_agent_request_tx.lock().await.is_none()
+    {
+        room.clear_active_kernel_launch_if_agent(&active.runtime_agent_id);
+        return None;
+    }
+    let launched_config = room.runtime_agent_launched_config.read().await.clone()?;
+
+    Some(NotebookResponse::KernelAlreadyRunning {
+        kernel_type: active.kernel_type,
+        env_source: active.env_source,
+        launched_config,
+    })
+}
+
+async fn complete_manual_launch(
+    room: &NotebookRoom,
+    launch_attempt: &mut Option<KernelLaunchAttempt>,
+    runtime_agent_id: &str,
+    kernel_type: &str,
+    env_source: &EnvSource,
+    launched_config: &notebook_protocol::protocol::LaunchedEnvConfig,
+) -> Result<(), NotebookResponse> {
+    let attempt = launch_attempt
+        .take()
+        .expect("manual launch attempt must be owned");
+    let env_source_label = env_source.as_str().to_string();
+    let commit_result = {
+        let (mut config, mut presence_state) = tokio::join!(
+            room.runtime_agent_launched_config.write(),
+            room.broadcasts.presence.write()
+        );
+        attempt.succeed_with_agent(runtime_agent_id, || {
+            *config = Some(launched_config.clone());
+            update_kernel_presence_locked(
+                &mut presence_state,
+                &room.broadcasts.presence_tx,
+                presence::KernelStatus::Idle,
+                &env_source_label,
+            );
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+                sd.set_kernel_info(kernel_type, kernel_type, &env_source_label)?;
+                sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
+                sd.set_runtime_agent_id(runtime_agent_id)?;
+                Ok(())
+            }) {
+                warn!("[runtime-state] {}", e);
+            }
+            room.set_active_kernel_launch(
+                runtime_agent_id.to_string(),
+                kernel_type.to_string(),
+                env_source.clone(),
+            );
+        })
+    };
+
+    match commit_result {
+        Ok(()) => {
+            check_and_broadcast_sync_state(room).await;
+            Ok(())
+        }
+        Err((cancelled_attempt, KernelLaunchCommitRejection::Cancelled)) => {
+            // Shutdown won the gate before success was linearized. Keep the
+            // token until cleanup finishes so no successor can launch beside
+            // the kernel or agent we are stopping.
+            let _ = crate::requests::shutdown_kernel::handle(room).await;
+            cancelled_attempt.finish_cancelled();
+            Err(NotebookResponse::Error {
+                error: "Kernel launch cancelled by ShutdownKernel".to_string(),
+            })
+        }
+        Err((superseded_attempt, KernelLaunchCommitRejection::AgentUnavailable)) => {
+            drop(superseded_attempt);
+            let details = "Kernel launch was superseded by a newer runtime agent";
+            reset_starting_state_with_outcome(
+                room,
+                Some(runtime_agent_id),
+                ResetOutcome::Error {
+                    reason: None,
+                    details,
+                },
+            )
+            .await;
+            Err(NotebookResponse::Error {
+                error: details.to_string(),
+            })
+        }
+    }
+}
 
 pub(crate) async fn handle(
     room: &Arc<NotebookRoom>,
@@ -50,6 +205,48 @@ pub(crate) async fn handle(
     if let Err(rejection) = guarded::ensure_trusted(room).await {
         return rejection.into_response();
     }
+
+    let mut launch_attempt = Some(loop {
+        match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => {
+                // The active kernel can finish between admission and this
+                // check. Owning the gate makes a progress-phase projection
+                // safe here: no different launch can be in flight.
+                if let Some(response) = existing_kernel_response(room).await {
+                    attempt.release_without_cooldown();
+                    return response;
+                }
+                break attempt;
+            }
+            ManualLaunchAdmission::InFlight {
+                generation,
+                cancel_rx,
+            } => {
+                let completion = wait_for_joined_launch(room, generation, cancel_rx).await;
+                match completion {
+                    Ok(KernelLaunchCompletion::Succeeded) => {
+                        return existing_kernel_response(room).await.unwrap_or_else(|| {
+                            NotebookResponse::Error {
+                                error: "Kernel launch completed without an active launch identity"
+                                    .to_string(),
+                            }
+                        });
+                    }
+                    Ok(KernelLaunchCompletion::Released) => continue,
+                    Ok(KernelLaunchCompletion::Cancelled) => {
+                        return NotebookResponse::Error {
+                            error: "Kernel launch was cancelled by shutdown".to_string(),
+                        };
+                    }
+                    Ok(KernelLaunchCompletion::Failed) | Err(_) => {
+                        return NotebookResponse::Error {
+                            error: "Kernel launch timed out or failed".to_string(),
+                        };
+                    }
+                }
+            }
+        }
+    });
 
     // Fall back to the room's on-disk path when the caller doesn't
     // supply one. The frontend typically launches with
@@ -65,99 +262,23 @@ pub(crate) async fn handle(
             .await
             .map(|p| p.to_string_lossy().into_owned()),
     };
-    // Check RuntimeStateDoc for launch serialization.
-    // Uses write lock so we can atomically check + set "starting"
-    // to prevent two concurrent LaunchKernel requests from both
-    // proceeding past this gate.
-    //
-    // Scope the write guard so it drops before any async work
-    // (deadlock prevention: no lock held across `.await`).
-    let prior_lifecycle = room
-        .state
-        .with_doc(|sd| {
-            let prior = sd.read_state().kernel.lifecycle;
-            let already_progressing = matches!(
-                prior,
-                RuntimeLifecycle::Running(_)
-                    | RuntimeLifecycle::Resolving
-                    | RuntimeLifecycle::PreparingEnv
-                    | RuntimeLifecycle::Launching
-                    | RuntimeLifecycle::Connecting
-            );
-            if !already_progressing {
-                // Atomically claim the launch by moving into Resolving
-                // while we hold the sync mutex. Prevents a concurrent
-                // LaunchKernel from also proceeding past this gate.
-                sd.clear_env_progress().ok();
-                sd.set_trust("trusted", false).ok();
-                sd.set_lifecycle(&RuntimeLifecycle::Resolving).ok();
-            }
-            Ok(prior)
+    // The room-local launch gate above owns serialization. RuntimeStateDoc is
+    // the client-facing projection, not a lock: concurrent Automerge lifecycle
+    // writes can legitimately resolve to an intermediate phase.
+    if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+        room.state.with_doc(|sd| {
+            sd.clear_env_progress().ok();
+            sd.set_trust("trusted", false).ok();
+            sd.set_lifecycle(&RuntimeLifecycle::Resolving)
         })
-        .unwrap_or_else(|e| {
-            warn!("[runtime-state] {}", e);
-            RuntimeLifecycle::NotStarted
-        });
-    if !matches!(
-        prior_lifecycle,
-        RuntimeLifecycle::Running(_)
-            | RuntimeLifecycle::Resolving
-            | RuntimeLifecycle::PreparingEnv
-            | RuntimeLifecycle::Launching
-            | RuntimeLifecycle::Connecting
-    ) {
-        if let Err(e) = room.comms.with_doc(|cd| cd.clear_comms()) {
-            warn!("[comms-doc] {}", e);
-        }
-        if let Err(e) = room.state.with_doc(|sd| sd.clear_comms()) {
-            warn!("[runtime-state] {}", e);
-        }
+    }) {
+        warn!("[runtime-state] {}", e);
     }
-    match prior_lifecycle {
-        RuntimeLifecycle::Running(_) => {
-            // Agent already has a running kernel — check for restart path below.
-        }
-        RuntimeLifecycle::Resolving
-        | RuntimeLifecycle::PreparingEnv
-        | RuntimeLifecycle::Launching
-        | RuntimeLifecycle::Connecting => {
-            // Another launch in progress — wait for it to complete.
-            let wait_result = tokio::time::timeout(std::time::Duration::from_secs(60), async {
-                loop {
-                    let lc = room
-                        .state
-                        .read(|sd| sd.read_state().kernel.lifecycle)
-                        .unwrap_or(RuntimeLifecycle::NotStarted);
-                    if matches!(
-                        lc,
-                        RuntimeLifecycle::Running(_)
-                            | RuntimeLifecycle::Error
-                            | RuntimeLifecycle::Shutdown
-                            | RuntimeLifecycle::NotStarted
-                            | RuntimeLifecycle::AwaitingEnvBuild
-                    ) {
-                        return lc;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-            })
-            .await;
-
-            match wait_result {
-                Ok(RuntimeLifecycle::Running(_)) => {
-                    // Launch completed — fall through to restart check below.
-                }
-                Ok(_) | Err(_) => {
-                    return NotebookResponse::Error {
-                        error: "Kernel launch timed out or failed".to_string(),
-                    };
-                }
-            }
-        }
-        _ => {
-            // NotStarted / Error / Shutdown / AwaitingTrust / AwaitingEnvBuild — already
-            // claimed above by writing Resolving; fall through.
-        }
+    if let Err(e) = room.comms.with_doc(|cd| cd.clear_comms()) {
+        warn!("[comms-doc] {}", e);
+    }
+    if let Err(e) = room.state.with_doc(|sd| sd.clear_comms()) {
+        warn!("[runtime-state] {}", e);
     }
 
     let notebook_path = notebook_path.map(std::path::PathBuf::from);
@@ -437,13 +558,15 @@ pub(crate) async fn handle(
                 // Error write lands, giving a concurrent retry a window to
                 // claim Resolving that we'd then clobber back to Error.
                 let env_source_label = parsed_resolved.as_str().to_string();
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::MissingIpykernel),
-                    )?;
-                    sd.set_kernel_info("python", "python", &env_source_label)?;
-                    Ok(())
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error(
+                            &RuntimeLifecycle::Error,
+                            Some(KernelErrorReason::MissingIpykernel),
+                        )?;
+                        sd.set_kernel_info("python", "python", &env_source_label)?;
+                        Ok(())
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -546,10 +669,10 @@ pub(crate) async fn handle(
     }
 
     // Transition to "preparing_env" phase
-    if let Err(e) = room
-        .state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
-    {
+    if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+    }) {
         warn!("[runtime-state] {}", e);
     }
 
@@ -669,9 +792,12 @@ pub(crate) async fn handle(
 
     // For inline deps, prepare a cached environment with rich progress
     let launch_progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
-        std::sync::Arc::new(crate::inline_env::RuntimeDocProgressHandler::new(
-            room.state.clone(),
-        ));
+        std::sync::Arc::new(
+            crate::inline_env::RuntimeDocProgressHandler::new_for_launch(
+                room.state.clone(),
+                room.current_launch_cancellation_receiver(),
+            ),
+        );
 
     // Fetch feature flags up front so inline cache hits can refresh vendored
     // launcher files when bootstrap_dx is active.
@@ -993,12 +1119,14 @@ pub(crate) async fn handle(
                         } else {
                             let details = format_conda_env_yml_build_details(&decision);
                             warn!("[notebook-sync] {}", details);
-                            if let Err(e) = room.state.with_doc(|sd| {
-                                sd.set_lifecycle_with_error_details(
-                                    &RuntimeLifecycle::AwaitingEnvBuild,
-                                    Some(KernelErrorReason::CondaEnvYmlMissing),
-                                    Some(&details),
-                                )
+                            if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                                room.state.with_doc(|sd| {
+                                    sd.set_lifecycle_with_error_details(
+                                        &RuntimeLifecycle::AwaitingEnvBuild,
+                                        Some(KernelErrorReason::CondaEnvYmlMissing),
+                                        Some(&details),
+                                    )
+                                })
                             }) {
                                 warn!("[runtime-state] {}", e);
                             }
@@ -1409,7 +1537,7 @@ pub(crate) async fn handle(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            let diagnostic = kernel_env::diagnose_ipykernel(&env.python_path);
+            let diagnostic = kernel_env::diagnose_ipykernel_async(&env.python_path).await;
             if !diagnostic.is_present() {
                 warn!(
                     "[launch-kernel] prepared env at {:?} ({}) cannot import ipykernel: {:?}",
@@ -1440,14 +1568,16 @@ pub(crate) async fn handle(
                 // will simply start a fresh launch.
                 reset_starting_state(room, None).await;
                 let env_source_label = parsed_resolved.as_str().to_string();
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(reason),
-                        Some(&details),
-                    )?;
-                    sd.set_kernel_info("python", "python", &env_source_label)?;
-                    Ok(())
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state.with_doc(|sd| {
+                        sd.set_lifecycle_with_error_details(
+                            &RuntimeLifecycle::Error,
+                            Some(reason),
+                            Some(&details),
+                        )?;
+                        sd.set_kernel_info("python", "python", &env_source_label)?;
+                        Ok(())
+                    })
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -1511,11 +1641,20 @@ pub(crate) async fn handle(
         captured_env_for_config.as_ref(),
     );
 
-    // Transition to "launching" phase before starting the kernel process
-    if let Err(e) = room
-        .state
-        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    if launch_attempt
+        .as_ref()
+        .is_some_and(KernelLaunchAttempt::is_cancelled)
     {
+        return NotebookResponse::Error {
+            error: "Kernel launch cancelled by ShutdownKernel".to_string(),
+        };
+    }
+
+    // Transition to "launching" phase before starting the kernel process
+    if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    }) {
         warn!("[runtime-state] {}", e);
     }
     let redact_env_values_in_outputs = daemon.redact_env_values_in_outputs().await;
@@ -1527,6 +1666,7 @@ pub(crate) async fn handle(
     // The overlay is re-evaluated per launch so the toggle takes effect on
     // the next restart without respawning the runtime-agent process.
     {
+        let existing_runtime_agent_id = room.current_runtime_agent_id.read().await.clone();
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
             info!("[notebook-sync] Agent connected — sending RestartKernel");
@@ -1560,34 +1700,50 @@ pub(crate) async fn handle(
                 Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelRestarted {
                     env_source: es,
                 }) => {
-                    // Store launched config for env sync drift detection
-                    {
-                        let mut lc = room.runtime_agent_launched_config.write().await;
-                        *lc = Some(launched_config.clone());
-                    }
-
-                    let es_label = es.as_str().to_string();
-                    publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es_label)
+                    let Some(runtime_agent_id) = existing_runtime_agent_id else {
+                        let details = "Kernel restarted without a current runtime agent";
+                        if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                            room.state.with_doc(|sd| {
+                                sd.set_lifecycle_with_error_details(
+                                    &RuntimeLifecycle::Error,
+                                    None,
+                                    Some(details),
+                                )
+                            })
+                        }) {
+                            warn!("[runtime-state] {}", e);
+                        }
+                        return NotebookResponse::Error {
+                            error: details.to_string(),
+                        };
+                    };
+                    if !room.is_current_runtime_agent(&runtime_agent_id).await {
+                        let details = "Kernel restart was superseded by a newer runtime agent";
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details,
+                            },
+                        )
                         .await;
-                    if let Err(e) = room.state.with_doc(|sd| {
-                        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-                        sd.set_kernel_info(
-                            &resolved_kernel_type,
-                            &resolved_kernel_type,
-                            &es_label,
-                        )?;
-                        sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
-                        // runtime_agent_id doesn't change on restart — same runtime agent
-                        Ok(())
-                    }) {
-                        warn!("[runtime-state] {}", e);
+                        return NotebookResponse::Error {
+                            error: details.to_string(),
+                        };
                     }
-
-                    // Compute env sync state against the freshly
-                    // stored launched_config (updated above).
-                    // Covers both inline-dep drift and the
-                    // prewarmed-with-added-inline-deps case.
-                    check_and_broadcast_sync_state(room).await;
+                    if let Err(response) = complete_manual_launch(
+                        room,
+                        &mut launch_attempt,
+                        &runtime_agent_id,
+                        &resolved_kernel_type,
+                        &es,
+                        &launched_config,
+                    )
+                    .await
+                    {
+                        return response;
+                    }
 
                     return NotebookResponse::KernelLaunched {
                         kernel_type: resolved_kernel_type,
@@ -1602,13 +1758,13 @@ pub(crate) async fn handle(
                         ..
                     },
                 ) => {
-                    reset_starting_state(room, None).await;
+                    reset_starting_state(room, existing_runtime_agent_id.as_deref()).await;
                     return NotebookResponse::Error {
                         error: format!("Agent restart failed: {}", error),
                     };
                 }
                 Ok(_) => {
-                    reset_starting_state(room, None).await;
+                    reset_starting_state(room, existing_runtime_agent_id.as_deref()).await;
                     return NotebookResponse::Error {
                         error: "Unexpected runtime agent response to RestartKernel".to_string(),
                     };
@@ -1636,9 +1792,27 @@ pub(crate) async fn handle(
 
         // Set provenance + bump generation + create oneshot BEFORE spawn
         // (see auto_launch_kernel for ordering rationale).
-        {
+        let agent_expected = {
             let mut id = room.current_runtime_agent_id.write().await;
-            *id = Some(runtime_agent_id.clone());
+            if launch_attempt
+                .as_ref()
+                .is_some_and(|attempt| attempt.expect_runtime_agent(&runtime_agent_id))
+            {
+                *id = Some(runtime_agent_id.clone());
+                true
+            } else {
+                false
+            }
+        };
+        if !agent_expected
+            || launch_attempt
+                .as_ref()
+                .is_some_and(KernelLaunchAttempt::is_cancelled)
+        {
+            reset_starting_state(room, None).await;
+            return NotebookResponse::Error {
+                error: "Kernel launch cancelled before runtime agent spawn".to_string(),
+            };
         }
         room.runtime_agent_generation
             .fetch_add(1, Ordering::Release);
@@ -1649,36 +1823,84 @@ pub(crate) async fn handle(
             rx
         };
 
-        match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
-            notebook_id,
-            runtime_agent_id.clone(),
-            room.blob_store.root().to_path_buf(),
-            socket_path,
-            daemon.config.runtime_agent_exe.clone(),
-        )
-        .await
-        {
+        let spawn_result = tokio::select! {
+            biased;
+            _ = crate::notebook_sync_server::wait_for_kernel_launch_cancellation(
+                launch_attempt
+                    .as_ref()
+                    .expect("manual launch attempt must be owned")
+                    .cancellation_receiver(),
+            ) => {
+                launch_attempt
+                    .as_ref()
+                    .expect("manual launch attempt must be owned")
+                    .discard_cancelled_runtime_agent(&runtime_agent_id)
+                    .await;
+                return NotebookResponse::Error {
+                    error: "Kernel launch cancelled while spawning runtime agent".to_string(),
+                };
+            }
+            result = crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
+                notebook_id,
+                runtime_agent_id.clone(),
+                room.blob_store.root().to_path_buf(),
+                socket_path,
+                daemon.config.runtime_agent_exe.clone(),
+            ) => result,
+        };
+
+        match spawn_result {
             Ok(ra) => {
                 {
                     let mut ra_guard = room.runtime_agent_handle.lock().await;
                     *ra_guard = Some(ra);
                 }
+                if launch_attempt
+                    .as_ref()
+                    .is_some_and(KernelLaunchAttempt::is_cancelled)
+                {
+                    launch_attempt
+                        .as_ref()
+                        .expect("manual launch attempt must be owned")
+                        .discard_cancelled_runtime_agent(&runtime_agent_id)
+                        .await;
+                    return NotebookResponse::Error {
+                        error: "Kernel launch cancelled after runtime agent spawn".to_string(),
+                    };
+                }
 
                 // Connecting lifecycle — fills the gap between spawn and connect
-                if let Err(e) = room
-                    .state
-                    .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
-                {
+                if let Some(Err(e)) = room.commit_unless_launch_cancelled(|| {
+                    room.state
+                        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
+                }) {
                     warn!("[runtime-state] {}", e);
                 }
 
                 // Wait for THIS runtime agent to connect back via socket
-                match recv_oneshot_with_timeout(
-                    runtime_agent_connect_rx,
-                    std::time::Duration::from_secs(30),
-                )
-                .await
-                {
+                let connect_result = tokio::select! {
+                    biased;
+                    _ = crate::notebook_sync_server::wait_for_kernel_launch_cancellation(
+                        launch_attempt
+                            .as_ref()
+                            .expect("manual launch attempt must be owned")
+                            .cancellation_receiver(),
+                    ) => {
+                        launch_attempt
+                            .as_ref()
+                            .expect("manual launch attempt must be owned")
+                            .discard_cancelled_runtime_agent(&runtime_agent_id)
+                            .await;
+                        return NotebookResponse::Error {
+                            error: "Kernel launch cancelled while waiting for runtime agent connection".to_string(),
+                        };
+                    }
+                    result = recv_oneshot_with_timeout(
+                        runtime_agent_connect_rx,
+                        std::time::Duration::from_secs(30),
+                    ) => result,
+                };
+                match connect_result {
                     TimedOneShot::Received(()) => {}
                     TimedOneShot::SenderDropped => {
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
@@ -1693,6 +1915,20 @@ pub(crate) async fn handle(
                             error: "Agent failed to connect within 30s".to_string(),
                         };
                     }
+                }
+
+                if launch_attempt
+                    .as_ref()
+                    .is_some_and(KernelLaunchAttempt::is_cancelled)
+                {
+                    launch_attempt
+                        .as_ref()
+                        .expect("manual launch attempt must be owned")
+                        .discard_cancelled_runtime_agent(&runtime_agent_id)
+                        .await;
+                    return NotebookResponse::Error {
+                        error: "Kernel launch cancelled before LaunchKernel RPC".to_string(),
+                    };
                 }
 
                 // Send LaunchKernel RPC. Same precedence as the restart path
@@ -1726,46 +1962,33 @@ pub(crate) async fn handle(
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
-                        // Store launched config for env sync drift detection
-                        {
-                            let mut lc = room.runtime_agent_launched_config.write().await;
-                            *lc = Some(launched_config.clone());
+                        if !room.is_current_runtime_agent(&runtime_agent_id).await {
+                            let details = "Kernel launch was superseded by a newer runtime agent";
+                            reset_starting_state_with_outcome(
+                                room,
+                                Some(&runtime_agent_id),
+                                ResetOutcome::Error {
+                                    reason: None,
+                                    details,
+                                },
+                            )
+                            .await;
+                            return NotebookResponse::Error {
+                                error: details.to_string(),
+                            };
                         }
-
-                        let es_label = es.as_str().to_string();
-                        publish_kernel_state_presence(
+                        if let Err(response) = complete_manual_launch(
                             room,
-                            presence::KernelStatus::Idle,
-                            &es_label,
+                            &mut launch_attempt,
+                            &runtime_agent_id,
+                            &resolved_kernel_type,
+                            &es,
+                            &launched_config,
                         )
-                        .await;
-
-                        // Write kernel status + info + prewarmed packages
-                        // to RuntimeStateDoc
+                        .await
                         {
-                            // Read agent ID before the sync mutex to
-                            // avoid holding two locks.
-                            let agent_id = room.current_runtime_agent_id.read().await.clone();
-                            if let Err(e) = room.state.with_doc(|sd| {
-                                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
-                                sd.set_kernel_info(
-                                    &resolved_kernel_type,
-                                    &resolved_kernel_type,
-                                    &es_label,
-                                )?;
-                                sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
-                                if let Some(ref aid) = agent_id {
-                                    sd.set_runtime_agent_id(aid)?;
-                                }
-                                Ok(())
-                            }) {
-                                warn!("[runtime-state] {}", e);
-                            }
+                            return response;
                         }
-
-                        // Compute env sync state against the freshly
-                        // stored launched_config (updated above).
-                        check_and_broadcast_sync_state(room).await;
 
                         NotebookResponse::KernelLaunched {
                             kernel_type: resolved_kernel_type,
@@ -1840,5 +2063,529 @@ pub(crate) async fn handle(
                 NotebookResponse::Error { error: details }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob_store::BlobStore;
+    use crate::notebook_sync_server::{AutoLaunchAdmission, ManualLaunchAdmission, NotebookRoom};
+
+    fn test_room() -> (tempfile::TempDir, Arc<NotebookRoom>) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        (tmp, room)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_launch_gate_completion_unblocks_stale_lifecycle_projection() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto-launch should be admitted"),
+        };
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+            .unwrap();
+
+        let waiter = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_launch_generation(&room, 1).await }
+        });
+        tokio::task::yield_now().await;
+
+        assert!(attempt.succeed().is_ok());
+        let later_attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("later auto-launch should be admitted"),
+        };
+        later_attempt.release_without_cooldown();
+        tokio::time::advance(std::time::Duration::from_millis(101)).await;
+
+        assert_eq!(waiter.await.unwrap(), KernelLaunchCompletion::Succeeded);
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Launching,
+            "the regression requires completion to be independent of the CRDT projection"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn joined_waiter_follows_successor_after_benign_release() {
+        let (_tmp, room) = test_room();
+        let first = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("first auto-launch should be admitted"),
+        };
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+            .unwrap();
+        let waiter = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_launch_generation(&room, 1).await }
+        });
+        tokio::task::yield_now().await;
+
+        first.release_without_cooldown();
+        let successor = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("successor auto-launch should be admitted"),
+        };
+        assert!(successor.succeed().is_ok());
+        tokio::time::advance(std::time::Duration::from_millis(101)).await;
+
+        assert_eq!(waiter.await.unwrap(), KernelLaunchCompletion::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn existing_kernel_response_reuses_active_launch() {
+        let (_tmp, room) = test_room();
+        let launched_config = notebook_protocol::protocol::LaunchedEnvConfig {
+            launch_id: Some("launch-1".to_string()),
+            ..Default::default()
+        };
+        *room.runtime_agent_launched_config.write().await = Some(launched_config.clone());
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        assert!(
+            room.record_active_kernel_launch_if_current(
+                "agent-1".to_string(),
+                "python".to_string(),
+                EnvSource::Prewarmed(PackageManager::Uv),
+            )
+            .await
+        );
+
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle)))
+            .unwrap();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(tx);
+        let response = existing_kernel_response(&room).await.unwrap();
+        match response {
+            NotebookResponse::KernelAlreadyRunning {
+                kernel_type,
+                env_source,
+                launched_config: actual_config,
+            } => {
+                assert_eq!(kernel_type, "python");
+                assert_eq!(env_source, EnvSource::Prewarmed(PackageManager::Uv));
+                assert_eq!(actual_config, launched_config);
+            }
+            other => panic!("expected existing-kernel response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_lifecycle_rejects_response_without_projection_driven_clear() {
+        let (_tmp, room) = test_room();
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        assert!(
+            room.record_active_kernel_launch_if_current(
+                "agent-1".to_string(),
+                "python".to_string(),
+                EnvSource::Prewarmed(PackageManager::Uv),
+            )
+            .await
+        );
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(tx);
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Error))
+            .unwrap();
+
+        assert!(existing_kernel_response(&room).await.is_none());
+        assert!(room.active_kernel_launch().is_some());
+    }
+
+    #[tokio::test]
+    async fn stale_agent_cleanup_preserves_replacement_launch() {
+        let (_tmp, room) = test_room();
+        *room.current_runtime_agent_id.write().await = Some("replacement-agent".to_string());
+        assert!(
+            room.record_active_kernel_launch_if_current(
+                "replacement-agent".to_string(),
+                "python".to_string(),
+                EnvSource::Prewarmed(PackageManager::Uv),
+            )
+            .await
+        );
+
+        assert!(
+            !room
+                .record_active_kernel_launch_if_current(
+                    "stale-agent".to_string(),
+                    "deno".to_string(),
+                    EnvSource::Deno,
+                )
+                .await
+        );
+
+        room.clear_active_kernel_launch_if_agent("stale-agent");
+
+        assert_eq!(
+            room.active_kernel_launch()
+                .map(|active| active.runtime_agent_id),
+            Some("replacement-agent".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_launch_joins_exact_auto_launch_generation() {
+        let (_tmp, room) = test_room();
+        let auto_attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto-launch should be admitted"),
+        };
+
+        assert_eq!(
+            match room.try_begin_manual_launch() {
+                ManualLaunchAdmission::InFlight { generation, .. } => generation,
+                ManualLaunchAdmission::Admitted(_) => {
+                    panic!("manual launch must join the auto-launch")
+                }
+            },
+            1
+        );
+        auto_attempt.release_without_cooldown();
+    }
+
+    #[tokio::test]
+    async fn concurrent_manual_launches_share_one_generation() {
+        let (_tmp, room) = test_room();
+        let first = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("first manual launch should be admitted")
+            }
+        };
+
+        assert_eq!(
+            match room.try_begin_manual_launch() {
+                ManualLaunchAdmission::InFlight { generation, .. } => generation,
+                ManualLaunchAdmission::Admitted(_) => {
+                    panic!("second manual launch must join the first")
+                }
+            },
+            1
+        );
+        first.release_without_cooldown();
+    }
+
+    #[tokio::test]
+    async fn failed_manual_launch_does_not_arm_auto_launch_cooldown() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("first manual launch should be admitted")
+            }
+        };
+        drop(attempt);
+        while room.launch_completion(1).is_none() {
+            tokio::task::yield_now().await;
+        }
+
+        match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt.release_without_cooldown(),
+            AutoLaunchAdmission::InFlight { .. } => {
+                panic!("manual failure must release the gate")
+            }
+            AutoLaunchAdmission::CoolingDown { .. } => {
+                panic!("manual failure must not throttle reconnect-driven launch")
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn manual_retry_preserves_existing_auto_launch_cooldown() {
+        let (_tmp, room) = test_room();
+        let auto_attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto launch should be admitted"),
+        };
+        drop(auto_attempt);
+        while room.launch_completion(1).is_none() {
+            tokio::task::yield_now().await;
+        }
+
+        let manual_attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("manual launch must bypass reconnect cooldown")
+            }
+        };
+        drop(manual_attempt);
+        while room.launch_completion(2).is_none() {
+            tokio::task::yield_now().await;
+        }
+        assert!(matches!(
+            room.try_begin_auto_launch(),
+            AutoLaunchAdmission::CoolingDown { .. }
+        ));
+
+        tokio::time::advance(crate::notebook_sync_server::AUTO_LAUNCH_FAILURE_COOLDOWN).await;
+        match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt.release_without_cooldown(),
+            _ => panic!("original cooldown should expire normally"),
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancellation_wins_manual_success_linearization() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("first manual launch should be admitted")
+            }
+        };
+        assert_eq!(room.cancel_in_flight_launch(), Some(1));
+
+        let cancelled_attempt = attempt
+            .succeed()
+            .expect_err("shutdown must prevent launch success from linearizing");
+        assert!(matches!(
+            room.try_begin_manual_launch(),
+            ManualLaunchAdmission::InFlight { generation: 1, .. }
+        ));
+        cancelled_attempt.finish_cancelled();
+
+        assert_eq!(
+            room.launch_completion(1),
+            Some(KernelLaunchCompletion::Cancelled)
+        );
+        match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt.release_without_cooldown(),
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("cancelled owner must release after cleanup")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_manual_success_does_not_publish_launched_config() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => panic!("launch should be admitted"),
+        };
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        room.expect_runtime_agent("agent-1");
+        assert!(room.mark_runtime_agent_connected("agent-1"));
+        assert_eq!(room.cancel_in_flight_launch(), Some(1));
+        let mut launch_attempt = Some(attempt);
+        let launched_config = notebook_protocol::protocol::LaunchedEnvConfig {
+            launch_id: Some("cancelled-launch".to_string()),
+            ..Default::default()
+        };
+
+        assert!(complete_manual_launch(
+            &room,
+            &mut launch_attempt,
+            "agent-1",
+            "python",
+            &EnvSource::Prewarmed(PackageManager::Uv),
+            &launched_config,
+        )
+        .await
+        .is_err());
+        assert!(room.runtime_agent_launched_config.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn abandoned_manual_launch_cleans_agent_slots_before_releasing_gate() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => panic!("launch should be admitted"),
+        };
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        assert!(attempt.expect_runtime_agent("agent-1"));
+        let (request_tx, _request_rx) = tokio::sync::mpsc::channel(1);
+        *room.runtime_agent_request_tx.lock().await = Some(request_tx);
+        let (connect_tx, _connect_rx) = tokio::sync::oneshot::channel();
+        *room.pending_runtime_agent_connect_tx.lock().await = Some(connect_tx);
+        room.state
+            .with_doc(|doc| doc.set_lifecycle(&RuntimeLifecycle::Launching))
+            .unwrap();
+
+        drop(attempt);
+        for _ in 0..20 {
+            if room.launch_completion(1).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            room.launch_completion(1),
+            Some(KernelLaunchCompletion::Failed)
+        );
+        assert!(room.current_runtime_agent_id.read().await.is_none());
+        assert!(room.runtime_agent_request_tx.lock().await.is_none());
+        assert!(room.pending_runtime_agent_connect_tx.lock().await.is_none());
+        assert_eq!(
+            room.state
+                .read(|doc| doc.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_attempt_drop_preserves_runtime_agent_disconnect_error() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => panic!("launch should be admitted"),
+        };
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        assert!(attempt.expect_runtime_agent("agent-1"));
+        assert!(room.mark_runtime_agent_connected("agent-1"));
+        assert!(room.disconnect_runtime_agent_and_commit_terminal(
+            "agent-1",
+            || {},
+            |doc| doc.set_lifecycle_with_error_details(
+                &RuntimeLifecycle::Error,
+                None,
+                Some("Runtime agent disconnected"),
+            ),
+        ));
+
+        drop(attempt);
+        for _ in 0..20 {
+            if room.launch_completion(1).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            room.launch_completion(1),
+            Some(KernelLaunchCompletion::Cancelled)
+        );
+        let state = room.state.read(|doc| doc.read_state()).unwrap();
+        assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(
+            state.kernel.error_details.as_deref(),
+            Some("Runtime agent disconnected")
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_launch_cannot_regress_shutdown_projection() {
+        let (_tmp, room) = test_room();
+        let attempt = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt,
+            ManualLaunchAdmission::InFlight { .. } => panic!("launch should be admitted"),
+        };
+        assert_eq!(room.cancel_in_flight_launch(), Some(1));
+        room.state
+            .with_doc(|doc| doc.set_lifecycle(&RuntimeLifecycle::Shutdown))
+            .unwrap();
+
+        let committed = room.commit_unless_launch_cancelled(|| {
+            room.state
+                .with_doc(|doc| doc.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+        });
+        assert!(committed.is_none());
+        assert_eq!(
+            room.state
+                .read(|doc| doc.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Shutdown
+        );
+        attempt.finish_cancelled();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_join_retains_launch_timeout_while_owner_cleanup_continues() {
+        let (_tmp, room) = test_room();
+        let owner = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto-launch should be admitted"),
+        };
+        let (generation, cancel_rx) = match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::InFlight {
+                generation,
+                cancel_rx,
+            } => (generation, cancel_rx),
+            ManualLaunchAdmission::Admitted(_) => {
+                panic!("manual request must join the auto-launch")
+            }
+        };
+        let waiter = tokio::spawn({
+            let room = Arc::clone(&room);
+            async move { wait_for_joined_launch(&room, generation, cancel_rx).await }
+        });
+
+        assert_eq!(room.cancel_in_flight_launch(), Some(generation));
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(61)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(waiter.await.unwrap(), Err(()));
+        assert!(
+            matches!(
+                room.try_begin_manual_launch(),
+                ManualLaunchAdmission::InFlight { generation: 1, .. }
+            ),
+            "timing out a joined request must not release the owner's safety fence"
+        );
+        owner.finish_cancelled();
+    }
+
+    #[tokio::test]
+    async fn manual_launch_can_take_over_after_benign_release_without_successor() {
+        let (_tmp, room) = test_room();
+        let auto_attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto-launch should be admitted"),
+        };
+        auto_attempt.release_without_cooldown();
+
+        match room.try_begin_manual_launch() {
+            ManualLaunchAdmission::Admitted(attempt) => attempt.release_without_cooldown(),
+            ManualLaunchAdmission::InFlight { .. } => {
+                panic!("manual launch should take ownership after release")
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_auto_launch_cannot_reuse_stale_active_response() {
+        let (_tmp, room) = test_room();
+        *room.current_runtime_agent_id.write().await = Some("agent-1".to_string());
+        assert!(
+            room.record_active_kernel_launch_if_current(
+                "agent-1".to_string(),
+                "python".to_string(),
+                EnvSource::Prewarmed(PackageManager::Uv),
+            )
+            .await
+        );
+        let attempt = match room.try_begin_auto_launch() {
+            AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("auto-launch should be admitted"),
+        };
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+            .unwrap();
+        room.clear_active_kernel_launch();
+        drop(attempt);
+
+        assert_eq!(
+            wait_for_launch_generation(&room, 1).await,
+            KernelLaunchCompletion::Failed
+        );
+        assert!(existing_kernel_response(&room).await.is_none());
     }
 }

--- a/crates/runtimed/src/requests/shutdown_kernel.rs
+++ b/crates/runtimed/src/requests/shutdown_kernel.rs
@@ -1,11 +1,52 @@
 //! `NotebookRequest::ShutdownKernel` handler.
 
-use runtime_doc::RuntimeLifecycle;
+use notebook_doc::presence;
 
-use crate::notebook_sync_server::{send_runtime_agent_request, NotebookRoom};
+use crate::notebook_sync_server::{
+    send_runtime_agent_request, update_kernel_presence_locked, NotebookRoom,
+};
 use crate::protocol::NotebookResponse;
 
+async fn begin_shutdown_with_agent_policy(
+    room: &NotebookRoom,
+    invalidate_runtime_agent: bool,
+) -> Option<u64> {
+    // Presence and RuntimeStateDoc become terminal at the same launch-gate
+    // linearization point. Success takes these locks in the same order, so it
+    // cannot republish Idle/Running after this shutdown is accepted.
+    let env_source = room
+        .active_kernel_launch()
+        .map(|launch| launch.env_source.as_str().to_string())
+        .unwrap_or_default();
+    {
+        let mut presence_state = room.broadcasts.presence.write().await;
+        let commit_presence = || {
+            update_kernel_presence_locked(
+                &mut presence_state,
+                &room.broadcasts.presence_tx,
+                presence::KernelStatus::Shutdown,
+                &env_source,
+            );
+        };
+        if invalidate_runtime_agent {
+            room.cancel_launch_and_mark_teardown_with(commit_presence)
+        } else {
+            room.cancel_launch_and_mark_shutdown_with(commit_presence)
+        }
+    }
+}
+
+pub(crate) async fn begin_shutdown(room: &NotebookRoom) -> Option<u64> {
+    begin_shutdown_with_agent_policy(room, false).await
+}
+
+pub(crate) async fn begin_teardown(room: &NotebookRoom) -> Option<u64> {
+    begin_shutdown_with_agent_policy(room, true).await
+}
+
 pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
+    let cancelled_launch = begin_shutdown(room).await;
+
     // Send shutdown RPC but keep the runtime agent alive — it stays
     // connected for potential RestartKernel. The kernel process dies
     // but the runtime agent subprocess and socket connection remain.
@@ -21,16 +62,251 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         // check kernel.lifecycle from RuntimeStateDoc and return NoKernel
         // when it's Shutdown.
         //
-        // Update RuntimeStateDoc to reflect shutdown.
-        if let Err(e) = room.state.with_doc(|sd| {
-            sd.set_lifecycle(&RuntimeLifecycle::Shutdown)?;
-            sd.set_queue(None, &[])?;
-            Ok(())
-        }) {
-            tracing::warn!("[runtime-state] {}", e);
-        }
+    }
+    if has_runtime_agent || cancelled_launch.is_some() {
         NotebookResponse::KernelShuttingDown {}
     } else {
         NotebookResponse::NoKernel {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use runtime_doc::{KernelActivity, QueueEntry, RuntimeLifecycle};
+
+    use super::*;
+    use crate::blob_store::BlobStore;
+
+    #[tokio::test]
+    async fn shutdown_without_agent_clears_stale_running_projection() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle)))
+            .unwrap();
+
+        assert!(matches!(handle(&room).await, NotebookResponse::NoKernel {}));
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Shutdown
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_terminalizes_queued_and_running_executions() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        room.state
+            .with_doc(|state| {
+                state.create_execution("queued")?;
+                state.create_execution("running")?;
+                state.set_execution_running("running")?;
+                let running = QueueEntry {
+                    execution_id: "running".to_string(),
+                };
+                let queued = [QueueEntry {
+                    execution_id: "queued".to_string(),
+                }];
+                state.set_queue(Some(&running), &queued)?;
+                state.set_env_progress("uv", &serde_json::json!({"phase": "installing"}))?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(matches!(handle(&room).await, NotebookResponse::NoKernel {}));
+        room.state
+            .read(|state| {
+                assert_eq!(state.get_execution("queued").unwrap().status, "cancelled");
+                let running = state.get_execution("running").unwrap();
+                assert_eq!(running.status, "error");
+                assert_eq!(running.success, Some(false));
+                let queue = state.read_state().queue;
+                assert!(queue.executing.is_none());
+                assert!(queue.queued.is_empty());
+                assert!(state.read_state().env.progress.is_none());
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_without_agent_cancels_in_flight_launch() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        let attempt = match room.try_begin_auto_launch() {
+            crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("first launch should be admitted"),
+        };
+        room.state
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+            .unwrap();
+
+        assert!(matches!(
+            handle(&room).await,
+            NotebookResponse::KernelShuttingDown {}
+        ));
+        assert!(attempt.is_cancelled());
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Shutdown
+        );
+        crate::notebook_sync_server::reset_starting_state_with_outcome(
+            &room,
+            None,
+            crate::notebook_sync_server::ResetOutcome::Error {
+                reason: None,
+                details: "late launch failure",
+            },
+        )
+        .await;
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Shutdown,
+            "late launch cleanup must not overwrite the accepted shutdown"
+        );
+        assert!(matches!(
+            room.try_begin_manual_launch(),
+            crate::notebook_sync_server::ManualLaunchAdmission::InFlight { .. }
+        ));
+
+        attempt.finish_cancelled();
+        assert_eq!(
+            room.launch_completion(1),
+            Some(crate::notebook_sync_server::KernelLaunchCompletion::Cancelled)
+        );
+        match room.try_begin_manual_launch() {
+            crate::notebook_sync_server::ManualLaunchAdmission::Admitted(attempt) => {
+                attempt.release_without_cooldown()
+            }
+            _ => panic!("cancelled owner should release the gate"),
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_shutdown_cannot_be_overwritten_by_concurrent_launch_reset() {
+        for _ in 0..100 {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let room = Arc::new(NotebookRoom::new_fresh(
+                uuid::Uuid::new_v4(),
+                None,
+                tmp.path(),
+                Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+                false,
+            ));
+            let attempt = match room.try_begin_auto_launch() {
+                crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+                _ => panic!("first launch should be admitted"),
+            };
+            room.state
+                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
+                .unwrap();
+
+            let reset = tokio::spawn({
+                let room = Arc::clone(&room);
+                async move {
+                    crate::notebook_sync_server::reset_starting_state_with_outcome(
+                        &room,
+                        None,
+                        crate::notebook_sync_server::ResetOutcome::Error {
+                            reason: None,
+                            details: "concurrent launch failure",
+                        },
+                    )
+                    .await;
+                }
+            });
+            let shutdown = tokio::spawn({
+                let room = Arc::clone(&room);
+                async move { handle(&room).await }
+            });
+            let (_, response) = tokio::join!(reset, shutdown);
+            assert!(matches!(
+                response.unwrap(),
+                NotebookResponse::KernelShuttingDown {}
+            ));
+            attempt.finish_cancelled();
+            assert_eq!(
+                room.state
+                    .read(|sd| sd.read_state().kernel.lifecycle)
+                    .unwrap(),
+                RuntimeLifecycle::Shutdown
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_shutdown_prevents_success_projection_from_republishing_running() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            Arc::new(BlobStore::new(tmp.path().join("blobs"))),
+            false,
+        ));
+        let attempt = match room.try_begin_auto_launch() {
+            crate::notebook_sync_server::AutoLaunchAdmission::Admitted(attempt) => attempt,
+            _ => panic!("first launch should be admitted"),
+        };
+        assert!(matches!(
+            handle(&room).await,
+            NotebookResponse::KernelShuttingDown {}
+        ));
+
+        let projection_ran = std::cell::Cell::new(false);
+        let cancelled_attempt = match attempt.succeed_with(|| {
+            projection_ran.set(true);
+            room.state
+                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle)))
+                .unwrap();
+        }) {
+            Err(attempt) => attempt,
+            Ok(()) => panic!("shutdown must win success linearization"),
+        };
+        assert!(
+            !projection_ran.get(),
+            "cancelled success must not run its Idle/Running projection"
+        );
+        assert_eq!(
+            room.state
+                .read(|sd| sd.read_state().kernel.lifecycle)
+                .unwrap(),
+            RuntimeLifecycle::Shutdown
+        );
+        let presence_state = room.broadcasts.presence.read().await;
+        let daemon = presence_state.peers().get("daemon").unwrap();
+        match daemon.channels.get(&presence::Channel::KernelState) {
+            Some(presence::ChannelData::KernelState(data)) => {
+                assert_eq!(data.status, presence::KernelStatus::Shutdown)
+            }
+            other => panic!("expected shutdown kernel presence, got {other:?}"),
+        }
+        drop(presence_state);
+        cancelled_attempt.finish_cancelled();
     }
 }

--- a/crates/runtimed/src/uv_project.rs
+++ b/crates/runtimed/src/uv_project.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
+use kernel_env::CommandOutputExt;
 use kernel_env::{EnvProgressPhase, ProgressHandler};
 use tokio::process::Command;
 use tracing::{info, warn};
@@ -231,7 +232,7 @@ async fn run_prepare_probe(
     if bootstrap_dx {
         apply_bootstrap_pythonpath(&mut cmd).await?;
     }
-    cmd.output().await.with_context(|| {
+    cmd.output_owned().await.with_context(|| {
         format!(
             "failed to run uv project prepare probe in {}",
             cwd.display()


### PR DESCRIPTION
## Summary

- serialize automatic and explicit kernel launches behind one daemon-local, exact-generation gate
- make launch success, cancellation, runtime-agent identity, shutdown, and last-peer teardown linearizable
- retry a frontend project-environment switch when it joined a background launch with different intent
- make launch-owned package-manager and interpreter probes cancellation-safe on Unix and Windows
- preserve reconnect liveness across rapid disconnect/reconnect and sleep/wake-shaped races

## Root cause

The original CI failure launched the automatic Python kernel successfully in about 800 ms, then a concurrent explicit `LaunchKernel` waited 60 seconds against a stale Automerge lifecycle projection. Runtime-state conflicts could resolve to `Resolving` or `Launching` even though a kernel was already running, so the explicit request missed the idempotent `KernelAlreadyRunning` response and fell through to a restart path.

The same split ownership also left cancellation gaps: a disconnected peer or last-peer teardown could release one layer of launch state while the runtime agent or package manager still owned work.

## What changed

- one `KernelLaunchGate` owns admission, cancellation, exact-generation completion, reconnect cooldown, active agent identity, and same-task readmission
- manual callers join the precise in-flight generation and use daemon-local completion rather than CRDT lifecycle as the synchronization primitive
- runtime-agent install/connect/disconnect and launched configuration publish under the launch identity fence
- shutdown terminalizes executions and cannot be overwritten by a late launch or disconnect
- last-peer teardown cancels and, if necessary, aborts the room-owned launch before notebook/environment cleanup; reconnect followers are single-flight and bounded
- process output collection owns the whole subprocess tree:
  - Unix: fresh process group, `SIGKILL`, bounded reap with `EINTR` handling
  - Windows: `CREATE_SUSPENDED`, assign to a kill-on-close Job Object, then resume; termination fences the leader and descendants
- the `ipykernel` import probe is async, bounded, and cancellation-safe

## Verification

- `cargo xtask lint --fix`
- `cargo check -p kernel-launch --target x86_64-pc-windows-gnu`
- `cargo check -p kernel-env --no-default-features`
- `cargo test -p kernel-launch -p kernel-env -p runtimed`
  - 1,321 runtimed unit tests passed, 3 ignored
  - all 72 runtimed Rust integration tests passed
  - 99 kernel-env tests passed
  - 23 kernel-launch tests passed, 1 ignored network test
  - lifecycle-transition, Tokio mutex, and cancellation-safety lints passed
- `cargo xtask integration`
  - 120 passed, 1 skipped
  - includes `TestExecutionIdScoping.test_queue_returns_execution_handle`, the test that failed on `main`
- notebook action policy: 9 passed
- focused launch/reconnect/shutdown/process-tree regressions passed
- Windows target cross-check passed without warnings
- independent Codex and Kilo correctness reviews; all verified findings addressed

## Nightly QA follow-up

Once merged, exercise explicit launch during auto-launch, restart/shutdown, project-environment switching, MCP plus desktop concurrency, locked-screen reconnect, and macOS sleep/wake reconnect. Sleep/wake was not proven as the root cause, but it is a plausible trigger for the peer/reconnect ordering that exposed the bug.
