### PR TITLE
fix(runtimed): recover legacy journal overflow upgrades

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -20,7 +20,7 @@ use notebook_sync::RelayHandle;
 
 use log::{debug, info, warn};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::OsStr;
 
 /// Shared notebook sync handle for cross-window state synchronization.
@@ -1310,11 +1310,13 @@ async fn setup_sync_receivers(
 #[cfg(test)]
 mod tests {
     use super::{
-        create_window_context_for_daemon, hosted_notebook_window_label,
+        create_window_context_for_daemon, daemon_upgrade_failure, hosted_notebook_window_label,
         is_reusable_startup_placeholder, next_available_sample_path, normalize_font_families,
         normalize_hosted_notebook_locator, pathless_file_open_policy, reopen_action,
-        require_current_sync_generation, reserve_window_context, PathlessFileOpenPolicy,
-        ReopenAction, Runtime, SyncReadyState, WindowContextReservation, WindowNotebookRegistry,
+        require_current_sync_generation, reserve_window_context, BoundedStderrTail,
+        PathlessFileOpenPolicy, ReopenAction, Runtime, SyncReadyState, WindowContextReservation,
+        WindowNotebookRegistry, DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS,
+        DAEMON_UPGRADE_STDERR_MAX_LINES,
     };
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Barrier};
@@ -1582,6 +1584,113 @@ mod tests {
             "a reused deterministic label must start with a fresh readiness gate"
         );
     }
+
+    #[test]
+    fn daemon_upgrade_failure_includes_last_nonempty_stderr_detail() {
+        let mut stderr = BoundedStderrTail::default();
+        stderr.push(b"preparing upgrade\n\n");
+        stderr
+            .push(b"clean shutdown blocked\nrepair stopped to preserve notebook recovery state\n");
+
+        assert_eq!(
+            daemon_upgrade_failure(Some(1), &stderr),
+            "Daemon upgrade failed (exit code 1): repair stopped to preserve notebook recovery state"
+        );
+    }
+
+    #[test]
+    fn daemon_upgrade_failure_keeps_stderr_collection_bounded() {
+        let mut stderr = BoundedStderrTail::default();
+        for index in 0..(DAEMON_UPGRADE_STDERR_MAX_LINES + 3) {
+            stderr.push(format!("detail {index}").as_bytes());
+        }
+
+        assert_eq!(stderr.lines.len(), DAEMON_UPGRADE_STDERR_MAX_LINES);
+        assert_eq!(stderr.lines.front().map(String::as_str), Some("detail 3"));
+        assert_eq!(stderr.last_detail(), Some("detail 10"));
+    }
+
+    #[test]
+    fn daemon_upgrade_failure_truncates_an_oversized_detail_on_a_char_boundary() {
+        let mut stderr = BoundedStderrTail::default();
+        let actionable_tail = "repair stopped to preserve notebook recovery state";
+        let detail = format!(
+            "{}{}",
+            "é".repeat(DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS + 20),
+            actionable_tail
+        );
+        stderr.push(detail.as_bytes());
+
+        let detail = stderr.last_detail().expect("stderr detail");
+        assert_eq!(
+            detail.chars().count(),
+            DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS
+        );
+        assert!(detail.starts_with('…'));
+        assert!(detail.ends_with(actionable_tail));
+    }
+
+    #[test]
+    fn daemon_upgrade_failure_falls_back_to_exit_status_without_stderr() {
+        assert_eq!(
+            daemon_upgrade_failure(None, &BoundedStderrTail::default()),
+            "Daemon upgrade failed (signal)"
+        );
+    }
+}
+
+const DAEMON_UPGRADE_STDERR_MAX_LINES: usize = 8;
+const DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS: usize = 512;
+
+/// Small, user-displayable tail of sidecar stderr.
+///
+/// Full sidecar output remains in the application log for diagnostics. This
+/// collector deliberately retains only a few single-line, size-capped details
+/// so a failed subprocess cannot inject unbounded output into progress events.
+#[derive(Default)]
+struct BoundedStderrTail {
+    lines: VecDeque<String>,
+}
+
+impl BoundedStderrTail {
+    fn push(&mut self, chunk: &[u8]) {
+        let text = String::from_utf8_lossy(chunk);
+        for line in text.lines().map(str::trim).filter(|line| !line.is_empty()) {
+            let detail = truncate_stderr_detail(line);
+            if self.lines.len() == DAEMON_UPGRADE_STDERR_MAX_LINES {
+                self.lines.pop_front();
+            }
+            self.lines.push_back(detail);
+        }
+    }
+
+    fn last_detail(&self) -> Option<&str> {
+        self.lines.back().map(String::as_str)
+    }
+}
+
+fn truncate_stderr_detail(detail: &str) -> String {
+    let char_count = detail.chars().count();
+    if char_count <= DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS {
+        return detail.to_string();
+    }
+    let tail_chars = DAEMON_UPGRADE_STDERR_MAX_DETAIL_CHARS.saturating_sub(1);
+    let tail = detail
+        .chars()
+        .skip(char_count - tail_chars)
+        .collect::<String>();
+    format!("…{tail}")
+}
+
+fn daemon_upgrade_failure(exit_code: Option<i32>, stderr: &BoundedStderrTail) -> String {
+    let status = match exit_code {
+        Some(code) => format!("exit code {code}"),
+        None => "signal".to_string(),
+    };
+    match stderr.last_detail() {
+        Some(detail) => format!("Daemon upgrade failed ({status}): {detail}"),
+        None => format!("Daemon upgrade failed ({status})"),
+    }
 }
 
 /// Get the version string of the bundled daemon.
@@ -1627,6 +1736,7 @@ where
 
     // Collect output for logging
     let mut exit_code = None;
+    let mut stderr_tail = BoundedStderrTail::default();
     while let Some(event) = rx.recv().await {
         match event {
             CommandEvent::Stdout(line) => {
@@ -1636,6 +1746,7 @@ where
                 );
             }
             CommandEvent::Stderr(line) => {
+                stderr_tail.push(&line);
                 log::warn!(
                     "[runtimed upgrade] {}",
                     String::from_utf8_lossy(&line).trim()
@@ -1649,11 +1760,7 @@ where
     }
 
     if exit_code != Some(0) {
-        let code_str = match exit_code {
-            Some(code) => format!("exit code {code}"),
-            None => "signal".to_string(),
-        };
-        let error = format!("Daemon upgrade failed ({code_str})");
+        let error = daemon_upgrade_failure(exit_code, &stderr_tail);
         log::error!("[startup] {}", error);
         on_progress(DaemonProgress::Failed {
             error: error.clone(),

--- a/crates/runtimed/src/notebook_sync_server/durability.rs
+++ b/crates/runtimed/src/notebook_sync_server/durability.rs
@@ -2034,6 +2034,7 @@ mod tests {
                 record: super::super::recovery::RecoveryRecord {
                     manifest,
                     automerge_snapshot: durable_snapshot.clone(),
+                    source_manifest_version: super::super::recovery::RECOVERY_MANIFEST_VERSION,
                 },
                 ignored_tail: None,
             },

--- a/crates/runtimed/src/notebook_sync_server/recovery.rs
+++ b/crates/runtimed/src/notebook_sync_server/recovery.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use automerge::AutoCommit;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -244,7 +245,10 @@ struct RecoveryManifestHeader {
 }
 
 enum DecodedRecoveryManifest {
-    Supported(Box<RecoveryManifest>),
+    Supported {
+        manifest: Box<RecoveryManifest>,
+        source_version: u16,
+    },
     Unsupported(u16),
 }
 
@@ -254,10 +258,16 @@ fn decode_manifest(bytes: &[u8]) -> Result<DecodedRecoveryManifest, serde_json::
         LEGACY_RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes)
             .map(LegacyRecoveryManifestV1::into)
             .map(Box::new)
-            .map(DecodedRecoveryManifest::Supported),
-        RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes)
-            .map(Box::new)
-            .map(DecodedRecoveryManifest::Supported),
+            .map(|manifest| DecodedRecoveryManifest::Supported {
+                manifest,
+                source_version: LEGACY_RECOVERY_MANIFEST_VERSION,
+            }),
+        RECOVERY_MANIFEST_VERSION => serde_json::from_slice(bytes).map(Box::new).map(|manifest| {
+            DecodedRecoveryManifest::Supported {
+                manifest,
+                source_version: RECOVERY_MANIFEST_VERSION,
+            }
+        }),
         version => Ok(DecodedRecoveryManifest::Unsupported(version)),
     }
 }
@@ -267,6 +277,10 @@ fn decode_manifest(bytes: &[u8]) -> Result<DecodedRecoveryManifest, serde_json::
 pub(crate) struct RecoveryRecord {
     pub(crate) manifest: RecoveryManifest,
     pub(crate) automerge_snapshot: Vec<u8>,
+    /// Manifest schema encoded in the source record before any in-memory
+    /// migration. Upgrade repair uses this to distinguish the affected v1
+    /// format from an unrelated durability failure.
+    pub(crate) source_manifest_version: u16,
 }
 
 /// A corrupt or incomplete suffix ignored after the newest valid record.
@@ -424,6 +438,17 @@ pub(crate) struct RecoveryArchiveReplacement {
     pub(crate) durability_warning: Option<String>,
 }
 
+/// A legacy journal that has passed the narrow updater-takeover preflight and
+/// whose original bytes have already been durably archived.
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedLegacyOverflowJournal {
+    pub(crate) notebook_id: Uuid,
+    journal: RecoveryJournal,
+    archive: RecoveryArchivePaths,
+    manifest: RecoveryManifest,
+    automerge_snapshot: Vec<u8>,
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum RecoveryJournalError {
     #[error("recovery journal I/O failed: {0}")]
@@ -454,6 +479,12 @@ pub(crate) enum RecoveryJournalError {
         #[source]
         source: io::Error,
     },
+    #[error("recovery snapshot could not be loaded: {0}")]
+    InvalidSnapshot(String),
+    #[error("recovery snapshot heads do not match the durable manifest heads")]
+    SnapshotHeadsMismatch,
+    #[error("recovery journal changed after its takeover archive was published")]
+    ChangedAfterArchive,
 }
 
 /// Filesystem-backed append-only journal.
@@ -778,6 +809,31 @@ impl RecoveryJournal {
         self.archive_and_replace_with(manifest, automerge_snapshot, replace_file_atomically)
     }
 
+    /// Atomically replace an active journal only when it still exactly matches
+    /// a previously published archive. This is the offline half of the narrow
+    /// legacy-overflow takeover: validation and archiving happen while the old
+    /// daemon is responsive, then replacement happens only after that exact
+    /// daemon incarnation has exited.
+    fn replace_after_verified_archive(
+        &self,
+        archive: &RecoveryArchivePaths,
+        manifest: &RecoveryManifest,
+        automerge_snapshot: &[u8],
+    ) -> Result<(), RecoveryJournalError> {
+        let active_bytes = std::fs::read(&self.path)?;
+        let archived_bytes = std::fs::read(&archive.journal)?;
+        if active_bytes != archived_bytes {
+            return Err(RecoveryJournalError::ChangedAfterArchive);
+        }
+
+        let encoded = encode_record(manifest, automerge_snapshot)?;
+        replace_file_atomically(&self.path, &encoded.bytes)?;
+        if let Ok(manifest_bytes) = serde_json::to_vec(manifest) {
+            let _ = replace_file_atomically(&self.manifest_path(), &manifest_bytes);
+        }
+        Ok(())
+    }
+
     fn archive_and_replace_with<ReplaceActive>(
         &self,
         manifest: &RecoveryManifest,
@@ -833,6 +889,111 @@ impl RecoveryJournal {
             durability_warning,
         })
     }
+}
+
+/// Validate and durably archive one version-1 journal before an updater takes
+/// over a daemon blocked by the historical manifest-size bug.
+pub(crate) fn prepare_legacy_overflow_journal(
+    docs_dir: &Path,
+    notebook_id: Uuid,
+) -> Result<PreparedLegacyOverflowJournal, RecoveryJournalError> {
+    let journal_path = docs_dir
+        .join(notebook_doc_filename(&notebook_id.to_string()))
+        .with_extension("recovery");
+    let journal = RecoveryJournal::new(journal_path);
+    // Publish one immutable byte image first, then derive every validation and
+    // migration input from that archive. Scanning the active file before the
+    // copy would allow a newer acknowledged record to land between the scan
+    // and archive and later be replaced by the older cached snapshot.
+    let archive = journal.publish_archive_copy()?;
+    let archived_journal = RecoveryJournal::new(archive.journal.clone());
+    let record = verified_recovery_record(
+        &archived_journal,
+        notebook_id,
+        Some(LEGACY_RECOVERY_MANIFEST_VERSION),
+    )?;
+
+    Ok(PreparedLegacyOverflowJournal {
+        notebook_id,
+        journal,
+        archive,
+        manifest: record.manifest,
+        automerge_snapshot: record.automerge_snapshot,
+    })
+}
+
+fn verified_recovery_record(
+    journal: &RecoveryJournal,
+    notebook_id: Uuid,
+    required_source_version: Option<u16>,
+) -> Result<RecoveryRecord, RecoveryJournalError> {
+    let recovered = match journal.latest_record()? {
+        RecoveryLatestOutcome::Recovered(recovered) => *recovered,
+        RecoveryLatestOutcome::Unavailable {
+            reason: RecoveryUnavailableReason::NoValidRecord { tail },
+        } => return Err(RecoveryJournalError::NoValidRecord { tail }),
+        RecoveryLatestOutcome::Unavailable { reason } => {
+            return Err(RecoveryJournalError::InvalidSnapshot(format!(
+                "recovery journal is unavailable: {reason:?}"
+            )));
+        }
+    };
+    if recovered.ignored_tail.is_some() {
+        return Err(RecoveryJournalError::InvalidSnapshot(
+            "recovery journal has a non-empty tail".to_string(),
+        ));
+    }
+    if let Some(required_source_version) = required_source_version {
+        if recovered.record.source_manifest_version != required_source_version {
+            return Err(RecoveryJournalError::UnsupportedManifestVersion {
+                version: recovered.record.source_manifest_version,
+            });
+        }
+    }
+    if recovered.record.manifest.notebook_id != notebook_id {
+        return Err(RecoveryJournalError::InvalidSnapshot(format!(
+            "journal claims notebook {}, expected {notebook_id}",
+            recovered.record.manifest.notebook_id
+        )));
+    }
+
+    let mut document = AutoCommit::load(&recovered.record.automerge_snapshot)
+        .map_err(|error| RecoveryJournalError::InvalidSnapshot(error.to_string()))?;
+    let mut actual_heads = document
+        .get_heads()
+        .into_iter()
+        .map(|head| head.0)
+        .collect::<Vec<_>>();
+    let mut durable_heads = recovered.record.manifest.durable_heads.clone();
+    actual_heads.sort_unstable();
+    durable_heads.sort_unstable();
+    if actual_heads != durable_heads {
+        return Err(RecoveryJournalError::SnapshotHeadsMismatch);
+    }
+    notebook_doc::NotebookDoc::load(&recovered.record.automerge_snapshot)
+        .map_err(|error| RecoveryJournalError::InvalidSnapshot(error.to_string()))?;
+    Ok(recovered.record)
+}
+
+/// Commit the bounded version-2 representation after the archived legacy
+/// journal's daemon has exited. The Automerge snapshot and causal heads remain
+/// unchanged.
+pub(crate) fn migrate_prepared_legacy_overflow_journal(
+    prepared: &PreparedLegacyOverflowJournal,
+) -> Result<(), RecoveryJournalError> {
+    prepared.journal.replace_after_verified_archive(
+        &prepared.archive,
+        &prepared.manifest,
+        &prepared.automerge_snapshot,
+    )
+}
+
+/// Re-prove that the now-offline active journal is independently safe for the
+/// replacement daemon to consume after an optional v2 rewrite failed.
+pub(crate) fn verify_prepared_legacy_overflow_fallback(
+    prepared: &PreparedLegacyOverflowJournal,
+) -> Result<(), RecoveryJournalError> {
+    verified_recovery_record(&prepared.journal, prepared.notebook_id, None).map(|_| ())
 }
 
 /// Find the UUID-owned recovery journal whose latest checksummed manifest
@@ -1109,8 +1270,11 @@ fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
             break;
         }
 
-        let manifest = match decode_manifest(&manifest_bytes) {
-            Ok(DecodedRecoveryManifest::Supported(manifest)) => *manifest,
+        let (manifest, source_manifest_version) = match decode_manifest(&manifest_bytes) {
+            Ok(DecodedRecoveryManifest::Supported {
+                manifest,
+                source_version,
+            }) => (*manifest, source_version),
             Ok(DecodedRecoveryManifest::Unsupported(version)) => {
                 ignored_tail =
                     Some(JournalTailIssue::UnsupportedManifestVersion { offset, version });
@@ -1130,6 +1294,7 @@ fn scan_file(file: &mut File) -> Result<JournalScan, RecoveryJournalError> {
         latest = Some(RecoveryRecord {
             manifest,
             automerge_snapshot,
+            source_manifest_version,
         });
         valid_record_count = valid_record_count.saturating_add(1);
     }
@@ -1492,6 +1657,10 @@ mod tests {
             RecoveryLatestOutcome::Recovered(recovered) => *recovered,
             other => panic!("expected migrated recovery record, got {other:?}"),
         };
+        assert_eq!(
+            recovered.record.source_manifest_version,
+            LEGACY_RECOVERY_MANIFEST_VERSION
+        );
         assert_eq!(recovered.record.manifest.version, RECOVERY_MANIFEST_VERSION);
         assert_eq!(
             recovered.record.manifest.peer_change_count,
@@ -1516,6 +1685,152 @@ mod tests {
         };
         assert_eq!(latest.record.manifest, next);
         assert!(latest.ignored_tail.is_none());
+    }
+
+    #[test]
+    fn updater_takeover_archives_and_replaces_exact_legacy_journal() {
+        let directory = tempfile::tempdir().unwrap();
+        let notebook_id = Uuid::new_v4();
+        let journal_path = directory
+            .path()
+            .join(notebook_doc_filename(&notebook_id.to_string()))
+            .with_extension("recovery");
+        let mut document =
+            notebook_doc::NotebookDoc::new_with_actor(&notebook_id.to_string(), "upgrade-test");
+        let heads = document.get_heads().iter().map(|head| head.0).collect();
+        let snapshot = document.save();
+        let legacy = LegacyRecoveryManifestV1 {
+            version: LEGACY_RECOVERY_MANIFEST_VERSION,
+            sequence: 2_355,
+            notebook_id,
+            canonical_path: None,
+            notebook_schema_version: notebook_doc::SCHEMA_VERSION,
+            source_fingerprint: source_fingerprint(b""),
+            source_generation: 0,
+            source_phase: RecoverySourcePhase::Pending,
+            staged_change_hashes: Vec::new(),
+            peer_change_hashes: vec![[7; 32]; 2_251],
+            durable_heads: heads,
+            exported_heads: Vec::new(),
+            file_save_sequence: None,
+            pending_file_checkpoint: None,
+        };
+        std::fs::write(&journal_path, encode_legacy_record(&legacy, &snapshot)).unwrap();
+        std::fs::write(
+            journal_path.with_file_name(format!(
+                "{}.manifest.json",
+                journal_path.file_name().unwrap().to_string_lossy()
+            )),
+            serde_json::to_vec(&legacy).unwrap(),
+        )
+        .unwrap();
+
+        let prepared = prepare_legacy_overflow_journal(directory.path(), notebook_id).unwrap();
+        assert!(prepared.archive.directory.is_dir());
+        assert_eq!(
+            std::fs::read(&prepared.archive.journal).unwrap(),
+            std::fs::read(&journal_path).unwrap()
+        );
+
+        migrate_prepared_legacy_overflow_journal(&prepared).unwrap();
+        let migrated = match RecoveryJournal::new(&journal_path).latest_record().unwrap() {
+            RecoveryLatestOutcome::Recovered(recovered) => *recovered,
+            other => panic!("expected migrated active journal, got {other:?}"),
+        };
+        assert_eq!(
+            migrated.record.source_manifest_version,
+            RECOVERY_MANIFEST_VERSION
+        );
+        assert_eq!(migrated.record.manifest.peer_change_count, 2_251);
+        assert_eq!(migrated.record.automerge_snapshot, snapshot);
+    }
+
+    #[test]
+    fn updater_takeover_refuses_active_bytes_changed_after_archive() {
+        let directory = tempfile::tempdir().unwrap();
+        let notebook_id = Uuid::new_v4();
+        let journal_path = directory
+            .path()
+            .join(notebook_doc_filename(&notebook_id.to_string()))
+            .with_extension("recovery");
+        let mut document =
+            notebook_doc::NotebookDoc::new_with_actor(&notebook_id.to_string(), "upgrade-test");
+        let heads = document.get_heads().iter().map(|head| head.0).collect();
+        let snapshot = document.save();
+        let legacy = LegacyRecoveryManifestV1 {
+            version: LEGACY_RECOVERY_MANIFEST_VERSION,
+            sequence: 1,
+            notebook_id,
+            canonical_path: None,
+            notebook_schema_version: notebook_doc::SCHEMA_VERSION,
+            source_fingerprint: source_fingerprint(b""),
+            source_generation: 0,
+            source_phase: RecoverySourcePhase::Pending,
+            staged_change_hashes: Vec::new(),
+            peer_change_hashes: vec![[9; 32]],
+            durable_heads: heads,
+            exported_heads: Vec::new(),
+            file_save_sequence: None,
+            pending_file_checkpoint: None,
+        };
+        std::fs::write(&journal_path, encode_legacy_record(&legacy, &snapshot)).unwrap();
+
+        let prepared = prepare_legacy_overflow_journal(directory.path(), notebook_id).unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(&journal_path)
+            .unwrap()
+            .write_all(b"changed")
+            .unwrap();
+
+        let error = migrate_prepared_legacy_overflow_journal(&prepared).unwrap_err();
+        assert!(matches!(error, RecoveryJournalError::ChangedAfterArchive));
+        assert!(verify_prepared_legacy_overflow_fallback(&prepared).is_err());
+    }
+
+    #[test]
+    fn updater_takeover_accepts_a_newer_valid_offline_fallback_after_rewrite_race() {
+        let directory = tempfile::tempdir().unwrap();
+        let notebook_id = Uuid::new_v4();
+        let journal_path = directory
+            .path()
+            .join(notebook_doc_filename(&notebook_id.to_string()))
+            .with_extension("recovery");
+        let mut document =
+            notebook_doc::NotebookDoc::new_with_actor(&notebook_id.to_string(), "upgrade-test");
+        let heads = document.get_heads().iter().map(|head| head.0).collect();
+        let snapshot = document.save();
+        let mut legacy = LegacyRecoveryManifestV1 {
+            version: LEGACY_RECOVERY_MANIFEST_VERSION,
+            sequence: 1,
+            notebook_id,
+            canonical_path: None,
+            notebook_schema_version: notebook_doc::SCHEMA_VERSION,
+            source_fingerprint: source_fingerprint(b""),
+            source_generation: 0,
+            source_phase: RecoverySourcePhase::Pending,
+            staged_change_hashes: Vec::new(),
+            peer_change_hashes: vec![[9; 32]],
+            durable_heads: heads,
+            exported_heads: Vec::new(),
+            file_save_sequence: None,
+            pending_file_checkpoint: None,
+        };
+        std::fs::write(&journal_path, encode_legacy_record(&legacy, &snapshot)).unwrap();
+
+        let prepared = prepare_legacy_overflow_journal(directory.path(), notebook_id).unwrap();
+        legacy.sequence = 2;
+        legacy.peer_change_hashes.push([8; 32]);
+        OpenOptions::new()
+            .append(true)
+            .open(&journal_path)
+            .unwrap()
+            .write_all(&encode_legacy_record(&legacy, &snapshot))
+            .unwrap();
+
+        let error = migrate_prepared_legacy_overflow_journal(&prepared).unwrap_err();
+        assert!(matches!(error, RecoveryJournalError::ChangedAfterArchive));
+        verify_prepared_legacy_overflow_fallback(&prepared).unwrap();
     }
 
     #[test]

--- a/crates/runtimed/src/service_repair.rs
+++ b/crates/runtimed/src/service_repair.rs
@@ -10,8 +10,15 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use runtimed_client::client::PoolClient;
+use runtimed_client::protocol::RoomInfo;
 use runtimed_client::singleton::{compatibility_error, query_daemon_info, DaemonInfo};
 use runtimed_service::ServiceManager;
+use uuid::Uuid;
+
+use crate::notebook_sync_server::recovery::{
+    migrate_prepared_legacy_overflow_journal, prepare_legacy_overflow_journal,
+    verify_prepared_legacy_overflow_fallback, PreparedLegacyOverflowJournal,
+};
 
 const DAEMON_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 // Clean shutdown may spend up to 20 seconds per notebook establishing its
@@ -23,6 +30,111 @@ const SERVICE_EXIT_TIMEOUT: Duration = Duration::from_secs(120);
 const FORCED_EXIT_TIMEOUT: Duration = Duration::from_secs(7);
 const READY_ATTEMPTS: u32 = 40;
 const READY_INTERVAL: Duration = Duration::from_millis(250);
+const QUIESCENCE_ATTEMPTS: u32 = 25;
+const QUIESCENCE_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone)]
+struct LegacyOverflowTakeover {
+    affected_rooms: Vec<Uuid>,
+    journals: Vec<PreparedLegacyOverflowJournal>,
+}
+
+/// Parse the exact shutdown prose emitted by already-shipped 2.7.0-2.7.3
+/// daemons. This is intentionally narrow, deny-by-default compatibility debt;
+/// new daemons must expose typed upgrade/shutdown state instead of extending
+/// this parser. Delete it when those releases leave the supported upgrade path.
+fn legacy_overflow_room_ids(error: &str) -> Option<Vec<Uuid>> {
+    let retained = regex::Regex::new(r"clean shutdown retained ([0-9]+) room\(s\)").ok()?;
+    let expected_count = retained
+        .captures(error)?
+        .get(1)?
+        .as_str()
+        .parse::<usize>()
+        .ok()?;
+    let failures = error.split_once("after durability failure: ")?.1;
+    let overflow = regex::Regex::new(
+        r"([0-9a-fA-F-]{36}): journal commit failed before peer acknowledgement: room recovery journal failed: recovery manifest is ([0-9]+) bytes; maximum is 262144",
+    )
+    .ok()?;
+    let mut rooms = Vec::new();
+    let mut consumed = 0;
+    for captures in overflow.captures_iter(failures) {
+        let matched = captures.get(0)?;
+        let expected_separator = if rooms.is_empty() { "" } else { "; " };
+        if failures.get(consumed..matched.start())? != expected_separator {
+            return None;
+        }
+        let actual = captures.get(2)?.as_str().parse::<usize>().ok()?;
+        if actual <= 262_144 {
+            return None;
+        }
+        rooms.push(Uuid::parse_str(captures.get(1)?.as_str()).ok()?);
+        consumed = matched.end();
+    }
+    if consumed != failures.len() {
+        return None;
+    }
+    rooms.sort_unstable();
+    rooms.dedup();
+    (rooms.len() == expected_count).then_some(rooms)
+}
+
+fn affected_legacy_daemon_version(version: &str) -> bool {
+    ["2.7.0-", "2.7.1-", "2.7.2-", "2.7.3-"]
+        .iter()
+        .any(|release| {
+            version.strip_prefix(release).is_some_and(|suffix| {
+                suffix.starts_with("stable.") || suffix.starts_with("nightly.")
+            })
+        })
+}
+
+fn rooms_are_quiescent_for_takeover(
+    rooms: &[RoomInfo],
+    affected_rooms: &[Uuid],
+) -> std::result::Result<(), String> {
+    for room in rooms {
+        if room.active_peers != 0 || room.has_kernel {
+            return Err(format!(
+                "room {} is not quiescent (active_peers={}, has_kernel={})",
+                room.notebook_id, room.active_peers, room.has_kernel
+            ));
+        }
+    }
+    for affected in affected_rooms {
+        let Some(room) = rooms
+            .iter()
+            .find(|room| room.notebook_id == affected.to_string())
+        else {
+            return Err(format!("affected room {affected} is not resident"));
+        };
+        if room.ephemeral {
+            return Err(format!("affected room {affected} is ephemeral"));
+        }
+    }
+    Ok(())
+}
+
+async fn wait_for_rooms_to_quiesce(
+    socket_path: &Path,
+    affected_rooms: &[Uuid],
+) -> std::result::Result<(), String> {
+    let mut last_error = None;
+    for attempt in 0..QUIESCENCE_ATTEMPTS {
+        let rooms = PoolClient::new(socket_path.to_path_buf())
+            .list_rooms()
+            .await
+            .map_err(|error| format!("could not inspect rooms before legacy takeover: {error}"))?;
+        match rooms_are_quiescent_for_takeover(&rooms, affected_rooms) {
+            Ok(()) => return Ok(()),
+            Err(error) => last_error = Some(error),
+        }
+        if attempt + 1 < QUIESCENCE_ATTEMPTS {
+            tokio::time::sleep(QUIESCENCE_INTERVAL).await;
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "room quiescence could not be established".to_string()))
+}
 
 fn same_incarnation(left: &DaemonInfo, right: &DaemonInfo) -> bool {
     left.pid == right.pid && left.started_at == right.started_at
@@ -70,6 +182,31 @@ trait DaemonRuntime {
     async fn request_shutdown(&self) -> std::result::Result<(), String>;
     async fn wait_for_pid_exit(&self, pid: u32, timeout: Duration) -> bool;
     async fn stop_process(&self, pid: u32) -> std::result::Result<(), String>;
+    async fn prepare_legacy_overflow_takeover(
+        &self,
+        _info: &DaemonInfo,
+        _shutdown_error: &str,
+    ) -> std::result::Result<Option<LegacyOverflowTakeover>, String> {
+        Ok(None)
+    }
+    async fn validate_legacy_overflow_takeover(
+        &self,
+        _takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        Err("legacy recovery takeover is unavailable".to_string())
+    }
+    fn migrate_legacy_overflow_takeover(
+        &self,
+        _takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        Err("legacy recovery migration is unavailable".to_string())
+    }
+    fn verify_legacy_overflow_fallback(
+        &self,
+        _takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        Err("legacy recovery fallback verification is unavailable".to_string())
+    }
     async fn sleep(&self, duration: Duration);
 }
 
@@ -132,6 +269,75 @@ impl DaemonRuntime for SystemDaemonRuntime {
         stop_process_by_pid(pid)
             .await
             .map_err(|error| error.to_string())
+    }
+
+    async fn prepare_legacy_overflow_takeover(
+        &self,
+        info: &DaemonInfo,
+        shutdown_error: &str,
+    ) -> std::result::Result<Option<LegacyOverflowTakeover>, String> {
+        if !affected_legacy_daemon_version(&info.version) {
+            return Ok(None);
+        }
+        let Some(affected_rooms) = legacy_overflow_room_ids(shutdown_error) else {
+            return Ok(None);
+        };
+        wait_for_rooms_to_quiesce(&self.socket_path, &affected_rooms).await?;
+
+        let docs_dir = runtimed_client::default_notebook_docs_dir();
+        let journals = affected_rooms
+            .iter()
+            .map(|notebook_id| {
+                prepare_legacy_overflow_journal(&docs_dir, *notebook_id).map_err(|error| {
+                    format!("could not preserve legacy recovery for {notebook_id}: {error}")
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(Some(LegacyOverflowTakeover {
+            affected_rooms,
+            journals,
+        }))
+    }
+
+    async fn validate_legacy_overflow_takeover(
+        &self,
+        takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        let rooms = PoolClient::new(self.socket_path.clone())
+            .list_rooms()
+            .await
+            .map_err(|error| format!("could not recheck rooms before legacy takeover: {error}"))?;
+        rooms_are_quiescent_for_takeover(&rooms, &takeover.affected_rooms)
+    }
+
+    fn migrate_legacy_overflow_takeover(
+        &self,
+        takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        for prepared in &takeover.journals {
+            migrate_prepared_legacy_overflow_journal(prepared).map_err(|error| {
+                format!(
+                    "could not migrate archived recovery for {}: {error}",
+                    prepared.notebook_id
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    fn verify_legacy_overflow_fallback(
+        &self,
+        takeover: &LegacyOverflowTakeover,
+    ) -> std::result::Result<(), String> {
+        for prepared in &takeover.journals {
+            verify_prepared_legacy_overflow_fallback(prepared).map_err(|error| {
+                format!(
+                    "active recovery for {} is not safe for deferred migration: {error}",
+                    prepared.notebook_id
+                )
+            })?;
+        }
+        Ok(())
     }
 
     async fn sleep(&self, duration: Duration) {
@@ -206,7 +412,11 @@ where
             "[service-repair] Legacy daemon became unresponsive during shutdown: {error}"
         );
     }
-    stop_service_with_retry(service, daemon).await;
+    if let Err(error) = stop_service_with_retry(service, daemon).await {
+        tracing::warn!(
+            "[service-repair] Could not disable unidentified legacy daemon service: {error}"
+        );
+    }
     for _ in 0..50 {
         if !daemon.is_responding().await {
             return Ok(());
@@ -230,20 +440,36 @@ where
         info.started_at
     );
 
+    let mut legacy_takeover = None;
     let graceful_completed = match daemon.request_shutdown().await {
         Ok(()) => true,
         Err(error) => {
             if daemon.is_responding().await {
-                return Err(anyhow!(
-                    "daemon remained responsive after clean shutdown did not complete: {error}; repair stopped to preserve notebook recovery state"
-                ));
+                legacy_takeover = daemon
+                    .prepare_legacy_overflow_takeover(info, &error)
+                    .await
+                    .map_err(|takeover_error| {
+                        anyhow!(
+                            "daemon remained responsive after clean shutdown failed: {error}; legacy recovery takeover was refused: {takeover_error}"
+                        )
+                    })?;
+                if legacy_takeover.is_none() {
+                    return Err(anyhow!(
+                        "daemon remained responsive after clean shutdown did not complete: {error}; repair stopped to preserve notebook recovery state"
+                    ));
+                }
+                tracing::warn!(
+                    "[service-repair] Verified legacy recovery-manifest overflow; archived recovery and preparing exact-incarnation takeover"
+                );
+                false
+            } else {
+                tracing::warn!(
+                    "[service-repair] Daemon pid {} became unresponsive during shutdown: {}",
+                    info.pid,
+                    error
+                );
+                false
             }
-            tracing::warn!(
-                "[service-repair] Daemon pid {} became unresponsive during shutdown: {}",
-                info.pid,
-                error
-            );
-            false
         }
     };
 
@@ -252,15 +478,37 @@ where
     // graceful request before repair has installed the new definition. Do this
     // even when is_installed() is false: a legacy SMAppService job can exist
     // without the current per-user service artifact.
-    stop_service_with_retry(service, daemon).await;
-    let exit_timeout = if graceful_completed {
+    if let Err(error) = stop_service_with_retry(service, daemon).await {
+        if legacy_takeover.is_some() {
+            return Err(anyhow!(
+                "legacy recovery takeover requires disabling the daemon service first: {error}"
+            ));
+        }
+        tracing::warn!("[service-repair] Could not disable daemon service: {error}");
+    }
+    let exit_timeout = if graceful_completed || legacy_takeover.is_some() {
         GRACEFUL_EXIT_TIMEOUT
     } else {
         SERVICE_EXIT_TIMEOUT
     };
     if daemon.wait_for_pid_exit(info.pid, exit_timeout).await {
         tracing::info!("[service-repair] Daemon process exited");
-        return ensure_socket_owner_released(daemon, info).await;
+        ensure_socket_owner_released(daemon, info).await?;
+        if let Some(takeover) = &legacy_takeover {
+            if let Err(error) = daemon.migrate_legacy_overflow_takeover(takeover) {
+                daemon
+                    .verify_legacy_overflow_fallback(takeover)
+                    .map_err(|verify_error| {
+                        anyhow!(
+                            "offline legacy journal rewrite failed: {error}; replacement journal verification also failed: {verify_error}"
+                        )
+                    })?;
+                tracing::warn!(
+                    "[service-repair] Offline legacy journal rewrite did not complete; continuing after re-verifying the active v1/v2 journal: {error}"
+                );
+            }
+        }
+        return Ok(());
     }
 
     match daemon.inspect().await {
@@ -280,6 +528,15 @@ where
         }
     }
 
+    if let Some(takeover) = &legacy_takeover {
+        daemon
+            .validate_legacy_overflow_takeover(takeover)
+            .await
+            .map_err(|error| {
+                anyhow!("legacy recovery takeover became unsafe before process stop: {error}")
+            })?;
+    }
+
     tracing::warn!(
         "[service-repair] Daemon pid {} is orphaned; escalating process stop",
         info.pid
@@ -297,27 +554,48 @@ where
             info.pid
         ));
     }
-    ensure_socket_owner_released(daemon, info).await
+    ensure_socket_owner_released(daemon, info).await?;
+    if let Some(takeover) = &legacy_takeover {
+        if let Err(error) = daemon.migrate_legacy_overflow_takeover(takeover) {
+            daemon
+                .verify_legacy_overflow_fallback(takeover)
+                .map_err(|verify_error| {
+                    anyhow!(
+                        "offline legacy journal rewrite failed: {error}; replacement journal verification also failed: {verify_error}"
+                    )
+                })?;
+            tracing::warn!(
+                "[service-repair] Offline legacy journal rewrite did not complete; continuing after re-verifying the active v1/v2 journal: {error}"
+            );
+        }
+    }
+    Ok(())
 }
 
-async fn stop_service_with_retry<S, D>(service: &mut S, daemon: &D)
+async fn stop_service_with_retry<S, D>(
+    service: &mut S,
+    daemon: &D,
+) -> std::result::Result<(), String>
 where
     S: ServiceRuntime,
     D: DaemonRuntime,
 {
     match service.stop() {
-        Ok(()) => {}
+        Ok(()) => Ok(()),
         Err(first_error) => {
             tracing::warn!(
                 "[service-repair] Service-manager stop did not complete: {first_error}; retrying"
             );
             daemon.sleep(Duration::from_millis(250)).await;
             match service.stop() {
-                Ok(()) => {}
+                Ok(()) => Ok(()),
                 Err(second_error) => {
                     tracing::warn!(
                         "[service-repair] Service-manager stop retry did not complete: {second_error}"
                     );
+                    Err(format!(
+                        "service-manager stop failed twice: {first_error}; {second_error}"
+                    ))
                 }
             }
         }
@@ -483,11 +761,35 @@ mod tests {
         }
     }
 
+    fn room_info(notebook_id: Uuid, active_peers: usize, has_kernel: bool) -> RoomInfo {
+        RoomInfo {
+            notebook_id: notebook_id.to_string(),
+            active_peers,
+            had_peers: active_peers > 0,
+            has_kernel,
+            kernel_type: None,
+            env_source: None,
+            kernel_status: None,
+            ephemeral: false,
+            notebook_path: None,
+            state: if active_peers > 0 {
+                runtimed_client::protocol::RoomState::Active
+            } else if has_kernel {
+                runtimed_client::protocol::RoomState::Idle
+            } else {
+                runtimed_client::protocol::RoomState::Inactive
+            },
+        }
+    }
+
     struct FakeDaemon {
         info: Arc<Mutex<Option<DaemonInfo>>>,
         events: Arc<Mutex<Vec<&'static str>>>,
         shutdown_exits: bool,
         shutdown_error: Option<&'static str>,
+        legacy_takeover: bool,
+        migration_error: Option<&'static str>,
+        fallback_valid: bool,
         responds_without_info: Arc<AtomicBool>,
     }
 
@@ -529,11 +831,57 @@ mod tests {
             Ok(())
         }
 
+        async fn prepare_legacy_overflow_takeover(
+            &self,
+            _info: &DaemonInfo,
+            _shutdown_error: &str,
+        ) -> std::result::Result<Option<LegacyOverflowTakeover>, String> {
+            self.events.lock().unwrap().push("prepare_takeover");
+            Ok(self.legacy_takeover.then_some(LegacyOverflowTakeover {
+                affected_rooms: Vec::new(),
+                journals: Vec::new(),
+            }))
+        }
+
+        async fn validate_legacy_overflow_takeover(
+            &self,
+            _takeover: &LegacyOverflowTakeover,
+        ) -> std::result::Result<(), String> {
+            self.events.lock().unwrap().push("validate_takeover");
+            self.legacy_takeover
+                .then_some(())
+                .ok_or_else(|| "legacy takeover disabled".to_string())
+        }
+
+        fn migrate_legacy_overflow_takeover(
+            &self,
+            _takeover: &LegacyOverflowTakeover,
+        ) -> std::result::Result<(), String> {
+            self.events.lock().unwrap().push("migrate_takeover");
+            if let Some(error) = self.migration_error {
+                return Err(error.to_string());
+            }
+            self.legacy_takeover
+                .then_some(())
+                .ok_or_else(|| "legacy takeover disabled".to_string())
+        }
+
+        fn verify_legacy_overflow_fallback(
+            &self,
+            _takeover: &LegacyOverflowTakeover,
+        ) -> std::result::Result<(), String> {
+            self.events.lock().unwrap().push("verify_fallback");
+            self.fallback_valid
+                .then_some(())
+                .ok_or_else(|| "active journal did not pass offline verification".to_string())
+        }
+
         async fn sleep(&self, _duration: Duration) {}
     }
 
     struct FakeService {
         installed: bool,
+        stop_succeeds: bool,
         info: Arc<Mutex<Option<DaemonInfo>>>,
         events: Arc<Mutex<Vec<&'static str>>>,
         replacement: DaemonInfo,
@@ -547,7 +895,9 @@ mod tests {
 
         fn stop(&mut self) -> std::result::Result<(), String> {
             self.events.lock().unwrap().push("service_stop");
-            Err("service artifact missing".to_string())
+            self.stop_succeeds
+                .then_some(())
+                .ok_or_else(|| "service artifact missing".to_string())
         }
 
         fn install_and_start(&mut self, _source_binary: &Path) -> std::result::Result<(), String> {
@@ -573,6 +923,106 @@ mod tests {
             .contains("older than required"));
     }
 
+    #[test]
+    fn recognizes_only_the_exact_legacy_manifest_overflow_shape() {
+        let room = Uuid::new_v4();
+        let error = format!(
+            "Daemon returned error: clean shutdown blocked: clean shutdown retained 1 room(s) after durability failure: {room}: journal commit failed before peer acknowledgement: room recovery journal failed: recovery manifest is 262178 bytes; maximum is 262144"
+        );
+        assert_eq!(legacy_overflow_room_ids(&error), Some(vec![room]));
+
+        let second_room = Uuid::new_v4();
+        let two_rooms = format!(
+            "clean shutdown blocked: clean shutdown retained 2 room(s) after durability failure: {room}: journal commit failed before peer acknowledgement: room recovery journal failed: recovery manifest is 262178 bytes; maximum is 262144; {second_room}: journal commit failed before peer acknowledgement: room recovery journal failed: recovery manifest is 300000 bytes; maximum is 262144"
+        );
+        let mut expected = vec![room, second_room];
+        expected.sort_unstable();
+        assert_eq!(legacy_overflow_room_ids(&two_rooms), Some(expected));
+
+        assert_eq!(
+            legacy_overflow_room_ids(
+                "clean shutdown retained 1 room(s): durability barrier still active"
+            ),
+            None
+        );
+        assert_eq!(
+            legacy_overflow_room_ids(&two_rooms.replace(
+                &format!(
+                    "{second_room}: journal commit failed before peer acknowledgement: room recovery journal failed: recovery manifest is 300000 bytes; maximum is 262144"
+                ),
+                &format!("{second_room}: source publication is still active")
+            )),
+            None,
+            "a mixed durability failure must never authorize takeover"
+        );
+        assert_eq!(
+            legacy_overflow_room_ids(&error.replace("262178", "262144")),
+            None
+        );
+        assert_eq!(
+            legacy_overflow_room_ids(&error.replace("retained 1", "retained 2")),
+            None
+        );
+    }
+
+    #[test]
+    fn limits_takeover_to_the_affected_release_family() {
+        assert!(affected_legacy_daemon_version(
+            "2.7.0-stable.202608172336+f28fa66"
+        ));
+        assert!(affected_legacy_daemon_version(
+            "2.7.1-nightly.202608220012+360d265"
+        ));
+        assert!(affected_legacy_daemon_version(
+            "2.7.2-nightly.202608221655+af1351d"
+        ));
+        assert!(affected_legacy_daemon_version(
+            "2.7.3-stable.202608230344+0b711d4"
+        ));
+        assert!(affected_legacy_daemon_version(
+            "2.7.3-nightly.202608230344+0b711d4"
+        ));
+        assert!(!affected_legacy_daemon_version(
+            "2.7.4-stable.202608261821+1d39250"
+        ));
+        assert!(!affected_legacy_daemon_version(
+            "2.6.9-stable.202608120000+old"
+        ));
+        assert!(!affected_legacy_daemon_version("2.7.3+local"));
+    }
+
+    #[test]
+    fn takeover_requires_every_room_to_be_quiescent_and_affected_room_resident() {
+        let affected = Uuid::new_v4();
+        let unrelated = Uuid::new_v4();
+        assert!(
+            rooms_are_quiescent_for_takeover(&[room_info(affected, 0, false)], &[affected]).is_ok()
+        );
+        assert!(rooms_are_quiescent_for_takeover(
+            &[
+                room_info(affected, 0, false),
+                room_info(unrelated, 1, false)
+            ],
+            &[affected]
+        )
+        .unwrap_err()
+        .contains("not quiescent"));
+        assert!(
+            rooms_are_quiescent_for_takeover(&[room_info(affected, 0, true)], &[affected])
+                .unwrap_err()
+                .contains("not quiescent")
+        );
+        assert!(rooms_are_quiescent_for_takeover(&[], &[affected])
+            .unwrap_err()
+            .contains("not resident"));
+
+        let mut ephemeral = room_info(affected, 0, false);
+        ephemeral.ephemeral = true;
+        assert!(rooms_are_quiescent_for_takeover(&[ephemeral], &[affected])
+            .unwrap_err()
+            .contains("ephemeral"));
+    }
+
     #[tokio::test]
     async fn live_orphan_is_stopped_before_fresh_service_install() {
         let info = Arc::new(Mutex::new(Some(daemon_info(41, "2.4.6+old", 0))));
@@ -582,11 +1032,15 @@ mod tests {
             events: events.clone(),
             shutdown_exits: false,
             shutdown_error: None,
+            legacy_takeover: false,
+            migration_error: None,
+            fallback_valid: false,
             responds_without_info: Arc::new(AtomicBool::new(false)),
         };
         let replacement = daemon_info(84, "2.7.1+new", DAEMON_API_VERSION);
         let mut service = FakeService {
             installed: false,
+            stop_succeeds: false,
             info,
             events: events.clone(),
             replacement: replacement.clone(),
@@ -638,11 +1092,15 @@ mod tests {
             events: events.clone(),
             shutdown_exits: false,
             shutdown_error: None,
+            legacy_takeover: false,
+            migration_error: None,
+            fallback_valid: false,
             responds_without_info: Arc::new(AtomicBool::new(false)),
         };
         let replacement = daemon_info(84, "2.7.2+new", DAEMON_API_VERSION);
         let mut service = FakeService {
             installed: true,
+            stop_succeeds: false,
             info,
             events: events.clone(),
             replacement: replacement.clone(),
@@ -703,11 +1161,15 @@ mod tests {
             events: events.clone(),
             shutdown_exits: true,
             shutdown_error: None,
+            legacy_takeover: false,
+            migration_error: None,
+            fallback_valid: false,
             responds_without_info: Arc::new(AtomicBool::new(true)),
         };
         let replacement = daemon_info(91, "2.7.1+new", DAEMON_API_VERSION);
         let mut service = FakeService {
             installed: false,
+            stop_succeeds: false,
             info,
             events: events.clone(),
             replacement: replacement.clone(),
@@ -750,11 +1212,15 @@ mod tests {
             events: events.clone(),
             shutdown_exits: false,
             shutdown_error: Some("durability barrier still active"),
+            legacy_takeover: false,
+            migration_error: None,
+            fallback_valid: false,
             responds_without_info: Arc::new(AtomicBool::new(false)),
         };
         let replacement = daemon_info(84, "2.7.1+new", DAEMON_API_VERSION);
         let mut service = FakeService {
             installed: true,
+            stop_succeeds: false,
             info,
             events: events.clone(),
             replacement,
@@ -777,5 +1243,207 @@ mod tests {
         assert!(!events.contains(&"service_stop"));
         assert!(!events.contains(&"stop_process"));
         assert!(!events.contains(&"install_start"));
+    }
+
+    #[tokio::test]
+    async fn verified_legacy_overflow_is_migrated_only_after_exact_process_stops() {
+        let old = daemon_info(41, "2.7.3-stable.202608230344+0b711d4", DAEMON_API_VERSION);
+        let info = Arc::new(Mutex::new(Some(old)));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let daemon = FakeDaemon {
+            info: info.clone(),
+            events: events.clone(),
+            shutdown_exits: false,
+            shutdown_error: Some("known legacy overflow"),
+            legacy_takeover: true,
+            migration_error: None,
+            fallback_valid: false,
+            responds_without_info: Arc::new(AtomicBool::new(false)),
+        };
+        let replacement = daemon_info(84, "2.7.4+new", DAEMON_API_VERSION);
+        let mut service = FakeService {
+            installed: true,
+            stop_succeeds: true,
+            info,
+            events: events.clone(),
+            replacement: replacement.clone(),
+        };
+
+        let result = repair_service_with(
+            &mut service,
+            &daemon,
+            Path::new("/Applications/nteract.app/Contents/MacOS/runtimed"),
+            &replacement.version,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.pid, replacement.pid);
+        let events = events.lock().unwrap();
+        let prepare = events
+            .iter()
+            .position(|event| *event == "prepare_takeover")
+            .unwrap();
+        let validate = events
+            .iter()
+            .position(|event| *event == "validate_takeover")
+            .unwrap();
+        let stop_process = events
+            .iter()
+            .position(|event| *event == "stop_process")
+            .unwrap();
+        let migrate = events
+            .iter()
+            .position(|event| *event == "migrate_takeover")
+            .unwrap();
+        let upgrade_start = events
+            .iter()
+            .position(|event| *event == "upgrade_start")
+            .unwrap();
+        assert!(prepare < validate);
+        assert!(validate < stop_process);
+        assert!(stop_process < migrate);
+        assert!(migrate < upgrade_start);
+    }
+
+    #[tokio::test]
+    async fn failed_offline_rewrite_still_installs_daemon_that_can_read_v1() {
+        let old = daemon_info(41, "2.7.3-stable.202608230344+0b711d4", DAEMON_API_VERSION);
+        let info = Arc::new(Mutex::new(Some(old)));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let daemon = FakeDaemon {
+            info: info.clone(),
+            events: events.clone(),
+            shutdown_exits: false,
+            shutdown_error: Some("known legacy overflow"),
+            legacy_takeover: true,
+            migration_error: Some("active journal changed after archive"),
+            fallback_valid: true,
+            responds_without_info: Arc::new(AtomicBool::new(false)),
+        };
+        let replacement = daemon_info(84, "2.7.4+new", DAEMON_API_VERSION);
+        let mut service = FakeService {
+            installed: true,
+            stop_succeeds: true,
+            info,
+            events: events.clone(),
+            replacement: replacement.clone(),
+        };
+
+        let result = repair_service_with(
+            &mut service,
+            &daemon,
+            Path::new("/Applications/nteract.app/Contents/MacOS/runtimed"),
+            &replacement.version,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.pid, replacement.pid);
+        let events = events.lock().unwrap();
+        let migrate = events
+            .iter()
+            .position(|event| *event == "migrate_takeover")
+            .unwrap();
+        let verify_fallback = events
+            .iter()
+            .position(|event| *event == "verify_fallback")
+            .unwrap();
+        let upgrade_start = events
+            .iter()
+            .position(|event| *event == "upgrade_start")
+            .unwrap();
+        assert!(migrate < verify_fallback);
+        assert!(verify_fallback < upgrade_start);
+    }
+
+    #[tokio::test]
+    async fn legacy_takeover_refuses_when_service_launcher_cannot_be_disabled() {
+        let old = daemon_info(41, "2.7.3-stable.202608230344+0b711d4", DAEMON_API_VERSION);
+        let info = Arc::new(Mutex::new(Some(old)));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let daemon = FakeDaemon {
+            info: info.clone(),
+            events: events.clone(),
+            shutdown_exits: false,
+            shutdown_error: Some("known legacy overflow"),
+            legacy_takeover: true,
+            migration_error: None,
+            fallback_valid: false,
+            responds_without_info: Arc::new(AtomicBool::new(false)),
+        };
+        let replacement = daemon_info(84, "2.7.4+new", DAEMON_API_VERSION);
+        let mut service = FakeService {
+            installed: true,
+            stop_succeeds: false,
+            info,
+            events: events.clone(),
+            replacement,
+        };
+
+        let error = repair_service_with(
+            &mut service,
+            &daemon,
+            Path::new("/Applications/nteract.app/Contents/MacOS/runtimed"),
+            "2.7.4+new",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requires disabling"));
+        let events = events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == "service_stop")
+                .count(),
+            2
+        );
+        assert!(!events.contains(&"stop_process"));
+        assert!(!events.contains(&"migrate_takeover"));
+        assert!(!events.contains(&"upgrade_start"));
+    }
+
+    #[tokio::test]
+    async fn rewrite_failure_refuses_install_when_active_fallback_is_not_verified() {
+        let old = daemon_info(41, "2.7.3-stable.202608230344+0b711d4", DAEMON_API_VERSION);
+        let info = Arc::new(Mutex::new(Some(old)));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let daemon = FakeDaemon {
+            info: info.clone(),
+            events: events.clone(),
+            shutdown_exits: false,
+            shutdown_error: Some("known legacy overflow"),
+            legacy_takeover: true,
+            migration_error: Some("active journal changed after archive"),
+            fallback_valid: false,
+            responds_without_info: Arc::new(AtomicBool::new(false)),
+        };
+        let replacement = daemon_info(84, "2.7.4+new", DAEMON_API_VERSION);
+        let mut service = FakeService {
+            installed: true,
+            stop_succeeds: true,
+            info,
+            events: events.clone(),
+            replacement,
+        };
+
+        let error = repair_service_with(
+            &mut service,
+            &daemon,
+            Path::new("/Applications/nteract.app/Contents/MacOS/runtimed"),
+            "2.7.4+new",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("replacement journal verification also failed"));
+        let events = events.lock().unwrap();
+        assert!(events.contains(&"stop_process"));
+        assert!(events.contains(&"migrate_takeover"));
+        assert!(events.contains(&"verify_fallback"));
+        assert!(!events.contains(&"upgrade_start"));
     }
 }


### PR DESCRIPTION
## Summary

Recover upgrades from the recovery-manifest overflow shipped in runtimed 2.7.0 through 2.7.3, and show the final daemon error detail instead of only `exit code 1` when an upgrade still fails.

This is deliberately narrow compatibility code for already-shipped binaries. It does not make generic durability failures eligible for forced takeover, and it is marked for deletion once the affected releases leave the supported upgrade path.

## Incident

The 2.7.4 app bundle installed successfully, but the running 2.7.3 Stable daemon refused clean shutdown because one valid version-1 recovery manifest was about to exceed the 256 KiB limit. The new bounded writer could not take ownership of the Stable socket, leaving the updater at `Daemon upgrade failed (exit code 1)`.

The affected legacy daemons expose the failure only as human-readable shutdown prose. Their room protocol does not include a typed durability failure reason, so this compatibility bridge pins the exact semicolon-joined message emitted by the shipped 2.7.0-2.7.3 Stable and Nightly builds. Any mixed, malformed, differently sized, or unrelated failure continues to refuse takeover.

## Safety contract

- Require an affected 2.7.0-2.7.3 Stable or Nightly daemon and the exact legacy overflow signature.
- Require every resident room to settle to zero peers and no kernel; require each affected room to be resident and non-ephemeral.
- Publish an immutable archive before scanning, then derive all migration data only from those archived bytes.
- Require a valid checksummed v1 journal with no tail, the expected notebook UUID, a loadable Automerge/NotebookDoc snapshot, and exact durable-head equality.
- Require successful service-launcher disable before stopping the exact daemon incarnation.
- Re-check quiescence and socket ownership before process-stop escalation.
- Replace the active journal only if it is still byte-identical to the validated archive.
- If the optional v2 rewrite fails, continue installation only after a fresh offline proof that the active v1/v2 journal is independently valid; otherwise fail closed while preserving the archive.
- Preserve the existing refusal behavior for every generic clean-shutdown or durability failure.

## User-visible diagnostics

The updater now retains a bounded eight-line stderr tail and surfaces the final non-empty detail with the exit status. Each line is capped at 512 Unicode characters, preserving the actionable tail while full output remains in logs.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p notebook`
- `cargo test -p runtimed`
- 12 focused service-repair tests
- 3 focused archive/rewrite race tests
- Independent correctness, operability, and architecture review panel
- Follow-up read-only race review: no actionable findings

The final full run passed 86 notebook unit tests plus its integration targets, and 1,337 runtimed unit tests plus 72 integration tests and all repository lint targets (3 intentional ignores).

## Follow-up

Replace this legacy string parser and sidecar coordination with a typed upgrade handoff: prepare/freeze, durable-head proof, ownership transfer, and explicit commit/rollback. Recovery schema migration should become an idempotent repository-storage migration rather than updater-specific control flow.
