### PR TITLE
fix(notebook): preserve command-mode cell focus

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -865,6 +865,14 @@ export const MarkdownCell = memo(function MarkdownCell({
         if (readOnly) {
           return;
         }
+        const interactionTarget = getActiveInteractionTarget();
+        // Cell insertion updates the notebook interaction target synchronously,
+        // but the previously selected Markdown preview may retain DOM focus.
+        // Let the document-level command-mode handler process Enter for the
+        // newly selected cell instead of reclaiming focus for this stale view.
+        if (interactionTarget && interactionTarget.cellId !== cell.id) {
+          return;
+        }
         // Enter: enter edit mode
         enterEditing();
         e.preventDefault();
@@ -872,6 +880,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     },
     [
       enterEditing,
+      cell.id,
       onEnterCommandMode,
       onFocusNext,
       onFocusPrevious,

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -896,6 +896,23 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
+  it("does not let a stale preview reclaim focus from another selected cell", () => {
+    const cell = makeCell();
+    const onFocus = vi.fn();
+    mockActiveInteractionTarget = { kind: "cell", cellId: "new-code-cell" };
+
+    const { getByLabelText } = render(
+      <MarkdownCell cell={cell} onFocus={onFocus} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    const handled = fireEvent.keyDown(preview, { key: "Enter" });
+
+    expect(handled).toBe(true);
+    expect(onFocus).not.toHaveBeenCalled();
+    expect(preview.className).not.toContain("hidden");
+  });
+
   it("stays editable when an empty cell loses notebook focus", async () => {
     // Empty cells begin in edit mode and must not be forced into an
     // uneditable preview when notebook focus moves away.


### PR DESCRIPTION
## Summary

- keep a stale rendered Markdown preview from reclaiming focus after command-mode cell insertion
- allow the document-level Enter handler to edit the newly selected cell
- add regression coverage for mismatched DOM focus and notebook interaction state

## Reproduction

1. Edit a Markdown cell.
2. Press Escape to enter command mode.
3. Press B to insert a code cell below.
4. Press Enter.

Before this fix, DOM focus remained on the Markdown preview, so its local Enter handler reopened the old Markdown editor. The newly inserted code cell now correctly enters edit mode.

## Validation

- `cargo xtask lint --fix`
- `corepack pnpm test:run -- apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx apps/notebook/src/hooks/__tests__/useCommandMode.test.ts` (2,930 passed, 6 skipped)
- `corepack pnpm exec tsc --noEmit -p apps/notebook/tsconfig.json`
- manual desktop reproduction before and after the fix