### PR TITLE
feat(notebook): add command-mode arrow navigation

### DIFF
--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -219,6 +219,45 @@ test.describe("markdown parity", () => {
     await expect(secondMarkdown.getByLabel("Markdown cell content")).toBeFocused();
   });
 
+  test("navigates mixed cells with arrows while staying in command mode", async ({ page }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    const firstCodeId = await mcp.createCell("# command navigation first", "code");
+    const markdownId = await mcp.createCell("# Command navigation middle", "markdown");
+    const secondCodeId = await mcp.createCell("# command navigation last", "code");
+    await waitForCellCount(page, 4);
+
+    const firstCode = page.locator(`[data-cell-id="${firstCodeId}"]`);
+    const markdown = page.locator(`[data-cell-id="${markdownId}"]`);
+    const secondCode = page.locator(`[data-cell-id="${secondCodeId}"]`);
+    const firstEditor = firstCode.locator('.cm-content[contenteditable="true"]');
+    const secondEditor = secondCode.locator('.cm-content[contenteditable="true"]');
+    const markdownPreview = markdown.getByLabel("Markdown cell content");
+
+    await firstEditor.focus();
+    await page.keyboard.press("Escape");
+    await expect(firstEditor).not.toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await expect(markdownPreview).toBeFocused();
+
+    // The Markdown preview retains DOM focus when selection moves to code.
+    // A subsequent arrow must use the live command-mode target, not this
+    // preview's stale cell closure.
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowUp");
+    await expect(markdownPreview).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+    await expect(secondEditor).toBeFocused();
+    await expect(firstEditor).not.toBeFocused();
+    await expect(secondCode).toBeInViewport();
+  });
+
   test("renders selectable markdown outputs without changing output routing semantics", async ({
     page,
   }) => {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -847,10 +847,12 @@ export const MarkdownCell = memo(function MarkdownCell({
         onEnterCommandMode?.();
         e.preventDefault();
       } else if (e.key === "ArrowDown") {
+        if (getActiveInteractionTarget()?.kind === "cell") return;
         if (onPreviewFocusNext) onPreviewFocusNext();
         else onFocusNext?.("start");
         e.preventDefault();
       } else if (e.key === "ArrowUp") {
+        if (getActiveInteractionTarget()?.kind === "cell") return;
         if (onPreviewFocusPrevious) onPreviewFocusPrevious();
         else onFocusPrevious?.("end");
         e.preventDefault();

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -41,6 +41,7 @@ import type { TracebackCellTarget } from "@/components/outputs/traceback-output"
 import { usePresenceContext } from "@/components/notebook/presence-context";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { type CommandModeCommand, useCommandMode } from "../hooks/useCommandMode";
+import { findAdjacentVisibleCellId, type CellNavigationDirection } from "../lib/cell-navigation";
 import {
   flushCellUIState,
   getFocusedCellId,
@@ -777,9 +778,38 @@ function NotebookViewContent({
     [canMutateCells, handleDeleteCell, onAddCell, onChangeCellType, onSetCellOutputsHidden],
   );
 
+  const isVisibleCell = useCallback((cellId: string) => {
+    const group = hiddenGroupsRef.current.get(cellId);
+    return !group || group.isFirst;
+  }, []);
+
+  const navigateCommandModeSelection = useCallback(
+    (direction: CellNavigationDirection, cellId: string): boolean => {
+      const targetCellId = findAdjacentVisibleCellId(
+        cellIdsRef.current,
+        cellId,
+        direction,
+        isVisibleCell,
+      );
+      if (!targetCellId) return false;
+
+      focusInteractionTarget({ kind: "cell", cellId: targetCellId });
+      window.requestAnimationFrame(() => {
+        containerRef.current
+          ?.querySelector<HTMLElement>(
+            `[data-slot="cell-container"][data-cell-id="${CSS.escape(targetCellId)}"]`,
+          )
+          ?.scrollIntoView({ block: "nearest" });
+      });
+      return true;
+    },
+    [focusInteractionTarget, isVisibleCell],
+  );
+
   useCommandMode({
     showCommandMode,
     enterEditMode,
+    navigateSelection: navigateCommandModeSelection,
     runCommand: runCommandModeAction,
     disabled: isLoading || cellIds.length === 0,
   });
@@ -896,22 +926,17 @@ function NotebookViewContent({
       dragHandleProps?: Record<string, unknown>,
       isDragging?: boolean,
     ) => {
-      // Navigation callbacks — skip cells that are collapsed into a hidden group
-      const isVisibleCell = (id: string) => {
-        const g = hiddenGroupsRef.current.get(id);
-        return !g || g.isFirst;
-      };
-
       const onFocusPrevious = (cursorPosition: "start" | "end") => {
         logger.debug(
           `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        let prevIndex = index - 1;
-        while (prevIndex >= 0 && !isVisibleCell(cellIdsRef.current[prevIndex])) {
-          prevIndex--;
-        }
-        if (prevIndex >= 0) {
-          const prevCellId = cellIdsRef.current[prevIndex];
+        const prevCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          "previous",
+          isVisibleCell,
+        );
+        if (prevCellId) {
           logger.debug(`[cell-nav] Focusing previous: ${prevCellId.slice(0, 8)}`);
           focusInteractionTarget({ kind: "editor", cellId: prevCellId });
           focusCell(prevCellId, cursorPosition);
@@ -924,15 +949,13 @@ function NotebookViewContent({
         logger.debug(
           `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        let nextIndex = index + 1;
-        while (
-          nextIndex < cellIdsRef.current.length &&
-          !isVisibleCell(cellIdsRef.current[nextIndex])
-        ) {
-          nextIndex++;
-        }
-        if (nextIndex < cellIdsRef.current.length) {
-          const nextCellId = cellIdsRef.current[nextIndex];
+        const nextCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          "next",
+          isVisibleCell,
+        );
+        if (nextCellId) {
           logger.debug(`[cell-nav] Focusing next: ${nextCellId.slice(0, 8)}`);
           focusInteractionTarget({ kind: "editor", cellId: nextCellId });
           focusCell(nextCellId, cursorPosition);
@@ -942,18 +965,13 @@ function NotebookViewContent({
       };
 
       const focusRenderedCell = (direction: "previous" | "next") => {
-        const step = direction === "previous" ? -1 : 1;
-        let targetIndex = index + step;
-        while (
-          targetIndex >= 0 &&
-          targetIndex < cellIdsRef.current.length &&
-          !isVisibleCell(cellIdsRef.current[targetIndex])
-        ) {
-          targetIndex += step;
-        }
-        if (targetIndex < 0 || targetIndex >= cellIdsRef.current.length) return;
-
-        const targetCellId = cellIdsRef.current[targetIndex];
+        const targetCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          direction,
+          isVisibleCell,
+        );
+        if (!targetCellId) return;
         const targetCell = getCellById(targetCellId);
         if (targetCell?.cell_type !== "markdown") {
           focusInteractionTarget({ kind: "editor", cellId: targetCellId });
@@ -1241,6 +1259,7 @@ function NotebookViewContent({
     [
       runtime,
       focusInteractionTarget,
+      isVisibleCell,
       suppressTailFollowForInPlaceExecution,
       onExecuteCell,
       onInterruptKernel,

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -993,6 +993,28 @@ describe("MarkdownCell theme sync", () => {
     expect(onFocusPrevious).not.toHaveBeenCalled();
   });
 
+  it("lets command-mode arrows bubble to notebook selection navigation", () => {
+    const cell = makeCell();
+    mockActiveInteractionTarget = { kind: "cell", cellId: cell.id };
+    const onPreviewFocusNext = vi.fn();
+    const onPreviewFocusPrevious = vi.fn();
+
+    const { getByLabelText } = render(
+      <MarkdownCell
+        cell={cell}
+        onFocus={() => {}}
+        onPreviewFocusNext={onPreviewFocusNext}
+        onPreviewFocusPrevious={onPreviewFocusPrevious}
+      />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(fireEvent.keyDown(preview, { key: "ArrowDown" })).toBe(true);
+    expect(fireEvent.keyDown(preview, { key: "ArrowUp" })).toBe(true);
+    expect(onPreviewFocusNext).not.toHaveBeenCalled();
+    expect(onPreviewFocusPrevious).not.toHaveBeenCalled();
+  });
+
   it("updates markdown task markers from projected task checkboxes", () => {
     const onUpdateSource = vi.fn();
 

--- a/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
@@ -115,6 +115,106 @@ describe("useCommandMode", () => {
   });
 
   it.each([
+    ["ArrowUp", "previous"],
+    ["ArrowDown", "next"],
+  ] as const)("routes %s to command-mode %s selection", (key, direction) => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    expect(dispatchKeyDown({ key })).toBe(false);
+    expect(navigateSelection).toHaveBeenCalledWith(direction, "cell-1");
+  });
+
+  it("leaves an arrow unhandled when selection cannot move", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => false);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    expect(dispatchKeyDown({ key: "ArrowUp" })).toBe(true);
+    expect(navigateSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores arrows outside command mode or with modifiers", () => {
+    mockTarget = { kind: "editor", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    dispatchKeyDown({ key: "ArrowDown" });
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    dispatchKeyDown({ key: "ArrowDown", shiftKey: true });
+    dispatchKeyDown({ key: "ArrowDown", metaKey: true });
+
+    expect(navigateSelection).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest arrow navigation callback after rerender", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const firstNavigate = vi.fn(() => true);
+    const secondNavigate = vi.fn(() => true);
+    const { rerender } = renderHook(
+      ({ navigateSelection }) =>
+        useCommandMode({
+          showCommandMode: vi.fn(),
+          enterEditMode: vi.fn(),
+          navigateSelection,
+          runCommand: vi.fn(),
+        }),
+      { initialProps: { navigateSelection: firstNavigate } },
+    );
+
+    rerender({ navigateSelection: secondNavigate });
+    dispatchKeyDown({ key: "ArrowDown" });
+
+    expect(firstNavigate).not.toHaveBeenCalled();
+    expect(secondNavigate).toHaveBeenCalledWith("next", "cell-1");
+  });
+
+  it("does not complete D,D after arrow navigation", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const runCommand = vi.fn();
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection: vi.fn(() => true),
+        runCommand,
+      }),
+    );
+
+    dispatchKeyDown({ key: "d" });
+    dispatchKeyDown({ key: "ArrowDown" });
+    dispatchKeyDown({ key: "d" });
+
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["a", "insert-above"],
     ["b", "insert-below"],
     ["m", "change-to-markdown"],
@@ -192,23 +292,28 @@ describe("useCommandMode", () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
-  it("does not hijack Enter, Escape, or letter keys from a focused button", () => {
+  it("does not hijack Enter, Escape, arrows, or letter keys from a focused button", () => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
     const showCommandMode = vi.fn();
     const enterEditMode = vi.fn();
+    const navigateSelection = vi.fn(() => true);
     const runCommand = vi.fn();
     const button = document.createElement("button");
     document.body.appendChild(button);
     button.focus();
 
-    renderHook(() => useCommandMode({ showCommandMode, enterEditMode, runCommand }));
+    renderHook(() =>
+      useCommandMode({ showCommandMode, enterEditMode, navigateSelection, runCommand }),
+    );
 
     dispatchKeyDown({ key: "Enter" });
     dispatchKeyDown({ key: "Escape" });
+    dispatchKeyDown({ key: "ArrowDown" });
     dispatchKeyDown({ key: "a" });
 
     expect(showCommandMode).not.toHaveBeenCalled();
     expect(enterEditMode).not.toHaveBeenCalled();
+    expect(navigateSelection).not.toHaveBeenCalled();
     expect(runCommand).not.toHaveBeenCalled();
   });
 
@@ -286,21 +391,25 @@ describe("useCommandMode", () => {
     expect(runCommand).toHaveBeenCalledWith("delete", "cell-2");
   });
 
-  it("does nothing for letter shortcuts when disabled", () => {
+  it("does nothing for command-mode shortcuts when disabled", () => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
     const runCommand = vi.fn();
 
     renderHook(() =>
       useCommandMode({
         showCommandMode: vi.fn(),
         enterEditMode: vi.fn(),
+        navigateSelection,
         runCommand,
         disabled: true,
       }),
     );
 
     dispatchKeyDown({ key: "a" });
+    dispatchKeyDown({ key: "ArrowDown" });
 
+    expect(navigateSelection).not.toHaveBeenCalled();
     expect(runCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook/src/hooks/useCommandMode.ts
+++ b/apps/notebook/src/hooks/useCommandMode.ts
@@ -13,12 +13,15 @@ export type CommandModeCommand =
   | "toggle-output";
 
 type RunCommand = (command: CommandModeCommand, cellId: string) => boolean;
+type NavigateSelection = (direction: "previous" | "next", cellId: string) => boolean;
 
 interface UseCommandModeOptions {
   /** Enter command mode: blur the active element, select the focused cell (no editor). */
   showCommandMode: () => void;
   /** Leave command mode: focus the source editor of the selected cell. */
   enterEditMode: () => boolean;
+  /** Select an adjacent visible cell without entering its editor. */
+  navigateSelection?: NavigateSelection;
   /** Apply a command through the shared notebook surface. */
   runCommand: RunCommand;
   /** Skip attaching the listener entirely (e.g. no notebook loaded). */
@@ -49,6 +52,7 @@ function isInteractiveTarget(el: Element | null): boolean {
  *
  *   Escape → blur the editor/output, enter command mode (`{kind:"cell"}`)
  *   Enter  → leave command mode, focus the cell's source editor
+ *   Up/Down → select the previous/next visible cell without editing
  *
  * While in command mode, single letters mirror the most common Jupyter
  * shortcuts: A/B insert a cell above/below, M/Y change cell type, O toggles
@@ -60,14 +64,17 @@ function isInteractiveTarget(el: Element | null): boolean {
 export function useCommandMode({
   showCommandMode,
   enterEditMode,
+  navigateSelection,
   runCommand,
   disabled = false,
 }: UseCommandModeOptions): void {
   const showCommandModeRef = useRef(showCommandMode);
   const enterEditModeRef = useRef(enterEditMode);
+  const navigateSelectionRef = useRef(navigateSelection);
   const runCommandRef = useRef(runCommand);
   showCommandModeRef.current = showCommandMode;
   enterEditModeRef.current = enterEditMode;
+  navigateSelectionRef.current = navigateSelection;
   runCommandRef.current = runCommand;
 
   // Timestamp + cell id of the last bare "d" press, for the D,D delete
@@ -108,6 +115,14 @@ export function useCommandMode({
 
       if (target?.kind !== "cell") {
         pendingDeleteRef.current = null;
+        return;
+      }
+
+      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+        pendingDeleteRef.current = null;
+        if (event.shiftKey) return;
+        const direction = event.key === "ArrowUp" ? "previous" : "next";
+        if (navigateSelectionRef.current?.(direction, target.cellId)) event.preventDefault();
         return;
       }
 

--- a/apps/notebook/src/lib/__tests__/cell-navigation.test.ts
+++ b/apps/notebook/src/lib/__tests__/cell-navigation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findAdjacentVisibleCellId } from "../cell-navigation";
+
+describe("findAdjacentVisibleCellId", () => {
+  const cellIds = ["a", "b", "c", "d", "e"];
+  const visible = new Set(["a", "b", "e"]);
+  const isVisible = (cellId: string) => visible.has(cellId);
+
+  it("finds adjacent visible cells in both directions", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "a", "next", isVisible)).toBe("b");
+    expect(findAdjacentVisibleCellId(cellIds, "e", "previous", isVisible)).toBe("b");
+  });
+
+  it("skips collapsed hidden-group members", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "b", "next", isVisible)).toBe("e");
+    expect(findAdjacentVisibleCellId(cellIds, "e", "previous", isVisible)).toBe("b");
+  });
+
+  it("returns null at boundaries and for missing current cells", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "a", "previous", isVisible)).toBeNull();
+    expect(findAdjacentVisibleCellId(cellIds, "e", "next", isVisible)).toBeNull();
+    expect(findAdjacentVisibleCellId(cellIds, "missing", "next", isVisible)).toBeNull();
+  });
+});

--- a/apps/notebook/src/lib/cell-navigation.ts
+++ b/apps/notebook/src/lib/cell-navigation.ts
@@ -1,0 +1,21 @@
+export type CellNavigationDirection = "previous" | "next";
+
+export function findAdjacentVisibleCellId(
+  cellIds: readonly string[],
+  currentCellId: string,
+  direction: CellNavigationDirection,
+  isVisible: (cellId: string) => boolean,
+): string | null {
+  const currentIndex = cellIds.indexOf(currentCellId);
+  if (currentIndex < 0) return null;
+
+  const step = direction === "previous" ? -1 : 1;
+  let targetIndex = currentIndex + step;
+  while (targetIndex >= 0 && targetIndex < cellIds.length) {
+    const targetCellId = cellIds[targetIndex];
+    if (isVisible(targetCellId)) return targetCellId;
+    targetIndex += step;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- add Jupyter-style `ArrowUp` and `ArrowDown` navigation while a cell is selected in command mode
- keep navigation in command mode, skip collapsed hidden-group members, and scroll the selected cell into view
- preserve rendered Markdown and interactive-control keyboard behavior across mixed cell types

## Dependency

Depends on #4196. This branch is stacked on `fix/markdown-command-mode-focus`; once #4196 merges, this PR diff reduces to commit `37f157f5`.

## Testing

- `pnpm test:run apps/notebook/src/hooks/__tests__/useCommandMode.test.ts apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx apps/notebook/src/lib/__tests__/cell-navigation.test.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/markdown-parity.spec.ts --grep "navigates mixed cells"`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`

## Manual verification

Verified in the worktree-isolated desktop dev app: pressing `Escape` enters command mode, and Up/Down moves selection across mixed code and Markdown cells without entering edit mode.