### PR TITLE
fix(mcp): allow kernel restart through shutdown

### DIFF
--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -141,6 +141,10 @@ pub enum SessionRequirement {
     ProjectionRead,
     DocumentRead,
     DocumentMutation,
+    /// Kernel lifecycle operations require a healthy interactive notebook,
+    /// but must remain available while the runtime is intentionally absent
+    /// between shutdown and launch.
+    KernelControl,
     RuntimeRead,
     Execute,
 }
@@ -483,19 +487,10 @@ impl NotebookSession {
         requirement: SessionRequirement,
     ) -> Result<SessionAccess, SessionAccessError> {
         let readiness = self.readiness();
-        let allowed = match requirement {
-            SessionRequirement::ProjectionRead => {
-                readiness.projection_ready || readiness.interactive
-            }
-            SessionRequirement::DocumentRead => readiness.interactive,
-            SessionRequirement::DocumentMutation => readiness.capabilities.mutate,
-            SessionRequirement::RuntimeRead => {
-                let status = self.handle.status();
-                status.connection == ConnectionState::Connected
-                    && status.runtime_state == RuntimeStatePhase::Ready
-            }
-            SessionRequirement::Execute => readiness.capabilities.execute,
-        };
+        let status = self.handle.status();
+        let runtime_connected_and_ready = status.connection == ConnectionState::Connected
+            && status.runtime_state == RuntimeStatePhase::Ready;
+        let allowed = requirement_allowed(requirement, &readiness, runtime_connected_and_ready);
         if !allowed {
             let (code, message) = if self.handle.status().connection
                 == ConnectionState::Disconnected
@@ -590,9 +585,25 @@ impl SessionRequirement {
             Self::ProjectionRead => "projection reads",
             Self::DocumentRead => "document reads",
             Self::DocumentMutation => "document mutations",
+            Self::KernelControl => "kernel control",
             Self::RuntimeRead => "runtime reads",
             Self::Execute => "execution",
         }
+    }
+}
+
+fn requirement_allowed(
+    requirement: SessionRequirement,
+    readiness: &SessionReadiness,
+    runtime_connected_and_ready: bool,
+) -> bool {
+    match requirement {
+        SessionRequirement::ProjectionRead => readiness.projection_ready || readiness.interactive,
+        SessionRequirement::DocumentRead => readiness.interactive,
+        SessionRequirement::DocumentMutation => readiness.capabilities.mutate,
+        SessionRequirement::KernelControl => readiness.interactive,
+        SessionRequirement::RuntimeRead => runtime_connected_and_ready,
+        SessionRequirement::Execute => readiness.capabilities.execute,
     }
 }
 
@@ -659,6 +670,26 @@ pub struct SessionDropInfo {
 mod tests {
     use super::*;
 
+    fn readiness(interactive: bool, runtime_ready: bool) -> SessionReadiness {
+        SessionReadiness {
+            session_generation: 1,
+            target: "notebook:test".to_string(),
+            source_state: serde_json::json!({ "phase": "ready" }),
+            projection_ready: true,
+            document_ready: true,
+            runtime_ready,
+            interactive,
+            projection_heads: vec!["notebook-head".to_string()],
+            runtime_state_heads: vec!["runtime-head".to_string()],
+            projection_completeness: Some("complete".to_string()),
+            capabilities: SessionCapabilities {
+                read: true,
+                mutate: interactive,
+                execute: interactive && runtime_ready,
+            },
+        }
+    }
+
     #[tokio::test]
     async fn daemon_incarnation_sample_retries_transient_unavailability() {
         let expected = DaemonIncarnation {
@@ -701,5 +732,28 @@ mod tests {
             retained_readiness_axes(true, true, true, false, true, true),
             (true, false, true)
         );
+    }
+
+    #[test]
+    fn kernel_control_stays_available_between_shutdown_and_launch() {
+        let runtime_absent = readiness(true, false);
+
+        assert!(requirement_allowed(
+            SessionRequirement::KernelControl,
+            &runtime_absent,
+            false,
+        ));
+        assert!(!requirement_allowed(
+            SessionRequirement::Execute,
+            &runtime_absent,
+            false,
+        ));
+
+        let notebook_not_interactive = readiness(false, false);
+        assert!(!requirement_allowed(
+            SessionRequirement::KernelControl,
+            &notebook_not_interactive,
+            false,
+        ));
     }
 }

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -54,7 +54,7 @@ pub async fn restart_kernel(
     server: &NteractMcp,
     _request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let access = require_session_access!(server, Execute);
+    let access = require_session_access!(server, KernelControl);
     let handle = access.handle.clone();
     let notebook_id = access.notebook_id.clone();
 
@@ -105,7 +105,7 @@ pub async fn restart_kernel(
     // a daemon restart during the shutdown sequence). If the session was
     // replaced by daemon_watch's rejoin, we pick up the new one.
     let refreshed_access = match server
-        .session_access(crate::session::SessionRequirement::Execute)
+        .session_access(crate::session::SessionRequirement::KernelControl)
         .await
     {
         Ok(Some(access)) => access,
@@ -114,7 +114,7 @@ pub async fn restart_kernel(
             // Session dropped — wait for daemon_watch to rejoin.
             tokio::time::sleep(std::time::Duration::from_secs(8)).await;
             match server
-                .session_access(crate::session::SessionRequirement::Execute)
+                .session_access(crate::session::SessionRequirement::KernelControl)
                 .await
             {
                 Ok(Some(access)) => access,
@@ -225,7 +225,7 @@ pub async fn restart_kernel(
             }
             match restart_retry_access(
                 server
-                    .session_access(crate::session::SessionRequirement::Execute)
+                    .session_access(crate::session::SessionRequirement::KernelControl)
                     .await,
             ) {
                 Ok(access) => {


### PR DESCRIPTION
## Summary

- add a dedicated `KernelControl` session requirement that stays available while a healthy notebook temporarily has no running kernel
- use that requirement throughout MCP `restart_kernel`, including reconnect and retry paths
- preserve the stricter `Execute` requirement for cell execution and kernel interruption

## Why

`restart_kernel` previously reacquired `Execute` access after sending `ShutdownKernel`. A successful shutdown makes `runtime_ready` false, so the tool rejected its own launch phase with `runtime_not_ready` and left the notebook with a shut-down kernel.

The new gate still requires an interactive, non-degraded notebook. Daemon-side owner scope, trust checks, and session-generation/target identity checks remain unchanged.

## Verification

- `cargo test -p runt-mcp` (218 passed)
- `cargo xtask lint --fix`
- built the patched `runt` client and exercised it against packaged Nightly `2.7.4-nightly.202608262357+46e6ef8`
- restarted the live `nightly-hf-air-quality-qa.ipynb` kernel through MCP, then re-executed the Hugging Face dataset cell successfully (87,672 rows x 11 columns)
- independent Kilo correctness review with Claude Opus 4.8: no actionable findings
- independent Kilo security review with GPT-5.6 Sol: no actionable findings
