### PR TITLE
fix(comments): tolerate pending sync identity

### DIFF
--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -219,8 +219,10 @@ impl CommentsDoc {
     /// (`new_empty_for_sync`); the daemon-authoritative id reaches the
     /// document through the first sync round. Returns `true` if an identity
     /// was adopted, `false` if the cache was already set or the document
-    /// carries no id yet. Errors if the document's id is invalid or
-    /// conflicted.
+    /// carries no materialized id yet. The shared schema genesis stores an
+    /// empty placeholder, so both a missing value and an empty value are
+    /// normal while the initial sync handshake is still in progress. Errors
+    /// if a non-empty document id is invalid or conflicted.
     pub fn adopt_synced_identity(&mut self) -> Result<bool, CommentsDocError> {
         if !self.comments_doc_id.is_empty() {
             return Ok(false);
@@ -228,6 +230,9 @@ impl CommentsDoc {
         let Some(raw) = self.raw_comments_doc_id() else {
             return Ok(false);
         };
+        if raw.is_empty() {
+            return Ok(false);
+        }
         self.ensure_raw_comments_doc_id_matches_value(&raw)?;
         self.comments_doc_id = raw;
         Ok(true)
@@ -1251,6 +1256,30 @@ mod tests {
             .expect_err("seed without id must not project")
             .to_string()
             .contains("comments_doc_id is required"));
+    }
+
+    #[test]
+    fn schema_seed_identity_adoption_waits_for_materialized_identity() {
+        let mut seed = CommentsDoc::new_empty_for_sync();
+
+        assert_eq!(seed.raw_comments_doc_id().as_deref(), Some(""));
+        assert!(!seed
+            .adopt_synced_identity()
+            .expect("empty schema identity is a pending sync state"));
+        assert_eq!(seed.comments_doc_id().as_deref(), Some(""));
+    }
+
+    #[test]
+    fn identity_adoption_still_rejects_non_empty_invalid_identity() {
+        let mut seed = CommentsDoc::new_empty_for_sync();
+        seed.doc_mut()
+            .put(&ROOT, "comments_doc_id", "not-a-comments-doc-id")
+            .unwrap();
+
+        let err = seed
+            .adopt_synced_identity()
+            .expect_err("non-empty invalid identity must not be tolerated");
+        assert!(matches!(err, CommentsDocError::InvalidCommentsDocId(_)));
     }
 
     #[test]

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -227,13 +227,13 @@ impl CommentsDoc {
         if !self.comments_doc_id.is_empty() {
             return Ok(false);
         }
-        let Some(raw) = self.raw_comments_doc_id() else {
+        let Some(raw) = self.unambiguous_raw_comments_doc_id()? else {
             return Ok(false);
         };
         if raw.is_empty() {
             return Ok(false);
         }
-        self.ensure_raw_comments_doc_id_matches_value(&raw)?;
+        validate_comments_doc_id(&raw)?;
         self.comments_doc_id = raw;
         Ok(true)
     }
@@ -247,6 +247,20 @@ impl CommentsDoc {
         expected_comments_doc_id: &str,
     ) -> Result<(), CommentsDocError> {
         validate_comments_doc_id(expected_comments_doc_id)?;
+        let actual = self
+            .unambiguous_raw_comments_doc_id()?
+            .ok_or(CommentsDocError::MissingCommentsDocId)?;
+        validate_comments_doc_id(&actual)?;
+        if actual != expected_comments_doc_id {
+            return Err(CommentsDocError::CommentsDocIdMismatch {
+                expected: expected_comments_doc_id.to_string(),
+                actual,
+            });
+        }
+        Ok(())
+    }
+
+    fn unambiguous_raw_comments_doc_id(&self) -> Result<Option<String>, CommentsDocError> {
         let conflicts = self
             .doc
             .get_all(&ROOT, "comments_doc_id")
@@ -261,18 +275,7 @@ impl CommentsDoc {
         if values.len() > 1 {
             return Err(CommentsDocError::CommentsDocIdConflict);
         }
-        let actual = values
-            .into_iter()
-            .next()
-            .ok_or(CommentsDocError::MissingCommentsDocId)?;
-        validate_comments_doc_id(&actual)?;
-        if actual != expected_comments_doc_id {
-            return Err(CommentsDocError::CommentsDocIdMismatch {
-                expected: expected_comments_doc_id.to_string(),
-                actual,
-            });
-        }
-        Ok(())
+        Ok(values.into_iter().next())
     }
 
     fn set_notebook_ref(
@@ -1280,6 +1283,33 @@ mod tests {
             .adopt_synced_identity()
             .expect_err("non-empty invalid identity must not be tolerated");
         assert!(matches!(err, CommentsDocError::InvalidCommentsDocId(_)));
+    }
+
+    #[test]
+    fn identity_adoption_rejects_conflict_with_empty_placeholder() {
+        let mut baseline = CommentsDoc::new_with_actor(DOC_ID, &notebook_ref(), "client:base");
+        let bytes = baseline.save();
+        let mut empty_branch =
+            CommentsDoc::load_with_actor(&bytes, DOC_ID, "client:empty").unwrap();
+        let mut other_branch =
+            CommentsDoc::load_with_actor(&bytes, DOC_ID, "client:other").unwrap();
+        empty_branch
+            .doc_mut()
+            .put(&ROOT, "comments_doc_id", "")
+            .unwrap();
+        other_branch
+            .doc_mut()
+            .put(&ROOT, "comments_doc_id", "comments:other")
+            .unwrap();
+
+        let mut receiver = CommentsDoc::new_empty_for_sync();
+        sync_pair_without_projection_check(&mut empty_branch, &mut receiver);
+        sync_pair_without_projection_check(&mut other_branch, &mut receiver);
+
+        let err = receiver
+            .adopt_synced_identity()
+            .expect_err("empty and materialized identities must remain a conflict");
+        assert!(matches!(err, CommentsDocError::CommentsDocIdConflict));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat the empty `comments_doc_id` in the shared CommentsDoc genesis as a normal pending-sync state
- keep rejecting non-empty malformed or conflicting CommentsDoc identities
- cover both sides of the tolerance boundary with regression tests

## Why

Comments clients start from `CommentsDoc::new_empty_for_sync()`. The shared schema genesis intentionally contains `comments_doc_id = ""` until the daemon's authoritative identity arrives. An early sync round can therefore attempt identity adoption before the identity has materialized, producing a misleading warning even though later rounds converge normally.

This patch makes absence lenient only during bootstrap. A materialized CommentsDoc still requires a valid, unambiguous identity.

## Verification

- `cargo test -p comments-doc`
- `cargo test -p notebook-sync`
- `cargo xtask lint --fix`

## Independent review

- correctness review identified a latent empty-value/conflict ordering edge; fixed by classifying all visible Automerge register values before treating the identity as pending
- operability review found no actionable issues
- source-integrity guard passed for both review sessions
