### PR TITLE
fix(runtimed): stop creating notebook lock sidecars

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3803,17 +3803,16 @@ impl Daemon {
     /// source, or degraded durability), or a post-disconnect teardown that
     /// has not completed (`last_kernel_torn_down_at` unset). The teardown
     /// gate matters: the disconnect teardown performs one final `.ipynb`
-    /// save that re-claims the on-disk autosave owner marker, so releasing
-    /// the path before it completes would let that late save wedge a
-    /// successor daemon behind our live-pid marker.
+    /// save, so releasing the path before it completes would let that late
+    /// save race a successor daemon.
     ///
     /// Wanted claims are acquired if missing and renewed while our own
     /// record ages past `FILE_CLAIM_RENEW_AFTER`. A live foreign
     /// claim is never overwritten: the registry states facts, and stealing
     /// another daemon's lease would silently split-brain the file. A clean
-    /// idle room releases its claim (and the autosave owner marker) once
-    /// the idle-grace window elapses, handing the path to other daemon
-    /// processes while the room stays resident for fast rejoin.
+    /// idle room releases its claim once the idle-grace window elapses,
+    /// handing the path to other daemon processes while the room stays
+    /// resident for fast rejoin. Legacy markers are cleaned up along the way.
     ///
     /// `pub` so integration tests can drive the reconciler synchronously
     /// instead of waiting on `FILE_CLAIM_RECONCILE_INTERVAL`.
@@ -3853,7 +3852,8 @@ impl Daemon {
                     room.file_claim_hold.note_wanted();
                     continue;
                 }
-                crate::notebook_sync_server::release_autosave_owner_marker_for_path(&path).await;
+                crate::notebook_sync_server::cleanup_legacy_autosave_owner_marker_for_path(&path)
+                    .await;
                 if let Err(error) = self.file_claims.release(&path, &owner) {
                     debug!(
                         "[runtimed] file-claim release failed for {:?}: {}",
@@ -5309,11 +5309,10 @@ impl Daemon {
                     // daemon's writers are gone, mirroring the reaper's eviction
                     // ordering: journal barrier for the exact live heads, stop
                     // the autosave task (it owns a room Arc and flushes one
-                    // final save), stop the file watchers, drop the on-disk
-                    // autosave owner marker, then release the cross-daemon
-                    // file claim. Releasing the claim any earlier invites a
-                    // successor daemon that cannot save past our live-pid marker
-                    // and could race a late autosave flush over its writes.
+                    // final save), stop the file watchers, clean up any legacy
+                    // autosave marker, then release the cross-daemon file claim.
+                    // Releasing the claim any earlier could race a late
+                    // autosave flush over a successor's writes.
                     //
                     // Unlike the reaper, barrier failure cannot keep the room
                     // resident (it is already out of the registry on an
@@ -5370,16 +5369,18 @@ impl Daemon {
                     )
                     .await;
                     // Latch eviction between our final save (the autosave
-                    // shutdown above) and the marker release below: from here
+                    // shutdown above) and the claim release below: from here
                     // on, any straggler save on this room Arc (a pending
                     // disconnect-teardown, a lingering peer session) refuses
-                    // instead of re-claiming the marker after the handoff.
+                    // instead of writing after the handoff.
                     room.mark_evicted();
                     room.file_binding.shutdown_notebook_watcher().await;
                     room.file_binding.shutdown_project_file_watcher().await;
                     if let Some(path) = room.file_binding.path().await {
-                        crate::notebook_sync_server::release_autosave_owner_marker_for_path(&path)
-                            .await;
+                        crate::notebook_sync_server::cleanup_legacy_autosave_owner_marker_for_path(
+                            &path,
+                        )
+                        .await;
                         let _ = self.file_claims.release(&path, &self.file_claim_owner());
                     }
                     // Take the persist debouncer so its senders drop and the task
@@ -6042,9 +6043,9 @@ impl Daemon {
             )
             .await;
 
-            // Latch eviction between the final save above and the marker
-            // release below, so a straggler save on this room Arc cannot
-            // re-claim the marker after the path is handed off.
+            // Latch eviction between the final save above and claim release
+            // below, so a straggler save on this room Arc cannot write after
+            // the path is handed off.
             room.mark_evicted();
 
             // Step 5: fire-and-forget watcher shutdowns. Each task
@@ -6053,7 +6054,8 @@ impl Daemon {
             room.file_binding.shutdown_notebook_watcher().await;
             room.file_binding.shutdown_project_file_watcher().await;
             if let Some(path) = path.as_ref() {
-                crate::notebook_sync_server::release_autosave_owner_marker_for_path(path).await;
+                crate::notebook_sync_server::cleanup_legacy_autosave_owner_marker_for_path(path)
+                    .await;
                 let _ = self.file_claims.release(path, &self.file_claim_owner());
             }
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -1,13 +1,12 @@
 use super::*;
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 
 pub(crate) const JUPYTER_WIDGET_TARGET: &str = "jupyter.widget";
 pub(crate) const WIDGET_STATE_MIME: &str = "application/vnd.jupyter.widget-state+json";
 const WIDGET_STATE_VERSION_MAJOR: i64 = 2;
 const WIDGET_STATE_VERSION_MINOR: i64 = 0;
-const AUTOSAVE_OWNER_SCHEMA_VERSION: u32 = 1;
+const LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug)]
 pub(crate) enum SaveError {
@@ -370,7 +369,7 @@ pub(crate) async fn save_notebook_to_disk_with_claim_and_intent(
                 ))
             })?;
         }
-        claim_autosave_owner(&notebook_path).await?;
+        guard_and_cleanup_legacy_autosave_owner(&notebook_path).await?;
     }
 
     // Read cells, metadata, and per-cell execution_ids from the doc.
@@ -905,7 +904,7 @@ fn checkpoint_blocked_reason(
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct AutosaveOwnerMarker {
+pub(crate) struct LegacyAutosaveOwnerMarker {
     pub(crate) schema_version: u32,
     pub(crate) daemon_id: String,
     pub(crate) pid: u32,
@@ -913,27 +912,13 @@ pub(crate) struct AutosaveOwnerMarker {
     pub(crate) claimed_at_unix_ms: u64,
 }
 
-impl AutosaveOwnerMarker {
-    fn current(notebook_path: &Path) -> Self {
-        Self {
-            schema_version: AUTOSAVE_OWNER_SCHEMA_VERSION,
-            daemon_id: current_autosave_owner_id().to_string(),
-            pid: std::process::id(),
-            notebook_path: notebook_path.to_path_buf(),
-            claimed_at_unix_ms: unix_now_ms(),
-        }
-    }
-
-    fn is_current_daemon(&self) -> bool {
-        self.pid == std::process::id() && self.daemon_id == current_autosave_owner_id()
+impl LegacyAutosaveOwnerMarker {
+    fn belongs_to_current_process(&self) -> bool {
+        self.pid == std::process::id()
     }
 }
 
-fn current_autosave_owner_id() -> &'static str {
-    static OWNER_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    OWNER_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
-}
-
+#[cfg(test)]
 fn unix_now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -941,7 +926,7 @@ fn unix_now_ms() -> u64 {
         .as_millis() as u64
 }
 
-fn autosave_owner_marker_path(notebook_path: &Path) -> PathBuf {
+fn legacy_autosave_owner_marker_path(notebook_path: &Path) -> PathBuf {
     let file_name = notebook_path
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -949,133 +934,82 @@ fn autosave_owner_marker_path(notebook_path: &Path) -> PathBuf {
     notebook_path.with_file_name(format!("{file_name}.runtlock"))
 }
 
-async fn claim_autosave_owner(notebook_path: &Path) -> Result<(), SaveError> {
-    let marker_path = autosave_owner_marker_path(notebook_path);
-    loop {
-        let marker = AutosaveOwnerMarker::current(notebook_path);
-        let marker_bytes = serde_json::to_vec_pretty(&marker).map_err(|e| {
-            SaveError::Retryable(format!("failed to serialize autosave owner: {e}"))
-        })?;
-
-        match tokio::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&marker_path)
-            .await
-        {
-            Ok(mut file) => {
-                if let Err(e) = file.write_all(&marker_bytes).await {
-                    let _ = tokio::fs::remove_file(&marker_path).await;
-                    return Err(save_error_for_owner_io(
-                        "write autosave owner marker",
-                        &marker_path,
-                        e,
-                    ));
-                }
-                if let Err(e) = file.write_all(b"\n").await {
-                    let _ = tokio::fs::remove_file(&marker_path).await;
-                    return Err(save_error_for_owner_io(
-                        "write autosave owner marker",
-                        &marker_path,
-                        e,
-                    ));
-                }
-                return Ok(());
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-            Err(e) => {
-                return Err(save_error_for_owner_io(
-                    "create autosave owner marker",
-                    &marker_path,
-                    e,
-                ));
-            }
-        }
-
-        let existing = match read_autosave_owner_marker(&marker_path).await {
-            Ok(marker) => marker,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => {
-                warn!(
-                    "[notebook-sync] Reclaiming unreadable autosave owner marker {:?}: {}",
-                    marker_path, e
-                );
-                remove_stale_autosave_owner_marker(&marker_path).await?;
-                continue;
-            }
-        };
-
-        if existing.is_current_daemon() {
-            write_autosave_owner_marker(&marker_path, notebook_path).await?;
+/// Honor markers written by older nteract daemons without creating any new
+/// sidecar beside the user's notebook. Cross-daemon ownership now lives in
+/// `runt_workspace::file_claims`; the file-checkpoint fingerprint remains the
+/// final guard against an external write that raced that best-effort lease.
+async fn guard_and_cleanup_legacy_autosave_owner(notebook_path: &Path) -> Result<(), SaveError> {
+    let marker_path = legacy_autosave_owner_marker_path(notebook_path);
+    let existing = match read_legacy_autosave_owner_marker(&marker_path).await {
+        Ok(marker) => marker,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            warn!(
+                "[notebook-sync] Removing unreadable legacy autosave owner marker {:?}: {}",
+                marker_path, e
+            );
+            remove_legacy_autosave_owner_marker(&marker_path).await?;
             return Ok(());
         }
+    };
 
-        if autosave_owner_process_is_live(existing.pid) {
-            error!(
-                "[notebook-sync] Refusing to save {:?}: autosave owner marker {:?} belongs to live daemon pid={} daemon_id={}. Stop that daemon or reconnect through it before saving this path.",
-                notebook_path,
-                marker_path,
-                existing.pid,
-                existing.daemon_id
-            );
-            return Err(SaveError::Unrecoverable(format!(
-                "notebook '{}' is owned by live daemon pid {} (marker '{}')",
-                notebook_path.display(),
-                existing.pid,
-                marker_path.display()
-            )));
-        }
-
+    if existing.schema_version != LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION
+        || existing.notebook_path != notebook_path
+    {
         warn!(
-            "[notebook-sync] Taking over stale autosave owner marker {:?} for {:?} from pid={} daemon_id={}",
-            marker_path, notebook_path, existing.pid, existing.daemon_id
+            "[notebook-sync] Removing invalid legacy autosave owner marker {:?}",
+            marker_path
         );
-        remove_stale_autosave_owner_marker(&marker_path).await?;
+        remove_legacy_autosave_owner_marker(&marker_path).await?;
+        return Ok(());
     }
+
+    if !existing.belongs_to_current_process() && autosave_owner_process_is_live(existing.pid) {
+        error!(
+            "[notebook-sync] Refusing to save {:?}: legacy autosave owner marker {:?} belongs to live daemon pid={} daemon_id={}. Stop that daemon or reconnect through it before saving this path.",
+            notebook_path,
+            marker_path,
+            existing.pid,
+            existing.daemon_id
+        );
+        return Err(SaveError::Unrecoverable(format!(
+            "notebook '{}' is owned by live legacy daemon pid {} (marker '{}')",
+            notebook_path.display(),
+            existing.pid,
+            marker_path.display()
+        )));
+    }
+
+    warn!(
+        "[notebook-sync] Removing legacy autosave owner marker {:?} for {:?} from pid={} daemon_id={}",
+        marker_path, notebook_path, existing.pid, existing.daemon_id
+    );
+    remove_legacy_autosave_owner_marker(&marker_path).await
 }
 
-async fn read_autosave_owner_marker(path: &Path) -> std::io::Result<AutosaveOwnerMarker> {
+async fn read_legacy_autosave_owner_marker(
+    path: &Path,
+) -> std::io::Result<LegacyAutosaveOwnerMarker> {
     let bytes = tokio::fs::read(path).await?;
     serde_json::from_slice(&bytes)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
-pub(crate) async fn release_autosave_owner_marker_for_path(notebook_path: &Path) {
-    let marker_path = autosave_owner_marker_path(notebook_path);
-    match read_autosave_owner_marker(&marker_path).await {
-        Ok(marker) if marker.is_current_daemon() => {
-            if let Err(e) = tokio::fs::remove_file(&marker_path).await {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    warn!(
-                        "[notebook-sync] Failed to release autosave owner marker {:?}: {}",
-                        marker_path, e
-                    );
-                }
-            }
-        }
-        Ok(_) | Err(_) => {}
+pub(crate) async fn cleanup_legacy_autosave_owner_marker_for_path(notebook_path: &Path) {
+    if let Err(error) = guard_and_cleanup_legacy_autosave_owner(notebook_path).await {
+        debug!(
+            "[notebook-sync] Leaving live legacy autosave owner marker for {:?}: {}",
+            notebook_path, error
+        );
     }
 }
 
-async fn write_autosave_owner_marker(
-    marker_path: &Path,
-    notebook_path: &Path,
-) -> Result<(), SaveError> {
-    let marker = AutosaveOwnerMarker::current(notebook_path);
-    let mut bytes = serde_json::to_vec_pretty(&marker)
-        .map_err(|e| SaveError::Retryable(format!("failed to serialize autosave owner: {e}")))?;
-    bytes.push(b'\n');
-    write_file_atomic(marker_path, &bytes)
-        .await
-        .map_err(|e| save_error_for_owner_io("refresh autosave owner marker", marker_path, e))
-}
-
-async fn remove_stale_autosave_owner_marker(marker_path: &Path) -> Result<(), SaveError> {
+async fn remove_legacy_autosave_owner_marker(marker_path: &Path) -> Result<(), SaveError> {
     match tokio::fs::remove_file(marker_path).await {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(save_error_for_owner_io(
-            "remove stale autosave owner marker",
+            "remove legacy autosave owner marker",
             marker_path,
             e,
         )),
@@ -1093,36 +1027,27 @@ fn save_error_for_owner_io(action: &str, path: &Path, e: std::io::Error) -> Save
 }
 
 #[cfg(test)]
-pub(crate) async fn write_autosave_owner_marker_for_test(
+pub(crate) async fn write_legacy_autosave_owner_marker_for_test(
     notebook_path: &Path,
     daemon_id: &str,
     pid: u32,
 ) {
-    let marker = AutosaveOwnerMarker {
-        schema_version: AUTOSAVE_OWNER_SCHEMA_VERSION,
+    let marker = LegacyAutosaveOwnerMarker {
+        schema_version: LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION,
         daemon_id: daemon_id.to_string(),
         pid,
         notebook_path: notebook_path.to_path_buf(),
         claimed_at_unix_ms: unix_now_ms(),
     };
-    let marker_path = autosave_owner_marker_path(notebook_path);
+    let marker_path = legacy_autosave_owner_marker_path(notebook_path);
     let mut bytes = serde_json::to_vec_pretty(&marker).unwrap();
     bytes.push(b'\n');
     tokio::fs::write(marker_path, bytes).await.unwrap();
 }
 
 #[cfg(test)]
-pub(crate) async fn read_autosave_owner_marker_for_test(
-    notebook_path: &Path,
-) -> AutosaveOwnerMarker {
-    read_autosave_owner_marker(&autosave_owner_marker_path(notebook_path))
-        .await
-        .unwrap()
-}
-
-#[cfg(test)]
-pub(crate) fn current_autosave_owner_id_for_test() -> String {
-    current_autosave_owner_id().to_string()
+pub(crate) fn legacy_autosave_owner_marker_path_for_test(notebook_path: &Path) -> PathBuf {
+    legacy_autosave_owner_marker_path(notebook_path)
 }
 
 #[cfg(test)]
@@ -2138,8 +2063,8 @@ fn sibling_temp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(".{file_name}.{}-{n}.tmp", std::process::id()))
 }
 
-/// Atomic-write core for the non-durable convenience tier (persisted
-/// notebook doc mirrors, autosave owner markers, comments sidecar docs).
+/// Atomic-write core for the non-durable convenience tier (persisted notebook
+/// doc mirrors and comments sidecar docs).
 ///
 /// Creates the parent directory, writes `bytes` to a same-directory temp
 /// file, preserves the destination's permissions when it already exists,
@@ -2171,16 +2096,6 @@ pub(crate) fn write_file_atomic_sync(path: &Path, bytes: &[u8]) -> std::io::Resu
             Err(e)
         }
     }
-}
-
-/// Async adapter over [`write_file_atomic_sync`] for callers already on the
-/// async save path; the blocking file I/O runs on the blocking pool.
-async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let path = path.to_path_buf();
-    let bytes = bytes.to_vec();
-    tokio::task::spawn_blocking(move || write_file_atomic_sync(&path, &bytes))
-        .await
-        .map_err(std::io::Error::other)?
 }
 
 // =============================================================================

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -953,17 +953,6 @@ async fn guard_and_cleanup_legacy_autosave_owner(notebook_path: &Path) -> Result
         }
     };
 
-    if existing.schema_version != LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION
-        || existing.notebook_path != notebook_path
-    {
-        warn!(
-            "[notebook-sync] Removing invalid legacy autosave owner marker {:?}",
-            marker_path
-        );
-        remove_legacy_autosave_owner_marker(&marker_path).await?;
-        return Ok(());
-    }
-
     if !existing.belongs_to_current_process() && autosave_owner_process_is_live(existing.pid) {
         error!(
             "[notebook-sync] Refusing to save {:?}: legacy autosave owner marker {:?} belongs to live daemon pid={} daemon_id={}. Stop that daemon or reconnect through it before saving this path.",
@@ -978,6 +967,17 @@ async fn guard_and_cleanup_legacy_autosave_owner(notebook_path: &Path) -> Result
             existing.pid,
             marker_path.display()
         )));
+    }
+
+    if existing.schema_version != LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION
+        || existing.notebook_path != notebook_path
+    {
+        warn!(
+            "[notebook-sync] Removing invalid legacy autosave owner marker {:?}",
+            marker_path
+        );
+        remove_legacy_autosave_owner_marker(&marker_path).await?;
+        return Ok(());
     }
 
     warn!(
@@ -1032,11 +1032,27 @@ pub(crate) async fn write_legacy_autosave_owner_marker_for_test(
     daemon_id: &str,
     pid: u32,
 ) {
+    write_legacy_autosave_owner_marker_with_recorded_path_for_test(
+        notebook_path,
+        notebook_path,
+        daemon_id,
+        pid,
+    )
+    .await;
+}
+
+#[cfg(test)]
+pub(crate) async fn write_legacy_autosave_owner_marker_with_recorded_path_for_test(
+    notebook_path: &Path,
+    recorded_path: &Path,
+    daemon_id: &str,
+    pid: u32,
+) {
     let marker = LegacyAutosaveOwnerMarker {
         schema_version: LEGACY_AUTOSAVE_OWNER_SCHEMA_VERSION,
         daemon_id: daemon_id.to_string(),
         pid,
-        notebook_path: notebook_path.to_path_buf(),
+        notebook_path: recorded_path.to_path_buf(),
         claimed_at_unix_ms: unix_now_ms(),
     };
     let marker_path = legacy_autosave_owner_marker_path(notebook_path);

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1523,11 +1523,11 @@ pub struct NotebookRoom {
     /// Read via `is_hosted()`; set once via `mark_hosted()` before peers attach.
     pub(crate) hosted: AtomicBool,
     /// Latched by eviction (reaper or ShutdownNotebook) after the final
-    /// autosave flush, right before the autosave owner marker and file
-    /// claim release hand the path to other daemon processes. Once set,
+    /// autosave flush, right before legacy sidecar cleanup and file-claim
+    /// release hand the path to other daemon processes. Once set,
     /// primary-path saves refuse and late disconnect-teardown work
-    /// aborts, so no straggler task can re-claim the marker or rewrite
-    /// the file after the handoff. Monotonic: an evicted room Arc is
+    /// aborts, so no straggler task can rewrite the file after the handoff.
+    /// Monotonic: an evicted room Arc is
     /// never re-registered (reconnects mint a fresh room instance).
     pub(crate) evicted: AtomicBool,
     /// Blob store for output manifests.
@@ -1751,7 +1751,7 @@ impl NotebookRoom {
     }
 
     /// Latch eviction. Call after the eviction path's final autosave
-    /// flush and before releasing the autosave owner marker; see the
+    /// flush and before releasing the cache-scoped file claim; see the
     /// `evicted` field docs for what the latch suppresses.
     pub fn mark_evicted(&self) {
         self.evicted.store(true, Ordering::Release);

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7268,18 +7268,19 @@ async fn autosave_refuses_to_overwrite_externally_changed_file() {
     );
 }
 
-/// Cross-daemon ownership guard (#2285): if another live daemon has claimed
-/// this autosave path, this daemon must make the collision loud and leave the
-/// existing file untouched.
+/// Mixed-version guard: a live pre-fix daemon's sibling marker still blocks a
+/// save, so upgrading one of two concurrently running channels cannot silently
+/// clobber the older daemon's notebook.
 #[tokio::test]
-async fn autosave_refuses_live_foreign_owner_marker() {
+async fn autosave_refuses_live_legacy_owner_marker() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, notebook_path) = test_room_with_path(&tmp, "live-owner.ipynb");
     write_two_cell_notebook(&notebook_path).await;
 
     let foreign_pid = 424_242;
     let _live = override_autosave_owner_liveness_for_test(foreign_pid, true);
-    write_autosave_owner_marker_for_test(&notebook_path, "foreign-daemon", foreign_pid).await;
+    write_legacy_autosave_owner_marker_for_test(&notebook_path, "foreign-daemon", foreign_pid)
+        .await;
 
     {
         let mut doc = room.doc.write().await;
@@ -7292,7 +7293,7 @@ async fn autosave_refuses_live_foreign_owner_marker() {
         panic!("live foreign owner must be unrecoverable, got {err:?}");
     };
     assert!(
-        message.contains("owned by live daemon pid 424242"),
+        message.contains("owned by live legacy daemon pid 424242"),
         "error should name the live owner pid; got {message}"
     );
     assert_eq!(
@@ -7301,22 +7302,24 @@ async fn autosave_refuses_live_foreign_owner_marker() {
         "live owner refusal must not clobber the existing notebook"
     );
 
-    let marker = read_autosave_owner_marker_for_test(&notebook_path).await;
-    assert_eq!(marker.daemon_id, "foreign-daemon");
-    assert_eq!(marker.pid, foreign_pid);
+    assert!(
+        legacy_autosave_owner_marker_path_for_test(&notebook_path).exists(),
+        "a live older daemon's marker must be left alone"
+    );
 }
 
-/// A dead daemon's marker is safe to adopt. This keeps crash recovery working:
-/// a new daemon can autosave the path once the recorded owner process is gone.
+/// A dead daemon's old marker is removed rather than adopted. The shared claim
+/// registry now carries ownership, so successful migration leaves no sibling
+/// coordination file in the user's directory.
 #[tokio::test]
-async fn autosave_takes_over_dead_foreign_owner_marker() {
+async fn autosave_removes_dead_legacy_owner_marker() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, notebook_path) = test_room_with_path(&tmp, "dead-owner.ipynb");
     write_two_cell_notebook(&notebook_path).await;
 
     let dead_pid = 515_151;
     let _dead = override_autosave_owner_liveness_for_test(dead_pid, false);
-    write_autosave_owner_marker_for_test(&notebook_path, "dead-daemon", dead_pid).await;
+    write_legacy_autosave_owner_marker_for_test(&notebook_path, "dead-daemon", dead_pid).await;
 
     {
         let mut doc = room.doc.write().await;
@@ -7326,16 +7329,39 @@ async fn autosave_takes_over_dead_foreign_owner_marker() {
 
     save_notebook_to_disk(&room, None)
         .await
-        .expect("dead owner marker should be adopted");
+        .expect("dead legacy owner marker should be removed");
 
     let on_disk = tokio::fs::read_to_string(&notebook_path).await.unwrap();
     assert!(
         on_disk.contains("takeover = 1"),
         "takeover save should write the local room state"
     );
-    let marker = read_autosave_owner_marker_for_test(&notebook_path).await;
-    assert_eq!(marker.pid, std::process::id());
-    assert_eq!(marker.daemon_id, current_autosave_owner_id_for_test());
+    assert!(
+        !legacy_autosave_owner_marker_path_for_test(&notebook_path).exists(),
+        "a successful save must not replace the legacy marker with new sidecar state"
+    );
+}
+
+/// A normal primary-path save never creates a `.runtlock` sibling. Ownership
+/// belongs to the cache-scoped file-claim registry, not the user's project.
+#[tokio::test]
+async fn autosave_does_not_create_notebook_sidecar() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "clean-directory.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "clean = true").unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    assert!(notebook_path.exists());
+    assert!(
+        !legacy_autosave_owner_marker_path_for_test(&notebook_path).exists(),
+        "saving must not pollute the notebook directory with a .runtlock file"
+    );
 }
 
 /// Saves to a non-primary path (Save As) are not staleness-guarded:

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7308,6 +7308,38 @@ async fn autosave_refuses_live_legacy_owner_marker() {
     );
 }
 
+/// A live marker remains authoritative even when its recorded path is from an
+/// older daemon's non-canonical spelling. Validate shape only after liveness so
+/// a path-normalization skew cannot delete another process's active guard.
+#[tokio::test]
+async fn autosave_refuses_live_legacy_owner_marker_with_path_mismatch() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "live-owner-path-skew.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    let foreign_pid = 424_243;
+    let _live = override_autosave_owner_liveness_for_test(foreign_pid, true);
+    write_legacy_autosave_owner_marker_with_recorded_path_for_test(
+        &notebook_path,
+        &tmp.path().join("different-spelling.ipynb"),
+        "foreign-daemon",
+        foreign_pid,
+    )
+    .await;
+
+    let err = save_notebook_to_disk(&room, None).await.unwrap_err();
+    assert!(matches!(err, SaveError::Unrecoverable(_)));
+    assert!(
+        legacy_autosave_owner_marker_path_for_test(&notebook_path).exists(),
+        "path validation must not remove a live older daemon's marker"
+    );
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        2,
+        "path normalization skew must not permit a conflicting save"
+    );
+}
+
 /// A dead daemon's old marker is removed rather than adopted. The shared claim
 /// registry now carries ownership, so successful migration leaves no sibling
 /// coordination file in the user's directory.

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -7,9 +7,9 @@ use tracing::warn;
 
 use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
-    canonical_target_path, finalize_untitled_promotion, format_notebook_cells,
-    persist_notebook_bytes, refresh_primary_baseline_from_checkpoint,
-    release_autosave_owner_marker_for_path, save_notebook_to_disk_with_claim_and_intent,
+    canonical_target_path, cleanup_legacy_autosave_owner_marker_for_path,
+    finalize_untitled_promotion, format_notebook_cells, persist_notebook_bytes,
+    refresh_primary_baseline_from_checkpoint, save_notebook_to_disk_with_claim_and_intent,
     FileSaveIntent, FileSaveOutcome, NotebookFileBinding, NotebookRoom, SaveError,
 };
 use crate::protocol::NotebookResponse;
@@ -284,7 +284,7 @@ async fn handle_with_intent(
             // Move the persistent binding with the room: the old path is now a
             // different (or absent) file and must not resolve to this id.
             daemon.notebook_registry.forget(old);
-            release_autosave_owner_marker_for_path(old).await;
+            cleanup_legacy_autosave_owner_marker_for_path(old).await;
             // Move the cross-daemon file claim with the room too: this
             // daemon no longer serves the old path.
             let _ = daemon.file_claims.release(old, &daemon.file_claim_owner());

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -5212,11 +5212,9 @@ async fn test_open_notebook_same_daemon_reopen_refreshes_claim() {
     stop_claiming_daemon(&socket_a, handle_a).await;
 }
 
-/// Evicting the room via ShutdownNotebook releases both the cross-daemon
-/// claim and the on-disk autosave owner marker, so a second daemon can not
-/// only open the path but also save to it. A claim release without the
-/// marker release would advertise a handoff the successor cannot use: its
-/// first save would refuse against the first daemon's live-pid marker.
+/// Evicting the room via ShutdownNotebook releases the cache-scoped
+/// cross-daemon claim, so a second daemon can open and save the path without
+/// any coordination files appearing beside the notebook.
 #[tokio::test]
 async fn test_notebook_shutdown_releases_claim_for_other_daemons() {
     let claims_root = TempDir::new().unwrap();
@@ -5234,8 +5232,7 @@ async fn test_notebook_shutdown_releases_claim_for_other_daemons() {
         .expect("daemon A should open the notebook");
     let notebook_id = opened.info.notebook_id.clone();
 
-    // An explicit save stamps the autosave owner marker next to the file
-    // with daemon A's identity, exactly like any autosave would.
+    // An explicit save must not stamp coordination state next to user data.
     let save = opened
         .handle
         .send_request(NotebookRequest::SaveNotebook {
@@ -5253,16 +5250,15 @@ async fn test_notebook_shutdown_releases_claim_for_other_daemons() {
         "unexpected save response: {save:?}"
     );
     assert!(
-        marker_path.exists(),
-        "save must stamp the autosave owner marker"
+        !marker_path.exists(),
+        "save must not create an autosave owner marker beside the notebook"
     );
     drop(opened);
 
     let registry = runt_workspace::file_claims::FileClaimRegistry::at_dir(claims_dir.clone());
     assert!(registry.read(&canonical).is_some());
 
-    // Close the room on daemon A; the claim and the marker must be
-    // released with it.
+    // Close the room on daemon A; the shared claim must be released with it.
     let pool_client_a = PoolClient::new(socket_a.clone());
     assert!(pool_client_a
         .shutdown_notebook(&notebook_id)
@@ -5274,7 +5270,7 @@ async fn test_notebook_shutdown_releases_claim_for_other_daemons() {
     );
     assert!(
         !marker_path.exists(),
-        "room eviction must release the autosave owner marker along with the claim"
+        "room eviction must leave the notebook directory free of lock sidecars"
     );
 
     // Daemon B can now open the path and save to it.
@@ -5408,9 +5404,9 @@ async fn test_claim_reconciler_never_overwrites_live_foreign_claim() {
     stop_claiming_daemon(&socket_a, handle_a).await;
 }
 
-/// Claims follow activity, not room residency: a clean idle room
-/// releases its claim (and the autosave owner marker) after the grace
-/// window, another daemon can then take the path, and reconnecting
+/// Claims follow activity, not room residency: a clean idle room releases its
+/// cache-scoped claim after the grace window, another daemon can then take the
+/// path, and reconnecting
 /// through the first daemon's still-resident room is refused with the
 /// structured error while the foreign claim is live.
 #[tokio::test]
@@ -5453,7 +5449,7 @@ async fn test_idle_clean_room_releases_claim_and_hands_off() {
     }
     assert!(
         !marker_path.exists(),
-        "idle release must drop the autosave owner marker with the claim"
+        "idle release must leave the notebook directory free of lock sidecars"
     );
 
     // Daemon B takes the freed path.


### PR DESCRIPTION
## Summary

- stop creating `<notebook>.ipynb.runtlock` coordination files beside user notebooks
- rely on the existing cache-scoped cross-daemon file claim plus causal file-checkpoint fingerprinting
- retain mixed-version safety by refusing saves while a valid legacy marker names another live daemon
- remove dead, invalid, or unreadable legacy markers during save and handoff instead of adopting or recreating them

## Compatibility

A fixed daemon still honors a live marker written by an older daemon. Once that older process exits, the next save removes the marker. Fixed daemons publish ownership through the shared file-claim registry, which every released 2.7 stable build already consults before opening a notebook. The 2.6 stable line predates both the shared claims and `.runtlock`, so retiring the sidecar does not remove a compatibility signal that those builds previously understood.

## Tests

- `cargo xtask lint --fix`
- `cargo test -p runtimed autosave_ --lib`
- `cargo test -p runtimed --test integration test_notebook_shutdown_releases_claim_for_other_daemons -- --exact`
- `cargo test -p runtimed --test integration test_idle_clean_room_releases_claim_and_hands_off -- --exact`
- `cargo test -p runtimed --lib -- --test-threads=1` (1,338 passed; 3 ignored)
- `cargo test -p runtimed --test tokio_mutex_lint`

The default parallel library suite also completed every code-path test, but its shell-startup smoke test intermittently observed an empty shell environment under load. That test passed alone and in the serialized full suite.
