### PR TITLE
fix(macos): declare microphone access for notebook kernels

### DIFF
--- a/crates/notebook/Info.plist
+++ b/crates/notebook/Info.plist
@@ -7,5 +7,7 @@
   <false/>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Notebook code needs microphone access to record or stream audio.</string>
 </dict>
 </plist>

--- a/crates/notebook/entitlements.plist
+++ b/crates/notebook/entitlements.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.inherit</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `NSMicrophoneUsageDescription` to the packaged desktop app: "Notebook code needs microphone access to record or stream audio."
- Add `com.apple.security.device.audio-input` to the existing macOS signing entitlements.
- Keep scope to packaged desktop builds; no camera permissions, system-audio capture permissions, automatic permission request, or dev-daemon identity changes.

## Why
Notebook code using `sounddevice` needs macOS microphone authorization. The app currently declares neither the usage description nor the audio-input entitlement, despite enabling Hardened Runtime. `soundfile` handles audio files; it does not itself capture microphone input.

The configured Tauri bundler merges this Info.plist and applies the entitlement file to configured app and sidecar signing targets, including `runtimed`. The packaged service normally runs the in-bundle daemon, which launches runtime agents and Python kernels. These declarations address known packaging gaps, but do not by themselves prove TCC attributes the entire process chain to nteract. Entitlements on the sidecar are not a blanket inheritance mechanism for arbitrary Python executables.

References: [Apple microphone usage description](https://developer.apple.com/documentation/bundleresources/information-property-list/nsmicrophoneusagedescription), [Apple Audio Input entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.device.audio-input).

## Validation
- [x] `plutil -lint crates/notebook/Info.plist crates/notebook/entitlements.plist`
- [x] `cargo xtask lint --fix` (Rust formatting, JS/TS formatting/lint, Python ruff and ty)
- [x] `git diff --check`
- [ ] Inspect a newly signed app artifact: verify the merged usage string and the audio-input entitlement on the main app and bundled runtimed.
- [ ] Launch that build normally, confirm its bundled daemon is serving the notebook, and trigger real input capture with `sounddevice.rec` or `sounddevice.InputStream` rather than just importing modules or listing devices. Verify prompt attribution and non-silent capture after approval.
- [ ] Exercise denied access and a fresh consent state; record observed behavior rather than assuming PortAudio always reports denial as an exception.

## Draft status
Signed-app microphone testing is still outstanding; no microphone capture or permission reset was performed during this change. Existing grants or denials can suppress the prompt. Bare dev/standalone daemons have a different launch/identity path and are deliberately deferred.