### PR TITLE
fix(notebook): align command-mode focus and navigation

### DIFF
--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -216,7 +216,8 @@ test.describe("markdown parity", () => {
     await firstPreview.focus();
     await page.keyboard.press("ArrowDown");
     await expect.poll(() => activeCellId(page)).toBe(secondCellId);
-    await expect(secondMarkdown.getByLabel("Markdown cell content")).toBeFocused();
+    await expect(page.locator(`[data-cell-command-focus="${secondCellId}"]`)).toBeFocused();
+    await expect(secondMarkdown.getByLabel("Markdown cell content")).not.toBeFocused();
   });
 
   test("navigates mixed cells with arrows while staying in command mode", async ({ page }) => {
@@ -241,21 +242,30 @@ test.describe("markdown parity", () => {
     await page.keyboard.press("Escape");
     await expect(firstEditor).not.toBeFocused();
 
+    const markdownCommandFocus = page.locator(`[data-cell-command-focus="${markdownId}"]`);
+    const codeCommandFocus = page.locator(`[data-cell-command-focus="${secondCodeId}"]`);
     await page.keyboard.press("ArrowDown");
-    await expect(markdownPreview).toBeFocused();
+    await expect(markdownCommandFocus).toBeFocused();
+    await expect(markdownPreview).not.toBeFocused();
 
-    // The Markdown preview retains DOM focus when selection moves to code.
-    // A subsequent arrow must use the live command-mode target, not this
-    // preview's stale cell closure.
+    await markdownPreview.focus();
     await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("ArrowUp");
-    await expect(markdownPreview).toBeFocused();
-
-    await page.keyboard.press("ArrowDown");
+    await expect(codeCommandFocus).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(codeCommandFocus).toBeFocused();
+    await expect.poll(() => activeCellId(page)).toBe(secondCodeId);
     await page.keyboard.press("Enter");
     await expect(secondEditor).toBeFocused();
     await expect(firstEditor).not.toBeFocused();
     await expect(secondCode).toBeInViewport();
+
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("k");
+    await expect(markdownCommandFocus).toBeFocused();
+    await page.keyboard.press("j");
+    await expect(codeCommandFocus).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(secondEditor).toBeFocused();
   });
 
   test("renders selectable markdown outputs without changing output routing semantics", async ({
@@ -456,7 +466,11 @@ async function activeCellId(page: Page): Promise<string | null> {
   return await page.evaluate(() => {
     const activeElement = document.activeElement;
     return (
-      activeElement?.closest('[data-slot="cell-container"]')?.getAttribute("data-cell-id") ?? null
+      activeElement
+        ?.closest("[data-cell-command-focus]")
+        ?.getAttribute("data-cell-command-focus") ??
+      activeElement?.closest('[data-slot="cell-container"]')?.getAttribute("data-cell-id") ??
+      null
     );
   });
 }

--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -219,6 +219,45 @@ test.describe("markdown parity", () => {
     await expect(secondMarkdown.getByLabel("Markdown cell content")).toBeFocused();
   });
 
+  test("navigates mixed cells with arrows while staying in command mode", async ({ page }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    const firstCodeId = await mcp.createCell("# command navigation first", "code");
+    const markdownId = await mcp.createCell("# Command navigation middle", "markdown");
+    const secondCodeId = await mcp.createCell("# command navigation last", "code");
+    await waitForCellCount(page, 4);
+
+    const firstCode = page.locator(`[data-cell-id="${firstCodeId}"]`);
+    const markdown = page.locator(`[data-cell-id="${markdownId}"]`);
+    const secondCode = page.locator(`[data-cell-id="${secondCodeId}"]`);
+    const firstEditor = firstCode.locator('.cm-content[contenteditable="true"]');
+    const secondEditor = secondCode.locator('.cm-content[contenteditable="true"]');
+    const markdownPreview = markdown.getByLabel("Markdown cell content");
+
+    await firstEditor.focus();
+    await page.keyboard.press("Escape");
+    await expect(firstEditor).not.toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await expect(markdownPreview).toBeFocused();
+
+    // The Markdown preview retains DOM focus when selection moves to code.
+    // A subsequent arrow must use the live command-mode target, not this
+    // preview's stale cell closure.
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowUp");
+    await expect(markdownPreview).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+    await expect(secondEditor).toBeFocused();
+    await expect(firstEditor).not.toBeFocused();
+    await expect(secondCode).toBeInViewport();
+  });
+
   test("renders selectable markdown outputs without changing output routing semantics", async ({
     page,
   }) => {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -847,10 +847,12 @@ export const MarkdownCell = memo(function MarkdownCell({
         onEnterCommandMode?.();
         e.preventDefault();
       } else if (e.key === "ArrowDown") {
+        if (getActiveInteractionTarget()?.kind === "cell") return;
         if (onPreviewFocusNext) onPreviewFocusNext();
         else onFocusNext?.("start");
         e.preventDefault();
       } else if (e.key === "ArrowUp") {
+        if (getActiveInteractionTarget()?.kind === "cell") return;
         if (onPreviewFocusPrevious) onPreviewFocusPrevious();
         else onFocusPrevious?.("end");
         e.preventDefault();

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -834,6 +834,8 @@ export const MarkdownCell = memo(function MarkdownCell({
   // Handle keyboard navigation in view mode (when not editing)
   const handleViewKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      const interactionTarget = getActiveInteractionTarget();
+      if (interactionTarget && interactionTarget.cellId !== cell.id) return;
       const key = e.key.toLowerCase();
       if (key === "m" && e.altKey && (e.metaKey || e.ctrlKey)) {
         if (requestRenderedSourceComment()) {
@@ -865,14 +867,6 @@ export const MarkdownCell = memo(function MarkdownCell({
         e.preventDefault();
       } else if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
         if (readOnly) {
-          return;
-        }
-        const interactionTarget = getActiveInteractionTarget();
-        // Cell insertion updates the notebook interaction target synchronously,
-        // but the previously selected Markdown preview may retain DOM focus.
-        // Let the document-level command-mode handler process Enter for the
-        // newly selected cell instead of reclaiming focus for this stale view.
-        if (interactionTarget && interactionTarget.cellId !== cell.id) {
           return;
         }
         // Enter: enter edit mode
@@ -1095,15 +1089,6 @@ export const MarkdownCell = memo(function MarkdownCell({
       frameRef.current.search(searchQuery || "");
     }
   }, [searchQuery, editing, canRenderProjectionInHost]);
-
-  // Focus view section when cell becomes focused but not editing
-  useEffect(() => {
-    if (isFocused && !editing) {
-      requestAnimationFrame(() => {
-        viewRef.current?.focus({ preventScroll: true });
-      });
-    }
-  }, [isFocused, editing]);
 
   return (
     <CellContainer

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -41,6 +41,7 @@ import type { TracebackCellTarget } from "@/components/outputs/traceback-output"
 import { usePresenceContext } from "@/components/notebook/presence-context";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { type CommandModeCommand, useCommandMode } from "../hooks/useCommandMode";
+import { findAdjacentVisibleCellId, type CellNavigationDirection } from "../lib/cell-navigation";
 import {
   flushCellUIState,
   getFocusedCellId,
@@ -777,9 +778,38 @@ function NotebookViewContent({
     [canMutateCells, handleDeleteCell, onAddCell, onChangeCellType, onSetCellOutputsHidden],
   );
 
+  const isVisibleCell = useCallback((cellId: string) => {
+    const group = hiddenGroupsRef.current.get(cellId);
+    return !group || group.isFirst;
+  }, []);
+
+  const navigateCommandModeSelection = useCallback(
+    (direction: CellNavigationDirection, cellId: string): boolean => {
+      const targetCellId = findAdjacentVisibleCellId(
+        cellIdsRef.current,
+        cellId,
+        direction,
+        isVisibleCell,
+      );
+      if (!targetCellId) return false;
+
+      focusInteractionTarget({ kind: "cell", cellId: targetCellId });
+      window.requestAnimationFrame(() => {
+        containerRef.current
+          ?.querySelector<HTMLElement>(
+            `[data-slot="cell-container"][data-cell-id="${CSS.escape(targetCellId)}"]`,
+          )
+          ?.scrollIntoView({ block: "nearest" });
+      });
+      return true;
+    },
+    [focusInteractionTarget, isVisibleCell],
+  );
+
   useCommandMode({
     showCommandMode,
     enterEditMode,
+    navigateSelection: navigateCommandModeSelection,
     runCommand: runCommandModeAction,
     disabled: isLoading || cellIds.length === 0,
   });
@@ -896,22 +926,17 @@ function NotebookViewContent({
       dragHandleProps?: Record<string, unknown>,
       isDragging?: boolean,
     ) => {
-      // Navigation callbacks — skip cells that are collapsed into a hidden group
-      const isVisibleCell = (id: string) => {
-        const g = hiddenGroupsRef.current.get(id);
-        return !g || g.isFirst;
-      };
-
       const onFocusPrevious = (cursorPosition: "start" | "end") => {
         logger.debug(
           `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        let prevIndex = index - 1;
-        while (prevIndex >= 0 && !isVisibleCell(cellIdsRef.current[prevIndex])) {
-          prevIndex--;
-        }
-        if (prevIndex >= 0) {
-          const prevCellId = cellIdsRef.current[prevIndex];
+        const prevCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          "previous",
+          isVisibleCell,
+        );
+        if (prevCellId) {
           logger.debug(`[cell-nav] Focusing previous: ${prevCellId.slice(0, 8)}`);
           focusInteractionTarget({ kind: "editor", cellId: prevCellId });
           focusCell(prevCellId, cursorPosition);
@@ -924,15 +949,13 @@ function NotebookViewContent({
         logger.debug(
           `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        let nextIndex = index + 1;
-        while (
-          nextIndex < cellIdsRef.current.length &&
-          !isVisibleCell(cellIdsRef.current[nextIndex])
-        ) {
-          nextIndex++;
-        }
-        if (nextIndex < cellIdsRef.current.length) {
-          const nextCellId = cellIdsRef.current[nextIndex];
+        const nextCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          "next",
+          isVisibleCell,
+        );
+        if (nextCellId) {
           logger.debug(`[cell-nav] Focusing next: ${nextCellId.slice(0, 8)}`);
           focusInteractionTarget({ kind: "editor", cellId: nextCellId });
           focusCell(nextCellId, cursorPosition);
@@ -942,18 +965,13 @@ function NotebookViewContent({
       };
 
       const focusRenderedCell = (direction: "previous" | "next") => {
-        const step = direction === "previous" ? -1 : 1;
-        let targetIndex = index + step;
-        while (
-          targetIndex >= 0 &&
-          targetIndex < cellIdsRef.current.length &&
-          !isVisibleCell(cellIdsRef.current[targetIndex])
-        ) {
-          targetIndex += step;
-        }
-        if (targetIndex < 0 || targetIndex >= cellIdsRef.current.length) return;
-
-        const targetCellId = cellIdsRef.current[targetIndex];
+        const targetCellId = findAdjacentVisibleCellId(
+          cellIdsRef.current,
+          cell.id,
+          direction,
+          isVisibleCell,
+        );
+        if (!targetCellId) return;
         const targetCell = getCellById(targetCellId);
         if (targetCell?.cell_type !== "markdown") {
           focusInteractionTarget({ kind: "editor", cellId: targetCellId });
@@ -1241,6 +1259,7 @@ function NotebookViewContent({
     [
       runtime,
       focusInteractionTarget,
+      isVisibleCell,
       suppressTailFollowForInPlaceExecution,
       onExecuteCell,
       onInterruptKernel,

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -44,8 +44,10 @@ import { type CommandModeCommand, useCommandMode } from "../hooks/useCommandMode
 import { findAdjacentVisibleCellId, type CellNavigationDirection } from "../lib/cell-navigation";
 import {
   flushCellUIState,
+  getActiveInteractionTarget,
   getFocusedCellId,
   setActiveInteractionTarget,
+  useActiveInteractionTarget,
   useFocusedCellId,
   useSearchCurrentMatch,
 } from "@/components/notebook/state/cell-ui-state";
@@ -305,6 +307,8 @@ function SortableCell({
   onDeleteCell,
   isLastCell,
   isHiddenInGroup,
+  isCommandTarget,
+  onCommandFocus,
   canMutateCells,
 }: {
   cellId: string;
@@ -319,6 +323,8 @@ function SortableCell({
   onDeleteCell: (cellId: string) => void;
   isLastCell?: boolean;
   isHiddenInGroup?: boolean;
+  isCommandTarget: boolean;
+  onCommandFocus: (cellId: string) => void;
   canMutateCells: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -347,7 +353,22 @@ function SortableCell({
   }
 
   return (
-    <div id={anchorId} ref={setNodeRef} style={style}>
+    <div
+      id={anchorId}
+      ref={setNodeRef}
+      style={style}
+      role="group"
+      aria-label={`Cell ${index + 1}`}
+      tabIndex={isCommandTarget ? 0 : -1}
+      data-cell-command-focus={cellId}
+      className="outline-none"
+      onFocus={(event) => {
+        if (event.target !== event.currentTarget) return;
+        const target = getActiveInteractionTarget();
+        if (target?.kind === "cell" && target.cellId === cellId) return;
+        onCommandFocus(cellId);
+      }}
+    >
       {canMutateCells && index === 0 && <CellAdder afterCellId={null} onAdd={onAddCell} />}
       <ErrorBoundary
         fallback={(error, resetErrorBoundary) => (
@@ -417,6 +438,28 @@ function NotebookViewContent({
 
   // Read transient UI state from the store instead of props
   const focusedCellId = useFocusedCellId();
+  const activeInteractionTarget = useActiveInteractionTarget();
+  const focusCommandCell = useCallback((cellId: string) => {
+    containerRef.current
+      ?.querySelector<HTMLElement>(`[data-cell-command-focus="${CSS.escape(cellId)}"]`)
+      ?.focus({ preventScroll: true });
+  }, []);
+
+  const commandFocusCellId =
+    activeInteractionTarget?.kind === "cell" && cellIds.includes(activeInteractionTarget.cellId)
+      ? activeInteractionTarget.cellId
+      : null;
+
+  useLayoutEffect(() => {
+    if (!commandFocusCellId) return;
+    const target = containerRef.current?.querySelector<HTMLElement>(
+      `[data-cell-command-focus="${CSS.escape(commandFocusCellId)}"]`,
+    );
+    const active = document.activeElement;
+    if (active && target?.contains(active) && !active.closest(".cm-editor")) return;
+    target?.focus({ preventScroll: true });
+  }, [commandFocusCellId]);
+
   const searchCurrentMatch = useSearchCurrentMatch();
   const outputFocusedCellId = useOutputFocusedCellId();
   // FSB-1 failure surface: outputs whose projection failed after retries.
@@ -467,6 +510,11 @@ function NotebookViewContent({
     [onFocusCell, publishInteractionTarget],
   );
 
+  const handleCommandCellFocus = useCallback(
+    (cellId: string) => focusInteractionTarget({ kind: "cell", cellId }),
+    [focusInteractionTarget],
+  );
+
   // Shared "leave output focus, select the cell without editing" exit,
   // used by both command mode (Escape) and the click-outside dismissal
   // below, so the two paths can't drift on what "exit to cell" means.
@@ -493,7 +541,8 @@ function NotebookViewContent({
       document.activeElement.blur();
     }
     exitToCellSelection(cellId);
-  }, [exitToCellSelection]);
+    focusCommandCell(cellId);
+  }, [exitToCellSelection, focusCommandCell]);
 
   // Click-outside-container exit. Clicking another cell's editor already
   // clears focus via the selection-change effect above, but clicking another
@@ -794,6 +843,7 @@ function NotebookViewContent({
       if (!targetCellId) return false;
 
       focusInteractionTarget({ kind: "cell", cellId: targetCellId });
+      focusCommandCell(targetCellId);
       window.requestAnimationFrame(() => {
         containerRef.current
           ?.querySelector<HTMLElement>(
@@ -803,7 +853,7 @@ function NotebookViewContent({
       });
       return true;
     },
-    [focusInteractionTarget, isVisibleCell],
+    [focusCommandCell, focusInteractionTarget, isVisibleCell],
   );
 
   useCommandMode({
@@ -981,6 +1031,8 @@ function NotebookViewContent({
 
         focusInteractionTarget({ kind: "cell", cellId: targetCellId });
         requestAnimationFrame(() => {
+          const target = getActiveInteractionTarget();
+          if (target?.kind !== "cell" || target.cellId !== targetCellId) return;
           document
             .getElementById(targetCellId)
             ?.querySelector<HTMLElement>('[aria-label="Markdown cell content"]')
@@ -999,6 +1051,7 @@ function NotebookViewContent({
       // cell stays selected but its editor no longer holds DOM focus.
       const onEnterCommandMode = () => {
         focusInteractionTarget({ kind: "cell", cellId: cell.id });
+        focusCommandCell(cell.id);
       };
 
       // Build right gutter content — delete button for all cells,
@@ -1258,6 +1311,7 @@ function NotebookViewContent({
     },
     [
       runtime,
+      focusCommandCell,
       focusInteractionTarget,
       isVisibleCell,
       suppressTailFollowForInPlaceExecution,
@@ -1405,6 +1459,8 @@ function NotebookViewContent({
                     onDeleteCell={handleDeleteCell}
                     isLastCell={index === cellIds.length - 1}
                     isHiddenInGroup={group != null && !group.isFirst}
+                    isCommandTarget={commandFocusCellId === cellId}
+                    onCommandFocus={handleCommandCellFocus}
                     canMutateCells={canMutateCells}
                   />
                 );

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -445,7 +445,7 @@ describe("MarkdownCell theme sync", () => {
     expect(frameProps?.minHeight).toBeGreaterThan(24);
   });
 
-  it("focuses the markdown preview without scrolling when the cell becomes focused", async () => {
+  it("does not focus the markdown preview merely because the cell becomes selected", async () => {
     const focusSpy = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
 
     const { rerender } = render(
@@ -457,9 +457,8 @@ describe("MarkdownCell theme sync", () => {
     mockIsFocused = true;
     rerender(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
 
-    await waitFor(() => {
-      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
-    });
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    expect(focusSpy).not.toHaveBeenCalled();
   });
 
   it("selects a rendered markdown cell without publishing editor focus", () => {
@@ -896,20 +895,43 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
-  it("does not let a stale preview reclaim focus from another selected cell", () => {
+  it.each([
+    { key: "Enter" },
+    { key: "Enter", shiftKey: true },
+    { key: "Enter", ctrlKey: true },
+    { key: "Escape" },
+    { key: "ArrowDown" },
+    { key: "ArrowUp" },
+    { key: "j" },
+    { key: "k" },
+    { key: "m", ctrlKey: true, altKey: true },
+  ])("does not let a stale preview handle $key for another selected cell", (event) => {
     const cell = makeCell();
     const onFocus = vi.fn();
+    const onEnterCommandMode = vi.fn();
+    const onFocusNext = vi.fn();
+    const onFocusPrevious = vi.fn();
+    const onCreateSourceComment = vi.fn();
     mockActiveInteractionTarget = { kind: "cell", cellId: "new-code-cell" };
 
     const { getByLabelText } = render(
-      <MarkdownCell cell={cell} onFocus={onFocus} onDelete={() => {}} />,
+      <MarkdownCell
+        cell={cell}
+        onFocus={onFocus}
+        onEnterCommandMode={onEnterCommandMode}
+        onFocusNext={onFocusNext}
+        onFocusPrevious={onFocusPrevious}
+        onCreateSourceComment={onCreateSourceComment}
+      />,
     );
 
     const preview = getByLabelText("Markdown cell content");
-    const handled = fireEvent.keyDown(preview, { key: "Enter" });
-
-    expect(handled).toBe(true);
+    expect(fireEvent.keyDown(preview, event)).toBe(true);
     expect(onFocus).not.toHaveBeenCalled();
+    expect(onEnterCommandMode).not.toHaveBeenCalled();
+    expect(onFocusNext).not.toHaveBeenCalled();
+    expect(onFocusPrevious).not.toHaveBeenCalled();
+    expect(onCreateSourceComment).not.toHaveBeenCalled();
     expect(preview.className).not.toContain("hidden");
   });
 

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -993,6 +993,28 @@ describe("MarkdownCell theme sync", () => {
     expect(onFocusPrevious).not.toHaveBeenCalled();
   });
 
+  it("lets command-mode arrows bubble to notebook selection navigation", () => {
+    const cell = makeCell();
+    mockActiveInteractionTarget = { kind: "cell", cellId: cell.id };
+    const onPreviewFocusNext = vi.fn();
+    const onPreviewFocusPrevious = vi.fn();
+
+    const { getByLabelText } = render(
+      <MarkdownCell
+        cell={cell}
+        onFocus={() => {}}
+        onPreviewFocusNext={onPreviewFocusNext}
+        onPreviewFocusPrevious={onPreviewFocusPrevious}
+      />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(fireEvent.keyDown(preview, { key: "ArrowDown" })).toBe(true);
+    expect(fireEvent.keyDown(preview, { key: "ArrowUp" })).toBe(true);
+    expect(onPreviewFocusNext).not.toHaveBeenCalled();
+    expect(onPreviewFocusPrevious).not.toHaveBeenCalled();
+  });
+
   it("updates markdown task markers from projected task checkboxes", () => {
     const onUpdateSource = vi.fn();
 

--- a/apps/notebook/src/components/__tests__/notebook-view-command-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-view-command-focus.test.tsx
@@ -1,0 +1,467 @@
+import { EditorView } from "@codemirror/view";
+import { NotebookHostProvider } from "@nteract/notebook-host";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { CrdtBridgeProvider } from "@/components/notebook/crdt-bridge";
+import {
+  flushCellUIState,
+  getActiveInteractionTarget,
+  setActiveInteractionTarget,
+  setSearchCurrentMatch,
+  setSearchQuery,
+} from "@/components/notebook/state/cell-ui-state";
+import { replaceNotebookCells } from "@/components/notebook/state/cell-store";
+import { resetNotebookExecutions } from "@/components/notebook/state/execution-store";
+import { resetNotebookOutputs } from "@/components/notebook/state/output-store";
+import { clearOutputFocusedCellId } from "@/components/notebook/state/output-focus-store";
+import { createFixtureNotebookHost } from "../../../../elements/components/fixture-notebook-host";
+import type { NotebookCell } from "../../types";
+import { NotebookView } from "../NotebookView";
+
+vi.mock("@/components/isolated/iframe-libraries", () => ({
+  injectPluginsForMimes: vi.fn(async () => {}),
+}));
+
+vi.mock("@/components/isolated", async () => {
+  const React = await import("react");
+  return {
+    IsolatedFrame: React.forwardRef(function IsolatedFrame(props: { onReady?: () => void }, ref) {
+      React.useImperativeHandle(ref, () => ({
+        send: vi.fn(),
+        render: vi.fn(),
+        renderBatch: vi.fn(),
+        eval: vi.fn(),
+        installRenderer: vi.fn(),
+        setTheme: vi.fn(),
+        setHostContext: vi.fn(),
+        clear: vi.fn(),
+        search: vi.fn(),
+        searchNavigate: vi.fn(),
+        measureElement: vi.fn(async () => null),
+        isReady: true,
+        isIframeReady: true,
+      }));
+      React.useEffect(() => props.onReady?.(), [props.onReady]);
+      return <iframe title="Markdown renderer" tabIndex={-1} />;
+    }),
+    useBokehSessionRuntime: () => null,
+  };
+});
+
+vi.mock("@/components/cell/OutputArea", () => ({ OutputArea: () => null }));
+
+const markdown: NotebookCell = {
+  id: "z-markdown",
+  cell_type: "markdown",
+  source: "# Command focus",
+  metadata: {},
+};
+const code: NotebookCell = {
+  id: "a-code",
+  cell_type: "code",
+  source: "answer = 42",
+  execution_count: null,
+  outputs: [],
+  metadata: {},
+};
+const raw: NotebookCell = {
+  id: "m-raw",
+  cell_type: "raw",
+  source: "raw content",
+  metadata: {},
+};
+
+function resetStores() {
+  setActiveInteractionTarget(null);
+  setSearchCurrentMatch(null);
+  setSearchQuery(undefined);
+  clearOutputFocusedCellId();
+  resetNotebookExecutions();
+  resetNotebookOutputs();
+  replaceNotebookCells([]);
+  flushCellUIState();
+}
+
+async function settleFocus() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+}
+
+async function press(key: string, modifiers: KeyboardEventInit = {}) {
+  const allowedDefault = fireEvent.keyDown(document.activeElement ?? document.body, {
+    key,
+    ...modifiers,
+  });
+  await settleFocus();
+  return allowedDefault;
+}
+
+async function mountNotebook(cells: NotebookCell[] = [markdown, code, raw]) {
+  replaceNotebookCells(cells);
+  const onAddCell = vi.fn(() => null);
+  const host = createFixtureNotebookHost();
+  const notebook = (currentCells: NotebookCell[], isLoading = false) => (
+    <NotebookHostProvider host={host}>
+      <CrdtBridgeProvider getHandle={() => null} onSyncNeeded={() => {}} localActor="focus-test">
+        <NotebookView
+          cellIds={currentCells.map((cell) => cell.id)}
+          isLoading={isLoading}
+          autoFocusFirstCell={false}
+          canAcceptCellMutations
+          onFocusCell={() => {}}
+          onExecuteCell={() => {}}
+          onInterruptKernel={() => {}}
+          onDeleteCell={() => {}}
+          onMoveCell={() => {}}
+          onAddCell={onAddCell}
+        />
+      </CrdtBridgeProvider>
+    </NotebookHostProvider>
+  );
+  const view = render(notebook(cells));
+  await settleFocus();
+  expect(screen.queryByText("This cell encountered an error")).toBeNull();
+  const rerenderCells = async (nextCells: NotebookCell[], isLoading = false) => {
+    act(() => {
+      replaceNotebookCells(nextCells);
+      view.rerender(notebook(nextCells, isLoading));
+    });
+    await settleFocus();
+    expect(screen.queryByText("This cell encountered an error")).toBeNull();
+  };
+  return { onAddCell, rerenderCells };
+}
+
+async function selectCell(cellId: string) {
+  act(() => {
+    setActiveInteractionTarget({ kind: "cell", cellId });
+    flushCellUIState();
+  });
+  await settleFocus();
+}
+
+function expectCommandFocus(cellId: string) {
+  expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId });
+  const target = document.querySelector<HTMLElement>(`[data-cell-command-focus="${cellId}"]`);
+  expect(target).not.toBeNull();
+  expect(target?.getAttribute("role")).toBe("group");
+  expect(screen.getAllByRole("group", { name: /\S/ })).toContain(target);
+  expect(target?.getAttribute("tabindex")).toBe("0");
+  expect(
+    [...document.querySelectorAll<HTMLElement>("[data-cell-command-focus]")].filter(
+      (cellTarget) => cellTarget.tabIndex === 0,
+    ),
+  ).toEqual([target]);
+  expect(document.activeElement).toBe(target);
+}
+
+function expectEditorFocus(cellId: string) {
+  expect(getActiveInteractionTarget()).toEqual({ kind: "editor", cellId });
+  const content = document.querySelector<HTMLElement>(`[data-cell-id="${cellId}"] .cm-content`);
+  expect(content).not.toBeNull();
+  expect(document.activeElement).toBe(content);
+  expect(EditorView.findFromDOM(content!)).not.toBeNull();
+}
+
+const domPolyfills: Array<[object, string, PropertyDescriptor | undefined]> = [];
+
+function polyfill(target: object, key: string, descriptor: PropertyDescriptor) {
+  domPolyfills.push([target, key, Object.getOwnPropertyDescriptor(target, key)]);
+  Object.defineProperty(target, key, { configurable: true, ...descriptor });
+}
+
+beforeEach(() => {
+  resetStores();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => {
+      throw new Error("Unexpected network request");
+    }),
+  );
+  vi.stubGlobal("CSS", { ...globalThis.CSS, escape: (value: string) => value });
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      matches: false,
+      media,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+  polyfill(HTMLElement.prototype, "scrollIntoView", { value: vi.fn() });
+  polyfill(HTMLElement.prototype, "isContentEditable", {
+    get(this: HTMLElement) {
+      return this.closest("[contenteditable]")?.getAttribute("contenteditable") === "true";
+    },
+  });
+  polyfill(Range.prototype, "getClientRects", { value: () => [] });
+  polyfill(Range.prototype, "getBoundingClientRect", { value: () => new DOMRect() });
+});
+
+afterEach(() => {
+  cleanup();
+  resetStores();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  for (const [target, key, descriptor] of domPolyfills.splice(0).reverse()) {
+    if (descriptor) Object.defineProperty(target, key, descriptor);
+    else Reflect.deleteProperty(target, key);
+  }
+});
+
+describe("NotebookView command focus", () => {
+  it.each([code, raw, markdown])(
+    "cycles Enter/Escape between command focus and the real $cell_type editor",
+    async (cell) => {
+      await mountNotebook();
+      await selectCell(cell.id);
+      expectCommandFocus(cell.id);
+      for (let cycle = 0; cycle < 2; cycle++) {
+        await press("Enter");
+        expectEditorFocus(cell.id);
+        await press("Escape");
+        expectCommandFocus(cell.id);
+      }
+    },
+  );
+
+  it.each(["ArrowDown", "j"])(
+    "keeps code selected through Escape after leaving an explicitly focused Markdown preview with %s",
+    async (next) => {
+      await mountNotebook();
+      await selectCell(markdown.id);
+      const preview = screen.getByRole("textbox", { name: "Markdown cell content" });
+      act(() => preview.focus());
+      expect(document.activeElement).toBe(preview);
+      expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: markdown.id });
+
+      await press(next);
+      expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: code.id });
+      expect.soft(document.activeElement).not.toBe(preview);
+      await press("Escape");
+      expect.soft(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: code.id });
+      expect.soft(document.activeElement?.getAttribute("data-cell-command-focus")).toBe(code.id);
+      await press("Enter");
+      expectEditorFocus(code.id);
+    },
+  );
+
+  it("allows explicit Markdown preview focus from a different selected cell", async () => {
+    await mountNotebook();
+    await selectCell(code.id);
+    expectCommandFocus(code.id);
+    const preview = screen.getByRole("textbox", { name: "Markdown cell content" });
+
+    act(() => preview.focus());
+    await settleFocus();
+    expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: markdown.id });
+    expect(document.activeElement).toBe(preview);
+    await press("Enter");
+    expectEditorFocus(markdown.id);
+    await press("Escape");
+    expectCommandFocus(markdown.id);
+  });
+
+  it("synchronizes selection when an inactive command wrapper receives direct focus", async () => {
+    await mountNotebook();
+    await selectCell(code.id);
+    expectCommandFocus(code.id);
+    const rawTarget = document.querySelector<HTMLElement>(`[data-cell-command-focus="${raw.id}"]`);
+    expect(rawTarget).not.toBeNull();
+
+    act(() => rawTarget?.focus());
+    await settleFocus();
+
+    expectCommandFocus(raw.id);
+  });
+
+  it("keeps Shift+Enter in command mode", async () => {
+    await mountNotebook();
+    await selectCell(markdown.id);
+
+    expect(await press("Enter", { shiftKey: true })).toBe(true);
+    expectCommandFocus(markdown.id);
+  });
+
+  it.each(["input", "button"])("does not hijack keys from a focused %s", async (controlType) => {
+    const { onAddCell } = await mountNotebook();
+    render(
+      controlType === "input" ? (
+        <input aria-label="Notebook search" />
+      ) : (
+        <button type="button">Notebook action</button>
+      ),
+    );
+    await selectCell(code.id);
+    expectCommandFocus(code.id);
+    const control =
+      controlType === "input"
+        ? screen.getByRole("textbox", { name: "Notebook search" })
+        : screen.getByRole("button", { name: "Notebook action" });
+    act(() => control.focus());
+
+    for (const key of ["ArrowDown", "ArrowUp", "j", "k", "Enter", "Escape", "a", "b", "d", "d"]) {
+      expect(await press(key)).toBe(true);
+      expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: code.id });
+      expect(document.activeElement).toBe(control);
+    }
+    expect(onAddCell).not.toHaveBeenCalled();
+  });
+
+  it.each(["reordered", "inserted"])(
+    "preserves external input focus when cells are %s without changing the selection",
+    async (change) => {
+      const { rerenderCells } = await mountNotebook();
+      render(<input aria-label="Notebook search" />);
+      await selectCell(code.id);
+      expectCommandFocus(code.id);
+      const selection = getActiveInteractionTarget();
+      const commandTarget = document.activeElement;
+      const input = screen.getByRole("textbox", { name: "Notebook search" });
+      act(() => input.focus());
+      expect(document.activeElement).toBe(input);
+
+      const inserted: NotebookCell = { ...code, id: "inserted-code" };
+      const nextCells =
+        change === "reordered" ? [raw, markdown, code] : [markdown, inserted, code, raw];
+      await rerenderCells(nextCells);
+
+      expect(getActiveInteractionTarget()).toBe(selection);
+      expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: code.id });
+      expect(document.activeElement).toBe(input);
+      const retainedTarget = document.querySelector<HTMLElement>(
+        `[data-cell-command-focus="${code.id}"]`,
+      );
+      expect(retainedTarget).toBe(commandTarget);
+      expect(retainedTarget?.style.order).toBe(String(nextCells.indexOf(code)));
+      if (change === "inserted") {
+        expect(document.querySelector('[data-cell-command-focus="inserted-code"]')).not.toBeNull();
+      }
+    },
+  );
+
+  it("preserves external input focus across loading transitions", async () => {
+    const { rerenderCells } = await mountNotebook();
+    render(<input aria-label="Notebook search" />);
+    await selectCell(code.id);
+    const input = screen.getByRole("textbox", { name: "Notebook search" });
+    act(() => input.focus());
+
+    for (const isLoading of [true, false]) {
+      await rerenderCells([markdown, code, raw], isLoading);
+      expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: code.id });
+      expect(document.activeElement).toBe(input);
+    }
+  });
+
+  it("focuses a deferred command selection when the selected cell is inserted", async () => {
+    const { rerenderCells } = await mountNotebook();
+    await selectCell(code.id);
+    expectCommandFocus(code.id);
+    const inserted: NotebookCell = { ...code, id: "deferred-code" };
+    await selectCell(inserted.id);
+    const selection = getActiveInteractionTarget();
+    expect(selection).toEqual({ kind: "cell", cellId: inserted.id });
+    expect(document.querySelector('[data-cell-command-focus="deferred-code"]')).toBeNull();
+
+    await rerenderCells([markdown, code, inserted, raw]);
+
+    expect(getActiveInteractionTarget()).toBe(selection);
+    expectCommandFocus(inserted.id);
+    await press("Enter");
+    expectEditorFocus(inserted.id);
+  });
+
+  it.each(["ctrlKey", "metaKey", "altKey", "shiftKey"] as const)(
+    "rejects command navigation with %s",
+    async (modifier) => {
+      const { onAddCell } = await mountNotebook();
+      await selectCell(code.id);
+      const keys = ["ArrowDown", "ArrowUp", "j", "k"];
+      if (modifier !== "shiftKey") keys.push("Enter", "a", "b");
+      for (const key of keys) {
+        expect(await press(key, { [modifier]: true })).toBe(true);
+        expectCommandFocus(code.id);
+      }
+      expect(onAddCell).not.toHaveBeenCalled();
+    },
+  );
+
+  it("never automatically focuses Markdown preview on command selection", async () => {
+    await mountNotebook();
+    const preview = screen.getByRole("textbox", { name: "Markdown cell content" });
+    const previewFocus = vi.fn();
+    preview.addEventListener("focus", previewFocus);
+    await selectCell(code.id);
+    await press("ArrowUp");
+    expect(getActiveInteractionTarget()).toEqual({ kind: "cell", cellId: markdown.id });
+    expect(previewFocus).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(preview);
+    expectCommandFocus(markdown.id);
+  });
+
+  it.each([
+    ["ArrowDown", "ArrowUp"],
+    ["j", "k"],
+    ["J", "K"],
+  ])(
+    "uses %s/%s for command navigation and preserves notebook boundaries",
+    async (next, previous) => {
+      const { onAddCell } = await mountNotebook();
+      await selectCell(markdown.id);
+      await press(previous);
+      expectCommandFocus(markdown.id);
+      await press(next);
+      expectCommandFocus(code.id);
+      await press(next);
+      expectCommandFocus(raw.id);
+      await press(next);
+      expectCommandFocus(raw.id);
+      expect(onAddCell).not.toHaveBeenCalled();
+      await press("Enter");
+      expectEditorFocus(raw.id);
+      await press("Escape");
+      expectCommandFocus(raw.id);
+      await press(previous);
+      expectCommandFocus(code.id);
+      await press(previous);
+      expectCommandFocus(markdown.id);
+    },
+  );
+
+  it.each([
+    ["ArrowDown", "ArrowUp"],
+    ["j", "k"],
+  ])(
+    "skips collapsed group members with %s/%s while retaining the group leader",
+    async (next, previous) => {
+      const hidden = (id: string): NotebookCell => ({
+        ...code,
+        id,
+        metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+      });
+      await mountNotebook([markdown, hidden("hidden-first"), hidden("hidden-second"), raw]);
+      expect(document.querySelector('[data-cell-id="hidden-second"]')).toBeNull();
+      await selectCell(markdown.id);
+      await press(next);
+      expectCommandFocus("hidden-first");
+      await press(next);
+      expectCommandFocus(raw.id);
+      await press(previous);
+      expectCommandFocus("hidden-first");
+      await press(previous);
+      expectCommandFocus(markdown.id);
+    },
+  );
+});

--- a/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
@@ -114,9 +114,25 @@ describe("useCommandMode", () => {
     expect(enterEditMode).not.toHaveBeenCalled();
   });
 
+  it("does not treat Shift+Enter as bare Enter", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const enterEditMode = vi.fn(() => true);
+
+    renderHook(() =>
+      useCommandMode({ showCommandMode: vi.fn(), enterEditMode, runCommand: vi.fn() }),
+    );
+
+    expect(dispatchKeyDown({ key: "Enter", shiftKey: true })).toBe(true);
+    expect(enterEditMode).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["ArrowUp", "previous"],
     ["ArrowDown", "next"],
+    ["k", "previous"],
+    ["j", "next"],
+    ["K", "previous"],
+    ["J", "next"],
   ] as const)("routes %s to command-mode %s selection", (key, direction) => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
     const navigateSelection = vi.fn(() => true);
@@ -151,26 +167,31 @@ describe("useCommandMode", () => {
     expect(navigateSelection).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores arrows outside command mode or with modifiers", () => {
-    mockTarget = { kind: "editor", cellId: "cell-1" };
-    const navigateSelection = vi.fn(() => true);
+  it.each(["ArrowDown", "ArrowUp", "j", "k"])(
+    "ignores %s outside command mode or with modifiers",
+    (key) => {
+      mockTarget = { kind: "editor", cellId: "cell-1" };
+      const navigateSelection = vi.fn(() => true);
 
-    renderHook(() =>
-      useCommandMode({
-        showCommandMode: vi.fn(),
-        enterEditMode: vi.fn(),
-        navigateSelection,
-        runCommand: vi.fn(),
-      }),
-    );
+      renderHook(() =>
+        useCommandMode({
+          showCommandMode: vi.fn(),
+          enterEditMode: vi.fn(),
+          navigateSelection,
+          runCommand: vi.fn(),
+        }),
+      );
 
-    dispatchKeyDown({ key: "ArrowDown" });
-    mockTarget = { kind: "cell", cellId: "cell-1" };
-    dispatchKeyDown({ key: "ArrowDown", shiftKey: true });
-    dispatchKeyDown({ key: "ArrowDown", metaKey: true });
+      dispatchKeyDown({ key });
+      mockTarget = { kind: "cell", cellId: "cell-1" };
+      dispatchKeyDown({ key, shiftKey: true });
+      dispatchKeyDown({ key, metaKey: true });
+      dispatchKeyDown({ key, ctrlKey: true });
+      dispatchKeyDown({ key, altKey: true });
 
-    expect(navigateSelection).not.toHaveBeenCalled();
-  });
+      expect(navigateSelection).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses the latest arrow navigation callback after rerender", () => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
@@ -194,7 +215,7 @@ describe("useCommandMode", () => {
     expect(secondNavigate).toHaveBeenCalledWith("next", "cell-1");
   });
 
-  it("does not complete D,D after arrow navigation", () => {
+  it.each(["ArrowDown", "ArrowUp", "j", "k"])("does not complete D,D after %s", (key) => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
     const runCommand = vi.fn();
 
@@ -208,7 +229,7 @@ describe("useCommandMode", () => {
     );
 
     dispatchKeyDown({ key: "d" });
-    dispatchKeyDown({ key: "ArrowDown" });
+    dispatchKeyDown({ key });
     dispatchKeyDown({ key: "d" });
 
     expect(runCommand).not.toHaveBeenCalled();

--- a/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useCommandMode.test.ts
@@ -115,6 +115,106 @@ describe("useCommandMode", () => {
   });
 
   it.each([
+    ["ArrowUp", "previous"],
+    ["ArrowDown", "next"],
+  ] as const)("routes %s to command-mode %s selection", (key, direction) => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    expect(dispatchKeyDown({ key })).toBe(false);
+    expect(navigateSelection).toHaveBeenCalledWith(direction, "cell-1");
+  });
+
+  it("leaves an arrow unhandled when selection cannot move", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => false);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    expect(dispatchKeyDown({ key: "ArrowUp" })).toBe(true);
+    expect(navigateSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores arrows outside command mode or with modifiers", () => {
+    mockTarget = { kind: "editor", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection,
+        runCommand: vi.fn(),
+      }),
+    );
+
+    dispatchKeyDown({ key: "ArrowDown" });
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    dispatchKeyDown({ key: "ArrowDown", shiftKey: true });
+    dispatchKeyDown({ key: "ArrowDown", metaKey: true });
+
+    expect(navigateSelection).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest arrow navigation callback after rerender", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const firstNavigate = vi.fn(() => true);
+    const secondNavigate = vi.fn(() => true);
+    const { rerender } = renderHook(
+      ({ navigateSelection }) =>
+        useCommandMode({
+          showCommandMode: vi.fn(),
+          enterEditMode: vi.fn(),
+          navigateSelection,
+          runCommand: vi.fn(),
+        }),
+      { initialProps: { navigateSelection: firstNavigate } },
+    );
+
+    rerender({ navigateSelection: secondNavigate });
+    dispatchKeyDown({ key: "ArrowDown" });
+
+    expect(firstNavigate).not.toHaveBeenCalled();
+    expect(secondNavigate).toHaveBeenCalledWith("next", "cell-1");
+  });
+
+  it("does not complete D,D after arrow navigation", () => {
+    mockTarget = { kind: "cell", cellId: "cell-1" };
+    const runCommand = vi.fn();
+
+    renderHook(() =>
+      useCommandMode({
+        showCommandMode: vi.fn(),
+        enterEditMode: vi.fn(),
+        navigateSelection: vi.fn(() => true),
+        runCommand,
+      }),
+    );
+
+    dispatchKeyDown({ key: "d" });
+    dispatchKeyDown({ key: "ArrowDown" });
+    dispatchKeyDown({ key: "d" });
+
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["a", "insert-above"],
     ["b", "insert-below"],
     ["m", "change-to-markdown"],
@@ -192,23 +292,28 @@ describe("useCommandMode", () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
-  it("does not hijack Enter, Escape, or letter keys from a focused button", () => {
+  it("does not hijack Enter, Escape, arrows, or letter keys from a focused button", () => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
     const showCommandMode = vi.fn();
     const enterEditMode = vi.fn();
+    const navigateSelection = vi.fn(() => true);
     const runCommand = vi.fn();
     const button = document.createElement("button");
     document.body.appendChild(button);
     button.focus();
 
-    renderHook(() => useCommandMode({ showCommandMode, enterEditMode, runCommand }));
+    renderHook(() =>
+      useCommandMode({ showCommandMode, enterEditMode, navigateSelection, runCommand }),
+    );
 
     dispatchKeyDown({ key: "Enter" });
     dispatchKeyDown({ key: "Escape" });
+    dispatchKeyDown({ key: "ArrowDown" });
     dispatchKeyDown({ key: "a" });
 
     expect(showCommandMode).not.toHaveBeenCalled();
     expect(enterEditMode).not.toHaveBeenCalled();
+    expect(navigateSelection).not.toHaveBeenCalled();
     expect(runCommand).not.toHaveBeenCalled();
   });
 
@@ -286,21 +391,25 @@ describe("useCommandMode", () => {
     expect(runCommand).toHaveBeenCalledWith("delete", "cell-2");
   });
 
-  it("does nothing for letter shortcuts when disabled", () => {
+  it("does nothing for command-mode shortcuts when disabled", () => {
     mockTarget = { kind: "cell", cellId: "cell-1" };
+    const navigateSelection = vi.fn(() => true);
     const runCommand = vi.fn();
 
     renderHook(() =>
       useCommandMode({
         showCommandMode: vi.fn(),
         enterEditMode: vi.fn(),
+        navigateSelection,
         runCommand,
         disabled: true,
       }),
     );
 
     dispatchKeyDown({ key: "a" });
+    dispatchKeyDown({ key: "ArrowDown" });
 
+    expect(navigateSelection).not.toHaveBeenCalled();
     expect(runCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook/src/hooks/useCommandMode.ts
+++ b/apps/notebook/src/hooks/useCommandMode.ts
@@ -13,12 +13,15 @@ export type CommandModeCommand =
   | "toggle-output";
 
 type RunCommand = (command: CommandModeCommand, cellId: string) => boolean;
+type NavigateSelection = (direction: "previous" | "next", cellId: string) => boolean;
 
 interface UseCommandModeOptions {
   /** Enter command mode: blur the active element, select the focused cell (no editor). */
   showCommandMode: () => void;
   /** Leave command mode: focus the source editor of the selected cell. */
   enterEditMode: () => boolean;
+  /** Select an adjacent visible cell without entering its editor. */
+  navigateSelection?: NavigateSelection;
   /** Apply a command through the shared notebook surface. */
   runCommand: RunCommand;
   /** Skip attaching the listener entirely (e.g. no notebook loaded). */
@@ -49,6 +52,7 @@ function isInteractiveTarget(el: Element | null): boolean {
  *
  *   Escape → blur the editor/output, enter command mode (`{kind:"cell"}`)
  *   Enter  → leave command mode, focus the cell's source editor
+ *   Up/Down → select the previous/next visible cell without editing
  *
  * While in command mode, single letters mirror the most common Jupyter
  * shortcuts: A/B insert a cell above/below, M/Y change cell type, O toggles
@@ -60,14 +64,17 @@ function isInteractiveTarget(el: Element | null): boolean {
 export function useCommandMode({
   showCommandMode,
   enterEditMode,
+  navigateSelection,
   runCommand,
   disabled = false,
 }: UseCommandModeOptions): void {
   const showCommandModeRef = useRef(showCommandMode);
   const enterEditModeRef = useRef(enterEditMode);
+  const navigateSelectionRef = useRef(navigateSelection);
   const runCommandRef = useRef(runCommand);
   showCommandModeRef.current = showCommandMode;
   enterEditModeRef.current = enterEditMode;
+  navigateSelectionRef.current = navigateSelection;
   runCommandRef.current = runCommand;
 
   // Timestamp + cell id of the last bare "d" press, for the D,D delete
@@ -108,6 +115,14 @@ export function useCommandMode({
 
       if (target?.kind !== "cell") {
         pendingDeleteRef.current = null;
+        return;
+      }
+
+      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+        pendingDeleteRef.current = null;
+        if (event.shiftKey) return;
+        const direction = event.key === "ArrowUp" ? "previous" : "next";
+        if (navigateSelectionRef.current?.(direction, target.cellId)) event.preventDefault();
         return;
       }
 

--- a/apps/notebook/src/hooks/useCommandMode.ts
+++ b/apps/notebook/src/hooks/useCommandMode.ts
@@ -106,7 +106,9 @@ export function useCommandMode({
       // modifiers and that DOM focus isn't inside a native editable control
       // (search box, comment composer, dialog input, etc).
       if (event.ctrlKey || event.metaKey || event.altKey) return;
-      if (event.key === "Enter") {
+      // Bare Enter enters edit mode. Shift+Enter is an execution/advance
+      // command and is intentionally outside this hook's current contract.
+      if (event.key === "Enter" && !event.shiftKey) {
         if (target?.kind === "cell") {
           if (enterEditModeRef.current()) event.preventDefault();
         }
@@ -118,15 +120,14 @@ export function useCommandMode({
         return;
       }
 
-      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+      const key = event.key.toLowerCase();
+      if (key === "arrowup" || key === "arrowdown" || key === "j" || key === "k") {
         pendingDeleteRef.current = null;
         if (event.shiftKey) return;
-        const direction = event.key === "ArrowUp" ? "previous" : "next";
+        const direction = key === "arrowup" || key === "k" ? "previous" : "next";
         if (navigateSelectionRef.current?.(direction, target.cellId)) event.preventDefault();
         return;
       }
-
-      const key = event.key.toLowerCase();
 
       if (key === "d") {
         // OS/browser keyboard auto-repeat fires additional keydown events

--- a/apps/notebook/src/lib/__tests__/cell-navigation.test.ts
+++ b/apps/notebook/src/lib/__tests__/cell-navigation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+import { findAdjacentVisibleCellId } from "../cell-navigation";
+
+describe("findAdjacentVisibleCellId", () => {
+  const cellIds = ["a", "b", "c", "d", "e"];
+  const visible = new Set(["a", "b", "e"]);
+  const isVisible = (cellId: string) => visible.has(cellId);
+
+  it("finds adjacent visible cells in both directions", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "a", "next", isVisible)).toBe("b");
+    expect(findAdjacentVisibleCellId(cellIds, "e", "previous", isVisible)).toBe("b");
+  });
+
+  it("skips collapsed hidden-group members", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "b", "next", isVisible)).toBe("e");
+    expect(findAdjacentVisibleCellId(cellIds, "e", "previous", isVisible)).toBe("b");
+  });
+
+  it("returns null at boundaries and for missing current cells", () => {
+    expect(findAdjacentVisibleCellId(cellIds, "a", "previous", isVisible)).toBeNull();
+    expect(findAdjacentVisibleCellId(cellIds, "e", "next", isVisible)).toBeNull();
+    expect(findAdjacentVisibleCellId(cellIds, "missing", "next", isVisible)).toBeNull();
+  });
+});

--- a/apps/notebook/src/lib/cell-navigation.ts
+++ b/apps/notebook/src/lib/cell-navigation.ts
@@ -1,0 +1,21 @@
+export type CellNavigationDirection = "previous" | "next";
+
+export function findAdjacentVisibleCellId(
+  cellIds: readonly string[],
+  currentCellId: string,
+  direction: CellNavigationDirection,
+  isVisible: (cellId: string) => boolean,
+): string | null {
+  const currentIndex = cellIds.indexOf(currentCellId);
+  if (currentIndex < 0) return null;
+
+  const step = direction === "previous" ? -1 : 1;
+  let targetIndex = currentIndex + step;
+  while (targetIndex >= 0 && targetIndex < cellIds.length) {
+    const targetCellId = cellIds[targetIndex];
+    if (isVisible(targetCellId)) return targetCellId;
+    targetIndex += step;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- keep command-mode selection and DOM focus aligned on a single roving cell target
- stop rendered Markdown previews from reclaiming selection after navigation
- route J/K through the same visible-cell navigation path as ArrowUp/ArrowDown
- preserve explicit preview interaction, native control focus, collapsed-group skipping, modifiers, and D,D cancellation

## Stack

Depends on #4197 and is based directly on its rebased head (`23ada0e`). Review the top commit only. After #4197 merges, this branch should be rebased onto `main` before merge.

This intentionally does not add Shift+Arrow multi-cell selection or ArrowLeft/ArrowRight heading behavior.

## Test plan

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components apps/notebook/src/hooks apps/notebook/src/lib/__tests__/cell-navigation.test.ts src/components/cell src/components/notebook/state` (438 tests)
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --filter notebook-ui build`
- Chromium: projected Markdown keyboard-focus navigation
- Chromium: mixed Markdown/code Arrow and J/K command-mode navigation, including Markdown → code → Escape → Enter

## Review

The implementation was challenged with independent adversarial review passes. Findings around structural/loading updates, direct wrapper focus, modified Enter handling, and browser-level DOM focus were corrected and covered before publication.
