### PR TITLE
feat(notebook): show logo in notebook header

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -212,6 +212,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     sourceText,
     /presence=\{[\s\S]*<CloudNotebookTitle[\s\S]*title=\{notebookStageGated \? gatedNotebookTitle : notebookTitle\}[\s\S]*canRename=\{catalogAccessResolved && catalogGrantsDocumentEdit\}[\s\S]*onRename=\{saveCloudNotebookTitle\}/,
   );
+  assert.match(sourceText, /presence=\{[\s\S]*<NotebookBrandMark[\s\S]*<CloudNotebookTitle/);
   assert.match(
     sourceText,
     /import \{ CloudNotebookTitle, cloudNotebookRouteTitle \} from "\.\/cloud-notebook-title";/,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -37,6 +37,7 @@ import {
   NotebookSettingsDrawer,
   notebookToolbarActors,
   NotebookCommentsPanel,
+  NotebookBrandMark,
   NotebookCommandToolbar,
   NotebookDocumentToolbar,
   NotebookToolbarFrame,
@@ -1744,14 +1745,17 @@ export function NotebookViewer({
       frameClassName="z-20"
       headerClassName="cloud-room-toolbar"
       presence={
-        <CloudNotebookTitle
-          title={notebookStageGated ? gatedNotebookTitle : notebookTitle}
-          renameTitle={catalogNotebookTitle?.trim() ?? ""}
-          canRename={catalogAccessResolved && catalogGrantsDocumentEdit}
-          renameSaving={notebookTitleSaving}
-          renameError={notebookTitleError}
-          onRename={saveCloudNotebookTitle}
-        />
+        <div className="flex min-w-0 items-center gap-2">
+          <NotebookBrandMark className="size-8" />
+          <CloudNotebookTitle
+            title={notebookStageGated ? gatedNotebookTitle : notebookTitle}
+            renameTitle={catalogNotebookTitle?.trim() ?? ""}
+            canRename={catalogAccessResolved && catalogGrantsDocumentEdit}
+            renameSaving={notebookTitleSaving}
+            renameError={notebookTitleError}
+            onRename={saveCloudNotebookTitle}
+          />
+        </div>
       }
       utilityControls={
         notebookHeaderChrome.showPresenceStatus ? (

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -2,6 +2,7 @@ import { Copy, Info } from "lucide-react";
 import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
+  NotebookBrandMark,
   NotebookCommandToolbar,
   NotebookNotice,
   NotebookNoticeAction,
@@ -249,6 +250,7 @@ export function NotebookToolbar({
     <NotebookToolbarFrame notices={notices}>
       <NotebookCommandToolbar
         capabilities={capabilities}
+        leadingControls={<NotebookBrandMark />}
         runtime={runtime}
         environmentManager={envManager}
         environmentPanelOpen={isDepsOpen}

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -88,6 +88,12 @@ const baseProps = {
 };
 
 describe("NotebookToolbar", () => {
+  it("shows the nteract brand at the leading edge", () => {
+    render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.IDLE)} />);
+
+    expect(screen.getByRole("img", { name: "nteract" })).toBeVisible();
+  });
+
   describe("start button visibility", () => {
     it("hides start button when kernel is idle", () => {
       render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.IDLE)} />);

--- a/src/components/notebook/NotebookBrandMark.tsx
+++ b/src/components/notebook/NotebookBrandMark.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+import logoDarkUrl from "../../../logo-dark.svg";
+import logoLightUrl from "../../../logo.svg";
+
+export interface NotebookBrandMarkProps {
+  className?: string;
+}
+
+export function NotebookBrandMark({ className }: NotebookBrandMarkProps) {
+  return (
+    <span
+      role="img"
+      aria-label="nteract"
+      className={cn("block size-6 shrink-0 select-none", className)}
+      data-testid="notebook-brand-mark"
+    >
+      <img
+        src={logoLightUrl}
+        alt=""
+        aria-hidden="true"
+        draggable={false}
+        className="block size-full dark:hidden"
+      />
+      <img
+        src={logoDarkUrl}
+        alt=""
+        aria-hidden="true"
+        draggable={false}
+        className="hidden size-full dark:block"
+      />
+    </span>
+  );
+}

--- a/src/components/notebook/__tests__/NotebookBrandMark.test.tsx
+++ b/src/components/notebook/__tests__/NotebookBrandMark.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookBrandMark } from "../NotebookBrandMark";
+
+describe("NotebookBrandMark", () => {
+  it("provides light and dark theme artwork under one accessible name", () => {
+    render(<NotebookBrandMark />);
+
+    const mark = screen.getByRole("img", { name: "nteract" });
+    const artwork = mark.querySelectorAll("img");
+
+    expect(artwork).toHaveLength(2);
+    expect(artwork[0]).toHaveClass("dark:hidden");
+    expect(artwork[1]).toHaveClass("dark:block");
+    expect(artwork[0]).toHaveAttribute("aria-hidden", "true");
+    expect(artwork[1]).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -170,6 +170,7 @@ export {
   type NotebookCommandToolbarWorkstationAction,
   type NotebookEnvironmentManager,
 } from "./NotebookCommandToolbar";
+export { NotebookBrandMark, type NotebookBrandMarkProps } from "./NotebookBrandMark";
 export {
   NotebookDocumentToolbar,
   shouldShowNotebookDocumentCommandToolbar,


### PR DESCRIPTION
## Summary

- add a shared, theme-aware nteract brand mark using the existing light and dark logo artwork
- place the mark at the leading edge of the desktop notebook toolbar
- place the mark beside the cloud notebook title so both hosts retain the same notebook identity

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run src/components/notebook/__tests__/NotebookBrandMark.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts`
- visual check of the desktop notebook shell in dark mode
