### PR TITLE
fix(notebook): anchor branding and title rail panels

### DIFF
--- a/apps/elements/components/full-shell-composition-example.tsx
+++ b/apps/elements/components/full-shell-composition-example.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { Share2 } from "lucide-react";
+import { PanelLeftOpen, Share2 } from "lucide-react";
+import Image from "next/image";
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { resolveNotebookOutlineSelection } from "runtimed";
 import {
@@ -28,6 +29,7 @@ import {
 } from "@/components/notebook";
 import type { CommentsProjection } from "@/components/notebook/comment-types";
 import {
+  NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
   NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
   type NotebookRailPanelId,
 } from "@/components/notebook-rail";
@@ -50,6 +52,8 @@ import {
 } from "@/components/notebook/state/execution-store";
 import { resetNotebookOutputs, setOutput } from "@/components/notebook/state/output-store";
 import { cn } from "@/lib/utils";
+import logoDarkUrl from "../../../logo-dark.svg";
+import logoLightUrl from "../../../logo.svg";
 import { NotebookView } from "../../notebook/src/notebook-surface";
 import { createFixtureNotebookHost } from "./fixture-notebook-host";
 import {
@@ -218,6 +222,7 @@ const workstationSelection = projectNotebookWorkstationSelection({
 });
 
 export function FullShellCompositionExample() {
+  const [host, setHost] = useState<"cloud" | "desktop">("cloud");
   const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [mode, setMode] = useState<NotebookInteractionMode>("edit");
@@ -253,6 +258,10 @@ export function FullShellCompositionExample() {
   useEffect(() => setMounted(true), []);
 
   useLayoutEffect(() => {
+    setHost(
+      new URLSearchParams(window.location.search).get("host") === "desktop" ? "desktop" : "cloud",
+    );
+    setRailCollapsed(window.matchMedia(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY).matches);
     seedFullShellFixtures(scenario);
     setFixturesSeeded(true);
   }, []);
@@ -277,38 +286,51 @@ export function FullShellCompositionExample() {
     });
   };
 
+  const togglePanel = (panel: NotebookRailPanelId) => {
+    setActivePanel(panel);
+    setRailCollapsed(activePanel === panel && !railCollapsed);
+  };
+  const commandToolbar = (
+    <FullShellCommandToolbar
+      capabilities={capabilities}
+      activePanel={activePanel}
+      railCollapsed={railCollapsed}
+      onOpenPanels={host === "cloud" ? () => setRailCollapsed(false) : undefined}
+      onTogglePackages={() => togglePanel("packages")}
+      onToggleWorkstations={host === "cloud" ? () => togglePanel("workstations") : undefined}
+    />
+  );
+
   return (
     <NotebookHostProvider host={notebookHost}>
       <NotebookDocumentShell
         rootElement="main"
         className="h-dvh bg-background text-foreground"
         toolbarClassName="bg-background/95"
-        toolbarLabel="Full shell composition toolbar"
-        toolbarPlacement="stage"
-        stageClassName="bg-muted/20"
-        stageLabel="Full notebook composition"
+        toolbarLabel={host === "cloud" ? "Cloud notebook session" : "Notebook commands"}
+        toolbarPlacement={host === "cloud" ? "shell" : "stage-content"}
+        stageClassName="bg-background"
+        stageLabel={`Full ${host} notebook composition`}
         railPanelPlacement="stage"
         capabilities={capabilities}
         toolbar={
-          <FullShellHeader
-            capabilities={capabilities}
-            interaction={interaction}
-            mode={mode}
-            onModeChange={setMode}
-          />
+          host === "cloud" ? (
+            <FullShellHeader
+              capabilities={capabilities}
+              interaction={interaction}
+              mode={mode}
+              onModeChange={setMode}
+            />
+          ) : (
+            commandToolbar
+          )
         }
-        stageToolbar={
-          <FullShellCommandToolbar
-            capabilities={capabilities}
-            activePanel={activePanel}
-            onTogglePackages={() => setActivePanel("packages")}
-            onToggleWorkstations={() => setActivePanel("workstations")}
-          />
-        }
+        stageToolbar={host === "cloud" ? commandToolbar : undefined}
         stageToolbarPlacement="stage-content"
-        stageContentClassName={NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME}
+        stageContentClassName={cn(!railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME)}
         rail={
           <NotebookDocumentRail
+            leadingSlot={host === "desktop" ? <FullShellBrandMark /> : undefined}
             viewModel={scenario.viewModel}
             activePanelId={activePanel}
             collapsed={railCollapsed}
@@ -321,10 +343,12 @@ export function FullShellCompositionExample() {
             }
             commentsPanel={commentsPanel}
             workstationsPanel={
-              <NotebookWorkstationsPanel
-                capabilities={capabilities}
-                selection={workstationSelection}
-              />
+              host === "cloud" ? (
+                <NotebookWorkstationsPanel
+                  capabilities={capabilities}
+                  selection={workstationSelection}
+                />
+              ) : undefined
             }
             onActivePanelChange={setActivePanel}
             onCollapsedChange={setRailCollapsed}
@@ -337,67 +361,67 @@ export function FullShellCompositionExample() {
               setSelectedOutlineItemId(item.id);
               setFocusedCellId(item.cellId);
               focusFullShellCell(item.cellId);
+              if (window.matchMedia(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY).matches) {
+                setRailCollapsed(true);
+              }
             }}
-            className="bg-background"
+            className={cn(
+              "bg-background",
+              host === "cloud" && railCollapsed && "max-[599.98px]:hidden",
+            )}
           />
         }
       >
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <CrdtBridgeProvider {...crdtAdapter}>
-            <section
-              aria-label="Notebook document"
-              className="min-h-0 overflow-y-auto bg-background"
-              data-slot="full-shell-notebook-stage"
-            >
-              <div className="mx-auto min-h-full w-full max-w-5xl px-5 py-5 sm:px-7 lg:px-10">
-                {fixturesSeeded ? (
-                  <NotebookView
-                    cellIds={notebookViewCellIds}
-                    capabilities={capabilities}
-                    canAcceptCellMutations={false}
-                    readOnly={!capabilities.canEditCells}
-                    runtime="python"
-                    sessionRuntimeState={capabilities.canExecute ? "ready" : "unavailable"}
-                    onFocusCell={(cellId) => {
-                      setFocusedCellId(cellId);
-                      setSelectedOutlineItemId(null);
-                      focusFullShellCell(cellId);
-                    }}
-                    onExecuteCell={noop}
-                    onInterruptKernel={noop}
-                    onDeleteCell={noop}
-                    onAddCell={() => null}
-                    onMoveCell={moveNotebookViewCell}
-                    onSetCellSourceHidden={noop}
-                    onSetCellOutputsHidden={noop}
-                    onCreateSourceComment={(anchor) => {
-                      setFocusedCellId(anchor.cell_id);
-                      focusFullShellCell(anchor.cell_id);
-                    }}
-                    onActivateCommentThread={(threadId) => {
-                      const thread = commentsProjection.threads.find(
-                        (item) => item.id === threadId,
-                      );
-                      const cellId =
-                        thread?.anchor.kind === "source_range" || thread?.anchor.kind === "cell"
-                          ? thread.anchor.cell_id
-                          : null;
-                      if (cellId) {
-                        setFocusedCellId(cellId);
-                        focusFullShellCell(cellId);
-                      }
-                    }}
-                    autoFocusFirstCell={false}
-                  />
-                ) : (
-                  <div className="px-4 py-6 text-sm text-muted-foreground">
-                    Loading notebook fixture...
-                  </div>
-                )}
+        <CrdtBridgeProvider {...crdtAdapter}>
+          <section
+            aria-label="Notebook document"
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"
+            data-slot="full-shell-notebook-stage"
+          >
+            {fixturesSeeded ? (
+              <NotebookView
+                cellIds={notebookViewCellIds}
+                capabilities={capabilities}
+                canAcceptCellMutations={false}
+                readOnly={!capabilities.canEditCells}
+                runtime="python"
+                sessionRuntimeState={capabilities.canExecute ? "ready" : "unavailable"}
+                onFocusCell={(cellId) => {
+                  setFocusedCellId(cellId);
+                  setSelectedOutlineItemId(null);
+                  focusFullShellCell(cellId);
+                }}
+                onExecuteCell={noop}
+                onInterruptKernel={noop}
+                onDeleteCell={noop}
+                onAddCell={() => null}
+                onMoveCell={moveNotebookViewCell}
+                onSetCellSourceHidden={noop}
+                onSetCellOutputsHidden={noop}
+                onCreateSourceComment={(anchor) => {
+                  setFocusedCellId(anchor.cell_id);
+                  focusFullShellCell(anchor.cell_id);
+                }}
+                onActivateCommentThread={(threadId) => {
+                  const thread = commentsProjection.threads.find((item) => item.id === threadId);
+                  const cellId =
+                    thread?.anchor.kind === "source_range" || thread?.anchor.kind === "cell"
+                      ? thread.anchor.cell_id
+                      : null;
+                  if (cellId) {
+                    setFocusedCellId(cellId);
+                    focusFullShellCell(cellId);
+                  }
+                }}
+                autoFocusFirstCell={false}
+              />
+            ) : (
+              <div className="px-4 py-6 text-sm text-muted-foreground">
+                Loading notebook fixture...
               </div>
-            </section>
-          </CrdtBridgeProvider>
-        </div>
+            )}
+          </section>
+        </CrdtBridgeProvider>
       </NotebookDocumentShell>
     </NotebookHostProvider>
   );
@@ -416,46 +440,61 @@ function FullShellHeader({
 }) {
   return (
     <NotebookToolbarFrame className="static top-auto z-auto bg-background/95">
-      <NotebookDocumentHeader
-        capabilities={capabilities}
-        className={cn(
-          "min-h-14 border-b border-border/70 px-3 py-2 sm:px-4",
-          "[&_[data-slot=notebook-document-header-presence]]:flex-[1_1_min(28rem,48vw)]",
-          "[&_[data-slot=notebook-document-header-controls]]:flex-none",
-          "max-[920px]:min-h-[4.75rem] max-[920px]:flex-wrap max-[920px]:items-center max-[920px]:justify-start",
-          "max-[920px]:[&_[data-slot=notebook-document-header-presence]]:flex-[1_1_100%]",
-          "max-[920px]:[&_[data-slot=notebook-document-header-controls]]:flex-[1_1_100%]",
-          "max-[920px]:[&_[data-slot=notebook-document-header-controls]]:justify-start",
-        )}
-        presence={<FullShellTitle />}
-        utilityControls={
-          <>
-            <NotebookIdentityGroup
-              actors={hostedPeople}
-              maxVisible={2}
-              label="Hosted participants"
-              className="hidden sm:inline-flex"
-            />
-            <NotebookEditModeButton
-              mode={mode}
-              state={interaction.state}
-              onModeChange={onModeChange}
-              variant="segmented"
-              className="bg-muted/35"
-            />
-          </>
-        }
-        sharingControls={
-          <button
-            type="button"
-            className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-            title="Share notebook"
-          >
-            <Share2 className="size-3.5" aria-hidden="true" />
-            <span className="hidden sm:inline">Share</span>
-          </button>
-        }
-      />
+      <div className="flex min-w-0" data-slot="full-shell-cloud-header">
+        <NotebookDocumentHeader
+          capabilities={capabilities}
+          className={cn(
+            "min-h-15 border-b pl-0 pr-[clamp(0.5rem,2vw,1rem)]",
+            "[&_[data-slot=notebook-document-header-presence]]:flex [&_[data-slot=notebook-document-header-presence]]:items-center [&_[data-slot=notebook-document-header-presence]]:gap-2",
+            "[&_[data-slot=notebook-document-header-presence]]:flex-[1_1_min(24rem,44vw)] [&_[data-slot=notebook-document-header-presence]]:max-w-[min(38rem,48vw)]",
+            "[&_[data-slot=notebook-document-header-controls]]:flex-none [&_[data-slot=notebook-document-header-controls]]:min-w-max [&_[data-slot=notebook-document-header-controls]]:gap-[clamp(0.375rem,1vw,0.75rem)]",
+            "max-[900px]:flex-nowrap max-[900px]:content-center max-[900px]:gap-1.5 max-[900px]:py-1.5",
+            "max-[900px]:[&_[data-slot=notebook-document-header-presence]]:flex-auto max-[900px]:[&_[data-slot=notebook-document-header-presence]]:max-w-none",
+            "max-[900px]:[&_[data-slot=notebook-document-header-controls]]:min-w-0 max-[900px]:[&_[data-slot=notebook-document-header-controls]]:gap-x-2.5 max-[900px]:[&_[data-slot=notebook-document-header-controls]]:gap-y-1",
+            "max-[520px]:[&_[data-slot=notebook-document-header-controls]]:gap-x-1.5 max-[520px]:[&_[data-slot=notebook-document-header-controls]]:gap-y-0.5",
+          )}
+          presence={
+            <>
+              <a
+                href="/n"
+                aria-label="Notebook home"
+                title="Notebook home"
+                className="flex h-11 w-14 shrink-0 items-center justify-center rounded-md hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring"
+              >
+                <FullShellBrandMark className="size-8" />
+              </a>
+              <FullShellTitle />
+            </>
+          }
+          utilityControls={
+            <>
+              <NotebookIdentityGroup
+                actors={hostedPeople}
+                maxVisible={2}
+                label="Hosted participants"
+              />
+              <NotebookEditModeButton
+                mode={mode}
+                state={interaction.state}
+                onModeChange={onModeChange}
+                variant="segmented"
+                className="bg-muted/35"
+              />
+            </>
+          }
+          sharingControls={
+            <button
+              type="button"
+              className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Share notebook"
+              title="Share notebook"
+            >
+              <Share2 className="size-3.5" aria-hidden="true" />
+              <span className="hidden sm:inline">Share</span>
+            </button>
+          }
+        />
+      </div>
     </NotebookToolbarFrame>
   );
 }
@@ -463,13 +502,17 @@ function FullShellHeader({
 function FullShellCommandToolbar({
   activePanel,
   capabilities,
+  railCollapsed,
+  onOpenPanels,
   onTogglePackages,
   onToggleWorkstations,
 }: {
   activePanel: NotebookRailPanelId;
   capabilities: NotebookShellCapabilities;
+  railCollapsed: boolean;
+  onOpenPanels?: () => void;
   onTogglePackages: () => void;
-  onToggleWorkstations: () => void;
+  onToggleWorkstations?: () => void;
 }) {
   const runtimeStatus: NotebookCommandToolbarStatus = {
     state: capabilities.canExecute ? "idle" : "unknown",
@@ -479,14 +522,33 @@ function FullShellCommandToolbar({
   };
 
   return (
-    <NotebookToolbarFrame className="static top-auto z-auto bg-background/95">
+    <NotebookToolbarFrame
+      className={cn(
+        "static top-auto z-auto bg-background/95",
+        !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+      )}
+    >
       <div className="min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <NotebookCommandToolbar
           capabilities={capabilities}
+          leadingControls={
+            onOpenPanels ? (
+              <button
+                type="button"
+                className="hidden size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-[599.98px]:inline-flex"
+                aria-label="Open notebook panels"
+                aria-expanded={!railCollapsed}
+                title="Notebook panels"
+                onClick={onOpenPanels}
+              >
+                <PanelLeftOpen className="size-4" aria-hidden="true" />
+              </button>
+            ) : undefined
+          }
           runtime="python"
           runtimeTarget={capabilities.runtime.target ?? null}
           environmentManager={null}
-          environmentPanelOpen={activePanel === "packages"}
+          environmentPanelOpen={activePanel === "packages" && !railCollapsed}
           runtimeStatus={runtimeStatus}
           addAfterCellId={initialFocusedCellId}
           onAddCell={noop}
@@ -496,15 +558,53 @@ function FullShellCommandToolbar({
           onRunAllCells={noop}
           onRestartAndRunAll={noop}
           onTogglePackages={onTogglePackages}
-          workstationAction={{
-            label: "Workstation",
-            title: "Open workstation panel",
-            onClick: onToggleWorkstations,
-          }}
-          className="w-max min-w-full border-b-0"
+          workstationAction={
+            onToggleWorkstations
+              ? {
+                  label: "Workstation",
+                  title: "Open workstation panel",
+                  onClick: onToggleWorkstations,
+                }
+              : undefined
+          }
+          className={cn(
+            "w-max min-w-full border-b-0",
+            onOpenPanels &&
+              "max-[599.98px]:h-11 max-[599.98px]:[&_button]:min-h-8 max-[599.98px]:[&_button]:min-w-8",
+          )}
         />
       </div>
     </NotebookToolbarFrame>
+  );
+}
+
+function FullShellBrandMark({ className }: { className?: string }) {
+  return (
+    <span
+      role="img"
+      aria-label="nteract"
+      className={cn("block size-6 shrink-0 select-none", className)}
+      data-slot="full-shell-brand-mark"
+    >
+      <Image
+        src={logoLightUrl}
+        alt=""
+        aria-hidden="true"
+        width={24}
+        height={24}
+        draggable={false}
+        className="block size-full dark:hidden"
+      />
+      <Image
+        src={logoDarkUrl}
+        alt=""
+        aria-hidden="true"
+        width={24}
+        height={24}
+        draggable={false}
+        className="hidden size-full dark:block"
+      />
+    </span>
   );
 }
 
@@ -514,7 +614,7 @@ function FullShellTitle() {
       <span className="truncate text-sm font-semibold text-foreground">
         MathNet topic visualization
       </span>
-      <span className="hidden truncate text-[11px] leading-4 text-muted-foreground sm:block">
+      <span className="truncate text-[11px] leading-4 text-muted-foreground max-[900px]:hidden">
         Hosted preview - preview.runt.run/n/topic-viz/topic-viz
       </span>
     </div>

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -144,6 +144,17 @@ test("cloud notebook startup loading uses route-shaped shell chrome", () => {
   assert.match(loadingSource, /className="cloud-startup-workspace"/);
   assert.match(loadingSource, /className="cloud-startup-rail"/);
   assert.match(loadingSource, /className="cloud-startup-stage"/);
+  assert.match(
+    loadingSource,
+    /<header className="cloud-startup-toolbar">[\s\S]*<\/header>\s*<div className="cloud-startup-workspace">/,
+  );
+  assert.match(
+    loadingSource,
+    /className="cloud-startup-main">\s*<div className="cloud-startup-command-row" aria-hidden="true">/,
+  );
+  assert.doesNotMatch(loadingSource, /cloud-startup-rail-home|<House/);
+  assert.match(cssText, /\.cloud-startup-command-row \{[^}]*min-height: 2\.5rem;/);
+  assert.match(cssText, /\.cloud-startup-rail \{[^}]*padding: 3\.25rem 0\.5rem 0\.75rem;/);
   assert.match(viewerCorpus, /cloudNotebookRouteTitleFromPathname\(window\.location\.pathname\)/);
   assert.match(loadingSource, /Opening notebook/);
   assert.doesNotMatch(loadingSource, /className="flex min-h-screen/);
@@ -155,6 +166,42 @@ test("cloud notebook startup loading uses route-shaped shell chrome", () => {
     cssText,
     /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-startup-rail,[\s\S]*\.cloud-notebook-rail\[data-collapsed="true"\]\s*\{[\s\S]*display: none;/,
   );
+});
+
+test("cloud app header owns one accessible home brand above the notebook rail", () => {
+  const notebookSource = viewerFunctionSource("NotebookViewer");
+  const toolbarSource = notebookSource.slice(
+    notebookSource.indexOf("const toolbar ="),
+    notebookSource.indexOf("const stageToolbar ="),
+  );
+  const loadingSource = viewerFunctionSource("ViewerStartupLoading");
+  const cssText = readFileSync(new URL("../viewer/index.css", import.meta.url), "utf8");
+
+  for (const source of [toolbarSource, loadingSource]) {
+    assert.equal(source.match(/<NotebookBrandMark\b/g)?.length, 1);
+    assert.match(
+      source,
+      /<a className="cloud-app-home" href="\/n" aria-label="Notebook home" title="Notebook home">\s*<NotebookBrandMark className="size-8" \/>\s*<\/a>/,
+    );
+  }
+  assert.equal(notebookSource.match(/<NotebookBrandMark\b/g)?.length, 1);
+  assert.match(toolbarSource, /presence=\{\s*<>\s*<a[\s\S]*<\/a>\s*<CloudNotebookTitle/);
+  assert.doesNotMatch(notebookSource, /NotebookRailHomeButton|leadingSlot=/);
+  assert.doesNotMatch(toolbarSource, /<NotebookCommandToolbar/);
+  assert.match(notebookSource, /toolbarPlacement="shell"/);
+  assert.match(notebookSource, /stageToolbarPlacement="stage-content"/);
+  assert.match(
+    cssText,
+    /\.cloud-app-home \{[^}]*width: 3\.5rem;[^}]*height: 2\.75rem;[^}]*flex: 0 0 3\.5rem;[^}]*justify-content: center;/,
+  );
+  assert.match(cssText, /\.cloud-app-home:focus-visible \{[^}]*outline: 2px solid var\(--ring\);/);
+  for (const headerClass of ["cloud-room-toolbar", "cloud-startup-toolbar"]) {
+    assert.match(
+      cssText,
+      new RegExp(`\\.${headerClass} \\{[^}]*padding-inline: 0 clamp\\(0\\.5rem, 2vw, 1rem\\);`),
+    );
+  }
+  assert.doesNotMatch(cssText, /\.cloud-app-home[^}]*display: none/);
 });
 
 test("cloud viewer keeps pending access-request polling quiet", () => {
@@ -604,7 +651,17 @@ test("cloud rail takes over constrained widths instead of pushing the stage offs
   );
   assert.match(
     sourceText,
-    /\[data-slot="notebook-document-rail-panel-host"\]:has\(\[data-slot="notebook-rail-panel"\]\)\s*\+ \[data-slot="notebook-document-stage-content"\]\s*\{[\s\S]*display: none;/,
+    /\[data-slot="notebook-document-stage-body"\]:has\(\[data-slot="notebook-rail-panel"\]\)\s*> :is\(\s*\[data-slot="notebook-document-stage-content-toolbar"\],\s*\[data-slot="notebook-document-stage-content"\]\s*\)\s*\{\s*display: none;/,
+  );
+  assert.doesNotMatch(
+    sourceText,
+    /\[data-slot="(?:notebook-rail-panel-title-row|rail-panel-header)"\][^}]*display: none;/,
+  );
+  assert.doesNotMatch(
+    sourceText.match(
+      /\.cloud-notebook-stage > \[data-slot="notebook-document-stage-body"\]\s*\{[^}]*\}/,
+    )?.[0] ?? "",
+    /grid-template-rows:/,
   );
 });
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -33,7 +33,7 @@ body {
   justify-content: space-between;
   gap: 0.5rem;
   border-bottom: 1px solid var(--border);
-  padding-inline: 0.5rem clamp(0.5rem, 2vw, 1rem);
+  padding-inline: 0 clamp(0.5rem, 2vw, 1rem);
 }
 
 .cloud-startup-toolbar > .cloud-notebook-title-group {
@@ -94,6 +94,15 @@ body {
   flex: 1;
 }
 
+.cloud-startup-command-row {
+  display: flex;
+  min-height: 2.5rem;
+  flex: 0 0 auto;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  padding-inline: 0.5rem;
+}
+
 .cloud-startup-main {
   display: flex;
   min-width: 0;
@@ -110,7 +119,7 @@ body {
   align-items: center;
   gap: 0.25rem;
   border-right: 1px solid var(--border);
-  padding: 0.75rem 0.5rem;
+  padding: 3.25rem 0.5rem 0.75rem;
   color: color-mix(in srgb, var(--foreground) 48%, transparent);
   background: var(--background);
 }
@@ -131,25 +140,13 @@ body {
   box-sizing: content-box;
 }
 
-.cloud-startup-rail > span:not(.cloud-startup-rail-home)::after {
+.cloud-startup-rail > span::after {
   width: 1rem;
   height: 1rem;
   border-radius: 4px;
   background: currentColor;
   opacity: 0.24;
   content: "";
-}
-
-.cloud-startup-rail-home {
-  margin-bottom: 1rem;
-  color: var(--background);
-  background: var(--foreground);
-}
-
-.cloud-startup-rail-home svg {
-  width: 1rem;
-  height: 1rem;
-  stroke-width: 2.25;
 }
 
 .cloud-startup-stage {
@@ -249,7 +246,6 @@ body {
   min-width: 0;
   flex: 1;
   grid-template-columns: auto minmax(0, 1fr);
-  grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
 }
 
@@ -303,10 +299,29 @@ body {
   }
 }
 
+.cloud-app-home {
+  display: flex;
+  width: 3.5rem;
+  height: 2.75rem;
+  flex: 0 0 3.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.375rem;
+}
+
+.cloud-app-home:hover {
+  background: var(--muted);
+}
+
+.cloud-app-home:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
 .cloud-room-toolbar {
   min-height: 3.75rem;
   border-bottom: 1px solid var(--border);
-  padding-inline: 0.5rem clamp(0.5rem, 2vw, 1rem);
+  padding-inline: 0 clamp(0.5rem, 2vw, 1rem);
 }
 
 .cloud-room-toolbar [data-slot="notebook-document-header-presence"] {
@@ -315,6 +330,7 @@ body {
   min-width: 0;
   max-width: min(38rem, 48vw);
   align-items: center;
+  gap: 0.5rem;
 }
 
 .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {
@@ -695,8 +711,11 @@ body {
   }
 
   .cloud-notebook-stage
-    [data-slot="notebook-document-rail-panel-host"]:has([data-slot="notebook-rail-panel"])
-    + [data-slot="notebook-document-stage-content"] {
+    [data-slot="notebook-document-stage-body"]:has([data-slot="notebook-rail-panel"])
+    > :is(
+      [data-slot="notebook-document-stage-content-toolbar"],
+      [data-slot="notebook-document-stage-content"]
+    ) {
     display: none;
   }
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,7 @@
 import { lazy, Profiler, Suspense, useState, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
-import { BookOpen, House, Loader2 } from "lucide-react";
+import { BookOpen, Loader2 } from "lucide-react";
+import { NotebookBrandMark } from "@/components/notebook/NotebookBrandMark";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { setLoggerHost } from "@/lib/logger";
 import { setOpenUrlHost } from "@/lib/open-url";
@@ -149,31 +150,37 @@ function ViewerStartupError({ message }: { message: string }) {
 function ViewerStartupLoading({ title }: { title: string }) {
   return (
     <main className="cloud-startup-shell" aria-busy="true">
+      <header className="cloud-startup-toolbar">
+        <a className="cloud-app-home" href="/n" aria-label="Notebook home" title="Notebook home">
+          <NotebookBrandMark className="size-8" />
+        </a>
+        <div className="cloud-notebook-title-group">
+          <div className="cloud-notebook-title">
+            <h1 className="cloud-startup-title">{title}</h1>
+            <p className="cloud-startup-status" role="status">
+              <Loader2 aria-hidden="true" />
+              Opening notebook
+            </p>
+          </div>
+        </div>
+        <div className="cloud-startup-toolbar-actions" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+      </header>
       <div className="cloud-startup-workspace">
         <aside className="cloud-startup-rail" aria-hidden="true">
-          <span className="cloud-startup-rail-home">
-            <House aria-hidden="true" />
-          </span>
           <BookOpen aria-hidden="true" />
           <span />
         </aside>
         <div className="cloud-startup-main">
-          <header className="cloud-startup-toolbar">
-            <div className="cloud-notebook-title-group">
-              <div className="cloud-notebook-title">
-                <h1 className="cloud-startup-title">{title}</h1>
-                <p className="cloud-startup-status" role="status">
-                  <Loader2 aria-hidden="true" />
-                  Opening notebook
-                </p>
-              </div>
-            </div>
-            <div className="cloud-startup-toolbar-actions" aria-hidden="true">
-              <span />
+          <div className="cloud-startup-command-row" aria-hidden="true">
+            <div className="cloud-startup-toolbar-actions">
               <span />
               <span />
             </div>
-          </header>
+          </div>
           <section className="cloud-startup-stage" aria-hidden="true">
             <div className="cloud-startup-cell">
               <span className="cloud-startup-line cloud-startup-line--wide" />

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -24,7 +24,7 @@ import {
   useHasIsolatedOutputs,
   useIsolatedRenderer,
 } from "@/components/isolated/isolated-renderer-context";
-import { NotebookRailHomeButton, type NotebookRailPanelId } from "@/components/notebook-rail";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import {
   markdownProjectionMatchesSource,
@@ -1653,7 +1653,6 @@ export function NotebookViewer({
     );
   const rail = (
     <NotebookDocumentRail
-      leadingSlot={<NotebookRailHomeButton href="/n" />}
       trailingSlot={identityControls}
       viewModel={notebookViewModel}
       activePanelId={renderedActiveRailPanel}
@@ -1745,8 +1744,10 @@ export function NotebookViewer({
       frameClassName="z-20"
       headerClassName="cloud-room-toolbar"
       presence={
-        <div className="flex min-w-0 items-center gap-2">
-          <NotebookBrandMark className="size-8" />
+        <>
+          <a className="cloud-app-home" href="/n" aria-label="Notebook home" title="Notebook home">
+            <NotebookBrandMark className="size-8" />
+          </a>
           <CloudNotebookTitle
             title={notebookStageGated ? gatedNotebookTitle : notebookTitle}
             renameTitle={catalogNotebookTitle?.trim() ?? ""}
@@ -1755,7 +1756,7 @@ export function NotebookViewer({
             renameError={notebookTitleError}
             onRename={saveCloudNotebookTitle}
           />
-        </div>
+        </>
       }
       utilityControls={
         notebookHeaderChrome.showPresenceStatus ? (

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -36,6 +36,48 @@ test.describe("notebook rail outline", () => {
     mcp = null;
   });
 
+  test("keeps the logo fixed and panel titles level with notebook commands", async ({ page }) => {
+    const { dir, notebookPath } = copyOutlineFixture();
+    try {
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await openNotebookPath(page, notebookPath, { environmentMode: "notebook" });
+      await waitForCellCount(page, 3);
+      const logo = page.getByRole("img", { name: "nteract", exact: true });
+      const toolbar = page.getByTestId("notebook-toolbar");
+      const initialLogo = await logo.boundingBox();
+      expect(initialLogo).not.toBeNull();
+      await expect(page.locator('[data-slot="rail-leading-slot"]').getByRole("img")).toBeVisible();
+      await expect(toolbar.getByRole("img", { name: "nteract" })).toHaveCount(0);
+
+      for (const panel of ["Outline", "Packages"]) {
+        await page.getByRole("button", { name: panel, exact: true }).click();
+        await expect(page.getByRole("heading", { name: panel, exact: true })).toBeVisible();
+        expect(await logo.boundingBox()).toEqual(initialLogo);
+        const headerBox = await page.locator('[data-slot="rail-panel-header"]').boundingBox();
+        const toolbarBox = await toolbar.boundingBox();
+        expect(headerBox).not.toBeNull();
+        expect(toolbarBox).not.toBeNull();
+        expect(headerBox!.y).toBe(toolbarBox!.y);
+        expect(headerBox!.height).toBe(toolbarBox!.height);
+      }
+
+      await page.getByTestId("add-code-cell-button").focus();
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect(toolbar).toBeHidden();
+      await expect(page.getByRole("heading", { name: "Packages", exact: true })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Packages", exact: true })).toBeFocused();
+      await expect(logo).toBeVisible();
+      await page.getByRole("button", { name: "Packages", exact: true }).click();
+      await expect(toolbar).toBeVisible();
+
+      await page.getByTestId("deps-toggle").click();
+      await expect(toolbar).toBeHidden();
+      await expect(page.getByRole("button", { name: "Packages", exact: true })).toBeFocused();
+    } finally {
+      cleanupOutlineFixture(dir);
+    }
+  });
+
   test("renders every heading from the outline fixture", async ({ page }) => {
     const { dir, notebookPath } = copyOutlineFixture();
     try {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -62,6 +62,7 @@ import {
   ComputeDisconnectedNotice,
   KernelLaunchErrorBanner,
   isRuntimePeerDisconnectedErrorDetails,
+  NotebookBrandMark,
   NotebookCommentsPanel,
   NotebookConnectionIdentity,
   NotebookDocumentRail,
@@ -133,6 +134,7 @@ import {
   useNotebookRailUiState,
 } from "@/components/notebook/state/rail-ui-state";
 import {
+  isNotebookStageTarget,
   navigateNotebookOutlineFromRail,
   navigateToNotebookStageFromRail,
 } from "@/components/notebook/rail-stage-navigation";
@@ -177,8 +179,7 @@ function focusActiveRailButtonWhenStageIsHidden(
   const activeElement = document.activeElement;
   if (!(activeElement instanceof HTMLElement)) return;
 
-  const stage = document.querySelector('[data-slot="notebook-document-stage-content"]');
-  const focusWasInStage = stage?.contains(activeElement);
+  const focusWasInStage = isNotebookStageTarget(activeElement);
   const focusWasClearedFromHiddenStage =
     stageHadFocusBeforeTakeover && activeElement === document.body;
   if (!focusWasInStage && !focusWasClearedFromHiddenStage) return;
@@ -452,10 +453,7 @@ function AppContent() {
     if (typeof document === "undefined") return;
 
     const handleFocusIn = (event: FocusEvent) => {
-      const stage = document.querySelector('[data-slot="notebook-document-stage-content"]');
-      stageHadFocusBeforeRailTakeoverRef.current = Boolean(
-        event.target instanceof Node && stage?.contains(event.target),
-      );
+      stageHadFocusBeforeRailTakeoverRef.current = isNotebookStageTarget(event.target);
     };
 
     document.addEventListener("focusin", handleFocusIn);
@@ -2077,7 +2075,10 @@ function AppContent() {
             ) : null
           }
           toolbarPlacement="stage-content"
-          toolbarClassName="shrink-0 bg-background"
+          toolbarClassName={cn(
+            "shrink-0 bg-background",
+            !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+          )}
           toolbarLabel="Notebook execution and runtime controls"
           toolbar={
             <NotebookToolbar
@@ -2117,6 +2118,7 @@ function AppContent() {
           stageContentClassName={cn(!railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME)}
           rail={
             <NotebookDocumentRail
+              leadingSlot={<NotebookBrandMark />}
               trailingSlot={
                 <NotebookConnectionIdentity
                   capabilities={shellCapabilities}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -2,7 +2,6 @@ import { Copy, Info } from "lucide-react";
 import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
-  NotebookBrandMark,
   NotebookCommandToolbar,
   NotebookNotice,
   NotebookNoticeAction,
@@ -250,7 +249,6 @@ export function NotebookToolbar({
     <NotebookToolbarFrame notices={notices}>
       <NotebookCommandToolbar
         capabilities={capabilities}
-        leadingControls={<NotebookBrandMark />}
         runtime={runtime}
         environmentManager={envManager}
         environmentPanelOpen={isDepsOpen}

--- a/apps/notebook/src/components/__tests__/elements-style-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/elements-style-boundary.test.ts
@@ -44,6 +44,17 @@ describe("Elements visual style boundary", () => {
     ).toEqual([]);
   });
 
+  it("lets the production notebook viewport own full-shell spacing and scrolling", () => {
+    const source = readFileSync(
+      join(elementsComponentsDir, "full-shell-composition-example.tsx"),
+      "utf8",
+    );
+    expect(source).toMatch(
+      /<section\s+aria-label="Notebook document"\s+className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background"\s+data-slot="full-shell-notebook-stage"\s*>\s*\{fixturesSeeded \? \(\s*<NotebookView/,
+    );
+    expect(source).not.toMatch(/max-w-5xl|overflow-y-auto|mx-auto/);
+  });
+
   it("keeps catalog-only labels out of production cell gutters", () => {
     expect(matchingLines(/rightGutterContent=\{\s*<span/)).toEqual([]);
   });

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -88,10 +88,12 @@ const baseProps = {
 };
 
 describe("NotebookToolbar", () => {
-  it("shows the nteract brand at the leading edge", () => {
+  it("leaves branding to the fixed rail instead of the notebook command row", () => {
     render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.IDLE)} />);
 
-    expect(screen.getByRole("img", { name: "nteract" })).toBeVisible();
+    expect(screen.queryByRole("img", { name: "nteract" })).not.toBeInTheDocument();
+    const appSource = readFileSync(resolve(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
+    expect(appSource).toMatch(/<NotebookDocumentRail\s+leadingSlot=\{<NotebookBrandMark \/>\}/);
   });
 
   describe("start button visibility", () => {

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -84,13 +84,13 @@ export function NotebookRail({
       ? [{ id: "workstations" as const, label: "Workstations", icon: Server }]
       : []),
   ];
-  const title = activePanelId === "workstations" ? "Workstations" : null;
+  const title = railButtons.find((item) => item.id === activePanelId)?.label;
   return (
     <Rail
       activePanelId={activePanelId}
       collapsed={collapsed}
       items={railButtons}
-      panelTitle={title ?? undefined}
+      panelTitle={title}
       panelAction={activePanelId === "workstations" ? workstationsPanelAction : undefined}
       leadingSlot={leadingSlot}
       trailingSlot={trailingSlot}

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -149,7 +149,7 @@ describe("NotebookRail", () => {
     );
 
     expect(screen.getByRole("button", { name: "Discussions" })).toBeVisible();
-    expect(screen.queryByRole("heading", { name: "Discussions" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Discussions" })).toBeVisible();
     expect(screen.getByText("Thread list")).toBeVisible();
   });
 
@@ -211,7 +211,7 @@ describe("NotebookRail", () => {
     );
   });
 
-  it("omits redundant package panel header chrome", () => {
+  it("names the packages panel without duplicating package metadata", () => {
     const { container } = render(
       <NotebookRail
         activePanelId="packages"
@@ -223,8 +223,10 @@ describe("NotebookRail", () => {
       />,
     );
 
-    expect(screen.queryByRole("heading", { name: "Packages" })).not.toBeInTheDocument();
-    expect(container.querySelector('[data-slot="rail-panel-header"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "Packages" })).toBeVisible();
+    expect(container.querySelector('[data-slot="rail-panel-header"]')).toContainElement(
+      screen.getByRole("heading", { name: "Packages" }),
+    );
     expect(screen.queryByText("../pyproject.toml · 25 packages")).not.toBeInTheDocument();
   });
 

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -10,12 +10,6 @@ export interface NotebookDocumentShellProps {
    */
   rootElement?: "div" | "main";
   rail?: ReactNode;
-  /**
-   * `rail` keeps an expanded rail panel inside the rail column, level with the
-   * toolbar chrome. `stage` hosts it in the stage instead, so the panel slides
-   * out below the utility bar and beside the notebook content while the rail's
-   * icon strip stays at the far left of the page content.
-   */
   railPanelPlacement?: "rail" | "stage";
   toolbar?: ReactNode;
   /**
@@ -137,16 +131,9 @@ export function NotebookDocumentShell({
                   ) : null}
                 </div>
               ) : null}
-              {/* Portal target for the expanded rail panel: it slides out here,
-                  beneath the notebook command row, while the rail strip stays
-                  on the left. Its width also anchors the command row and the
-                  notebook content to the same live stage edge. */}
               <div
                 ref={setRailPanelSlotNode}
-                className={cn(
-                  "col-start-1 flex min-h-0 shrink-0",
-                  hasStageContentToolbar ? "row-start-2" : "row-start-1",
-                )}
+                className="col-start-1 row-start-1 row-end-[-1] flex min-h-0 shrink-0"
                 data-slot="notebook-document-rail-panel-host"
               />
               <div

--- a/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
@@ -42,7 +42,7 @@ describe("NotebookDocumentRail", () => {
     expect(screen.getByText("Package details")).toBeVisible();
   });
 
-  it("omits redundant package header chrome and view-model summaries", () => {
+  it("names the packages panel without duplicating view-model summaries", () => {
     render(
       <NotebookDocumentRail
         viewModel={viewModel}
@@ -54,7 +54,7 @@ describe("NotebookDocumentRail", () => {
       />,
     );
 
-    expect(screen.queryByRole("heading", { name: "Packages" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Packages" })).toBeVisible();
     expect(screen.queryByText("uv · 2 packages")).not.toBeInTheDocument();
     expect(screen.getByText("Package details")).toBeVisible();
   });

--- a/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
@@ -4,6 +4,8 @@ import { ListTree } from "lucide-react";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { Rail } from "@/components/rail";
+import { NotebookRail, type NotebookRailPanelId } from "@/components/notebook-rail";
+import { NotebookBrandMark } from "../NotebookBrandMark";
 import { NotebookDocumentShell } from "../NotebookDocumentShell";
 import type { NotebookShellCapabilities } from "../capabilities";
 
@@ -92,7 +94,7 @@ describe("NotebookDocumentShell", () => {
     expect(contentToolbar).toHaveClass("col-start-2", "row-start-1");
     expect(contentToolbar).toContainElement(screen.getByRole("button", { name: "Run" }));
     expect(contentToolbar).toContainElement(screen.getByRole("button", { name: "Restart" }));
-    expect(panelHost).toHaveClass("col-start-1", "row-start-2");
+    expect(panelHost).toHaveClass("col-start-1", "row-start-1", "row-end-[-1]");
     expect(panelHost).toContainElement(screen.getByTestId("outline-content"));
     expect(stageContent).toHaveClass("col-start-2", "row-start-2");
     expect(stageContent).toContainElement(screen.getByLabelText("Notebook cells"));
@@ -118,6 +120,36 @@ describe("NotebookDocumentShell", () => {
     await user.click(screen.getByRole("button", { name: "Place panel in stage" }));
     expect(panelHost()).toContainElement(screen.getByTestId("outline-content"));
   });
+
+  it.each([false, true])(
+    "keeps branding fixed while panels toggle (hosted: %s)",
+    async (hosted) => {
+      const user = userEvent.setup();
+      const { container } = render(<BrandedShellHarness hosted={hosted} />);
+      const brand = screen.getByRole("img", { name: "nteract" });
+      const brandSlot = brand.closest(
+        hosted ? '[data-slot="notebook-document-toolbar"]' : '[data-slot="rail-leading-slot"]',
+      );
+      expect(brandSlot).not.toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "Outline" }));
+      const panelHost = container.querySelector('[data-slot="notebook-document-rail-panel-host"]');
+      expect(panelHost).toContainElement(screen.getByRole("heading", { name: "Outline" }));
+      expect(panelHost).toHaveClass("row-start-1", "row-end-[-1]");
+      expect(brandSlot).toContainElement(brand);
+      expect(panelHost).not.toContainElement(brand);
+
+      await user.click(screen.getByRole("button", { name: "Packages" }));
+      expect(panelHost).toContainElement(screen.getByRole("heading", { name: "Packages" }));
+      expect(screen.queryByRole("heading", { name: "Outline" })).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Packages" }));
+      expect(screen.queryByRole("heading", { name: "Packages" })).not.toBeInTheDocument();
+      expect(brandSlot).toContainElement(brand);
+      expect(screen.getAllByRole("img", { name: "nteract" })).toHaveLength(1);
+      expect(screen.getByRole("button", { name: "Run" })).toBeVisible();
+      if (hosted) expect(screen.getByRole("button", { name: "Share" })).toBeVisible();
+    },
+  );
 
   it("exposes host capabilities for adapters and smoke tests", () => {
     const capabilities: NotebookShellCapabilities = {
@@ -170,6 +202,41 @@ describe("NotebookDocumentShell", () => {
     expect(shell).toHaveAttribute("data-can-write-runtime-state", "false");
   });
 });
+
+function BrandedShellHarness({ hosted }: { hosted: boolean }) {
+  const [collapsed, setCollapsed] = useState(true);
+  const [activePanelId, setActivePanelId] = useState<NotebookRailPanelId>("outline");
+
+  return (
+    <NotebookDocumentShell
+      railPanelPlacement="stage"
+      toolbar={
+        hosted ? (
+          <>
+            <NotebookBrandMark />
+            <span>Notebook title</span>
+            <button type="button">Share</button>
+          </>
+        ) : null
+      }
+      stageToolbar={<button type="button">Run</button>}
+      stageToolbarPlacement="stage-content"
+      rail={
+        <NotebookRail
+          activePanelId={activePanelId}
+          collapsed={collapsed}
+          leadingSlot={hosted ? null : <NotebookBrandMark />}
+          outlineItems={[]}
+          packagesPanel={<p>Package details</p>}
+          onActivePanelChange={setActivePanelId}
+          onCollapsedChange={setCollapsed}
+        />
+      }
+    >
+      <section aria-label="Notebook cells">cells</section>
+    </NotebookDocumentShell>
+  );
+}
 
 function StageHostedRailHarness() {
   const [collapsed, setCollapsed] = useState(true);

--- a/src/components/notebook/__tests__/rail-stage-navigation.test.ts
+++ b/src/components/notebook/__tests__/rail-stage-navigation.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY } from "@/components/notebook-rail";
 import {
+  isNotebookStageTarget,
   navigateNotebookOutlineFromRail,
   navigateToNotebookStageFromRail,
 } from "@/components/notebook/rail-stage-navigation";
 
 describe("notebook rail stage navigation", () => {
+  it.each(["notebook-document-stage-content", "notebook-document-stage-content-toolbar"])(
+    "recognizes focus in %s before a rail takeover",
+    (slot) => {
+      const stage = document.createElement("div");
+      stage.dataset.slot = slot;
+      const control = document.createElement("button");
+      stage.append(control);
+      expect(isNotebookStageTarget(control)).toBe(true);
+    },
+  );
+
+  it.each(["notebook-document-rail-panel-host", "notebook-document-toolbar", "rail-leading-slot"])(
+    "does not move focus out of visible %s chrome during takeover",
+    (slot) => {
+      const chrome = document.createElement("div");
+      chrome.dataset.slot = slot;
+      const control = document.createElement("button");
+      chrome.append(control);
+      expect(isNotebookStageTarget(control)).toBe(false);
+      expect(isNotebookStageTarget(null)).toBe(false);
+    },
+  );
+
   it("collapses a narrow takeover rail before scheduling focus and scroll", () => {
     const events: string[] = [];
     let scheduledNavigation: (() => void) | null = null;

--- a/src/components/notebook/rail-stage-navigation.ts
+++ b/src/components/notebook/rail-stage-navigation.ts
@@ -9,6 +9,16 @@ interface NotebookRailStageNavigationOptions<Result> {
   scheduleAfterCollapse?: (callback: () => void) => void;
 }
 
+export function isNotebookStageTarget(target: EventTarget | null): boolean {
+  return (
+    typeof Element !== "undefined" &&
+    target instanceof Element &&
+    target.closest(
+      '[data-slot="notebook-document-stage-content"], [data-slot="notebook-document-stage-content-toolbar"]',
+    ) !== null
+  );
+}
+
 function browserMatchMedia(query: string): Pick<MediaQueryList, "matches"> {
   if (typeof window === "undefined") return { matches: false };
   return { matches: window.matchMedia?.(query).matches === true };

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -21,7 +21,6 @@ export interface RailProps<PanelId extends string = string> {
   activePanelId: PanelId;
   collapsed: boolean;
   items: readonly RailItem<PanelId>[];
-  /** Omit when the active rail control already names the panel. */
   panelTitle?: string;
   children: ReactNode;
   onActivePanelChange: (panelId: PanelId) => void;
@@ -59,24 +58,25 @@ export function Rail<PanelId extends string = string>({
   const panel = collapsed ? null : (
     <div
       className={cn(
-        "flex min-h-0 max-w-[calc(100vw-3.5rem)] flex-col border-r bg-muted/20",
+        "flex min-h-0 max-w-[calc(100vw-3.5rem)] flex-col border-r bg-muted/60",
         panelClassName,
         RAIL_TAKEOVER_PANEL_CLASS_NAMES,
       )}
       data-slot={panelSlot}
     >
       {showPanelHeader ? (
-        <div className="border-b px-4 py-3" data-slot="rail-panel-header">
-          <div className="flex flex-col gap-1.5">
-            <div
-              className="flex min-w-0 flex-wrap items-center justify-between gap-2"
-              data-slot={panelTitleRowSlot}
-            >
-              {panelTitle != null ? (
-                <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
-              ) : null}
-              {panelAction}
-            </div>
+        <div
+          className="flex min-h-10 shrink-0 items-center px-4 py-1.5"
+          data-slot="rail-panel-header"
+        >
+          <div
+            className="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-2"
+            data-slot={panelTitleRowSlot}
+          >
+            {panelTitle != null ? (
+              <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
+            ) : null}
+            {panelAction}
           </div>
         </div>
       ) : null}

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -43,7 +43,12 @@ describe("Rail", () => {
       ...RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
     expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass("border-r");
-    expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass("bg-muted/20");
+    expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass("bg-muted/60");
+    expect(container.querySelector('[data-slot="rail-panel-header"]')).toHaveClass(
+      "min-h-10",
+      "shrink-0",
+    );
+    expect(container.querySelector('[data-slot="rail-panel-header"]')).not.toHaveClass("border-b");
     expect(container.querySelector('[data-slot="example-rail-title-row"]')).toHaveClass(
       "flex-wrap",
     );


### PR DESCRIPTION
## Summary
- Anchor the desktop logo above the rail buttons rather than inside the moving notebook command row.
- Keep cloud notebook title, sharing, and presence in app-level chrome, with one accessible home logo aligned over the rail; match the startup shell to that layout.
- Give every open rail panel a title beside the command row and a continuous subtle background across its header and contents.
- Preserve narrow-screen panel takeover and recover desktop keyboard focus when notebook commands become hidden.
- Add desktop/cloud Elements previews that use the production notebook viewport without demo-only margins, width caps, or nested scrolling.

## Validation
- `cargo xtask lint --fix`
- 112 focused Vitest tests covering rail, shell, toolbar, focus navigation, branding, and Elements boundaries
- 13 cloud viewer regression tests
- Desktop, cloud, and Elements TypeScript checks
- New Chromium desktop E2E regression: fixed branding, title/toolbar alignment, resizing, and opening Packages from the toolbar
- Playwright screenshots and geometry/scroll checks for both hosts at 1920px, 1440px, and 390px in light/dark themes
- Desktop manually exercised in light and dark mode

## Preview
Run `pnpm --dir apps/elements dev:local`, then open `/full-shell-composition?host=desktop` or `/full-shell-composition?host=cloud`.
The preview uses fixture data with the real notebook components; it does not start kernels or perform hosted sharing actions.