### PR TITLE
docs: simplify prose and remove em dashes

### DIFF
--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -46,7 +46,7 @@ AutoCommit { doc: Automerge, transaction: Option<(PatchLog, TransactionInner)>,
 
 - **save()** serializes OpSet columns + ChangeGraph metadata + optional DEFLATE. Columnar format is canonical.
 - **load()** rebuilds OpSet from columns, reconstructs ChangeGraph, verifies heads.
-- **save/load round-trip clears corrupted indices** — the basis of nteract's `rebuild_from_save()` recovery.
+- **save/load round-trip clears corrupted indices.** This is the basis of nteract's `rebuild_from_save()` recovery.
 - **load_incremental()** adds changes to existing doc. This is what `receive_sync_message` calls internally.
 - **save_after(heads)** emits only changes after given heads (incremental saves).
 
@@ -85,7 +85,7 @@ Message { heads, need, have: Vec<Have>, changes: ChunkList, flags, version }
 - `changes`: actual change data
 - Sender sends a change only if all peer bloom filters say they lack it
 
-### sync::State — Per-Peer Session
+### sync::State: Per-Peer Session
 
 | Field | Persists across encode/decode? | Purpose |
 |-------|-------------------------------|---------|
@@ -96,7 +96,7 @@ Message { heads, need, have: Vec<Have>, changes: ChunkList, flags, version }
 | `in_flight` | No | Suppresses duplicate sends while awaiting ack |
 | `have_responded` | No | True after first message sent |
 
-**Critical:** `encode()` only serializes `shared_heads`. All else is session-ephemeral. `sync::State::new()` is always safe for reconnection — you lose optimization (may resend) but keep correctness.
+**Critical:** `encode()` only serializes `shared_heads`. All else is session-ephemeral. `sync::State::new()` is always safe for reconnection: you lose optimization (may resend) but keep correctness.
 
 ### In-Flight Suppression
 
@@ -131,7 +131,7 @@ For CommentsDoc, see `crates/comments-doc`, daemon persistence at
 WASM (`runtimed-wasm`) both hold CommentsDoc replicas. Optimistic client
 mutations apply via Automerge; the daemon validates change actor labels against
 the connection principal (clone-preview) and strips writes from scopes without
-comment authority. There is no daemon finalization step — attribution
+comment authority. There is no daemon finalization step. Attribution
 (`resolved_by_actor_label`, `resolved_at`) is projected from admitted change
 actors.
 
@@ -176,7 +176,7 @@ Principle: **reset transport state, preserve document truth.**
 |----------|-----|
 | Execute / run-all | `required_heads` via `send_request_after_heads` |
 | Client-initiated save | `confirm_sync` before `SaveNotebook` request |
-| Daemon-internal autosave | Neither — daemon reads its own doc directly |
+| Daemon-internal autosave | Neither; daemon reads its own doc directly |
 
 ### RuntimeStateDoc Output Pressure
 
@@ -243,7 +243,7 @@ If reconnect latency becomes a problem, preserving `shared_heads` (automerge-rep
 |----------|--------|
 | Synchronous batch mutation | `fork_and_merge(\|fork\| { ... })` |
 | Async write from captured heads | `transact_at_heads_recovering(&baseline_heads, actor, label, \|doc\| { ... })` |
-| Concurrent async fork | `fork_with_actor("runtimed:iopub:kernel-abc")` — unique actor per fork |
+| Concurrent async fork | `fork_with_actor("runtimed:iopub:kernel-abc")` (unique actor per fork) |
 | Per-cell O(1) reads (WASM) | Direct map lookups via `ObjIndex` |
 | Recovery from corrupted indices | `save()` → `load()` round-trip |
 
@@ -260,18 +260,18 @@ Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor tab
 3. **Add document-owned recovery helpers** (receive + generate with panic capture, rebuild, peer state reset)
 4. **Add rebuild function** (save→load→reset pattern)
 5. **Update biased select loop** or relevant frame handler
-6. **Consider subscription scope** — every peer or specific consumers?
-7. **Test with concurrent mutation** — actor/heads bugs only manifest under concurrent sync
+6. **Consider subscription scope:** Every peer or specific consumers?
+7. **Test with concurrent mutation:** Actor/heads bugs only manifest under concurrent sync
 
 ## Invariants
 
-- Each remote peer gets its own `sync::State` — sharing causes duplicate/missing sends
+- Each remote peer gets its own `sync::State`. Sharing causes duplicate/missing sends.
 - `generate_sync_message()` returning `None` after local mutations is correct (in-flight suppression)
-- Keep the frame reader draining — use waiters, not blocking waits
-- Lock scope drops before `.await` — compute inside lock, send outside
+- Keep the frame reader draining: use waiters, not blocking waits
+- Lock scope drops before `.await`: compute inside lock, send outside
 - Reset sync state on transport breaks (reconnect, panic), not on local mutations
 - Cell-count guard prevents silent cell loss during rebuild
-- Actor table is sorted lexicographically — disagreement corrupts OpIds
+- Actor table is sorted lexicographically. Disagreement corrupts OpIds.
 
 ## Decision Framework
 
@@ -280,8 +280,8 @@ Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor tab
 | Transport disconnect | Reset `sync::State` (new or encode/decode) |
 | Automerge panic caught | Rebuild doc (save/load), reset sync::State |
 | Local mutation | Let next `generate_sync_message` handle it |
-| Check if peer has changes | `change_graph.has_change(&hash)` — O(1) |
-| Document at earlier point | `fork_at(heads)` — expensive, views only |
+| Check if peer has changes | `change_graph.has_change(&hash)` (O(1)) |
+| Document at earlier point | `fork_at(heads)` (expensive, views only) |
 | Async notebook write at captured heads | `transact_at_heads_recovering()` |
 | Concurrent async fork | `fork_with_actor()` with unique actor |
 | Shrink document bytes | `save()` compacts; no history GC available |

--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -47,10 +47,10 @@ The daemon (`runtimed`) is a singleton coordinating notebook windows over a Unix
 
 ### How `cargo xtask build` works (4 phases)
 
-0. **Artifact guard** — verify gitignored WASM, renderer-plugin, and MCP widget outputs. Build/dev commands fingerprint workspace inputs and skip wasm-pack when outputs are current; rebuild only when outputs are missing, invalid, or stale.
-1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p nteract-mcp -p mcp-supervisor`. Sidecars copied to `crates/notebook/binaries/`. The `notebook` crate is intentionally excluded until the Tauri link phase after frontend assets exist.
-2. **Frontend build** — `pnpm build` (TypeScript + Vite). `--rust-only` skips this.
-3. **Tauri link** — `cargo tauri build --debug --no-bundle` with embedded frontend assets. Use `--skip-tauri` only for fast edit checks where updated sidecar binaries are enough; run a normal build before launching the bundled app.
+0. **Artifact guard:** Verify gitignored WASM, renderer-plugin, and MCP widget outputs. Build/dev commands fingerprint workspace inputs and skip wasm-pack when outputs are current; rebuild only when outputs are missing, invalid, or stale.
+1. **Single Rust compilation:** `cargo build -p runtimed -p runt -p nteract-mcp -p mcp-supervisor`. Sidecars copied to `crates/notebook/binaries/`. The `notebook` crate is intentionally excluded until the Tauri link phase after frontend assets exist.
+2. **Frontend build:** `pnpm build` (TypeScript + Vite). `--rust-only` skips this.
+3. **Tauri link:** `cargo tauri build --debug --no-bundle` with embedded frontend assets. Use `--skip-tauri` only for fast edit checks where updated sidecar binaries are enough; run a normal build before launching the bundled app.
 
 All Rust targets build in one `cargo build` call to avoid feature-unification recompilation. WASM outputs are gitignored; `runtimed`'s `build.rs` panics if missing. `nteract-mcp` embeds the MCP widget HTML; prepare it with `cargo xtask artifacts ensure mcp-widget`.
 
@@ -118,7 +118,7 @@ cargo test -p runtimed test_daemon_ping_pong    # Specific test
 ### Installation
 
 ```bash
-# Into workspace venv (most common — what `up rebuild=true` does)
+# Into workspace venv (most common; what `up rebuild=true` does)
 cd crates/runtimed-py
 VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 
@@ -126,7 +126,7 @@ VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 VIRTUAL_ENV=../../python/runtimed/.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
-Always set `VIRTUAL_ENV` explicitly — without it, the `.so` installs into whichever venv `uv run` resolves.
+Always set `VIRTUAL_ENV` explicitly. Without it, the `.so` installs into whichever venv `uv run` resolves.
 
 ### Basic usage
 
@@ -170,7 +170,7 @@ The MCP server ships as `runt mcp` (Rust). Run via `cargo xtask run-mcp` for dev
 
 **Advertised tools** (`all_tools()`): `list_active_notebooks`, `list_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`, `disconnect_notebook`, `create_cell`, `set_cell`, `delete_cell`, `move_cell`, `execute_cell`, `run_all_cells`, `get_results`, `interrupt_kernel`, `restart_kernel`, `manage_dependencies`, `replace_match`, `replace_regex`.
 
-**Hidden/callable read tools** (`hidden_tools()`): `get_cell`, `get_all_cells`. These are callable but not advertised in `list_tools()` — dispatch-only read paths for clients that prefer direct tool calls over resource URIs.
+**Hidden/callable read tools** (`hidden_tools()`): `get_cell`, `get_all_cells`. These are callable but not advertised in `list_tools()`. They are dispatch-only read paths for clients that prefer direct tool calls over resource URIs.
 
 Legacy dependency and cell-metadata tool names still dispatch for compatibility, but new workflows should use `manage_dependencies` for dependency inspection/edits and `get_results` for execution output lookup by `execution_id`.
 
@@ -217,7 +217,7 @@ Each open notebook has a room (`NotebookRoom`), keyed by UUID. A `PathIndex` map
 
 ## Key Invariants
 
-- `is_binary_mime()` has one canonical Rust implementation in `notebook-doc::mime` — single source of truth across all crates.
+- `is_binary_mime()` has one canonical Rust implementation in `notebook-doc::mime`, shared across all crates.
 - Iframe sandbox: `allow-same-origin` is forbidden.
 - Per-cell O(1) accessors must stay in sync across WASM, Rust, and Python.
 - Hold tokio mutex guards only within synchronous blocks (use block scoping, verify with `cargo test -p runtimed --test tokio_mutex_lint`).
@@ -239,4 +239,4 @@ Production daemon installs as a system service (macOS: launchd, Linux: systemd u
 
 **Key paths (macOS):** Binary at `~/Library/Application Support/runt/bin/runtimed`, socket at `~/Library/Caches/runt/runtimed.sock`, logs at `~/Library/Caches/runt/runtimed.log`.
 
-Use `./target/debug/runt daemon stop` to stop only your worktree's daemon. Avoid `pkill`/`killall` — they affect every worktree.
+Use `./target/debug/runt daemon stop` to stop only your worktree's daemon. Avoid `pkill`/`killall` because they affect every worktree.

--- a/.agents/skills/execution-pipeline/SKILL.md
+++ b/.agents/skills/execution-pipeline/SKILL.md
@@ -30,10 +30,10 @@ let required_heads = handle.current_heads_hex()?;
 These heads are attached to the request envelope. The daemon's
 `wait_for_required_heads()` defers processing until all listed change
 hashes exist in its copy of the notebook document (checked via
-`get_change_by_hash` — a ChangeGraph containment check).
+`get_change_by_hash`, a ChangeGraph containment check).
 
 **Why this matters:** Without `required_heads`, the daemon might
-execute against stale cell source — the client wrote "x = 1" but the
+execute against stale cell source: the client wrote "x = 1" but the
 daemon hasn't received that sync frame yet, so it executes the old
 "x = 0".
 
@@ -114,13 +114,13 @@ The client polls RuntimeStateDoc for execution completion:
 await_execution_terminal(handle, &execution_id, timeout, None).await
 ```
 
-**Phase 1 — Terminal status poll:**
+**Phase 1: Terminal status poll:**
 - Polls every 50ms
 - Checks `executions[eid].status` for `"done"` or `"error"`
 - Also watches for kernel-level failure (`kernel.lifecycle == Error|Shutdown`)
 - Returns `KernelFailed` if the kernel dies while execution is pending
 
-**Phase 2 — Output-sync grace:**
+**Phase 2: Output-sync grace:**
 - After terminal status is reached, the output list might still be
   empty on the client's replica (sync lag)
 - Polls every 10ms for up to 500ms (the grace period)
@@ -129,7 +129,7 @@ await_execution_terminal(handle, &execution_id, timeout, None).await
 **Why RuntimeStateDoc, not broadcasts:** The `ExecutionDone` broadcast
 arrives over a separate channel and the client's Automerge replica may
 not have caught up on the final stream writes. The RuntimeStateDoc is
-authoritative — once status is `"done"`, outputs are guaranteed to be
+authoritative: once status is `"done"`, outputs are guaranteed to be
 in the same document.
 
 ### Stage 5: Output Resolution
@@ -150,7 +150,7 @@ Resolution depends on MIME type:
   References comm topology/output routing in RuntimeStateDoc; mutable widget
   values live in the paired CommsDoc
 
-MCP execution paths use **preview mode** — output is truncated for
+MCP execution paths use **preview mode**: output is truncated for
 LLM consumption. Agents that need full output call
 `get_cell(full_output=true)` separately.
 
@@ -178,7 +178,7 @@ outputs.
 
 1. Captures `required_heads` once
 2. Sends `RunAllCells` request with all cell IDs
-3. Daemon returns `AllCellsQueued { cell_execution_ids }` — a map of
+3. Daemon returns `AllCellsQueued { cell_execution_ids }`: a map of
    `cell_id → execution_id` for every queued cell
 4. Client polls each `execution_id` in parallel with a shared deadline
 5. Returns per-cell results
@@ -211,7 +211,7 @@ If one cell takes 90% of the budget, remaining cells get less time.
 ### "Execution timed out"
 
 1. **Long-running cell:** The cell genuinely takes longer than the
-   timeout (default varies by caller — MCP uses 120s).
+   timeout (default varies by caller; MCP uses 120s).
 2. **Kernel hung:** The kernel process is alive but not responding.
    Check `kernel.lifecycle` in RuntimeStateDoc.
 3. **Sync stall:** Terminal status was written by the daemon but the
@@ -222,7 +222,7 @@ If one cell takes 90% of the budget, remaining cells get less time.
 
 The execution completed but the outputs visible belong to an earlier
 run. This happens when:
-1. Reading cell outputs without using the `execution_id` — the cell's
+1. Reading cell outputs without using the `execution_id`: the cell's
    "current" pointer may not have been updated yet
 2. The RuntimeStateDoc sync hasn't delivered the latest writes
 

--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -227,7 +227,7 @@ each async completion is a stale-write risk:
   consumption, never activation - its owner activates the instances it supplies.
   A controller that dispatches actions on the same store reads it from the same
   context too, so an override gets a coherent store.
-- **Capture at issue, drop at apply — for every completion.** Poll ticks AND
+- **Capture at issue, drop at apply for every completion.** Poll ticks AND
   imperative actions capture `{epoch, auth reference, endpoint}` when the
   request starts; after every `await` (success, error, and any follow-up
   refetch), the result is discarded if the identity moved. A guarded first
@@ -356,8 +356,8 @@ Starts dev daemon, launches `nteract-dev`, spawns child `runt mcp`, proxies note
 ### Hot Reload Watches
 
 `python/nteract/src/`, `python/runtimed/src/`, `crates/runtimed-py/src/`, `crates/runtimed/src/`:
-- **Python changes** — child restarts automatically
-- **Rust changes** — `maturin develop` runs first, then child restarts
+- **Python changes:** Child restarts automatically
+- **Rust changes:** `maturin develop` runs first, then child restarts
 
 ### Direct Mode (no proxy)
 

--- a/.agents/skills/mcp-session-lifecycle/SKILL.md
+++ b/.agents/skills/mcp-session-lifecycle/SKILL.md
@@ -176,7 +176,7 @@ not for the entire tool execution. `DocHandle` is cheaply cloneable
 
 **Ephemeral notebooks** call `connect(uuid)` directly and trust the daemon's
 resident/recoverable-room handling. The daemon is authoritative about whether
-a notebook still exists — a refusal comes back as `NotebookUnavailable` and
+a notebook still exists. A refusal comes back as `NotebookUnavailable` and
 is handled as evicted with no retry. No pre-check `list_rooms` call.
 
 **File-backed notebooks** use `connect_open(path)` which lets the daemon
@@ -233,11 +233,11 @@ is closed. Use `connect_open(path)` to let the daemon reload from disk.
 If an ephemeral room was evicted, `connect(uuid)` creates a new empty room
 with no cells and no kernel. Check `list_rooms` first.
 
-## North Star: Concurrent MCP Clients
+## Goal: Support Concurrent MCP Clients
 
 The current architecture assumes a single MCP client per daemon session.
-The north star is supporting multiple concurrent MCP clients against the
-same daemon. Key tension points:
+The goal is to support multiple concurrent MCP clients against the
+same daemon. Constraints to address:
 
 - **Session state is per-process:** Each `runt mcp` process has one
   `Arc<RwLock<Option<NotebookSession>>>`. Multiple clients would need

--- a/.agents/skills/releasing/SKILL.md
+++ b/.agents/skills/releasing/SKILL.md
@@ -25,8 +25,8 @@ version files.
 
 Two independent version numbers (incrementing integers, not semver):
 
-- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`, re-exported by `connection.rs`) — Wire compatibility. Validated by magic bytes preamble at connection time.
-- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — Automerge document compatibility. Stored in doc root.
+- **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection/handshake.rs`, re-exported by `connection.rs`): Wire compatibility. Validated by magic bytes preamble at connection time.
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`): Automerge document compatibility. Stored in doc root.
 
 These evolve independently from each other and from the artifact version.
 
@@ -103,13 +103,13 @@ Magic bytes preamble rejects mismatched protocol versions at wire level, before 
 2. Add migration logic in daemon's doc loading path (detect old schema, convert in-place)
 3. Update document schema comment in `notebook-doc/src/lib.rs`
 
-Schema changes don't require a protocol bump — wire format for sync frames stays the same.
+Schema changes don't require a protocol bump because the wire format for sync frames stays the same.
 
 ## CI Internals
 
 `release-common.yml` accepts inputs:
-- `github_release_prerelease: true` — applies PEP 440 alpha stamp to Python version
-- `github_release_prerelease: false` — stamps Python version from `crates/runt/Cargo.toml`
+- `github_release_prerelease: true`: applies PEP 440 alpha stamp to Python version
+- `github_release_prerelease: false`: stamps Python version from `crates/runt/Cargo.toml`
 
 Python wheels are always built (macOS arm64, macOS x64, Linux x64, Windows x64) and published.
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -133,7 +133,7 @@ cargo xtask e2e test-fixture <notebook> <spec>  # Single fixture test
 
 **Fixture test:** Create notebook in `crates/notebook/fixtures/audit-test/`, create spec in `e2e/specs/`, add to `FIXTURE_SPECS` in `e2e/wdio.conf.js`, add to `crates/xtask/src/main.rs`, add to CI.
 
-**Regular test:** Create spec in `e2e/specs/` — picked up automatically if not in `FIXTURE_SPECS`.
+**Regular test:** Create a spec in `e2e/specs/`. It is picked up automatically if not in `FIXTURE_SPECS`.
 
 ### Helpers (e2e/helpers.js)
 
@@ -150,10 +150,10 @@ cargo xtask e2e test-fixture <notebook> <spec>  # Single fixture test
 
 ### wry WebDriver Constraints
 
-- Use `data-testid` attributes — text selectors return broken refs
-- Use `browser.execute()` + `browser.waitUntil()` — `executeAsync()` unsupported
-- Use `typeSlowly()` for CodeMirror — fast input drops characters
-- Use `browser.execute()` for iframe testing — `switchToFrame()` broken
+- Use `data-testid` attributes. Text selectors return broken refs.
+- Use `browser.execute()` + `browser.waitUntil()`. `executeAsync()` is unsupported.
+- Use `typeSlowly()` for CodeMirror. Fast input drops characters.
+- Use `browser.execute()` for iframe testing. `switchToFrame()` is broken.
 
 ### Selectors
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -8,7 +8,7 @@ paths:
 
 Logging conventions for the daemon (Rust, `tracing`), the Tauri notebook crate (Rust, `log`), and the frontend (TypeScript, `logger` util).
 
-## Rust — daemon (`crates/runtimed`)
+## Rust: daemon (`crates/runtimed`)
 
 Use `tracing`:
 
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn, error};
 
 `tracing-subscriber` runs layered subscribers (stderr + file). Dependencies that use the `log` crate (jupyter-zmq-client, automerge, …) bridge into `tracing` automatically via `tracing-log`.
 
-## Rust — Tauri notebook crate
+## Rust: Tauri notebook crate
 
 Use `log` with `tauri-plugin-log`:
 
@@ -61,19 +61,19 @@ Send these to `debug` rather than `info`:
 ## Prefixes
 
 Rust (daemon):
-- `[runtimed]` — daemon core operations
-- `[notebook-sync]` — Automerge sync server
-- `[kernel-manager]` — kernel lifecycle and execution
-- `[doc-handle]` — CRDT document mutations and requests
-- `[comm_*]` — widget communication
+- `[runtimed]`: daemon core operations
+- `[notebook-sync]`: Automerge sync server
+- `[kernel-manager]`: kernel lifecycle and execution
+- `[doc-handle]`: CRDT document mutations and requests
+- `[comm_*]`: widget communication
 
 TypeScript (frontend):
-- `[automerge-notebook]` — WASM handle, bootstrap, materialization
-- `[sync-engine]` — frame processing, sync state, coalescing
-- `[crdt-bridge]` — CodeMirror ↔ CRDT character-level sync
-- `[frame-pipeline]` — changeset materialization, cache behavior
-- `[daemon-kernel]` — kernel execution, broadcasts, comms
-- `[flushSync]` — outbound sync flush
+- `[automerge-notebook]`: WASM handle, bootstrap, materialization
+- `[sync-engine]`: frame processing, sync state, coalescing
+- `[crdt-bridge]`: CodeMirror ↔ CRDT character-level sync
+- `[frame-pipeline]`: changeset materialization, cache behavior
+- `[daemon-kernel]`: kernel execution, broadcasts, comms
+- `[flushSync]`: outbound sync flush
 
 ## Channel defaults
 
@@ -82,7 +82,7 @@ TypeScript (frontend):
 | Nightly | `info` (with `debug` for `notebook_sync` and `notebook_sync_server`) | `Debug` |
 | Stable  | `warn` | `Info` |
 
-Nightly is intentionally chatty for field diagnosis. No configuration needed — the defaults are channel-aware.
+Nightly is intentionally chatty for field diagnosis. No configuration is needed because the defaults are channel-aware.
 
 ## Overrides
 
@@ -97,7 +97,7 @@ RUST_LOG=runtimed::notebook_sync_server=debug cargo xtask dev-daemon
 runtimed --log-level debug
 ```
 
-Daemon logs rotate on startup — each session gets a clean file, with the previous preserved as `runtimed.log.1`. That keeps `runt daemon logs -f` focused on the current session.
+Daemon logs rotate on startup. Each session gets a clean file, with the previous preserved as `runtimed.log.1`. That keeps `runt daemon logs -f` focused on the current session.
 
 ## Before adding a log statement
 

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -1,5 +1,5 @@
 ---
-description: MCP server selection — use the right server for the task
+description: Choosing the right MCP server for the task
 globs:
   - "**"
 ---
@@ -19,24 +19,24 @@ Three nteract MCP servers may be available. Always use the right one:
 1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes the dev tools for managing the build/daemon lifecycle.
 2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
 3. **Never use installed Codex plugin notebook servers for source work.** Servers named `nteract-notebook`, `nightly`, or older `notebook` tool aliases come from the installed stable/nightly plugin cache, not this worktree. They can attach to a different active notebook than the local Browser/Vite app.
-4. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system or installed plugin MCP servers.
-5. The dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) live on the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands when available.
+4. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands, not to the system or installed plugin MCP servers.
+5. The dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) live on the `nteract-dev` server. They manage the dev daemon and build pipeline. Prefer them over manual terminal commands when available.
 
 ## nteract-dev tool surface
 
 The advertised tool list varies by mode:
 
-**Owner/isolated mode** (Claude Code `.mcp.json`) — manages daemon lifecycle:
+**Owner/isolated mode** (Claude Code `.mcp.json`) manages daemon lifecycle:
 
 | Tool | Purpose |
 |------|---------|
-| `up` | Idempotent "bring the dev environment to a working state." Sweeps zombie Vite processes, ensures the daemon is running, ensures the MCP child is healthy. Optional args: `vite=true` to also start Vite, `rebuild=true` to rebuild daemon + Python bindings first, `mode='debug'\|'release'` to switch build mode. Safe to call repeatedly — this is the first thing to reach for when things feel off. |
+| `up` | Idempotent "bring the dev environment to a working state." Sweeps zombie Vite processes, ensures the daemon is running, ensures the MCP child is healthy. Optional args: `vite=true` to also start Vite, `rebuild=true` to rebuild daemon + Python bindings first, `mode='debug'\|'release'` to switch build mode. Safe to call repeatedly. Try this first when things feel off. |
 | `down` | Stop the managed Vite dev server. Leaves the daemon running by default (launchd / the installed app may own it). Pass `daemon=true` to also stop the managed daemon process. |
 | `status` | Read-only report of `nteract-dev`, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log. Arg: `lines` (default 50). |
 | `vite_logs` | Tail the Vite dev server log. Arg: `lines` (default 50). |
 
-**Attach mode** (Codex `.codex/config.toml`) — connects to an existing daemon:
+**Attach mode** (Codex `.codex/config.toml`) connects to an existing daemon:
 
 | Tool | Purpose |
 |------|---------|
@@ -48,7 +48,7 @@ All modes proxy the full `runt mcp` notebook tool surface.
 
 ## MCP Server
 
-`nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
+`nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary; no Python or uv is required.
 
 `nteract-dev` runs in explicit modes. Claude Code uses owner mode from
 `.mcp.json`, so it may start, restart, rebuild, and stop the worktree daemon.
@@ -104,7 +104,7 @@ mcp__nteract-dev__list_active_notebooks
 ps aux | grep "runt.*mcp" | grep -v grep
 # For each nteract-nightly PID:
 cat /proc/{PID}/environ | tr '\0' '\n' | grep RUNTIMED
-# Should return nothing — no RUNTIMED_DEV or RUNTIMED_WORKSPACE_PATH
+# Should return nothing: no RUNTIMED_DEV or RUNTIMED_WORKSPACE_PATH
 
 # 5. Verify nteract-nightly daemon socket (should be system socket)
 env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status --json | jq -r '.socket_path'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ apps/elements/          Elements design system catalog
 packages/               Shared JS/TS packages
 plugins/nteract/        Agent plugin distribution (Codex)
 crates/                 Rust workspace
-  runtimed/             Daemon — owns kernels and document state
+  runtimed/             Daemon (owns kernels and document state)
   notebook/             Tauri application shell
   runt-mcp/             MCP server
   notebook-doc/         CRDT document model (Automerge)
@@ -90,7 +90,7 @@ cd crates/runtimed-py && VIRTUAL_ENV=../../.venv uv run --directory ../../python
 cargo xtask notebook
 ```
 
-This opens the GUI and blocks until quit — run it from your own terminal.
+This opens the GUI and blocks until you quit. Run it from your own terminal.
 
 ## 4. Testing
 
@@ -144,10 +144,10 @@ docs: update contributing guide
 
 ### CI-enforced invariants
 
-**Tokio mutex guards** — Hold a `tokio::sync::Mutex` or `RwLock` guard only within a synchronous block; release before any `.await`. Use block scoping, not `drop()`.
+**Tokio mutex guards:** Hold a `tokio::sync::Mutex` or `RwLock` guard only within a synchronous block; release before any `.await`. Use block scoping, not `drop()`.
 
-**Cell rendering order** — In `NotebookView.tsx`, always iterate `stableDomOrder`, never `cellIds` directly. Visual order is controlled by CSS `order`; iterating `cellIds` directly causes React to call `insertBefore` on reorder, destroying iframes and losing widget state.
+**Cell rendering order:** In `NotebookView.tsx`, always iterate `stableDomOrder`, never `cellIds` directly. Visual order is controlled by CSS `order`; iterating `cellIds` directly causes React to call `insertBefore` on reorder, destroying iframes and losing widget state.
 
-**Execution references synced cell IDs** — Execution requests must reference a `cell_id` from the Automerge document, not a side-channel code string.
+**Execution references synced cell IDs:** Execution requests must reference a `cell_id` from the Automerge document, not a side-channel code string.
 
-**Control-plane signals use a separate transport** — Kernel lifecycle signals (`KernelIdle`, `ExecutionDone`, `CellError`) must not share the bounded output transport with stdout or display data.
+**Control-plane signals use a separate transport:** Kernel lifecycle signals (`KernelIdle`, `ExecutionDone`, `CellError`) must not share the bounded output transport with stdout or display data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nteract
 
-nteract is a local-first notebook environment where humans, kernels, and AI agents can work against the same live document. It ships as a native desktop app with instant startup, realtime sync across windows and programmatic clients, and managed local environments.
+nteract is a local-first notebook environment where humans, kernels, and AI agents can work with the same live document. It ships as a native desktop app with realtime sync across windows and programmatic clients, and managed local environments.
 
 Built on [jupyter-zmq-client](https://crates.io/crates/jupyter-zmq-client) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
 
@@ -8,9 +8,9 @@ Built on [jupyter-zmq-client](https://crates.io/crates/jupyter-zmq-client) and [
 
 Download the latest release from [GitHub Releases](https://github.com/nteract/nteract/releases).
 
-Linux x64 and macOS (Apple silicon or Intel) can install with one command —
-the AppImage or signed .app bundle plus CLI/daemon and the per-user service
-(systemd or launchd) in one step:
+On Linux x64 and macOS (Apple silicon or Intel), this command installs the
+AppImage or signed .app bundle, CLI/daemon, and per-user service
+(systemd or launchd):
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash
@@ -21,23 +21,21 @@ installs are not currently supported because `runtimed` is a per-user daemon
 managed by the app and CLI, not by system package-manager scripts.
 
 For remote workstations (Outerbounds, JupyterHub) that offer compute to
-hosted notebooks, use the headless one-liner — see
-[Remote workstations](docs/runbooks/remote-workstation.md):
+hosted notebooks, use the headless installer. See
+[Remote workstations](docs/runbooks/remote-workstation.md) for details:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless
 ```
 
-The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
-
-The `runt` CLI and `runtimed` Python bindings ship with the app and stay up to date automatically. For nightly builds, use `runt-nightly` instead.
+The desktop app bundles the `runt` CLI, `runtimed` daemon, and `runtimed` Python bindings. The CLI and Python bindings stay up to date automatically. For nightly builds, use `runt-nightly` instead.
 
 ## What's in here
 
 | Component | Description |
 |-----------|-------------|
 | `nteract` | Desktop notebook editor (Tauri + React) |
-| `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
+| `runtimed` | Background daemon for environment pools, notebook sync, and kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
 | `runtimed` (Python) | Python bindings for the daemon (ships with the app) |
 
@@ -49,7 +47,7 @@ Execution requests name a synced `cell_id`; the daemon reads the cell source fro
 
 ## MCP Server
 
-The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents can run code, read and write cells, manage dependencies, and collaborate with humans in real-time — watching the notebook update live in the desktop app while the agent works.
+The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents can run code, read and write cells, manage dependencies, and collaborate with humans in real time. The notebook updates live in the desktop app while the agent works.
 
 ### Install the Codex plugin
 
@@ -85,7 +83,7 @@ Pin a specific version:
 /plugin install nteract@nteract --ref v2.3.0
 ```
 
-The plugin ships the right `nteract-mcp` binary for your platform (macOS arm64/x64, Linux x64, Windows x64) — no separate install needed. `main` of `nteract/agent-plugins` always points at the latest stable release.
+The plugin ships the `nteract-mcp` binary for your platform (macOS arm64/x64, Linux x64, Windows x64), so no separate install is needed. `main` of `nteract/agent-plugins` always points at the latest stable release.
 
 For pre-release builds (updated daily):
 
@@ -99,7 +97,7 @@ If you use the nteract desktop app with Claude Desktop, there's a one-click inst
 
 ![nteract menu showing 'Install Extension for Claude...'](https://img.runt.run/install-claude-extension.png)
 
-The desktop app builds a `.mcpb` bundle at runtime (manifest, icons, `nteract-mcp` binary) and hands it to Claude Desktop, which prompts you to confirm the install. Requires the nteract desktop app; Claude Desktop picks up the bundle from there.
+The nteract desktop app is required: it builds a `.mcpb` bundle at runtime (manifest, icons, `nteract-mcp` binary) and hands it to Claude Desktop, which prompts you to confirm the install.
 
 ## Usage
 
@@ -282,18 +280,18 @@ cargo clippy --all-targets -- -D warnings               # Lint Rust
 
 The underlying Rust libraries are published to crates.io:
 
-- [`jupyter-protocol`](https://crates.io/crates/jupyter-protocol) — Jupyter messaging protocol
-- [`jupyter-zmq-client`](https://crates.io/crates/jupyter-zmq-client) - Jupyter kernel interactions over ZeroMQ
-- [`nbformat`](https://crates.io/crates/nbformat) — Notebook parsing
+- [`jupyter-protocol`](https://crates.io/crates/jupyter-protocol): Jupyter messaging protocol
+- [`jupyter-zmq-client`](https://crates.io/crates/jupyter-zmq-client): Jupyter kernel interactions over ZeroMQ
+- [`nbformat`](https://crates.io/crates/nbformat): Notebook parsing
 
 ## Contributing
 
 See `AGENTS.md` for the subsystem map and development guidance. Key entry points:
 
-- `crates/runtimed/AGENTS.md` — architecture, daemon, state ownership
-- `apps/notebook/src/AGENTS.md` — frontend architecture
-- `crates/notebook-wire/AGENTS.md` — wire protocol
-- `cargo xtask help` — all build commands
+- `crates/runtimed/AGENTS.md`: architecture, daemon, state ownership
+- `apps/notebook/src/AGENTS.md`: frontend architecture
+- `crates/notebook-wire/AGENTS.md`: wire protocol
+- `cargo xtask help`: all build commands
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,11 @@
 # Documentation
 
-This directory separates thinking, decisions, product requirements, execution
-plans, evidence, and operations so product, design, engineering, research, and
-AI collaborators can use the same vocabulary.
+This directory contains design discussions, technical decisions, product
+requirements, implementation plans, evidence, and operational guides.
 
 ## Start Here
 
-Use these entry points when you need the current durable framing for a subsystem.
-They are not a complete inventory; they route to the docs most likely to anchor
-new product, engineering, or agent work.
+Start here to understand a subsystem. This is not a complete inventory.
 
 | Topic | Start with |
 |-------|------------|

--- a/docs/adr/cloud-user-store.md
+++ b/docs/adr/cloud-user-store.md
@@ -14,10 +14,10 @@ the dashboard did not, so it leaks the identifier.
 The parts to fix this already exist. They are just not connected, and each
 consumer reinvents the connection.
 
-**The pure display layer (already shared, already correct).**
+**The shared display layer.**
 `resolveActorDisplay({actorLabel, peers, source})` in
 `packages/runtimed/src/notebook-actor-display.ts` turns an opaque actor label
-into an `ActorDisplay` — `{displayName, principalId, kind, isAgent, onBehalfOf,
+into an `ActorDisplay`: `{displayName, principalId, kind, isAgent, onBehalfOf,
 agentSlug, color, initials, imageUrl}`. It parses the label
 (`notebook-actor-projection.ts`), hashes a deterministic color
 (`notebook-actor-color.ts`), computes initials, and overlays a caller-supplied
@@ -25,8 +25,8 @@ agentSlug, color, initials, imageUrl}`. It parses the label
 imageUrl}`) to replace the parsed fallback with a real name and avatar. It does
 no I/O (its projection helpers keep module-level caches, but nothing fetches). It
 is exported from `packages/runtimed/src/index.ts` and is framework agnostic.
-Color is a pure hash of the identity key, so it is globally consistent for free —
-resolution only has to solve **name and avatar**.
+Color is a pure hash of the identity key, so it is globally consistent.
+Resolution only has to solve **name and avatar**.
 
 The two halves of an actor label have different trust meanings. The host-issued,
 authenticated principal is authoritative for attribution and for the
@@ -34,7 +34,7 @@ authenticated principal is authoritative for attribution and for the
 presentation metadata: they may select a familiar product mark, but the mark is
 not proof that a particular vendor produced or authenticated the client.
 
-**The host source of truth (already durable).** The Worker runs a D1 table
+**The host source of truth.** The Worker runs a D1 table
 `principal_profiles` (`apps/notebook-cloud/src/storage.ts`): `principal` (PK),
 `provider`, `provider_subject`, `email_normalized`, `email_verified`,
 `display_name`, `avatar_url`, `first_seen_at`, `last_seen_at`, `raw_claims_json`.
@@ -43,7 +43,7 @@ canonical `account:<ns>:email:<sha256>` principal on verified email, so the same
 human arriving through different providers converges on one row. Rows are read in
 batch through `getPrincipalProfiles(env, principals[])`
 (`apps/notebook-cloud/src/sharing-storage.ts`, `PRINCIPAL_PROFILE_LOOKUP_BATCH_SIZE
-= 50` per query). Rows are written on authenticated OIDC / Anaconda requests — at
+= 50` per query). Rows are written on authenticated OIDC / Anaconda requests at
 login and on app-session re-sync, through `syncAuthenticatedProfile` /
 `syncStoredAppSessionProfile` → `resolveNotebookInvitesForLogin` →
 `upsertPrincipalProfileWithAccount`, gated to `provider === 'oidc' ||
@@ -61,8 +61,8 @@ login and on app-session re-sync, through `syncAuthenticatedProfile` /
    (`cloudNotebookOwnerLabel` / `cloudNotebookOwnerInitials` in
    `apps/notebook-cloud/viewer/notebook-dashboard.ts`, rendered by
    `cloud-notebook-dashboard-view.tsx`) then derives a label from the raw
-   principal — trim, take an email local-part, else split on `:` and use the tail
-   or the whole string — which for an opaque subject like `b0204af7084b` yields
+   principal: trim, take an email local-part, else split on `:` and use the tail
+   or the whole string. For an opaque subject like `b0204af7084b`, this yields
    the identifier itself, shown as both name and initials.
 
 **"Never show a raw principal" is not yet a property any surface has.** The
@@ -73,11 +73,11 @@ principal, and the shared `NotebookCommentsPanel` with no resolver injected fall
 back to the raw actor label. So the never-raw guarantee is new work this store
 centralizes, not something to copy.
 
-**Everything else is duplicated.** The same principal is resolved several
-different ways server-side — `owner_display` and `current_user_display` strings on
+**Resolution is duplicated.** The same principal is resolved several
+different ways server-side: `owner_display` and `current_user_display` strings on
 `/api/n`, the `ShareTargetDisplay` union on `/acl` and `/access-requests`,
 `{principal, label, image_url}` on `/api/n/:notebookId/author-profiles`, and
-`display_name` on presence control frames — and assembled client-side per surface:
+`display_name` on presence control frames. Clients assemble these per surface:
 comments merge a fetched author-profiles batch with live presence peers; presence
 (`cloud-presence-status.tsx`) shows initials-only avatars because the room roster
 protocol carries no image; self-identity flows through a separate `identityLabel`
@@ -90,15 +90,15 @@ render with a different name, and no avatar, depending on which surface is askin
 
 ### Neighbors
 
-- `docs/adr/frontend-sync-bridge.md` — the store/projection discipline this store
+- `docs/adr/frontend-sync-bridge.md`: the store/projection discipline this store
   follows: engine streams into `useSyncExternalStore`-backed stores, React never
   owns the source of truth, stale async writes are invalidated not just cleared.
-- `docs/adr/identity-and-trust.md` — actor label grammar (`<principal>/<operator>`)
+- `docs/adr/identity-and-trust.md`: actor label grammar (`<principal>/<operator>`)
   and the principal namespaces this store keys on.
-- `docs/adr/notebook-comments-document.md` — the first consumer of actor display.
-- `docs/adr/hosted-room-authorization.md` — the relationship gate the resolver
+- `docs/adr/notebook-comments-document.md`: the first consumer of actor display.
+- `docs/adr/hosted-room-authorization.md`: the relationship gate the resolver
   must honor.
-- `.claude/skills/frontend-dev` — App-Shell Latency, Projection Discipline, and
+- `.claude/skills/frontend-dev`: App-Shell Latency, Projection Discipline, and
   State Boundary rules this store is built to satisfy.
 
 ### Goals
@@ -141,22 +141,22 @@ render with a different name, and no avatar, depending on which surface is askin
 
 `resolveActorDisplay` and its projection/color helpers stay exactly as they are.
 They are the leaf: given an actor label and a peer directory, they produce an
-`ActorDisplay`. The problem was never the compute — it was that every consumer
-built the peer directory itself, from whatever inputs it happened to have.
+`ActorDisplay`. The problem is directory assembly: every consumer builds the
+peer directory itself, from whatever inputs it has.
 
 The store's job is to *be* that peer directory: one canonical, cached,
 subscribable `principal → {label, avatar}` map that feeds `peers` into
 `resolveActorDisplay`. Consumers stop assembling peers and instead ask the store
-to resolve a label. This keeps all the already-correct behavior (kind detection,
-on-behalf-of, deterministic color, initials) and replaces only the ad hoc
-directory assembly — and it is where the single never-raw fallback policy lives.
+to resolve a label. This keeps kind detection, on-behalf-of, deterministic color,
+and initials, and replaces only the ad hoc directory assembly. The single
+never-raw fallback policy lives in the store.
 
-## Decision 2: `CloudUserStore` — a Cloud-viewer source store, read through `useSyncExternalStore`
+## Decision 2: `CloudUserStore`, a Cloud-viewer source store read through `useSyncExternalStore`
 
 A new module `apps/notebook-cloud/viewer/cloud-user-store.ts`. Mirror the
-structure of `cloud-auth-store.ts` exactly — a private source, a synchronous
-snapshot, a named domain hook — rather than exporting a naked subject. Follow the
-RxJS Shape rules in the frontend-dev skill.
+structure of `cloud-auth-store.ts` exactly: a private source, a synchronous
+snapshot, and a named domain hook rather than an exported naked subject. Follow
+the RxJS Shape rules in the frontend-dev skill.
 
 **Shape.**
 
@@ -165,12 +165,12 @@ RxJS Shape rules in the frontend-dev skill.
   `.asObservable()` and a synchronous `getSnapshot()`. `ResolvedProfile` is
   `{principal, displayName?, avatarUrl?, source: 'self' | 'presence' | 'profile'
   | 'unresolved'}`.
-- Consumers subscribe to the **narrowest** projection —
-  `select(m => m.get(principal), Object.is)` with `distinctUntilChanged` — so a
+- Consumers subscribe to the **narrowest** projection:
+  `select(m => m.get(principal), Object.is)` with `distinctUntilChanged`. A
   backfill for one principal does not re-render every avatar. The
   `useSyncExternalStore` adapter emits synchronously on subscribe (the
   `BehaviorSubject` seeds the first value).
-- The public read is `resolve(actorLabel): ActorDisplay` — it parses the label to
+- The public read is `resolve(actorLabel): ActorDisplay`. It parses the label to
   a principal, looks up the cached `ResolvedProfile`, builds the single-entry
   `peers` array, and calls `resolveActorDisplay`. A React hook
   `useResolvedActor(actorLabel)` wraps it so any surface can name a label and
@@ -178,20 +178,20 @@ RxJS Shape rules in the frontend-dev skill.
 
 **Seeding, in precedence order.**
 
-1. **Self** — seed from the OIDC claims / dev auth already in `CloudPrototypeAuthState`
+1. **Self:** seed from the OIDC claims / dev auth already in `CloudPrototypeAuthState`
    (name + `picture` avatar). This retires the `identityLabel` / `identityImageUrl`
    side channel: the viewer's own badge resolves through the same cache as everyone
    else.
-2. **Presence** — subscribe to the existing `CloudViewerPresenceStore` roster
+2. **Presence:** subscribe to the existing `CloudViewerPresenceStore` roster
    (itself a `useSyncExternalStore` store) and seed `{principal → label}` as peers
    join. Presence carries a name today and an avatar once Decision 4 lands.
-3. **Backfill** — for any principal requested but not yet cached, enqueue a batched
+3. **Backfill:** for any principal requested but not yet cached, enqueue a batched
    fetch to the notebook-scoped resolver (Decision 3). Batch and dedupe (reuse the
    50-per-query size); coalesce concurrent misses into one request.
 
 **Fallback policy (single owner).** Resolution prefers `profile` > `presence` >
 `unresolved`. An `unresolved` principal produces the generic kind label from
-`resolveActorDisplay` — **never the raw principal**. The dashboard's
+`resolveActorDisplay`, **never the raw principal**. The dashboard's
 `cloudNotebookOwnerLabel` raw-string derive is deleted.
 
 **Async-write discipline.** The backfill writes into the store after `await`.
@@ -199,7 +199,7 @@ Follow the frontend-sync-bridge stale-write rule and the reconnect-empty-store
 rule: carry an activation epoch (bumped on sign-out / viewer teardown), and after
 the fetch resolves, merge only if the epoch still matches. A profile row that
 arrives after teardown or an identity change is dropped, not written. Never demote
-a cached `profile`/`presence` entry to `unresolved` on a failed or empty fetch —
+a cached `profile`/`presence` entry to `unresolved` on a failed or empty fetch:
 absence of a fresh answer is not evidence the name is gone.
 
 **Tests.** Virtual-time tests (`rxjs/testing`) for batch coalescing, dedupe,
@@ -208,28 +208,28 @@ tests for synchronous seeding and the never-raw fallback.
 
 ## Decision 3: Resolve within a notebook relationship, not a global directory
 
-The tempting shape — a global `GET /api/users?principals=…` — is an enumeration
-oracle: it would answer "this principal has a profile" for any principal the
-caller can associate with any visible notebook. Do not build it. Keep resolution
-scoped to a relationship the caller already holds.
+A global `GET /api/users?principals=…` is an enumeration oracle: it would answer
+"this principal has a profile" for any principal the caller can associate with
+any visible notebook. Do not build it. Keep resolution scoped to a relationship
+the caller already holds.
 
 - **`/n` owners resolve server-side in the list response.** The list handler
   already runs with the caller's visibility and already batch-resolves owners
   (`listNotebookPrincipalDisplays`). Fix them there: add `avatar_url`, and stop
-  dropping unknowns — return a `resolved` flag so the client shows a kind-label
+  dropping unknowns: return a `resolved` flag so the client shows a kind-label
   fallback instead of the hex. `/n` then needs no client resolver at all.
 - **In-notebook surfaces use a notebook-scoped endpoint.** Generalize today's
   `/api/n/:notebookId/author-profiles` (do not replace it with a global surface)
   to resolve the owner + ACL + comment-author + live-presence principals **of a
   notebook the caller can already see**. The endpoint only ever resolves
-  principals that appear in that notebook's own sets — never an arbitrary
+  principals that appear in that notebook's own sets, never an arbitrary
   principal the caller names.
 - **No oracle, no leak.** Cap batch size; return only positive display payloads
   (no "no such principal" signal, no reason codes); rate-limit and audit misses.
   Never reveal a canonical account link: resolving a transport principal must not
   expose its linked `account:<email-hash>` principal unless that canonical
-  principal is itself in the allowed set. `email` is never returned — display name
-  and avatar only.
+  principal is itself in the allowed set. Only display name and avatar are
+  returned, never `email`.
 - **One server-side projector.** A single `principal → {displayName, avatarUrl,
   resolved}` mapper is reused by the list projection, the notebook-scoped
   resolver, `/acl`, `/access-requests`, and `/author-profiles`, retiring the
@@ -242,7 +242,7 @@ Honor `docs/adr/hosted-room-authorization.md` and `identity-and-trust.md`. This
 gate gets an explicit human security review before it ships; it is the one part
 of this ADR that is summoned, not self-merged.
 
-## Decision 4: Populate `avatar_url` — the prerequisite that makes avatars appear at all
+## Decision 4: Populate `avatar_url`
 
 The avatar write path exists but is never fed, so the viewer's own badge is the
 only avatar that ever renders. Two changes unblock avatars everywhere:
@@ -263,28 +263,28 @@ being permanently initials-only. This is a protocol change; it can lag the rest.
 
 Once the store and endpoint exist, every *display* surface reads the store:
 
-- **Comments** — `resolveCloudCommentAuthor` (`notebook-viewer.tsx`) becomes
+- **Comments:** `resolveCloudCommentAuthor` (`notebook-viewer.tsx`) becomes
   `useResolvedActor`; delete the bespoke fetch-and-merge in
   `comment-author-profiles.ts` (keep its batch-URL helpers if the store reuses
   them).
-- **Presence** — `cloud-presence-status.tsx` resolves peer labels through the
-  store, gaining avatars for free once Decision 4 lands.
-- **Self-identity** — `NotebookIdentity` / `NotebookToolbarIdentity` /
+- **Presence:** `cloud-presence-status.tsx` resolves peer labels through the
+  store, gaining avatars once Decision 4 lands.
+- **Self-identity:** `NotebookIdentity` / `NotebookToolbarIdentity` /
   `shell-capabilities.ts` read self from the store, including
   `current_user_display` and the dashboard's self avatar; retire the
   `identityLabel` / `identityImageUrl` side channel.
-- **`/n` owners and live peers** — `cloud-notebook-dashboard-view.tsx` resolves
+- **`/n` owners and live peers:** `cloud-notebook-dashboard-view.tsx` resolves
   owners (server-projected per Decision 3) and any dashboard live-peer avatars
   from room summaries through the store; delete `cloudNotebookOwnerLabel` /
   `cloudNotebookOwnerInitials`.
-- **Sharing UI** — the ACL / access-request label/detail/title fallbacks in
+- **Sharing UI:** the ACL / access-request label/detail/title fallbacks in
   `sharing-client.ts` resolve through the store instead of hand-formatting the
   `ShareTargetDisplay` union where a display is all that is needed.
 
-**Not display consumers — leave them.** Auth diagnostics and collaborator-debug
+**Not display consumers: leave them.** Auth diagnostics and collaborator-debug
 surfaces intentionally show the raw principal / provider subject; do not converge
 them. Instant-paint and persistence principal *matching* are security keys, not
-display, and must keep comparing raw principals — never route them through the
+display, and must keep comparing raw principals. Never route them through the
 store.
 
 The competing fallback formatters collapse to one policy in the store; the server
@@ -298,25 +298,24 @@ ordered commits so review can follow the progression. Cross-model review
 (implementer and reviewer from different model families); the Decision 3 auth gate
 gets a human security review before merge, not self-merge.
 
-- **Stage 0 — stop the leak.** First commit, so the visible symptom dies early.
-  No visible raw-principal fallback *anywhere*: the dashboard owner fallback
-  (`notebook-dashboard.ts`) and the sharing ACL / access-request fallback labels
-  (`sharing-client.ts`) adopt the never-raw policy — an unresolved principal shows
-  a generic kind label, never the raw id. No store, no endpoint. Contained fix for
-  the visible symptom.
-- **Stage 1 — server.** One shared projector for owner / current-user / ACL /
+- **Stage 0: stop the leak.** The first commit removes visible raw-principal
+  fallback *anywhere*: the dashboard owner fallback (`notebook-dashboard.ts`) and
+  the sharing ACL / access-request fallback labels (`sharing-client.ts`) adopt
+  the never-raw policy. An unresolved principal shows a generic kind label, never
+  the raw id. No store, no endpoint.
+- **Stage 1: server.** One shared projector for owner / current-user / ACL /
   access-request / author-profile displays; OIDC `picture` avatar capture
   (Decision 4); `avatar_url` and a `resolved` flag on the list projection; the
   generalized notebook-scoped resolver with its relationship gate (Decision 3).
   Ships with the auth-gate review.
-- **Stage 2 — the store.** `cloud-user-store.ts` with `useSyncExternalStore`
+- **Stage 2: the store.** `cloud-user-store.ts` with `useSyncExternalStore`
   binding, self + presence seeding, batched backfill, epoch stale-write guard, and
   virtual-time tests (Decision 2). No consumer changes yet; land it green behind
   the existing paths.
-- **Stage 3 — converge.** Move consumers onto the store one surface at a time
+- **Stage 3: converge.** Move consumers onto the store one surface at a time
   (comments, presence, self, `/n` owners, sharing UI), deleting the duplicated
-  fetch-merge-fallback code — including `sharing-client.ts` and the comment-author
-  fetch/merge — as each moves (Decision 5).
+  fetch-merge-fallback code (including `sharing-client.ts` and the comment-author
+  fetch/merge) as each moves (Decision 5).
 
 ## Boundaries and non-goals
 

--- a/docs/measurements/runtime-output-optimization.md
+++ b/docs/measurements/runtime-output-optimization.md
@@ -1,7 +1,9 @@
 # Runtime Output Optimization Plan
 
-**Status:** Measurement / plan, 2026-05-25. This is not an ADR; it is the
-optimization sequence behind the output-related ADRs and measurements.
+**Status:** Measurement / plan, 2026-05-25.
+
+This plan orders the optimization work described in the output-related ADRs and
+measurements.
 
 Runtime output performance has two different problems:
 
@@ -42,13 +44,13 @@ new consumer protocol.
 
 Keep the manifest shape unchanged while removing known repeated work:
 
-1. ✅ **Done (a2bfef02).** Exact output lookup by `(execution_id, output_id)`
+1. **Done (a2bfef02).** Exact output lookup by `(execution_id, output_id)`
    via `get_display_index_entries` and `get_output`
    (`crates/runtimed/src/output_prep.rs:316-329`). Display updates no longer
    sort and scan every output in the execution.
 2. **Open.** Cached or indexed output ordering metadata so append/upsert paths
    do not recompute order by decoding all manifests.
-3. ✅ **Done (614ec946, 3c18ce8f).** Targeted RuntimeStateDoc readers for
+3. **Done (614ec946, 3c18ce8f).** Targeted RuntimeStateDoc readers for
    runtime-agent queue and comm handling. Measured via `doc.get_comms()` and
    `doc.get_queued_executions()`
    (`crates/runtimed/src/output_commit_measure.rs:345-348`). State-sync
@@ -56,10 +58,10 @@ Keep the manifest shape unchanged while removing known repeated work:
    queued execution metadata or widget comm state.
 4. **Open.** WASM-side output-id indexing so runtime sync handling does not
    repeatedly read the full runtime state just to derive output deltas.
-5. ✅ **Done (038caec2).** Removed the dormant frontend optimistic
+5. **Done (038caec2).** Removed the dormant frontend optimistic
    `update_display_data` overlay. RuntimeStateDoc changesets carry display
    updates to the output store.
-6. ✅ **Done.** In-place WASM output-id diff snapshots
+6. **Done.** In-place WASM output-id diff snapshots
    (`crates/runtimed-wasm/src/lib.rs:2908-2910`). Runtime sync compares the
    flat output set without cloning every unchanged manifest into a fresh
    snapshot on each frame.
@@ -74,8 +76,7 @@ eliminated work.
 
 The measured blob-backed segment model reduces Automerge traffic by storing
 ordered child manifests in blobs and putting one segment reference per chunk in
-RuntimeStateDoc. That model is promising, but production needs these layers
-first:
+RuntimeStateDoc. Before using it in production, implement:
 
 1. A shared output segment schema and resolver.
 2. Resolver support in MCP/Python/save paths that expands segments to flat
@@ -91,9 +92,9 @@ The first production writer should be conservative: segment only append-only
 ordinary outputs with no `display_id` and no widget capture until replacement
 semantics are explicitly handled.
 
-## Decision 4: Kernel-side easing is semantic
+## Decision 4: Buffer or coalesce only where output semantics allow
 
-Producer-side optimization is useful, but it cannot be a blanket coalescer:
+Kernel-side optimizations must preserve the meaning of each output type:
 
 - stdout/stderr buffering can be tuned because stream output is append-only
   text.
@@ -102,7 +103,7 @@ Producer-side optimization is useful, but it cannot be a blanket coalescer:
 - ordinary `display_data`, `execute_result`, `error`, and arbitrary comm events
   are durable semantic events and must not be collapsed transparently.
 
-Any runtime-controlled kernel buffering should be explicit nteract API surface,
+Any runtime-controlled kernel buffering should use an explicit nteract API,
 with a final flush before terminal execution state.
 
 ## Measurement Contract

--- a/docs/memos/execution-engines-and-marimo.md
+++ b/docs/memos/execution-engines-and-marimo.md
@@ -6,13 +6,13 @@ yet. Tracked by [issue #4002](https://github.com/nteract/nteract/issues/4002).
 
 Neighbors:
 
-- [execution-pipeline.md](../adr/execution-pipeline.md) — durable execution and
+- [execution-pipeline.md](../adr/execution-pipeline.md): durable execution and
   output-ordering invariants.
-- [document-split.md](../adr/document-split.md) — NotebookDoc,
+- [document-split.md](../adr/document-split.md): NotebookDoc,
   RuntimeStateDoc, and CommsDoc ownership.
-- [captured-environment-lifecycle.md](../adr/captured-environment-lifecycle.md)
-  — environment capture and kernel-launch behavior.
-- [deployment-topology.md](../adr/deployment-topology.md) — local and hosted
+- [captured-environment-lifecycle.md](../adr/captured-environment-lifecycle.md):
+  environment capture and kernel-launch behavior.
+- [deployment-topology.md](../adr/deployment-topology.md): local and hosted
   runtime placement.
 
 ## Summary
@@ -29,11 +29,9 @@ This memo specifies marimo support as the product and architecture boundary.
 The shipped integration must use a supported marimo surface or establish the
 smallest appropriate surface upstream.
 
-This is a memo rather than an ADR because several choices still need spike
-evidence: the supported marimo embedding boundary, the exact engine/executor
-API, the representation of reactive plans, restart semantics, and interactive
-UI-value transport. Once those are proven, the durable compatibility and
-authority rules can graduate into an ADR.
+Several choices still need spike evidence: the supported marimo embedding
+boundary, the exact engine/executor API, the representation of reactive plans,
+restart semantics, and interactive UI-value transport.
 
 ## Why execution engines
 
@@ -46,12 +44,11 @@ Jupyter kernel:
   RuntimeStateDoc, CommsDoc, and blob writes;
 - launch code selects a Python or Deno environment and constructs the process.
 
-That path is intentionally nteract-specific. It provides stronger lifecycle,
-provenance, output durability, and programmatic waiting semantics than a raw
-Jupyter connection. It is also not a suitable definition of all notebook
-execution. `KernelConnection` requires Jupyter ports, comms, completion, and
-history, while a reactive runtime needs the complete notebook graph and may
-turn one user intent into several cell executions.
+That combination of FIFO scheduling, Jupyter I/O, runtime projection, and
+environment selection does not define all notebook execution.
+`KernelConnection` requires Jupyter ports, comms, completion, and history,
+while a reactive runtime needs the complete notebook graph and may turn one
+user intent into several cell executions.
 
 marimo makes the mismatch concrete. Its documented contract is reactive: when
 a cell runs or a UI value changes, dependent cells run or become stale;
@@ -427,9 +424,8 @@ cadence, retention, and authority rather than convenience alone.
   keeping captured-environment mutation daemon-owned.
 - Define cold start, restart, reconnect, and explicit replay semantics.
 
-Raw Jupyter kernels and Pluto should be separate follow-up issues. They are
-valuable validation targets for the abstraction, but neither should enlarge the
-first marimo milestone.
+Raw Jupyter kernels and Pluto should be separate follow-up issues. They can
+validate the abstraction, but neither should enlarge the first marimo milestone.
 
 ## Non-goals
 

--- a/docs/memos/hosted-notebook-federation.md
+++ b/docs/memos/hosted-notebook-federation.md
@@ -310,8 +310,7 @@ An administrator installs an authenticated nteract extension in the
 single-user environment. The extension runs beside the kernel managers and can
 offer a narrower runtime attachment API than a generic user-server credential.
 
-This keeps the adapter close to kernels and can support richer, longer-lived
-sessions. It requires deployment cooperation, explicit handler authorization,
+This option requires deployment cooperation, explicit handler authorization,
 and a server image rollout or restart.
 
 #### C. Hub-proxied nteract service
@@ -322,9 +321,9 @@ desktop or nteract host -> /services/nteract -> Hub API -> user server
 
 A Hub-managed or externally managed service authenticates the user through Hub
 OAuth, selects or starts a default or named server, follows spawn progress, and
-brokers attachment. It is a good place for deployment policy and version
-normalization, but it still needs either standard Jupyter APIs or an extension
-inside the user server.
+brokers attachment. It can handle deployment policy and version normalization,
+but it still needs either standard Jupyter APIs or an extension inside the user
+server.
 
 Prefer delegated user credentials for user-server actions. A central service
 credential with broad cross-user server access has a much larger blast radius.

--- a/docs/plans/comments-rollout.md
+++ b/docs/plans/comments-rollout.md
@@ -1,8 +1,8 @@
 # Comments Rollout
 
-Scoped execution tracker for wiring notebook comments through the remaining app,
-agent, and hosted surfaces. The durable design lives in
-[Notebook Comments Document](../adr/notebook-comments-document.md).
+This plan tracks the remaining work to support notebook comments in the app,
+agents, and hosted notebooks. See
+[Notebook Comments Document](../adr/notebook-comments-document.md) for the design.
 
 ## Current Baseline
 
@@ -11,10 +11,10 @@ The core comments architecture has landed:
 - `crates/comments-doc` owns the document, identity, projection, and attribution
   model.
 - `COMMENTS_DOC_SYNC` is part of the typed-frame protocol.
-- `runtimed-wasm`, the TypeScript sync engine, and the local daemon have
-  CommentsDoc sync/projection seams.
-- The desktop app has comment projection and highlight/selection UI surfaces.
-- Elements contains comment-surface fixtures for visual iteration.
+- `runtimed-wasm`, the TypeScript sync engine, and the local daemon include
+  CommentsDoc sync and projection code.
+- The desktop app projects comments and provides highlighting and selection UI.
+- Elements contains comment fixtures for trying out UI changes.
 
 ## Remaining Work
 

--- a/docs/prd/notebook-identity-environment-surfaces.md
+++ b/docs/prd/notebook-identity-environment-surfaces.md
@@ -1,6 +1,6 @@
 # Notebook Identity and Environment Surfaces
 
-**Status:** Implemented product contract — acceptance criteria met. Remaining
+**Status:** Implemented product contract; acceptance criteria met. Remaining
 work in "Suggested Work Slices."
 
 **Owners:** nteract notebook UI, Cloud/Auth, Desktop runtime.
@@ -28,10 +28,10 @@ Shared component surfaces and projections:
 - `src/components/notebook/NotebookToolbarIdentity.tsx`
 - `src/components/notebook/NotebookEnvironmentSummary.tsx`
 - `src/components/notebook/interaction-mode.ts`
-- `packages/runtimed/src/notebook-shell-capabilities.ts` — exported shared
+- `packages/runtimed/src/notebook-shell-capabilities.ts`: exported shared
   projections for actor attribution, runtime authorship, access facts, runtime
   state, and environment capabilities
-- `apps/elements/components/notebook-scenarios.ts` — shipped scenario ids
+- `apps/elements/components/notebook-scenarios.ts`: shipped scenario ids
   including `cloud-public-viewer`, `agent-on-behalf`, `mixed-idp-authorship`,
   `runtime-peer`, `runtime-unavailable`, `untrusted-dependencies`
 
@@ -63,9 +63,8 @@ execution output.
    shared components the same projection shape used by cloud.
 4. Make Elements the runtime-free visual inventory for these surfaces using
    fixture-backed scenarios, not schematic replacements.
-5. Give short-term work enough guidance to ship compatible adapter props while
-   preserving space for later ADRs when low-level identity or runtime contracts
-   need to harden.
+5. Define compatible adapter props for current work. Leave unresolved low-level
+   identity and runtime contracts for later ADRs.
 
 ## Non-Goals
 
@@ -221,7 +220,7 @@ Elements and production host adapters should cover these states first:
 
 ## Shared Surface Projection
 
-This is a product contract. The current shared implementation already exposes
+The shared implementation exposes
 `NotebookActorProjection`, `NotebookInteractionModeProjection`, and
 `NotebookEnvironmentSurface`; host adapters should move facts into those shapes
 instead of adding page-local strings.
@@ -366,9 +365,8 @@ notebook UI sees provider `anaconda`.
    `NotebookEnvironmentSummary` or a sibling shared component only where the
    product intentionally shows environment/access/runtime/trust summary facts.
 6. Connect execution/cell attribution to the shared actor projection.
-7. Revisit this PRD and split out an ADR only when a durable code-level boundary
-   needs acceptance, such as the final TypeScript projection API or a runtime
-   peer capability extension.
+7. Write an ADR only when a durable code-level boundary needs acceptance, such
+   as the final TypeScript projection API or a runtime peer capability extension.
 
 ## Open Questions
 

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -3,12 +3,11 @@
 A *workstation* is any machine that offers compute to hosted nteract notebook
 rooms: an Outerbounds workstation, a JupyterHub single-user server, a beefy box
 under your desk. The daemon attaches to a room as a `runtime_peer` over an
-outbound WebSocket — no inbound ports, no reverse proxy — launches kernels
-locally, and syncs outputs back through the room.
+outbound WebSocket, launches kernels locally, and syncs outputs back through the
+room. You don't need inbound ports or a reverse proxy.
 
-This doc is the operator path. The architecture lives in
-`docs/adr/remote-workstation-doc-agents.md` and
-`docs/adr/deployment-topology.md`; the daemon-side surface in
+For the architecture, see `docs/adr/remote-workstation-doc-agents.md` and
+`docs/adr/deployment-topology.md`. The daemon implementation is in
 `crates/runtimed/src/workstation/`.
 
 ## Install (one-liner)
@@ -30,8 +29,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headle
 `--headless` skips the desktop app and installs just `runt`, `runtimed`, and
 `nteract-mcp` into `~/.local/share/nteract/stable` (on macOS, as the sidecars
 of the .app bundle kept under that prefix), links them into `~/.local/bin`,
-and installs the per-user daemon service (`runt daemon doctor --fix` —
-systemd on Linux, launchd on macOS). Everything is per-user; no root
+and installs the per-user daemon service with `runt daemon doctor --fix`
+(systemd on Linux, launchd on macOS). Everything is per-user; no root
 required. Re-run to upgrade.
 
 If this is a fresh shell, make the installed CLI available before running the
@@ -72,7 +71,7 @@ runt workstation connect https://<cloud-host> --code XXXX-XXXX-XXXX
    at `~/.config/nteract/workstation.json` (mode 0600), and registers the
    workstation so it appears in the panel immediately. `--id` / `--name`
    override the default `ws-<hostname>` identity. If the code is rejected,
-   mint a fresh one from the panel — codes expire and cannot be reused.
+   mint a fresh one from the panel. Codes expire and cannot be reused.
 
 3. On Linux, keep the workstation available with user systemd:
 
@@ -120,10 +119,10 @@ is the fast path; low-frequency attach-job polling remains as recovery for
 missed wakeup events and jobs that existed before the agent started. The socket
 is deliberately only a wakeup signal, not a replay log: attach jobs are durable
 in the hosted database, so reconnect recovery polls the queue. The credential
-rides the environment (`RUNT_CLOUD_TOKEN`), never argv. `RUNT_CLOUD_TOKEN` /
-`RUNT_CLOUD_URL` environment variables override the stored credential for
-foreground `runt workstation run`; the service path uses the stored credential
-file written by `connect`.
+is passed through the environment (`RUNT_CLOUD_TOKEN`), never argv.
+`RUNT_CLOUD_TOKEN` / `RUNT_CLOUD_URL` environment variables override the stored
+credential for foreground `runt workstation run`; the service path uses the
+stored credential file written by `connect`.
 
 In the hosted notebook, attaching compute to a workstation dispatches an attach
 job; the agent accepts it and the runtime peer attaches to the room as
@@ -177,8 +176,8 @@ externally issued bearer. It still works and remains useful for dev and for
 deployments that issue their own credentials:
 
 1. In the hosted notebook, grant the workstation principal an explicit
-   `runtime_peer` ACL row (owner alone is not sufficient — compute access is
-   never derived from human roles).
+   `runtime_peer` ACL row. Ownership alone is not sufficient: compute access is
+   never derived from human roles.
 2. On the workstation:
 
 ```bash
@@ -188,7 +187,7 @@ RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
   --python-path "$(command -v python3)"
 ```
 
-The credential always rides the environment, never argv. Defaults: scope
+The credential is always passed through the environment, never argv. Defaults: scope
 `runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda
 API keys, `--auth-kind workstation` for a pairing-flow credential). Blob root
 defaults under the daemon's standard cache. `--python-path` launches a kernel
@@ -223,7 +222,7 @@ extension, and Hub-service provisioning are explored in
 
 ## Outerbounds
 
-Outerbounds workstations are Linux x64 with a per-user home — the defaults
+Outerbounds workstations are Linux x64 with a per-user home. The defaults
 above apply unchanged. Use the workstation's task environment Python as
 `--python-path` so notebook execution sees the same dependencies as your
 flows.


### PR DESCRIPTION
## Summary

First editorial pass on entry docs, agent guidance, and selected architecture and operational documents.

- Remove 145 em dashes across 19 Markdown files using sentence-level rewrites.
- Trim repetitive framing, vague benefits, and unsupported comparisons.
- Keep technical constraints, commands, status qualifiers, and useful personality, including the beefy box under your desk.

## Scope

This is a prose cleanup, not a full verification of existing technical claims. Historical audits and the remaining Markdown are unchanged. No executable code changes.

## Validation

- cargo xtask lint --fix: passed, including Rust formatting, JS/TS checks, Ruff, and ty.
- Documentation guidance checker: passed for all 19 changed files.
- git diff --check: passed.
- No em dashes remain in the changed files.
- Read-only review found no introduced technical or safety issues.