### PR TITLE
docs: refresh runtime and cloud guidance from code audit

### DIFF
--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -11,6 +11,19 @@ description: >
 
 # Automerge Sync & Document Model
 
+## Dependency baseline (2026-09-04)
+
+Production Rust and `runtimed-wasm` use crates.io Automerge exactly `0.11.0`
+(`Cargo.toml:57`, `Cargo.lock:627`). Commit `ae6aef0f` adopted it on 2026-08-26.
+The frontend uses these Rust WASM bindings, not `@automerge/automerge`.
+
+The only remaining Automerge git dependency is `automerge-legacy`, a dev-dependency of
+`automerge-store` pinned to `nteract/automerge` revision
+`3fb6af5cc3af23b79f27cebfa339c8c98987e7b7` (Rust `0.10.0`). It is a test peer
+for snapshot and encoded-sync compatibility, not a production patch override.
+See `crates/automerge-store/Cargo.toml:17` and
+`crates/automerge-store/tests/version_compat.rs:282`.
+
 ## Document Model Essentials
 
 ### Core Types
@@ -46,7 +59,7 @@ AutoCommit { doc: Automerge, transaction: Option<(PatchLog, TransactionInner)>,
 
 - **save()** serializes OpSet columns + ChangeGraph metadata + optional DEFLATE. Columnar format is canonical.
 - **load()** rebuilds OpSet from columns, reconstructs ChangeGraph, verifies heads.
-- **save/load round-trip clears corrupted indices.** This is the basis of nteract's `rebuild_from_save()` recovery.
+- **save/load round-trip rebuilds indices from serialized state.** nteract's `rebuild_from_save()` can fail or reject cell loss; it is containment, not a guarantee that arbitrary corruption is repaired.
 - **load_incremental()** adds changes to existing doc. This is what `receive_sync_message` calls internally.
 - **save_after(heads)** emits only changes after given heads (incremental saves).
 
@@ -143,24 +156,36 @@ Mutex is `std::sync::Mutex`, never held across `.await`. Poison recovery: `unwra
 
 ### Document-Level Recovery
 
-Automerge is treated as a fallible boundary. Recovery lives inside the document owner while the guard is held.
+Automerge is treated as a fallible boundary. Policy belongs to the document
+owner; sync and mutation helpers do not handle panics the same way.
 
-```rust
-state.receive_sync_message_recovering(msg, "notebook-sync-receive");
-let bytes = state.generate_sync_message_recovering("notebook-sync-outbound");
-```
+**Sync policy (2026-09-04):**
 
-**Rebuild procedure (notebook doc):**
-1. `save()` → `AutoCommit::load()` (clears corrupted indices)
-2. Cell-count guard: skip rebuild if fewer cells (prevents silent loss)
-3. Preserve actor ID
-4. `peer_state = sync::State::new()`
+- `recoverable_automerge_operation` rebuilds and retries once only for a
+  caller-marked operation error. It returns a caught panic immediately, without
+  rebuild or retry (`crates/automerge-recovery/src/lib.rs:163–201`).
+- `NotebookDoc::receive_sync_message_recovering` marks only
+  `AutomergeError::PatchLogMismatch(_)` recoverable. It resets the peer's
+  `sync::State`, rebuilds the document, then retries the original frame once
+  (`crates/notebook-doc/src/lib.rs:2479–2508`,
+  `crates/automerge-recovery/src/lib.rs:159–160`).
+- `NotebookDoc::generate_sync_message_recovering` marks no operation error
+  recoverable; caught panics are returned to the caller
+  (`crates/notebook-doc/src/lib.rs:2446–2464`).
 
-**Rebuild procedure (RuntimeStateDoc / CommsDoc):** Round-trip via
-`rebuild_from_save()`, then reset the matching peer state with
-`sync::State::new()`.
+**Mutation policy:** `NotebookDoc::merge_recovering` attempts to rebuild both
+sides after a panic, then returns the failure. `transact_at_heads_recovering`
+restores actor/isolation state and attempts rebuild on panic without rerunning
+the mutation closure (`crates/notebook-doc/src/lib.rs:400–491`).
+`RuntimeStateDoc` has its own transaction recovery and rollback handling
+(`crates/runtime-doc/src/doc.rs:761–819`). These are nteract wrappers around
+upstream APIs, not fork-only methods.
 
-Principle: **reset transport state, preserve document truth.**
+**Notebook rebuild:** `rebuild_from_save` saves and loads the document, rejects
+a result with fewer cells, and preserves the actor before replacing the live
+document (`crates/notebook-doc/src/lib.rs:1477–1502`). Rebuild can fail. Peer
+state reset belongs to the calling sync helper, not to `rebuild_from_save`.
+Do not treat save/load as proof that arbitrary corruption has been repaired.
 
 ### Causal Ordering: required_heads (preferred)
 
@@ -247,9 +272,17 @@ If reconnect latency becomes a problem, preserving `shared_heads` (automerge-rep
 | Per-cell O(1) reads (WASM) | Direct map lookups via `ObjIndex` |
 | Recovery from corrupted indices | `save()` → `load()` round-trip |
 
-### Historical #1187 Panic
+### Historical desktop patches
 
-Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor table ordering shifts mid-batch. nteract's pinned Automerge 0.9 desktop patch covers this, plus `transact_at_heads_recovering` for writes at captured heads. Document-level catch/rebuild/reset remains as containment.
+The fork addressed historical MissingOps and patch-log failures. Production
+has since moved to crates.io `0.11.0`. The local upstream source contains the
+`fork_at` dependency-walk deduplication, no-op actor cleanup, stale-orphan sync
+correction, and historical-view patch finalization. This is not an exhaustive
+accounting of the 21 patches recorded in the earlier `b3502d42` rebase.
+
+Keep the regressions in `crates/automerge-recovery/src/lib.rs:416–483` and the
+document-owned policies above. A fixed historical bug does not justify
+removing recovery or treating every Automerge failure as rebuildable.
 
 ## Adding a New Sync Stream
 
@@ -257,8 +290,8 @@ Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor tab
 2. **Choose ownership pattern:**
    - SharedDocState pattern (notebook, runtime-state): doc + peer_state in `SharedDocState`, managed by `sync_task.rs`
    - Separate ownership (pool-state): frontend owns sync state; daemon carries peer state in peer loop
-3. **Add document-owned recovery helpers** (receive + generate with panic capture, rebuild, peer state reset)
-4. **Add rebuild function** (save→load→reset pattern)
+3. **Add document-owned recovery helpers** with explicit error classification; return sync panics rather than automatically rebuilding or retrying them.
+4. **Add rebuild validation and peer-state reset** for recoverable sync errors, following the document-owned policy above.
 5. **Update biased select loop** or relevant frame handler
 6. **Consider subscription scope:** Every peer or specific consumers?
 7. **Test with concurrent mutation:** Actor/heads bugs only manifest under concurrent sync
@@ -269,8 +302,8 @@ Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor tab
 - `generate_sync_message()` returning `None` after local mutations is correct (in-flight suppression)
 - Keep the frame reader draining: use waiters, not blocking waits
 - Lock scope drops before `.await`: compute inside lock, send outside
-- Reset sync state on transport breaks (reconnect, panic), not on local mutations
-- Cell-count guard prevents silent cell loss during rebuild
+- Reset sync state on reconnect and classified recoverable sync errors, not on local mutations; caught sync panics return a failure.
+- The notebook rebuild guard rejects fewer cells; it does not prove that all content is unchanged.
 - Actor table is sorted lexicographically. Disagreement corrupts OpIds.
 
 ## Decision Framework
@@ -278,7 +311,9 @@ Concurrent sync can trigger `PatchLog::migrate_actors()` mismatch when actor tab
 | Situation | Action |
 |-----------|--------|
 | Transport disconnect | Reset `sync::State` (new or encode/decode) |
-| Automerge panic caught | Rebuild doc (save/load), reset sync::State |
+| Recoverable sync error (`PatchLogMismatch`) | Reset peer state, rebuild, retry once; return failure if recovery fails |
+| Sync panic caught | Return failure without rebuild or retry |
+| Mutation panic caught | Follow the document helper's cleanup/rebuild policy; do not rerun the closure |
 | Local mutation | Let next `generate_sync_message` handle it |
 | Check if peer has changes | `change_graph.has_change(&hash)` (O(1)) |
 | Document at earlier point | `fork_at(heads)` (expensive, views only) |

--- a/.agents/skills/mcp-session-lifecycle/SKILL.md
+++ b/.agents/skills/mcp-session-lifecycle/SKILL.md
@@ -13,239 +13,241 @@ Use this skill when debugging session state, changing reconnection logic,
 working on the proxy, or reasoning about races between background rejoin
 and user-initiated tool calls.
 
+Source checkpoint: 2026-09-04 at `6bff3e7b`. The decision record is
+`docs/adr/mcp-session-lifecycle.md`. Read the source functions below rather
+than copying an abbreviated session struct or reconnect algorithm.
+
 ## Three Layers
 
-The MCP server has three layers, each with its own lifecycle:
+- **Process supervision:** installed `nteract-mcp` and development
+  `mcp-supervisor` use the `runt-mcp-proxy` library to supervise a `runt mcp`
+  child. The library is not an executable entrypoint.
+- **MCP session state:** the child owns one active `NotebookSession`, a bounded
+  map of parked sessions, explicit activation generations, and the daemon
+  watch loop.
+- **Daemon room state:** `runtimed` owns notebook rooms, runtime state, kernels,
+  recovery, and peer accounting. Kernel teardown and room reaping are separate.
 
-```
-MCP Client (Claude, etc.)
-    |
-    v
-[runt-mcp-proxy] Process supervision layer
-    |  - Tracks last_notebook_id from tool results
-    |  - Restarts child on crash / daemon upgrade
-    |  - Seeds NTERACT_MCP_REJOIN_NOTEBOOK env var
-    v
-[runt-mcp] Session state layer
-    |  - Arc<RwLock<Option<NotebookSession>>>
-    |  - daemon_watch loop (background rejoin)
-    |  - Tool dispatch (user-initiated session changes)
-    v
-[runtimed] Room lifecycle layer
-    - NotebookRoom per notebook UUID
-    - Peer counting, delayed eviction (30s)
-    - Automerge sync, RuntimeStateDoc
-```
+The shipped MCP entrypoints use stdio. Multiple MCP clients can run separate
+children against the same daemon, including the same notebook room. Concurrent
+requests on one stdio connection share that child's active slot; they are not
+independent MCP clients. The daemon's multiplexed notebook frames are a
+separate protocol, not an HTTP MCP endpoint.
 
-### Proxy Layer (`runt-mcp-proxy`)
+Entry points: `crates/runt/src/main.rs:739`,
+`crates/nteract-mcp/src/main.rs:260`, and
+`crates/mcp-supervisor/src/main.rs:2910`.
 
-The proxy is the outermost shell. It:
-- Spawns the actual `runt mcp` child process
-- Monitors stdout for MCP JSON-RPC and extracts `notebook_id` from
-  `connect_notebook` / `create_notebook` results
-- On child exit: if exit code is `EX_TEMPFAIL` (75), the daemon upgraded
-  and we restart with the new binary; otherwise just restart
-- Seeds `NTERACT_MCP_REJOIN_NOTEBOOK` env var so the child can rejoin
-  the notebook the previous child was attached to
-- Detects binary version changes (compares SHA of new binary path)
+## Proxy Layer
 
-### Session State Layer (`runt-mcp`)
+`McpProxy::track_session` and `session::extract_session_id` track one preferred
+restart target, despite the field name `last_notebook_id`:
 
-This is where most complexity lives. Key types:
+- Successful connect/create calls prefer the child's canonical file path for
+  local file-backed notebooks, falling back to a UUID. Hosted targets retain
+  their URL identity.
+- Successful `save_notebook` promotes a local UUID target to the saved path.
+- Disconnecting the active notebook clears the handoff. Disconnecting another
+  parked notebook preserves it. Failed calls do not replace the target.
+- Restart re-resolves the child executable and seeds
+  `NTERACT_MCP_REJOIN_NOTEBOOK`. It does not reconstruct the parked map.
+- Exit 75 is an intentional daemon-upgrade handoff, separate from the normal
+  crash budget. Other restarts are subject to the proxy's restart controls.
+- Daemon-version banners compare the old and new child's reported
+  `ServerInfo.server_info.title`, not binary SHA. A banner says rejoin was
+  requested; it does not prove that notebook readiness has completed.
+- The `reconnect` tool restarts the child, not the daemon.
 
-```rust
-// The shared session state
-session: Arc<RwLock<Option<NotebookSession>>>
+See `crates/runt-mcp-proxy/src/session.rs:17`,
+`crates/runt-mcp-proxy/src/proxy.rs:310`, `:962`, and `:1268`.
+A closed-child forwarding failure is retried once; this is not an exactly-once
+mutation guarantee (`proxy.rs:658`).
 
-// What's in a session
-struct NotebookSession {
-    handle: DocHandle,        // Automerge sync handle
-    broadcast_rx: Receiver,   // Daemon broadcast channel
-    notebook_id: String,      // UUID
-    notebook_path: Option<String>, // File path (None for untitled)
-}
-```
+## Active and Parked Sessions
 
-Two code paths compete for the session write lock:
+`NteractMcp` holds the active slot and parked map in
+`crates/runt-mcp/src/lib.rs:119`. `NotebookSession` in
+`crates/runt-mcp/src/session.rs` carries the handle, target, activation identity,
+readiness evidence, and local daemon incarnation when applicable.
 
-1. **Tool calls** (`connect_notebook`, `create_notebook`): User-initiated,
-   always win. Take write lock, install new session.
-2. **daemon_watch loop** (`rejoin`): Background auto-rejoin. Must check
-   that no tool call has changed the session during the async window.
+Switching targets parks the previous peer instead of immediately disconnecting
+it. `MAX_PARKED_SESSIONS` is eight; overflow removes an entry by arbitrary
+HashMap iteration order. Parked peers keep their rooms from reaching zero
+peers, so they can keep kernels alive. Local switch-back establishes a fresh
+activation and removes the old parked peer after successful publication;
+parked-handle reuse is not a universal reconnect contract.
 
-### Daemon Room Layer (`runtimed`)
+Most notebook tools operate on the active target. Exceptions include explicit
+parked-session disconnect and notebook-ID resource reads against connected or
+parked local sessions. A parked map does not provide independent active tool
+contexts for multiple MCP clients.
 
-- Rooms are keyed by UUID, never change identity
-- File paths are a secondary index (`PathIndex`)
-- Peer counting: each connection is a peer. When all peers disconnect,
-  a delayed eviction timer starts (default 30s, configurable via
-  `keep_alive_secs`)
-- If no peer reconnects within the eviction window: kernel shuts down,
-  file watcher stops, room removed
+See `park_session`, `install_activated_session`, and `disconnect_notebook` in
+`crates/runt-mcp/src/tools/session.rs:74`, `:742`, and `:949`, and
+`handle_for_notebook` in `crates/runt-mcp/src/resources.rs:285`.
 
 ## The Watch Loop State Machine
 
-`daemon_watch.rs` runs a classify → act loop on `DaemonEvent`s:
+`crates/runt-mcp/src/daemon_watch.rs:238` reconciles session ownership against a
+live daemon incarnation (`pid + started_at`), not a disconnect latch:
 
-```
-classify(event, initial_target, has_session, was_disconnected, disconnect_target)
-    -> WatchDecision { Exit | RejoinInitial | RejoinContinuation | MarkDisconnected | NoOp }
-```
+1. A daemon event wakes the watcher. Lagged delivery also requires a fresh
+   observation. The watcher directly calls `query_daemon_info(socket_path)`;
+   it does not decide from `DaemonConnection`'s cached heartbeat info.
+2. A failed identity query alone is not proof of daemon loss. Without an
+   explicit `Disconnected` event, defer reconciliation and retain the handles.
+3. Compare a live version with the startup baseline. A mismatch exits with 75;
+   if startup had no daemon, the first live version establishes the baseline.
+4. Remove active and parked local handles bound to a different incarnation, or
+   to no live incarnation after confirmed absence. Hosted sessions are excluded
+   from this local ownership reconciliation.
+5. Preserve the removed active session's best recovery target, preferring a
+   saved path. With a live daemon and empty slot, try the proxy handoff target
+   first, then that preserved target.
 
-### State Tracking
+A same-incarnation heartbeat leaves healthy bindings alone. A same-version
+restart changes incarnation and invalidates old local handles even if a
+`Disconnected` event was missed. Removing parked local handles does not enqueue
+recovery for every parked notebook.
 
-| Variable | Purpose |
-|----------|---------|
-| `initial_target` | From `NTERACT_MCP_REJOIN_NOTEBOOK` env var. Cleared once consumed or once a tool call establishes a session. |
-| `was_disconnected` | True after `Disconnected` event. Prevents heartbeat `Connected` events from triggering spurious rejoins. |
-| `disconnect_target` | Stashed notebook_id/path when session cleared on disconnect. Used for rejoin when daemon comes back. |
-
-### Event → Decision Matrix
-
-| Event | initial_target? | has_session? | was_disconnected? | Decision |
-|-------|----------------|-------------|-------------------|----------|
-| `Upgraded` (version change) | any | any | any | Exit(75) |
-| `Upgraded` (same version) | Some(t) | any | any | RejoinInitial(t) |
-| `Upgraded` (same version) | None | true | any | RejoinContinuation |
-| `Connected` | Some(t) | any | any | RejoinInitial(t) |
-| `Connected` | None | true | true | RejoinContinuation |
-| `Connected` | None | true | false | NoOp (heartbeat, not a real reconnect) |
-| `Connected` | None | false | true | RejoinInitial(disconnect_target) |
-| `Disconnected` | any | any | any | MarkDisconnected |
-
-### The Heartbeat Problem (#2088)
-
-`DaemonConnection` emits `Connected` every ~10s as a heartbeat. Without
-`was_disconnected` gating, every heartbeat would trigger a rejoin, creating
-a brief 2-peer spike that resets the room's eviction timer. The fix:
-only rejoin after a real `Disconnected` event.
+See `RecoveryState`, `reconcile_sessions`, and `watch`. Focused tests in the
+same file cover same-incarnation heartbeats, lagged delivery, failed identity
+queries, stale parked handles, and tool-installed replacements.
 
 ## The Session-Write Guard
 
-The critical race: rejoin is async (socket connect + initial sync load,
-potentially 120s). During that window, a tool call might establish a
-completely different session. Without a guard, rejoin would overwrite it.
+Background rejoin connects outside the session lock and samples the expected
+daemon incarnation before and after connection/readiness. Then
+`publish_rejoined_session` checks the captured `session_intent_epoch` and slot
+emptiness under the same write lock that installs the session. Any already
+installed session wins, including one for the same notebook. Explicit
+disconnect advances the epoch under that lock so a completed background
+connection cannot resurrect the disconnected session.
 
-The guard in `rejoin()`:
-```rust
-// After connect + initial load succeed...
-{
-    let guard = session.read().await;
-    if let Some(existing) = guard.as_ref() {
-        if existing.notebook_id != new_notebook_id {
-            info!("Rejoin superseded by active session; dropping");
-            return true;
-        }
-    }
-}
-// Only now install the rejoined session
-*session.write().await = Some(new_session);
-```
+Explicit connect/create activation has a separate generation owner:
+`SessionActivation`. Same-target in-flight connects share a result. Selecting a
+different canonical target supersedes the older attempt; A→B→A must not join
+stale A work. `ActivationLease::install_in_slot_recovering` rechecks ownership
+under the slot lock and restores the previous occupant if the installation
+commit is refused. A failed replacement does not invalidate the healthy
+installed session.
 
-**Invariant:** User-initiated session changes always win over background
-rejoin. The guard ensures this by checking the session state *after* the
-async work completes.
+Use these production helpers, not a read-lock check followed by a separate
+write. See `crates/runt-mcp/src/daemon_watch.rs:365`, `:493`, `:567`,
+`crates/runt-mcp/src/session_activation.rs:76`, `:225`, and
+`crates/runt-mcp/src/tools/session.rs:977`.
 
 ## Session Access Pattern
 
-All tool handlers use the `require_handle!` macro:
+An installed session is not a readiness guarantee. Acquire access through
+`require_session_access!` or `require_handle!` with the appropriate
+`SessionRequirement`. `NteractMcp::session_access` checks installed activation
+identity and delegates to `NotebookSession::access`; the returned handle is
+owned, so the slot lock is released before async work.
 
-```rust
-// Read lock → clone DocHandle → drop lock → work
-let handle = {
-    let guard = session.read().await;
-    match guard.as_ref() {
-        Some(s) => s.handle.clone(),
-        None => return no_session_error(...),
-    }
-};
-// handle is now owned; lock is dropped
-handle.with_doc(|doc| { ... });
-```
+| Requirement | Gate |
+|-------------|------|
+| `ProjectionRead` | Retained projection or interactive document; use the bounded projection before interactivity |
+| `DocumentRead`, `DocumentMutation` | Interactive local document with the required readiness evidence |
+| `KernelControl` | Interactive document; a running kernel is not required to launch or restart it |
+| `RuntimeRead` | Connected, ready local RuntimeStateDoc |
+| `Execute` | Interactive document and ready runtime; execution keeps its causal `required_heads` gate |
 
-This prevents lock contention: the read lock is held only for the clone,
-not for the entire tool execution. `DocHandle` is cheaply cloneable
-(`Arc<Mutex<SharedDocState>>`).
+Retained projection reads do not authorize mutations or execution. Local sync
+failure, source degradation, runtime unreadiness, and superseded activation
+have distinct error paths. Use `ensure_session_access_current` after async work
+before continuing an operation on the captured active target. Do not keep a
+session lock across connection, file loading, projection, or sync waits.
+
+See `crates/runt-mcp/src/tools/mod.rs:18`, `crates/runt-mcp/src/lib.rs:273`,
+`crates/runt-mcp/src/session.rs:323`, `:485`, and `:595`.
+
+Local `connect_notebook` returns a retained control-plane projection while
+peers converge. `create_notebook` and background local rejoin still await
+session readiness. Do not apply the progressive-connect contract to all three
+paths. The response fields and historical API sketch are distinguished in
+`docs/memos/mcp-connect-initial-projection.md`.
 
 ## Rejoin: File-Backed vs Ephemeral
 
-| Notebook type | Identified by | Rejoin method | Eviction check |
-|--------------|---------------|---------------|----------------|
-| File-backed | Has file path | `connect_open(path)` | File exists on disk |
-| Ephemeral (untitled) | UUID only | `connect(uuid)` | Daemon-authoritative refusal |
+Prefer a saved file path for automatic rejoin. The watcher verifies that the
+source file exists and calls `connect_open(path)`. UUID-only attachment is
+also recoverable when the daemon has a resident room, a persistent UUID/path
+registry binding with available source, or a persisted untitled document.
+The registry is identity, not content: a missing source file is not permission
+to load a stale mirror or invent an empty notebook.
 
-**Ephemeral notebooks** call `connect(uuid)` directly and trust the daemon's
-resident/recoverable-room handling. The daemon is authoritative about whether
-a notebook still exists. A refusal comes back as `NotebookUnavailable` and
-is handled as evicted with no retry. No pre-check `list_rooms` call.
+For a UUID target, call `connect(uuid)` and trust the daemon's attach-only
+admission. `SyncError::NotebookUnavailable` is definitive and records
+`Evicted` without retry. Do not use `list_rooms` as an existence precheck; an
+unlisted room may still be recoverable. Transient failures retain the recovery
+target for later attempts.
 
-**File-backed notebooks** use `connect_open(path)` which lets the daemon
-reload from disk. The `.automerge` persist files for file-backed rooms
-are deleted, so UUID-only connect would yield an empty document.
+Daemon authority is not an atomic check-and-load guarantee. The legacy snapshot
+existence check at `crates/runtimed/src/daemon.rs:3122` precedes awaited room
+creation. If that snapshot disappears and no journal is recovered,
+`crates/runtimed/src/notebook_sync_server/room.rs:1945–1955` can create a fresh
+document. Keep this limitation distinct from the already-absent UUID refusal.
+
+Persisted untitled notebooks are not the same as explicitly ephemeral
+notebooks. MCP `create_notebook` defaults to `ephemeral=true`; do not promise
+recovery after loss of its content merely because a UUID is known.
+
+See `crates/runtimed/src/daemon.rs:3041`,
+`crates/runt-mcp/src/daemon_watch.rs:485`, `:506`, `:615`, and
+`crates/runt-mcp/src/tools/session.rs:1602`. The daemon integration tests at
+`crates/runtimed/tests/integration.rs:4015` and `:4054` cover refusal without a
+phantom room and saved-path recovery by UUID across restart.
+
+## Daemon Room Lifetime
+
+Only the last peer leaving schedules kernel teardown, after `keep_alive_secs`
+(default 30 seconds). Room state, autosave, and file watchers remain resident.
+Teardown revalidates peer count and connection generation before destructive
+work; the destructive latch tells reconnecting peers not to reuse a doomed
+kernel.
+
+The ghost-room reaper separately sweeps eligible peerless, kernel-less rooms
+every five minutes, with a 24-hour TTL and soft cap of 32. Removal requires the
+durability barrier and final admission checks; reconnects and reservations
+protect rooms from stale reaping decisions.
+
+See `crates/runtimed/src/notebook_sync_server/peer_eviction.rs:107`, `:269`,
+and `crates/runtimed/src/daemon.rs:484`, `:5834`. Kernel teardown is not proof
+that a notebook has become unavailable.
 
 ## Session Drop Tracking
 
-When a session ends, `last_session_drop` records why:
+`last_session_drop` is best-effort recovery context, not another session:
 
-```rust
-enum SessionDropReason {
-    Evicted,       // Room evicted (all peers left, timer expired)
-    Switched,      // User connected to a different notebook
-    Disconnected,  // Daemon connection lost
-}
+- `Switched`: the old target was replaced and may still be parked.
+- `Disconnected`: stale local ownership was removed, recovery failed, or the
+  user explicitly disconnected. Explicit disconnect cancels automatic rejoin.
+- `Evicted`: rejoin received a definitive unavailable refusal or found a missing
+  saved source. It does not mean every kernel keepalive timeout deletes a room.
 
-struct SessionDropInfo {
-    reason: SessionDropReason,
-    notebook_id: String,
-    notebook_path: Option<String>,
-}
-```
+`SessionDropInfo` retains notebook ID, path, and rejoin target for
+`no_session_error`. See `crates/runt-mcp/src/session.rs:636` and the recording
+sites in `daemon_watch.rs` and `tools/session.rs`.
 
-The `no_session_error()` function uses this to give the MCP client
-actionable guidance: "notebook X was evicted, call connect_notebook"
-vs "daemon disconnected, retry in a moment."
+## Concurrent MCP Clients and Attribution
 
-## Common Mistakes
+Separate MCP children sharing a daemon are implemented. Each child has its own
+active selection; the room can have multiple peers. The upstream handshake
+supplies the display label and an `agent:<slug>:<session>` operator suffix.
+The proxy preserves the suffix across child restarts. Attribution is not a
+separate authorization boundary for every same-user local client.
 
-### 1. Taking write lock during tool execution
+Multiple independently routed MCP clients inside one child are not implemented
+by the shipped stdio entrypoints. Neither concurrent request IDs nor parked
+notebooks provide that routing. See `crates/runt-mcp/src/lib.rs:48`, `:119`,
+`:464`, and `crates/runt-mcp-proxy/src/proxy.rs:180`, `:227`.
 
-Tool handlers should clone the `DocHandle` under a read lock, then drop
-the lock before doing work. Holding a write lock during async work blocks
-all other tool calls and the rejoin loop.
+## MCP Protocol Checkpoint
 
-### 2. Not checking session after async work in rejoin
-
-Any async gap in rejoin (socket connect, initial load) is a window where
-a tool call can change the session. Always re-check before installing.
-
-### 3. Treating Connected events as reconnection signals
-
-`Connected` fires on every heartbeat (~10s). Only rejoin after a real
-`Disconnected` event (`was_disconnected` flag).
-
-### 4. UUID-only connect for file-backed notebooks
-
-File-backed rooms don't have persistent `.automerge` files after the room
-is closed. Use `connect_open(path)` to let the daemon reload from disk.
-
-### 5. Creating phantom rooms on rejoin
-
-If an ephemeral room was evicted, `connect(uuid)` creates a new empty room
-with no cells and no kernel. Check `list_rooms` first.
-
-## Goal: Support Concurrent MCP Clients
-
-The current architecture assumes a single MCP client per daemon session.
-The goal is to support multiple concurrent MCP clients against the
-same daemon. Constraints to address:
-
-- **Session state is per-process:** Each `runt mcp` process has one
-  `Arc<RwLock<Option<NotebookSession>>>`. Multiple clients would need
-  either multiple processes or per-client session tracking.
-- **Peer identity:** Currently one peer label per MCP process. Multiple
-  clients would need distinct peer identities for presence and
-  conflict resolution.
-- **Tool dispatch:** `require_handle!` assumes one active session. With
-  multiple notebooks open, tools would need notebook_id routing.
-- **Proxy supervision:** The proxy tracks one `last_notebook_id`. Multiple
-  concurrent notebooks would need a session registry.
+The locked `rmcp` 1.5.0 defaults to MCP `2025-11-25` and retains the
+initialize-based lifecycle described here. This is not conformance with the
+upstream `2026-07-28` revision. See the protocol checkpoint and followups in
+`docs/adr/mcp-session-lifecycle.md` and
+`docs/audits/mcp-cloud-automerge-audit.md` before changing the transport or
+handshake contract.

--- a/crates/notebook-doc/AGENTS.md
+++ b/crates/notebook-doc/AGENTS.md
@@ -125,7 +125,23 @@ let mut doc = room.doc.write().await;
 doc.merge_recovering(&mut fork, "external-worker-merge").ok();
 ```
 
-Reserve `fork_at(heads)` for views and diagnostics — it builds a separate historical document with its own actor stream, so don't use it as the historical write primitive. The pinned Automerge 0.9 desktop patch covers the old MissingOps panic, but actor sequencing, restoration, integration, and panic recovery stay centralized when you go through the document-owned helpers.
+Reserve `fork_at(heads)` for views and diagnostics — it builds a separate historical document with its own actor stream, so don't use it as the historical write primitive.
+
+As of 2026-09-04, production and WASM use crates.io Automerge exactly `0.11.0`
+(`Cargo.toml:57`), adopted in `ae6aef0f` on 2026-08-26. The old MissingOps
+regression remains in `crates/automerge-recovery/src/lib.rs:416`; its
+"desktop patch" test name records history, not the current dependency source.
+Only `automerge-store` retains the legacy `nteract/automerge` revision
+`3fb6af5cc3af23b79f27cebfa339c8c98987e7b7` (Rust `0.10.0`) as a dev-only
+compatibility peer (`crates/automerge-store/Cargo.toml:17`).
+
+`transact_at_heads_recovering` is our wrapper around upstream `set_actor`,
+`isolate`, and `integrate`, not a fork-only API. Actor restoration and
+panic-triggered rebuild stay in `crates/notebook-doc/src/lib.rs:438`.
+This differs from sync recovery: `receive_sync_message_recovering` retries once
+after `PatchLogMismatch`, resetting peer state and rebuilding, but returns
+panics without rebuild or retry (`crates/notebook-doc/src/lib.rs:2479`,
+`crates/automerge-recovery/src/lib.rs:159–201`).
 
 ### Synchronous blocks
 

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -121,7 +121,12 @@ Rules:
 
 ## Blob store
 
-Content-addressed storage lives under `runt_workspace::daemon_base_dir()/blobs` (stable expands to `~/.cache/runt/blobs/`; source builds normally use the nightly namespace). Entries are sharded by first 2 hex chars. Each blob has a `.meta` sidecar with `{media_type, size, created_at}`. Blobs are ephemeral — regenerated from `.ipynb` on daemon restart.
+Content-addressed storage lives under `runt_workspace::daemon_base_dir()/blobs` (stable expands to `~/.cache/runt/blobs/`; source builds normally use the nightly namespace). Entries are sharded by first 2 hex chars. Each blob has a `.meta` sidecar with `{media_type, size, created_at}`.
+
+Blobs are disk-backed and survive daemon restarts. Background mark-and-sweep
+removes unreferenced blobs older than the configured grace period (default
+30 days). Blobs explicitly marked ephemeral can be deleted when superseded.
+See `src/blob_store.rs` and `blob_gc_grace` in `src/daemon.rs`.
 
 Manifests are inline Automerge Maps in RuntimeStateDoc. Each contains `ContentRef` entries per MIME type: `{"inline": "<data>"}` for ≤1KB text, `{"blob": "<hash>", "size": N}` for content >1KB or any binary. MIME types and sizes are readable directly from the CRDT — no blob fetch needed for metadata.
 
@@ -131,9 +136,20 @@ HTTP server at `127.0.0.1:<dynamic-port>` serves `GET /blob/{hash}` with correct
 
 - **Autosave:** 2s quiet period, 10s max interval. Daemon writes `RuntimeStateDoc.last_saved`; frontend computes dirty as `local_edit_at > last_saved`.
 - **UUID-stable rooms:** Room keys are always UUIDs. Saving an untitled notebook updates `path_index` and writes `RuntimeStateDoc.path`. The UUID never changes.
-- **Crash recovery:** Untitled notebooks persist to `notebook-docs/{hash}.automerge`. Snapshots go to `notebook-docs/snapshots/`. Outputs are ephemeral.
+- **Crash recovery:** Persistent rooms, including untitled notebooks, recover
+  NotebookDoc from append-only `.recovery` journals in `notebook-docs/`.
+  Legacy `.automerge` files are an untitled migration fallback; explicitly
+  ephemeral rooms use volatile durability. Execution results have a separate
+  durable store. See `src/notebook_sync_server/room.rs` and
+  `build_execution_result` in `src/daemon.rs`.
 - **Multi-window:** Multiple windows join the same room as separate Automerge peers.
-- **Eviction:** After all peers disconnect, delayed eviction (default 30s) shuts down the kernel and removes the room.
+- **Kernel teardown:** After all peers disconnect, a delayed check (default 30s)
+  can shut down the kernel. The room, file binding, autosave, and watchers remain
+  resident; a reconnect invalidates the pending teardown.
+- **Room reaping:** A separate five-minute sweep removes eligible peerless,
+  kernel-less rooms after 24 hours, or earlier under the 32-room soft cap. It
+  checks durability before removal. See `src/notebook_sync_server/peer_eviction.rs`
+  and the resident-room reaper in `src/daemon.rs`.
 
 ## Settings sync
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start here to understand a subsystem. This is not a complete inventory.
 | Identity, trust, and hosted rooms | [`adr/identity-and-trust.md`](adr/identity-and-trust.md), [`adr/hosted-room-authorization.md`](adr/hosted-room-authorization.md), [`adr/deployment-topology.md`](adr/deployment-topology.md) |
 | Remote compute and workstations | [`adr/remote-workstation-doc-agents.md`](adr/remote-workstation-doc-agents.md), [`adr/runtime-principal-promotion.md`](adr/runtime-principal-promotion.md), [`runbooks/remote-workstation.md`](runbooks/remote-workstation.md) |
 | Product requirements | [`prd/notebook-identity-environment-surfaces.md`](prd/notebook-identity-environment-surfaces.md), [`prd/hosted-sharing-invites.md`](prd/hosted-sharing-invites.md) |
+| MCP, cloud embedding, and Automerge audit | [`audits/mcp-cloud-automerge-audit.md`](audits/mcp-cloud-automerge-audit.md) |
 | Evidence and measurements | [`audits/`](audits/), [`measurements/`](measurements/) |
 | Operational setup | [`runbooks/macos-setup.md`](runbooks/macos-setup.md), [`runbooks/hosted-direct-oidc-demo-runbook.md`](runbooks/hosted-direct-oidc-demo-runbook.md) |
 

--- a/docs/adr/cloud-connected-local-mcp.md
+++ b/docs/adr/cloud-connected-local-mcp.md
@@ -168,15 +168,17 @@ The following properties are load-bearing:
 - a missing file or empty registry means no cloud hosts are configured;
 - the stable Desktop/MCP registry starts empty and those clients synthesize no
   host or default, specifically not an implicit `preview.runt.run` entry;
-- configured non-loopback origins use `https`; cleartext `http` is accepted only
-  for explicitly recognized loopback/local-development origins and never as a
-  silent fallback, because catalog and room connections carry credentials;
+- configured non-loopback origins must use `https`; cleartext `http` must be
+  restricted to explicitly recognized loopback/local-development origins and
+  never used as a silent fallback, because catalog and room connections carry
+  credentials; enforcement is still incomplete as noted below;
 - `default_domain` is optional, must name an existing registry entry, and may
   be consulted only after the caller has explicitly chosen a cloud operation;
   it never reinterprets a bare notebook id as remote;
 - non-secret routing and domain data may live in the registry;
-- bearer values are read from environment variables, OS keychain, or a future
-  secret helper, not persisted as plaintext by `runt config`;
+- bearer values are currently read from environment references; OS keychain
+  and secret-helper integration remain future work, and `runt config` must not
+  persist bearer values as plaintext;
 - the registry is machine-local and may differ between Desktop, agent
   clients/harnesses, CI, workstation hosts, and user laptops;
 - the low-level registry is shared by daemon bridges and standalone MCP/CLI
@@ -186,6 +188,13 @@ The following properties are load-bearing:
   host metadata and catalog results, not bearer values;
 - `runt config` remains for synced daemon preferences unless we intentionally
   add a separate `runt cloud ...` or `runt remote ...` command group.
+
+**Current implementation, 2026-09-04:**
+`notebook-cloud-transport::registry::normalize_url_domain` accepts `http` and
+`https` without restricting HTTP to loopback. This is an unmet safety
+requirement, not approval to configure cleartext remote hosts. Use HTTPS for
+non-loopback origins; the explicit enforcement follow-up below must close the
+gap before the registry can claim that guarantee.
 
 The configured credential is the root credential for the hosted principal, not
 necessarily the credential sent on every sync frame or WebSocket. A hosted
@@ -242,8 +251,11 @@ desktop notebook use. The daemon dials the hosted room over
 ephemeral `NotebookRoom` (`hosted_bridge.rs`). Desktop windows and MCP sessions
 connect to that daemon-local room exactly like any daemon-local notebook. Echo
 suppression is structural (one `NotebookDoc`, one `sync::State` per peer). The
-hosted room is authoritative for `RuntimeStateDoc`; execution requests forward
-as hosted `Request` frames.
+hosted room is authoritative for `RuntimeStateDoc`. Execution forwarding
+handlers exist, but the current editor-only opener does not authorize execution:
+the local request gate rejects editor execution before it reaches those
+handlers, and the hosted room also requires owner scope. Forwarding plumbing
+must not be described as working execution through this opener.
 
 The shipped bridge is currently a hidden editor-oriented primitive, not yet a
 general hosted-catalog open contract. It requests `editor` for the hosted
@@ -453,10 +465,14 @@ change: old values keep meaning local notebook ids.
   open, propagate the server-authorized effective scope from
   `cloud_room_ready`, and restore/project that scope without treating every
   hosted window as an editor. Cover viewer downgrade and owner capability.
+- **Registry transport safety:** Enforce the HTTPS requirement during domain
+  normalization and target resolution before attaching credentials. The current
+  normalizer accepts non-loopback HTTP; add rejection tests and tests for the
+  explicit loopback development exception. This is required independently of
+  registry management UI.
 - **Machine-local registry management:** Add normalized, atomic list/upsert/
   remove/default operations and a headless CLI or equivalent native management
-  surface before exposing stable host-configuration UI. Reject non-loopback
-  cleartext origins and cover the explicit loopback development exception.
+  surface before exposing stable host-configuration UI.
 - **Per-connection operator precedence:** Ensure an explicit Desktop or MCP
   operator descriptor wins over the registry fallback, define one generic
   propagation contract across daemon-mediated and direct paths, and cover

--- a/docs/adr/deployment-topology.md
+++ b/docs/adr/deployment-topology.md
@@ -134,11 +134,13 @@ References:
 
 ## Decision 1: Cloudflare is the hosted document engine
 
-This decision records the current Cloudflare prototype and remains useful for
-understanding the shipped `preview.runt.run` path. For the next
-production-oriented hosted target, it is partially superseded by
-`../memos/aws-rust-room-host.md`, which moves live room authority to a native Rust room
-host on AWS while preserving the typed-frame protocol and document model.
+This decision records the current Cloudflare prototype and the shipped
+`preview.runt.run` path. `../memos/aws-rust-room-host.md` explores a native Rust
+room host on AWS as a possible future hosted target while preserving the
+typed-frame protocol and document model. As of 2026-09-04, that memo remains a
+proposal, not a superseding deployment decision or an implemented hosting
+alternative. The current hosted implementation still depends on Cloudflare
+Workers, Durable Objects, D1, and R2.
 
 The primary hosted topology is a Cloudflare Worker routing room requests to one
 Durable Object per notebook room. The Durable Object is the live room host:
@@ -240,10 +242,12 @@ Supported client-to-room patterns:
 - **Native direct.** Desktop, CLI, TUI, and agents connect directly to the room
   WebSocket with an `Authorization` header or equivalent native credential
   transport.
-- **Local daemon bridge.** A desktop daemon stores credentials in the OS
-  keychain, connects to the hosted room, and exposes local Tauri/Unix-socket
-  clients to that remote room. This is a convenience and credential-management
-  topology, not the security primitive.
+- **Local daemon bridge.** A desktop daemon resolves environment-backed
+  credential references from the machine-local `cloud-domains.toml`, connects
+  to the hosted room, and exposes local Tauri/Unix-socket clients to that remote
+  room. Keychain storage and device-flow acquisition remain future work. This
+  is a convenience and credential-management topology, not the security
+  primitive. Workstation pairing credentials are a separate credential path.
 - **Mixed local and hosted rooms.** One process may hold a `local:*` connection
   to a local daemon room and a `user:anaconda:*` hosted-room connection at the
   same time. The two rooms have separate actor spaces and ACLs.
@@ -333,9 +337,20 @@ The room should surface the active runtime peer, its provider, and its
 connection state as room metadata. Interrupt, restart, shutdown, and execution
 requests target the active runtime peer through scoped room requests; the room
 host creates the accepted execution entry and the runtime peer reports progress
-through `RuntimeStateDoc` transitions. If no runtime peer is attached, execution
-requests fail with a typed "no runtime attached" response rather than trying to
-infer compute from the document host.
+through `RuntimeStateDoc` transitions. Missing compute must not cause the room
+to infer a runtime from its document host or URL.
+
+**Current implementation, 2026-09-04:** hosted attachment and execution
+requests are owner-only. With no active runtime peer, owner execution can
+queue work while the selected attachment is already connecting, or create a
+resume attach job for a previously selected registered workstation whose
+attachment is `ready`, `disconnected`, or `idle`. Resume requires that
+workstation to belong to the notebook owner and pass the room's
+online/lease/heartbeat checks. If there
+is no eligible attachment to connect or resume, the room rejects execution
+with a no-runtime-peer reason. This uses explicit attachment state, not a
+fallback to unrelated compute. See `ensureRuntimeForHostedExecution` in
+`apps/notebook-cloud/src/notebook-room.ts`.
 
 ## Non-Goals
 
@@ -355,8 +370,10 @@ infer compute from the document host.
 1. **Runtime principal shape.** Should a JupyterHub runtime sidecar authenticate
    as `hub:<hub-host>:<user-server>` directly, or should the Cloudflare room
    mint a room-scoped runtime principal after Hub verification?
-2. **Runtime attachment grant UX.** Is attaching compute an owner-only action,
-   an editor action, or a separate capability?
+2. **Runtime attachment grant UX.** Attaching compute and requesting execution
+   are currently owner-only. Should a future explicit capability delegate either
+   action without granting owner authority? Editor access alone must not grant
+   execution authority.
 3. **Token exchange.** Do we need a first-party brokered token from Cloudflare
    to the Hub sidecar, or is direct Hub token validation by the Worker enough
    for v1?

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -1,20 +1,24 @@
 # MCP Session Lifecycle and Daemon Supervision
 
-**Status:** Accepted, 2026-07-13; amended 2026-08-20; supersedes Draft from 2026-05-23.
+**Status:** Accepted, 2026-07-13; amended 2026-08-20 and 2026-09-04; supersedes Draft from 2026-05-23.
+
+Source checkpoint: 2026-09-04 at `6bff3e7b`. This record describes the shipped
+initialize-based MCP implementation, not conformance with the upstream
+`2026-07-28` protocol revision. See [MCP protocol checkpoint](#mcp-protocol-checkpoint).
 
 **Neighbors:**
 - `docs/adr/room-source-lifecycle-and-file-recovery.md` - the room-owned source states, recovery journal, and progressive capability gates observed by MCP sessions.
 - `docs/adr/typed-frame-v4-wire-protocol.md` - the wire that backs every `DocHandle` the MCP server holds.
 - `docs/adr/document-split.md` - what `NotebookSession.handle` actually points at (`NotebookDoc`, `RuntimeStateDoc`, plus the runtime broadcast).
 - `docs/adr/execution-pipeline.md` - why a stale `DocHandle` is so painful for the agent: `required_heads`, output sync, and broadcast replay all run through it.
-- `docs/adr/blob-storage-and-content-addressing.md` - the blob HTTP port lives on the same `Daemon` the MCP proxy supervises.
-- `docs/adr/identity-and-trust.md` - the principal/operator model the proxy/child will eventually enforce per connection; today the MCP child connects as `local:<uid>` via peer creds.
+- `docs/adr/blob-storage-and-content-addressing.md` - the blob HTTP port belongs to the daemon, not the stdio MCP transport.
+- `docs/adr/identity-and-trust.md` - local peer credentials establish the principal; the MCP client identity supplies the agent operator suffix for attribution.
 
 ## Context
 
-The MCP server is the agent's only way into a live nteract notebook. It has to stand between three things that all have independent lifetimes:
+The MCP server gives agents stateful access to live nteract notebooks. It has to stand between three things that all have independent lifetimes:
 
-1. **The MCP client** (Claude Code, the inspector, Codex, Zed). Connects on stdio, sends a stream of tool calls, expects every successful call to map to *some* notebook.
+1. **The MCP client** (Claude Code, the inspector, Codex, Zed). Connects on stdio and sends tool and resource requests. Most notebook tools use the connection's active selection; discovery and session-management calls need not have an active notebook.
 2. **The runtimed daemon**. Unix-socket server that owns the Automerge rooms, the kernels, and the file watchers. Restarts on user upgrade, on a crash, or because the user toggled debug/release in dev. Versions bump independently of the MCP child.
 3. **The room.** The per-notebook entity inside the daemon. Holds the Automerge doc, source controller, recovery journal, kernel handle, file checkpoint writer, and peer counter. It survives the last peer disconnecting (for a while) so reconnects are cheap, and its journal survives reaping so acknowledged heads remain recoverable.
 
@@ -22,44 +26,62 @@ The MCP server is the only place all three meet. Tool calls are stateful by conv
 
 The shape that fell out:
 
-- A **supervisor** (`mcp-supervisor` in dev — the stdio entry the MCP client actually connects to) owns the child process and the daemon-version transition. Internally it uses `McpProxy` (the `runt-mcp-proxy` crate, a library) to drive the child-monitor loop and to assemble the reconnection banner; `runt-mcp-proxy` is not a binary the MCP client spawns directly.
-- A **child** (`runt-mcp`, the `runt mcp` subcommand) holds the single active `NotebookSession` and runs the watch loop.
-- The **daemon** holds the room and runs the ghost-room reaper.
+- A **supervisor** (`nteract-mcp` in installed distributions, `mcp-supervisor` in dev) owns the child process. Both use `McpProxy` from the `runt-mcp-proxy` library for child monitoring and reconnection banners; the library is not a binary the MCP client spawns directly.
+- A **child** (`runt-mcp`, the `runt mcp` subcommand) holds one active `NotebookSession`, a bounded parked map, and the watch loop.
+- The **daemon** holds rooms and kernels and runs the ghost-room reaper.
 
-Each layer has exactly one responsibility, and each one assumes the layer beneath it can disappear at any moment.
+Separate MCP clients can run separate children against one daemon and join the
+same room. This is implemented multi-client sharing, not a future goal.
+Concurrent requests on a child's stdio connection share its active selection;
+the entrypoints do not multiplex independent MCP clients within that child.
+The daemon's notebook framing is a separate transport protocol.
 
-This ADR pins down those responsibilities, the state machine on the session lock, the races the code does and does not handle, and where the model breaks if we try to extend it (concurrent MCP clients, remote rooms, identity per peer).
+The source entrypoints are `crates/runt/src/main.rs:739`,
+`crates/nteract-mcp/src/main.rs:260`, and
+`crates/mcp-supervisor/src/main.rs:2910`. Same-room peer propagation is covered
+by `test_notebook_sync_cross_window_propagation` in
+`crates/runtimed/tests/integration.rs:1135`.
+
+This ADR pins down session ownership, readiness, recovery, and the limits of
+sharing one active target across concurrent requests.
 
 ## Decision 1: Three layers, three lifetimes, no shared state
 
-The MCP server has three processes / loops with disjoint lifetimes:
+The proxy, child, and daemon have separate state and failure boundaries:
 
-```
-[MCP client]            (stdio)
-    |
-[mcp-supervisor]        Process supervisor. Owns the child process.
-                        (Uses runt-mcp-proxy as a library for monitor + banner.)
-    | tracks: last_notebook_id, last_daemon_version, restart_count
-    | does:   spawn child, monitor transport, restart on EOF or EX_TEMPFAIL,
-    |         seed NTERACT_MCP_REJOIN_NOTEBOOK, prepend reconnection banner
-    v (stdio)
-[runt-mcp child]        Session state. Owns the DocHandle.
-    | tracks: Arc<RwLock<Option<NotebookSession>>>,
-    |         parked sessions, last_session_drop, peer_label
-    | does:   daemon_watch loop, rejoin guard, tool dispatch
-    v (Unix socket)
-[runtimed daemon]       Room. Owns the kernel and the autosave debouncer.
-    | tracks: active_peers atomic, last_kernel_torn_down_at,
-    |         connection_generation, kernel_teardown_destructive
-    | does:   kernel teardown after keep_alive_secs idle,
-    |         ghost-room reaping at RESIDENT_ROOM_TTL_SECS
-```
+| Layer | Owns | Recovery responsibility |
+|-------|------|-------------------------|
+| `nteract-mcp` / `mcp-supervisor`, using `McpProxy` | Child process, one preferred handoff target, upstream identity, tool cache | Restart child, re-resolve executable, request rejoin |
+| `runt mcp` | Active and parked peers, activation generations, readiness evidence, daemon watcher | Reconcile local incarnation and publish only current sessions |
+| `runtimed` | Rooms, source state, recovery, kernels, peer accounting | Keep room content available independently of a particular client or kernel |
 
-Each boundary is a process boundary. No shared memory, no shared lock, no transactional handoff. State that crosses a boundary is either a single env var (`NTERACT_MCP_REJOIN_NOTEBOOK`), a tool-result body (`notebook_id` parsed from JSON), or an event in the broadcast stream the daemon publishes (`DaemonEvent::{Connected, Disconnected, Upgraded}`).
+There is no cross-process shared lock or transactional handoff. The proxy
+passes recovery and operator environment variables and parses tool results.
+The child talks to the daemon over its control and notebook connections.
+`DaemonEvent` values are emitted by the child's `DaemonConnection` supervisor;
+they wake the watcher rather than serving as authoritative daemon identity.
 
-This is deliberate. The proxy lives across daemon upgrades, but the child does not. The child lives across room evictions, but the session inside it does not. The room lives across peer disconnects, but the kernel inside it does not. The lifetime nesting is strict: proxy outlives child outlives session, room outlives session outlives kernel. Crossing one boundary never invalidates the layer above.
+A session can outlive a kernel restart, and another peer can keep a kernel
+alive after this child disconnects. These lifetimes are not strictly nested.
+A daemon replacement invalidates local handles without necessarily ending the
+proxy's MCP connection.
 
-The cost we pay for the strict nesting is that every layer has to be re-entrant. The proxy has to handle the daemon-restart, child-crash, and daemon-upgrade cases through the same restart path. The child has to handle proxy handoff, daemon reconnect, and same-version daemon restart through the same rejoin path. The daemon has to handle "last peer left then came back five seconds later" without tearing down the kernel.
+`McpProxy::restart_child_for_reason` re-resolves the executable on every
+restart. Exit 75 is an intentional upgrade handoff with separate limiting,
+not a charge against the ordinary crash budget. Version banners compare the
+old and new child's `ServerInfo.server_info.title`, not a binary SHA.
+`track_session` prefers the canonical path returned by connect, promotes a
+local UUID target after save, and clears the handoff after active disconnect.
+Disconnecting another parked session leaves the active handoff intact.
+Only that one target is seeded into a restarted child; parked sessions are not
+restored as a group.
+
+See `crates/runt-mcp-proxy/src/proxy.rs:310`, `:962`, and
+`crates/runt-mcp-proxy/src/session.rs:17`. The proxy's `reconnect` tool replaces
+the child, not the daemon (`proxy.rs:1268`). A requested rejoin is not proof of
+a ready notebook. Forwarding retries once after a closed child transport
+(`proxy.rs:658`), so transparent restart is not an exactly-once mutation
+contract.
 
 ## Decision 2: Proxy modes are policy, not state
 
@@ -71,13 +93,23 @@ The cost we pay for the strict nesting is that every layer has to be re-entrant.
 | `attach` | no | no, errors out if missing | Codex, second IDE |
 | `isolated` | yes, per session | yes, scoped to session dir | one-shot test runs |
 
-For the stable / nightly desktop apps (the non-dev path), there is no `NTERACT_DEV_MODE`. The installed `runt mcp` binary is a sidecar that the user's nteract app launches; the app owns the daemon directly. The MCP server only ever talks to a daemon someone else started, which is structurally the same as `attach`.
+The installed `nteract-mcp` wrapper has no `NTERACT_DEV_MODE`. It locates the
+channel's `runt` binary and spawns `runt mcp`; daemon service management remains
+outside that child. See `crates/nteract-mcp/src/main.rs:190` and
+`crates/runt/src/main.rs:715`.
 
-**Why these three and not "always own the daemon."** Because two MCP clients on the same machine *will* try to spawn the daemon at the same time. The first wins by socket bind; the second crashes with `EADDRINUSE`. Splitting "may spawn" out of the child explicitly forces the user (or `.mcp.json`) to decide who's responsible. Letting the second client `attach` is the only way two clients can share a worktree without one losing a race against a socket.
+**Why separate management from attachment.** Multiple children can share a
+worktree daemon without each managing its lifecycle. Attach mode makes that
+boundary explicit: it does not start, stop, rebuild, or restart the shared
+daemon. Owner mode can also reuse a running daemon, so attach mode is not the
+only mechanically possible way to share one. See
+`crates/mcp-supervisor/src/main.rs:819`, `:2975`, and `:3004`.
 
-**What attach mode does not guarantee.** It does not guarantee the daemon outlives the MCP child. If the owner kills the daemon, the attach-mode child sees `Disconnected` and goes through the normal rejoin loop. It does not get an "owner exited" notification. The watch loop has no concept of who owns the daemon, only whether the daemon is reachable.
-
-This is a structural choice, not an oversight: the daemon doesn't know who its clients are beyond a peer label, so it cannot push "owner exited" anywhere. If we want explicit owner handoff (e.g., owner relinquishes ownership cleanly without killing the daemon), that's a feature on the daemon, not the proxy.
+**What attach mode does not guarantee.** It does not guarantee the daemon
+outlives the child. If the daemon is stopped or replaced, the child reconciles
+its local handles and attempts recovery. There is no owner-handoff event in
+this watch loop. Peer attribution and daemon lifecycle ownership are separate:
+knowing an agent's operator label does not make it the daemon's owner.
 
 ## Decision 3: The active slot plus daemon incarnation are session truth
 
@@ -91,25 +123,85 @@ A local session also carries `local_daemon_incarnation: Option<DaemonIncarnation
 
 A local connect samples daemon identity before and after connection/readiness. Equal samples bind the session. A missing or changed sample leaves it unbound and it is not published as an active tool session. The watch loop removes any active or parked local session whose binding does not equal the live incarnation. Hosted sessions survive local-daemon reconciliation.
 
-Tool handlers still clone the `DocHandle` under a read lock and release the lock before async work. The parked map remains a bounded cache, but parked local entries obey the same incarnation rule as the active slot.
+The parked map holds up to eight previous peers, with arbitrary HashMap-order
+eviction at capacity. These are live connections, so parking can keep a room
+and kernel alive. Local switch-back establishes a fresh activation and removes
+the old parked peer only after successful publication; it does not generally
+reuse the parked handle. Hosted reconnect has a parked-peer resume path.
+Parked local entries obey the same incarnation rule as the active slot.
+
+Most notebook tools use the active slot through an operation-specific readiness
+gate, cloning an owned handle before releasing the read lock. Notebook resource
+reads and explicit disconnect can address parked local sessions by notebook ID
+without changing the active selection. This is not independent active routing
+for several MCP clients in one process.
+
+See `crates/runt-mcp/src/lib.rs:119`, `:273`,
+`crates/runt-mcp/src/tools/session.rs:74`, `:742`, `:949`, `:1200`, and
+`crates/runt-mcp/src/resources.rs:285`.
 
 ## Decision 4: Tool intent and guarded publication are the convergence point
 
-Recovery connects outside the session lock. It captures the explicit `session_intent_epoch` and expected daemon incarnation, verifies both after the async connect/readiness window, then takes the active-slot write lock. Publication occurs only if the epoch is unchanged and the slot is empty. A user tool that installs any session during recovery therefore wins, including a session for the same notebook.
+Recovery connects outside the session lock. It captures `session_intent_epoch`
+and the expected daemon incarnation, then verifies incarnation again after the
+async connection/readiness work. `publish_rejoined_session` checks the epoch
+and slot emptiness under the same write lock that installs the session. A tool
+that has installed any session wins, including one for the same notebook.
+Explicit disconnect advances the epoch under the active-slot write lock so
+background work cannot resurrect the disconnected selection.
 
-A completed recovery connection may be dropped after doing useful work. Dropping its handle cleanly releases the extra peer; it is preferable to overwriting the user's selected session.
+Explicit connect/create attempts use a separate `SessionActivation` generation.
+Same-target connects share the current in-flight result; different-target
+attempts supersede earlier attempts, including A→B→A. Publication rechecks the
+lease before and under the slot lock, and restores the previous occupant if
+its identity commit is refused. The installed identity remains usable until a
+replacement actually publishes; a failed attempt does not poison it.
+
+A completed recovery connection may be dropped after doing useful work.
+Dropping its handle releases the extra peer; it is preferable to overwriting
+the user's selected session. These guards order session publication, not all
+concurrent notebook operations into one transaction.
+
+See `crates/runt-mcp/src/daemon_watch.rs:365`, `:567`,
+`crates/runt-mcp/src/session_activation.rs:76`, `:225`, and
+`crates/runt-mcp/src/tools/session.rs:977`. Tests exercise the production
+publication helpers in `daemon_watch.rs:1066` and
+`session_activation.rs:501`, `:563`, as well as failed replacement at `:442`.
 
 ## Decision 5: Live daemon incarnation drives reconciliation
 
-The watch loop does not infer connection state from a boolean latch. For every `DaemonEvent`, and obligatorily after `RecvError::Lagged`, it re-reads `DaemonConnection::info()`. That current info is the sole authority for local-session ownership.
+The watch loop treats events as wake-ups, not cached connection truth. On each
+`DaemonEvent`, and after `RecvError::Lagged`, it directly queries
+`query_daemon_info(socket_path)`. It does not make ownership decisions from
+`DaemonConnection::info()`'s cached heartbeat. If that one-shot query fails,
+only an explicit `Disconnected` event permits reconciliation against absence;
+otherwise the watcher defers and retains the current handles.
 
-Reconciliation removes active and parked local handles whose incarnation is missing or unequal. Removing the active handle records its best recovery target, preferring a file path and never replacing a saved path with a later UUID-only observation. With a live incarnation and an empty active slot, recovery uses the proxy handoff target first, then the preserved target.
+Reconciliation removes active and parked local handles whose incarnation is
+missing or unequal to the verified live incarnation. Removing the active
+handle records its best recovery target, preferring a file path and never
+replacing a saved path with a later UUID-only observation. With a live
+incarnation and an empty active slot, recovery uses the proxy handoff target
+first, then the preserved target. It does not reconnect every discarded parked
+session.
 
-The daemon version observed when the child starts is the version baseline. Every live event and every current `info()` result is compared with it; a mismatch exits with 75. If startup had no live daemon, the first live version establishes the baseline.
+The daemon version observed when the child starts is the version baseline.
+Each successful live query is compared with it; a mismatch exits with 75. If
+startup had no live daemon, the first live version establishes the baseline.
+See `crates/runt-mcp/src/daemon_watch.rs:259–341`; the failed-query and lagged
+observation tests are at `:985` and `:1096`.
 
 ## Decision 6: A same-incarnation heartbeat is structurally a no-op
 
-`Connected` may be emitted as a routine liveness refresh. When its live incarnation equals the active and parked local bindings, reconciliation changes nothing and has no recovery target to act on. No separate `was_disconnected` gate is required. A same-version daemon restart has a different `pid + started_at`, so the same reconciliation removes the old handles and recovers them against the new incarnation.
+`Connected` may be emitted as a routine liveness refresh. When the queried
+incarnation equals the active and parked local bindings, reconciliation changes
+nothing. An installed session clears obsolete recovery targets. No separate
+`was_disconnected` gate is required. A same-version daemon restart has a
+different `pid + started_at`, so reconciliation removes old local handles and
+can recover the previous active target against the new incarnation.
+
+See `crates/runt-mcp/src/daemon_watch.rs:301–341` and the heartbeat and
+replacement tests at `:904`, `:1011`.
 
 ## Decision 7: Room is the durable entity; sessions and kernels are not
 
@@ -133,32 +225,78 @@ post-barrier protection.
 
 **Why the room outlives the kernel.** Reconnects are common. A user closes the desktop window and re-opens it; a Claude Code session ends and a new one begins on the same notebook; a daemon upgrade restarts the child. In every case the agent or the UI wants to land on the same `notebook_id` with the same outputs visible and (where possible) the kernel still warm. Tearing down the room on the last disconnect would force a full re-load of the document, the file watcher rebind, and (if there's no `.ipynb` to reload from) loss of ephemeral cell state. Keeping the room resident makes reconnects cheap and idempotent.
 
-**Why the kernel is torn down anyway.** Kernels are expensive (one Python process, one env directory). Holding them past the keep-alive window costs CPU, RAM, and disk for a notebook nobody is watching. The 30-second default is conservative for agents (who reconnect on every tool call burst) and generous for humans (who don't notice the 30 s).
+**Why the kernel is torn down anyway.** A kernel and its environment consume
+resources even when no peer is using the notebook. The keepalive delay permits
+brief reconnects without requiring every abandoned kernel to run indefinitely.
+Ordinary tool calls reuse their peer; they do not reconnect on every call.
 
-**The reconnect-during-teardown race.** Between the moment the last peer leaves and the moment the kernel-shutdown RPC fires, a peer can reconnect. The teardown task re-checks `active_peers == 0` and `connection_generation == teardown_generation` under the rooms lock before each destructive step (kernel shutdown RPC, env cleanup, `last_kernel_torn_down_at` stamp). The `kernel_teardown_destructive` flag is set under the same lock so the connect path knows to auto-launch a fresh kernel instead of using the doomed one.
+**The reconnect-during-teardown race.** The teardown task snapshots connection
+generation when the last peer leaves. It revalidates no peers, unchanged
+generation, and a non-evicted room through `NotebookRooms::serialize_with`
+before destructive work. Setting `kernel_teardown_destructive` in the same
+serialized check tells a reconnecting peer not to reuse the doomed kernel.
+Peer count, generation, and the latch cover different windows of the race;
+none should be removed as redundant.
 
-That's three layers of defense against the same race: peer count, generation counter, destructive latch. Each one would catch the race in isolation; together they cover the case where one is checked and then the rooms lock is released for the next step. The pattern is "snapshot, do work, revalidate under the lock, advance." Slow and defensive on purpose; tearing down a kernel a user is actively using is the worst failure mode.
+See `crates/runtimed/src/notebook_sync_server/peer_eviction.rs:107`, `:166`,
+`:269`, and the reaper at `crates/runtimed/src/daemon.rs:5834`.
+`test_kernel_teardown_keeps_room_resident` at
+`crates/runtimed/tests/integration.rs:1861` verifies that zero peers and completed
+teardown still leave a reconnectable room. Reaper tests at `:1991`, `:2088`,
+and `:2657` cover TTL removal, reconnects, and reservations.
 
 ## Decision 8: Rejoin is keyed on file path for file-backed rooms
 
-Ephemeral untitled notebooks are rejoined by UUID; file-backed notebooks are rejoined by path:
+Automatic rejoin prefers a saved path when available. UUID-only recovery is
+also implemented; it is not a request to create an empty room.
 
-| Notebook type | Identified by | Rejoin method | Eviction check |
-|--------------|---------------|---------------|----------------|
-| File-backed | Path; the UUID is daemon-local and not durable across restarts | `connect_open(path)` | Daemon source controller restores matching journal state or imports disk; conflicts degrade explicitly |
-| Untitled (persisted) | UUID | `connect(uuid)` | Daemon-authoritative (attaches if recoverable, refuses if gone) |
+| Target | Rejoin method | Admission |
+|--------|---------------|-----------|
+| Known saved path | `connect_open(path)` | Watcher requires an existing source file; daemon reconciles source and recovery state |
+| UUID with a resident room | `connect(uuid)` | Attach to that room |
+| UUID with a persistent saved-path binding | `connect(uuid)` | Follow the registry binding and recover from the available source and journal |
+| Persisted untitled UUID | `connect(uuid)` | Reload recoverable persisted content |
+| UUID already absent from resident/registry/persisted admission checks | `connect(uuid)` | Refuse with `SyncError::NotebookUnavailable` |
 
-The reason: the path is the durable user-facing identity for a file-backed
-room, while its UUID remains daemon-local. `connect_open(path)` lets the source
-controller bind the current `.ipynb` fingerprint to its Automerge recovery
-journal. A matching pair restores journal state; no journal imports disk; a
-divergent pair preserves both and returns a degraded `source_conflict`. Rejoin
-must not create an empty UUID room or delete unexported heads merely because the
-previous resident room was reaped.
+The path remains a durable user-facing locator. The daemon's persistent
+registry can also preserve a file-backed UUID across restart, including an
+untitled notebook that was later saved. A registry row is not notebook content:
+if its source file is missing, attachment refuses rather than importing a stale
+mirror. Source and journal conflicts remain governed by
+[Room Source Lifecycle and File-Backed Recovery](./room-source-lifecycle-and-file-recovery.md).
 
-An untitled notebook is persisted by id to `docs_dir`, so on a daemon restart the daemon can reload it on a connect-by-id. The phantom-room failure mode (`#2088` - connecting to an evicted UUID minting an empty kernel-less room) is handled by `NotebookSync`-by-uuid being **attach-only and daemon-authoritative**: the daemon attaches to a resident room, reloads one still recoverable from its persisted doc, and **refuses** a gone one (a `NotebookConnectionInfo` with `error`, surfaced by the client as `SyncError::Protocol`) rather than minting a phantom. The rejoin just attempts the reconnect: recovered -> keep, refused -> clear `Evicted`. The phantom is prevented at the authoritative layer instead of guessed at by the client. The NotebookSync route to `create_empty_notebook` on a pristine room is not part of this attach-by-id path; `create_empty_notebook` remains the live seeding helper for explicit create/open flows.
+UUID availability and refusal are daemon-authoritative. Admission refuses an
+already-unavailable UUID rather than deliberately creating a new notebook.
+Rejoin does not precheck `list_rooms`: an unlisted room may still be recoverable.
+`NotebookUnavailable` and a missing saved source record `Evicted` without retry.
+Transient connection/readiness failures retain the recovery target for later
+attempts. Explicit create/open flows remain separate from UUID attach.
 
-**The path has to actually be on the session, or this whole decision is a no-op.** A session established by `connect_notebook(notebook_id=...)` does not learn its path for free - the by-id connect path (`ConnectResult`) has no `notebook_path`, unlike `connect_open`'s `OpenResult`. Until 2026-06, the by-id branch stored `notebook_path: None`, so a file-backed room joined by UUID rejoined by *UUID*, which Decision 8 says creates an empty room. On the nightly channel (frequent daemon upgrades) this was the live "agent sees `cells: []` while the desktop shows the notebook" bug: the desktop kept the path and reloaded, the agent kept the UUID and did not. The fix resolves the room's canonical path from `list_rooms` on a by-id connect and stores it on the session (in-child rejoin), and surfaces `notebook_path` in the connect/create response so the proxy seeds the path (not the UUID) into a respawned child's rejoin target. See `docs/adr/notebook-identity-and-path-binding.md` for why the path, not the UUID, is the durable handle.
+This is not atomic protection against content disappearing during attachment.
+The legacy snapshot existence check at `crates/runtimed/src/daemon.rs:3122`
+precedes awaited room creation. If the snapshot disappears and no journal is
+recovered, `crates/runtimed/src/notebook_sync_server/room.rs:1945–1955` can create
+a fresh document. The already-absent UUID test does not cover that race.
+
+Persisted untitled notebooks and explicitly ephemeral notebooks are different.
+MCP creation defaults to `ephemeral=true`; a UUID alone does not guarantee
+recovery when its content has been lost. See
+`crates/runt-mcp/src/tools/session.rs:1602`.
+
+On explicit UUID connect, MCP obtains the path from the daemon projection with
+a `list_rooms` lookup fallback and stores it on the session. The response
+exposes `notebook_path`; successful save also updates the proxy's preferred
+handoff. These path preferences remain useful even though registry-backed UUID
+recovery now works. See `crates/runt-mcp/src/tools/session.rs:1436`,
+`crates/runt-mcp-proxy/src/session.rs:55`, and
+[Notebook Identity and Path Binding](./notebook-identity-and-path-binding.md).
+
+Admission is implemented at `crates/runtimed/src/daemon.rs:3041–3150` and
+rejoin refusal handling at `crates/runt-mcp/src/daemon_watch.rs:506`, `:615`.
+Tests at `crates/runtimed/tests/integration.rs:4015`, `:4054`, and `:4203`
+verify refusal without a phantom for an already-absent UUID, saved-path recovery
+by UUID across daemon restart, and refusal when only a journal remains without
+its source file.
 
 ## Decision 9: `SessionDropReason` is the agent-facing recovery hint
 
@@ -167,74 +305,109 @@ When a tool call lands and finds `session = None`, the error has to tell the age
 | Reason | What happened | Recovery |
 |--------|---------------|----------|
 | `Switched` | Agent called `connect_notebook` on a different notebook | Park slot may still have the previous one; call `connect_notebook` again with the old `notebook_id` |
-| `Evicted` | Room was reaped by the ghost-room sweep or evicted in `list_rooms` check | Notebook is gone; create a new one or open the file |
-| `Disconnected` | Daemon went away and rejoin failed; **also** set on user-initiated `disconnect_notebook` and on the immediate clear when `MarkDisconnected` fires (before any rejoin retry runs) | Wait for daemon to come back; the watch loop will retry on next `Connected`. For the user-initiated case there is no retry. |
+| `Evicted` | Rejoin received a definitive unavailable refusal or found a missing saved source | Restore/open the source or create a new notebook; no automatic retry of that target |
+| `Disconnected` | Reconciliation removed stale local ownership, rejoin exhausted its current attempts, or the user explicitly disconnected | Automatic recovery can retry on a later verified live observation; explicit disconnect cancels it |
 
-The error message is generated at the point of tool failure (`no_session_error()`), so the agent sees a reason that matches *the most recent* drop. The drop info is best-effort: if the session is cleared twice (e.g., disconnect followed by an evict on rejoin), the second one overwrites the first. The previous `notebook_id` and `notebook_path` are kept so the recovery message can name what was lost.
+The error message is generated at the point of tool failure (`no_session_error()`).
+Drop info is best-effort context, not another authoritative session: a later
+recording can replace an earlier reason. `SessionDropInfo` retains notebook ID,
+path, and rejoin target so the error can name what was lost. Kernel teardown
+alone does not mean `Evicted`; the room can still be resident or recoverable.
+See `crates/runt-mcp/src/session.rs:636` and the recording sites in
+`daemon_watch.rs` and `tools/session.rs`.
 
 ## Decision 10: Connection activation is progressive and generation-guarded
 
 `session: Some` identifies the selected target; it does not mean every
-subsystem is ready. Each connect activation carries a monotonically increasing
-`session_generation`, the normalized target, a retained daemon projection, and
-separate readiness for room projection, the local NotebookDoc peer, the local
-RuntimeStateDoc peer, and the runtime.
-Pending activation metadata is not a second active session; `session` remains
-the only installed target.
+subsystem is ready. Local path/UUID `connect_notebook` obtains a bounded,
+heads-qualified projection over the independent daemon control connection,
+retains it on the session, and returns while local peers continue converging.
+A readable degraded projection can be retained without authorizing mutation.
+Pending activation metadata is not a second active session.
 
-`connect_notebook` remains one call. It returns after the room offers a safe
-projection, either `ProjectionReady` or `Degraded` with a retained projection,
-with stable cell IDs, projection heads and completeness, source state, later
-readiness, and explicit read/mutate/execute capabilities. The local Automerge
-peers continue converging in the background.
+The current connect response includes:
 
-Tool handlers use operation-specific gates:
+- `session_generation` and `source_state`;
+- `readiness` booleans: `projection`, `document`, `runtime`, `interactive`;
+- `projection.heads`, `runtime_state_heads`, and `completeness`;
+- `capabilities.read`, `mutate`, and `execute`;
+- existing `runtime`, `dependencies`, `project_context`, and cell summaries.
 
-- daemon projection reads require `ProjectionReady`;
-- local NotebookDoc reads and mutations require `Interactive` and any requested
-  causal heads;
-- execution additionally requires runtime readiness and carries
-  `required_heads` through the existing execution gate.
+`cells` remains a formatted string containing stable IDs. Success is returned
+as JSON text plus a notebook resource link, not the structured cell-array
+response proposed in the initial-projection memo. See
+`crates/runt-mcp/src/tools/session.rs:583`, `:808`, `:1332`, and `:1406`.
 
-The UI and MCP mutation surface stay read-only before `Interactive`, while the
-low-level sync peer may still accept and durably journal Automerge changes. A
-retained projection is inspectable after local sync failure but never
-authorizes writes or execution against cached source.
+Tool handlers use `SessionRequirement` through `require_session_access!` or
+`require_handle!`:
 
-Every async wait captures its activation generation and re-checks it before
-installing state or dispatching an operation. A different target supersedes the
-old generation. Concurrent connects for the same canonical path, resident UUID,
-or normalized hosted target coalesce behind one in-flight attach and projection
-result. Path and UUID aliases for a known file-backed room resolve through the
-daemon to the same room key before coalescing. Session locks are not held across
-file loading, socket connection, projection, or sync waits.
+| Operation | Required evidence |
+|-----------|-------------------|
+| Bounded projection read | Retained projection or interactive document |
+| Full NotebookDoc read or mutation | Interactive document with local readiness/head evidence |
+| Kernel control | Interactive document, without requiring an already running kernel |
+| RuntimeStateDoc read | Connected and ready local RuntimeStateDoc |
+| Execution | Interactive document and ready runtime; preserve the execution `required_heads` gate |
 
-Failures are structured as `notebook_not_ready`, `runtime_not_ready`,
-`source_degraded`, `source_conflict`, `session_superseded`, or `sync_failed`.
-`notebook_not_ready` always carries closed mutate/execute capabilities. When
-the document plane is already interactive and only the runtime is missing,
-runtime reads and execution fail as `runtime_not_ready` instead, with mutation
-still open. Projection success followed by local peer failure leaves a
-degraded read-only session; source failure before a projection can be honored
-fails the connection directly.
+`get_all_cells` serves the retained bounded projection before interactivity;
+full notebook resources use `DocumentRead` and can remain unavailable then.
+This is inspection of a retained revision, not a fresh full-document read.
+Readiness is recomputed from current peer status, head containment, and source
+health. A failed local peer or degraded source does not authorize cached-source
+writes or execution.
+
+See `crates/runt-mcp/src/session.rs:323`, `:485`, `:595`,
+`crates/runt-mcp/src/tools/cell_read.rs:229`, and
+`crates/runt-mcp/src/resources.rs:285`. Access captures installed generation
+and target; `ensure_session_access_current` revalidates them after async work
+(`crates/runt-mcp/src/lib.rs:273–320`). Session locks must not span file loading,
+socket connection, projection, or sync waits.
+
+Concurrent same-target connects coalesce through `SessionActivation`; path and
+UUID aliases are resolved using the daemon and registered on the current
+flight. A different target supersedes earlier pending work without invalidating
+a healthy installed session until the replacement publishes. The implementation
+and tests are in `crates/runt-mcp/src/session_activation.rs:76`, `:254`, `:391`,
+`:442`, and `:605`.
+
+Readiness errors distinguish `notebook_not_ready`, `runtime_not_ready`,
+`source_degraded`, `source_conflict`, `session_superseded`, and `sync_failed`.
+Document unreadiness keeps mutation and execution closed. Runtime-only
+unreadiness can leave mutation open. Publication against a replaced daemon
+returns `daemon_replaced` (`crates/runt-mcp/src/tools/session.rs:742`). Other
+connection failures can still use text tool errors; not every failure is a
+structured readiness result.
+
+This progressive contract is specific to local connect. `create_notebook`
+still awaits session readiness (`tools/session.rs:1648`), as does background
+local rejoin (`daemon_watch.rs:517`). Hosted sessions use their existing
+connected-replica readiness path, not the local room's retained-projection
+contract (`session.rs:415`). The historical sketch and measurements remain in
+[the initial-projection memo](../memos/mcp-connect-initial-projection.md).
 
 ## Worked examples
 
 ### Cold start: Claude Code spawns owner-mode proxy
 
-1. Claude Code spawns `mcp-supervisor` over stdio. The supervisor's internal `McpProxy` reads cached tool list from disk and returns it immediately to the MCP `tools/list` request, so Claude Code's tool registry is populated without waiting on the daemon.
-2. Supervisor receives `notifications/initialized`. Spawns the `runt mcp` child.
-3. Child connects to the daemon socket via peer creds, sees no `NTERACT_MCP_REJOIN_NOTEBOOK`, sits idle with `session = None`.
-4. Agent calls `connect_notebook { path: "/tmp/foo.ipynb" }`. Proxy forwards to child. The daemon source controller creates or restores the room, publishes a heads-qualified projection, and the child installs the generation-guarded session. The call returns the `notebook_id` and stable cell projection while local peers continue converging.
-5. Proxy parses the response, stores `notebook_id` in `last_notebook_id`. This is the seed for the next restart.
-6. Subsequent tool calls clone the handle under a read lock and execute.
+1. Claude Code spawns `mcp-supervisor` over stdio. Before its proxy is initialized, the supervisor exposes its own tools and empty resource lists.
+2. Background setup finds or starts the worktree daemon, initializes the proxy and `runt mcp` child, and notifies the client of the available tool surface.
+3. With no handoff target, the child has `session = None` until a tool selects a notebook.
+4. Agent calls `connect_notebook { path: "/tmp/foo.ipynb" }`. The child attaches, obtains a heads-qualified daemon projection, and installs a generation-guarded session. The call returns stable cell IDs while local peers continue converging.
+5. Proxy parses the response and stores the preferred target, `/tmp/foo.ipynb`, in `last_notebook_id` for the next restart.
+6. Subsequent notebook tools acquire the active session through their readiness gate. A successful connect does not mean execution is ready.
+
+The installed wrapper differs at startup: `nteract-mcp` can serve cached tools
+before its child starts, then starts the child after
+`notifications/initialized` and sends list-change notifications. See
+`crates/mcp-supervisor/src/main.rs:2910` and
+`crates/runt-mcp-proxy/src/proxy.rs:1135`, `:1215`.
 
 ### Daemon upgrade during an active session
 
 1. User upgrades the nteract desktop app. The installed daemon restarts; the new binary has version 2.1.3 (old was 2.1.2).
 2. Child's `DaemonConnection` detects the daemon version change and emits `DaemonEvent::Upgraded { previous: 2.1.2, current: 2.1.3 }`.
-3. Watch loop compares the live version with its startup baseline and exits with `EX_TEMPFAIL` (75).
-4. Proxy's child monitor sees the transport close, calls `restart_child()`. Re-resolves the child binary (picks up new symlink target after upgrade), seeds `NTERACT_MCP_REJOIN_NOTEBOOK = <last_notebook_id>`, spawns the new child.
+3. The event wakes the watcher, which queries the live daemon version and compares it with its startup baseline. A mismatch exits with `EX_TEMPFAIL` (75), even if the original upgrade event was lost.
+4. Proxy's child monitor sees the transport close and classifies exit 75 as an intentional handoff. It re-resolves the child binary, seeds `NTERACT_MCP_REJOIN_NOTEBOOK` with the preferred target (path when known, otherwise UUID or hosted URL), and spawns the new child.
 5. New child's watch loop sees the handoff target. On the first live daemon observation it reconciles the empty slot, runs recovery against that daemon incarnation, and installs a freshly stamped `NotebookSession` if no tool activation won meanwhile.
 6. Supervisor detects the daemon-version change across the child boundary (compares `ServerInfo.title` of old vs new child) and stamps a reconnection banner. The banner says `Daemon upgraded (2.1.2 -> 2.1.3), session reconnect requested` when a handoff target was supplied; it intentionally reports the request rather than claiming the asynchronous rejoin already succeeded.
 7. The agent's next tool result has the banner prepended. The agent sees one message; underneath, the child has been completely replaced.
@@ -244,13 +417,13 @@ fails the connection directly.
 1. Agent calls `disconnect_notebook` (or the MCP client exits). Child's session goes to `None`. Daemon sees the peer disconnect; `active_peers` drops to 0.
 2. Daemon schedules kernel teardown for `keep_alive_secs` (default 30 s). Snapshots `teardown_generation = current connection_generation`.
 3. At 25 s, agent calls `connect_notebook` on the same notebook. Daemon increments `active_peers` from 0 to 1, bumps `connection_generation`, zeroes `last_kernel_torn_down_at`.
-4. At 30 s, teardown task wakes, requests a synchronous flush of the persist debouncer, then revalidates under the rooms lock: `active_peers != 0`. Teardown task returns without touching the kernel.
+4. At 30 s, the teardown task sees peers have reconnected and returns without touching the kernel. If reconnect instead races the later flush, the serialized peer/generation checks abort stale teardown work.
 5. Agent's reconnect lands on the same room with the same kernel. No env rebuild, no relaunch.
 
 ### Daemon goes away mid-execution
 
 1. The tool call owns a cloned local handle stamped with daemon incarnation A.
-2. When the daemon disappears, the watch loop re-reads no live daemon info. Reconciliation removes active and parked local handles, preserves the active session's path when available, and records `SessionDropReason::Disconnected`. Hosted handles remain installed.
+2. When a `Disconnected` event is accompanied by no live daemon identity, reconciliation removes active and parked local handles, preserves the active session's path when available, and records `SessionDropReason::Disconnected`. A failed query without that event instead defers reconciliation. Hosted handles are excluded from local ownership reconciliation.
 3. The in-flight tool's cloned handle observes the closed socket and returns failure; no session lock is held across that await.
 4. When daemon incarnation B becomes live, reconciliation still cannot retain any handle from A. With an empty active slot it reconnects using the preserved path (or UUID for recoverable untitled notebooks).
 5. Recovery verifies incarnation B again after readiness, then publishes only if explicit tool intent has not advanced and the slot is still empty. A tool-installed session for B wins the race and is retained.
@@ -260,79 +433,101 @@ fails the connection directly.
 1. Claude Code starts in `owner` mode, spawns the worktree daemon. Connects child to socket, opens a notebook.
 2. User starts Codex in `attach` mode against the same worktree. Codex's `mcp-supervisor` reads `NTERACT_DEV_MODE=attach`, asserts the daemon socket is reachable, spawns a child that connects without trying to start the daemon.
 3. Both children have their own `NotebookSession` slots. Both can call `connect_notebook` on the same notebook; each becomes a separate peer on the room, with `active_peers` going from 1 to 2.
-4. One agent calls `execute_cell`; the other agent sees the cell-state changes via Automerge sync. There is no per-client routing, no per-client identity, no per-client scope (Decision 5 in `identity-and-trust.md` will eventually change this).
-5. If Claude Code exits, its child closes the socket, daemon decrements `active_peers` to 1. The daemon does *not* tear down because Codex is still connected. The daemon is now orphan-owned (Claude Code started it, Codex is using it). If Codex also exits, `active_peers` goes to 0 and the kernel-teardown timer starts.
+4. One agent calls `execute_cell`; the other peer observes shared runtime changes. Each child has its own selection and agent operator suffix. That attribution does not create separate authorization boundaries for same-user local clients.
+5. Disconnecting one notebook peer leaves the other connected, so that disconnect does not schedule last-peer kernel teardown. This assumes the daemon itself remains running; stopping it through its lifecycle owner affects both clients.
 
-## 2026-08-20 implementation note
+The display label and `agent:<slug>:<session>` operator derive from the upstream
+MCP identity. The proxy keeps the operator session suffix stable across child
+restarts. See `crates/runt-mcp/src/lib.rs:48`, `:464`, and
+`crates/runt-mcp-proxy/src/proxy.rs:180`, `:227`. Tests at
+`crates/runt-mcp/src/lib.rs:628` and
+`crates/runt-mcp/src/daemon_watch.rs:776` cover identity derivation and the
+separation between rejoin actor identity and presence label.
 
-Decisions 3 through 6 use daemon incarnation rather than disconnect latches as
-the authority for whether a local `DocHandle` is usable.
+## 2026-09-04 implementation checkpoint
 
-Every local `NotebookSession` is stamped with a `DaemonIncarnation` consisting
-of the daemon PID and `started_at`. The connect path samples daemon identity
-before and after establishing the peer. Only an unchanged pair binds the
-session; a missing or changed sample produces an unbound local session, which
-is stale by definition. Hosted sessions have no local incarnation.
+The incarnation-based ownership decisions introduced in the 2026-08-20 amendment
+remain in force. The current watcher uses direct live identity queries and
+defers on unconfirmed absence, as described in Decision 5. It does not use the
+older classify/disconnect-latch algorithm.
 
-On every daemon event, and after a lagged broadcast receiver, the watch loop
-reads `DaemonConnection::info()` and reconciles the active slot and parked map
-under their locks. A local session survives exactly when its incarnation equals
-the live incarnation. Hosted sessions always survive local-daemon events. Thus
-a same-incarnation `Connected` heartbeat makes no state change, while a
-same-version restart with a new incarnation removes old handles without a
-separate disconnect latch. Parked local handles follow the same rule.
+Repeated connect can reuse the active same-target replica only when it is
+connected, its document or retained projection is readable, and its local
+incarnation matches the live daemon. A pending activation takes precedence over
+reuse. See `reuse_active_session` at
+`crates/runt-mcp/src/tools/session.rs:666` and
+`SessionActivation::can_reuse_installed` at
+`crates/runt-mcp/src/session_activation.rs:130`.
 
-When reconciliation removes the active local session it preserves the path,
-when known, as the recovery target; a later UUID-only observation cannot
-replace that path. Recovery connects outside the session lock, samples the
-expected incarnation again after readiness, and publishes only if the explicit
-`session_intent_epoch` is unchanged and no tool-installed session occupies the
-slot. Explicit tool activation therefore remains authoritative.
+The progressive harness at `scripts/mcp-connect-harness.py:1099` checks shared
+activation generation, projection, and bounded peer count for same-target
+connects. Its stalled-peer scenario at `:1367` checks that a connect projection
+remains inspectable while mutation and execution remain closed. These are
+application lifecycle checks, not an upstream MCP conformance suite.
 
-The child records the daemon version observed at startup. Every live event and
-every post-lag `info()` sample is compared with that baseline. A mismatch exits
-with `EX_TEMPFAIL` (75), even if the event stream dropped the original upgrade
-event. If no daemon was reachable at startup, the first live version becomes
-the baseline.
+## MCP protocol checkpoint
 
-Repeated `connect_notebook` calls may reuse the active same-target replica only
-when its peer is connected, its document or retained projection is readable,
-and (for local sessions) its incarnation equals the current daemon. Reuse of a
-stale but locally readable replica is forbidden.
+`Cargo.toml:90` requests `rmcp = "1.4"`; `Cargo.lock:7357` resolves it to 1.5.0.
+That SDK defaults `ServerInfo::new` to MCP `2025-11-25`, which the child and
+proxy use (`crates/runt-mcp/src/lib.rs:413`,
+`crates/runt-mcp-proxy/src/proxy.rs:1113`). Older requested revisions can be
+negotiated by the SDK, but negotiation is not proof of a complete old-client
+compatibility matrix. The child emits resource links without a version-specific
+fallback, and the proxy initializes its child with a separate default-capability
+handshake (`crates/runt-mcp/src/tools/session.rs:808`,
+`crates/runt-mcp-proxy/src/child.rs:28`).
 
-## Open Questions
+The upstream `2026-07-28` revision removes the initialize/protocol-session model
+and introduces per-request metadata, `server/discover`, and MRTR. The shipped
+entrypoints still use initialize-based stdio and do not implement that newer
+contract. Tools, resources, and the MCP Apps UI extension are advertised; the
+SDK dependency alone does not imply every protocol feature is exposed. Detailed
+compatibility and migration followups belong in the
+[MCP, cloud, and Automerge audit](../audits/mcp-cloud-automerge-audit.md).
 
-These are the architectural gaps surfaced while writing this ADR. None block the current shape; all need decisions before we scale beyond one-MCP-client-per-daemon.
+## Open Follow-ups
 
-1. **Concurrent MCP clients per child process.** The session state is `Arc<RwLock<Option<NotebookSession>>>` - one slot. The "north star" line in the skill is "multiple concurrent MCP clients against the same daemon," and today's answer is "run one child per client" (attach mode). If two MCP clients ever share a child, every tool call needs a `notebook_id` parameter, the `require_handle!` macro needs notebook routing, and the proxy needs a session registry instead of `last_notebook_id`. Open question: do we ever want this, or is the attach-mode "one child per client, share the daemon" pattern enough?
+These are remaining design or compatibility choices, not prerequisites for the
+already implemented separate-child/shared-daemon model.
 
-2. **Per-MCP-client peer identity.** Today every child connects to a room as a single peer with a single peer label. The default is `"Inkwell"`, optionally overridden by the upstream MCP client's `Implementation.name` (e.g., `"Claude Code"`) - see `crates/runt-mcp/src/lib.rs:56-57, :83, :245-255`. If multiple clients share a child, they need distinct peer identities so presence works and attribution is honest. This ties directly into Decision 1 of `identity-and-trust.md` (operator-per-actor labels), but the wiring from "MCP client identity" to "actor label" does not exist yet.
+1. **Several MCP clients within one child.** The shipped entrypoints expose one
+   active selection and one upstream identity per child. Supporting independent
+   clients there would require explicit routing and ownership, not merely more
+   parked entries. Decide whether this is needed beyond separate children.
+2. **Parked-peer policy and restart scope.** Eight live parked peers can keep
+   kernels alive; local switch-back creates a fresh activation. Consider an
+   idle/LRU policy only with explicit keepalive and resume semantics. Restoring
+   the full parked set after child restart would be a separate feature; today
+   only one preferred target is handed off.
+3. **Daemon ownership handoff.** Attach mode deliberately does not manage the
+   shared daemon. If ownership transfer between supervisors is needed, specify
+   it independently of peer attribution and notebook keepalive. A stopped
+   daemon affects all attached clients regardless of who started it.
+4. **Tool compatibility beyond names.** `detect_divergence` compares tool-name
+   sets, not input/output schemas (`crates/runt-mcp-proxy/src/tools.rs:98`).
+   Removal/rename can trigger exit; schema changes under an unchanged name need
+   a separate compatibility policy. Recovery hints are already caller-specific:
+   installed wrapper at `crates/nteract-mcp/src/main.rs:204`, dev supervisor at
+   `crates/mcp-supervisor/src/main.rs:3159`.
+5. **Retry and protocol compatibility.** The proxy's one retry after a closed
+   child transport does not establish exactly-once execution. Define any
+   stronger retry guarantee and migration to the newer upstream protocol
+   explicitly; do not infer either from transparent restart or SDK version.
 
-3. **Daemon ownership across attach/owner boundaries.** Attach-mode children do not know who owns the daemon. If the owner exits cleanly, the daemon may or may not exit too depending on whether anyone else is connected. There is no protocol-level "I am the owner, I am exiting now" signal. Today this is fine because the user is responsible for noticing. As we ship more agents that auto-spawn MCP clients, the implicit "first wins, others attach" rule will get racy.
-
-4. **Recovery-target precision after a daemon replacement.** The child retains
-   the removed session's best target, preferring a path over a UUID. The daemon
-   can still refuse an ephemeral UUID that is no longer recoverable, producing
-   a `Disconnected` then `Evicted` trail for the agent.
-
-5. **`parked_sessions` lifetime.** Capped at `MAX_PARKED_SESSIONS` with arbitrary HashMap-iteration eviction. Every parked session holds a live peer connection to the daemon, which means the daemon's `active_peers` for those rooms stays at 1 even when the agent is not actively using them. That keeps the kernel alive (good if the agent comes back), but it also disables the eviction timer for any notebook the agent has touched in the recent past. Open question: is the kernel-keep-alive the intended cost, or do we want parked sessions to drop the peer connection and rebuild on resume?
-
-6. **Cross-daemon proxy resumption.** Proxy stamps the reconnection banner from `(old_daemon_version, new_daemon_version)`. For **file-backed** notebooks this is now handled: the proxy seeds the *path* (not the UUID) into the respawned child's rejoin target, and the path is meaningful across daemon instances, so the source controller can reconcile the recovery journal and current file (Decision 8; `docs/adr/notebook-identity-and-path-binding.md` Decision 5). The remaining gaps are **ephemeral** notebooks (no path; their UUID is daemon-instance scoped, so a cross-daemon respawn loses them) and a daemon socket *path* change (dev-mode worktree switch in isolated mode), where even a file-backed `last_notebook_id` UUID would be meaningless - tracked as MSL-4.
-
-7. **MCP child as runtime peer.** The child connects as the user's "operator" today, but the daemon has no concept of `runtime_peer` vs `editor` scope (Decision 5 of `identity-and-trust.md`). If we ever split the kernel sidecar off into its own process, that process will connect as `runtime_peer`. The MCP child does both (edits cells and triggers kernel commands). Reconciling that with the per-connection scope model is unresolved.
-
-8. **`is_transport_closed` polling.** Proxy uses 500 ms polling because `RunningService` is not cloneable and `waiting()` consumes `self`. This is fine, but it adds up to 500 ms of latency between child exit and restart. Open question: is the rmcp API the right place to push back on, or do we live with the polling?
-
-9. **`should_exit` on tool divergence.** When a daemon upgrade introduces a tool whose name or shape collides incompatibly with the cache, the proxy sets `should_exit = true` and returns an error. The MCP client then has to reconnect. The error message says "you may need to reinstall the nteract extension," which is correct for the MCPB bundle but not for `nteract-dev` (where the supervisor manages the binary on disk). The branching on environment is missing.
-
-10. **Owner-mode and managed-daemon ownership across worktrees.** In dev, the supervisor manages a daemon per git worktree. If two worktrees of the same repo run owner-mode supervisors, each spawns its own daemon at a different socket. If a user switches worktrees mid-session by editing `.envrc`, the proxy keeps talking to the old daemon (the env vars only change for new shells). There is no detection. The fix is on the dev path, not the production path, but it bites regularly.
+Already-absent UUID refusal and file-backed UUID registry recovery are
+implemented; the snapshot-disappearance race in Decision 8 remains a separate
+limitation. Operator attribution and separate runtime-agent processes are also
+implemented, not open prerequisites for the current MCP model.
 
 ## References
 
 - `crates/runt-mcp/src/daemon_watch.rs` - incarnation reconciliation, `watch`, `rejoin`, and transition-sequence tests.
 - `crates/runt-mcp/src/session.rs` - `NotebookSession`, `SessionDropReason`, `SessionDropInfo`.
-- `crates/runt-mcp/src/lib.rs` - `NteractMcp` server, `require_handle!` macro, tool dispatch.
-- `crates/runt-mcp/src/tools/session.rs` - `connect_notebook`, `create_notebook`, parking, `disconnect_previous_session`.
+- `crates/runt-mcp/src/lib.rs` - `NteractMcp`, active-session access and revalidation, upstream attribution.
+- `crates/runt-mcp/src/session_activation.rs` - activation generations, coalescing, atomic publication helpers and tests.
+- `crates/runt-mcp/src/tools/mod.rs` - readiness-aware access macros and tool dispatch.
+- `crates/runt-mcp/src/tools/session.rs` - progressive local connect, create, parking, save, and disconnect.
+- `crates/runt-mcp/src/resources.rs` - notebook-ID reads against active and parked sessions.
 - `crates/runt-mcp-proxy/src/proxy.rs` - `McpProxy`, `restart_child`, child monitor, `track_session`.
 - `crates/runt-mcp-proxy/src/session.rs` - `extract_session_id` for parsing tool results.
 - `crates/runt-mcp-proxy/src/version.rs` - `ReconnectionEvent`, banner-message generation.

--- a/docs/audits/mcp-cloud-automerge-audit.md
+++ b/docs/audits/mcp-cloud-automerge-audit.md
@@ -1,0 +1,194 @@
+# MCP, cloud embedding, and Automerge audit
+
+**Status:** Audit, 2026-09-04. Source baseline: `6bff3e7b0a6e27b89c9ee3e700c6e7ffd6100885`.
+
+This checks implementation and tests against selected runtime and cloud docs.
+It separates available components from proposed integrations. It is not a
+live-deployment test or a complete review of every memo. This patch changes
+instructions and documentation, not runtime behavior or dependencies.
+
+## What can be reused today
+
+| Area | Implemented | Boundary to preserve |
+|---|---|---|
+| MCP clients | Separate MCP processes can share a daemon and notebook room. Each child serves one stdio connection. | Concurrent requests on that connection share its active notebook; they are not independently scoped clients. See [the entrypoint](../../crates/runt/src/main.rs#L739) and [session state](../../crates/runt-mcp/src/lib.rs#L119). |
+| Multiple notebooks | One active session plus up to eight parked peers; notebook-qualified resources can read parked sessions. | Ordinary notebook tools use the active target. Proxy restart restores one preferred target, not the parked collection. See [parking](../../crates/runt-mcp/src/tools/session.rs#L74) and [resource lookup](../../crates/runt-mcp/src/resources.rs#L285). |
+| Local embedded editor | `NotebookHost`, the Electron MessagePort adapter, and the native Node relay exist. | The integrating app must authorize notebook selection and privileged methods, supply output-document routing, and own lifecycle. This is not remote-service authentication. See [the Electron host](../../packages/notebook-host/src/electron/index.ts#L46). |
+| Hosted editor | The shared UI has a cloud host adapter and a Cloudflare room host. | The hosted shell sends `frame-ancestors 'none'`; it is not a ready-to-embed remote editor iframe. The Vite relay is a development transport, not a multi-user gateway. See [the CSP](../../apps/notebook-cloud/src/index.ts#L5914) and [browser relay](../../apps/notebook/vite-plugin-browser-relay.ts). |
+| Remote compute | Workstation registration, attach jobs, runtime-peer reconnect, and eligible owner-triggered resume exist. | The agent advertises its configured **Current Python**, not a hosted catalog of daemon pools. Running it inside a Hub does not implement the JupyterHub provider. See [registration](../../crates/runtimed/src/workstation/agent_loop.rs#L148) and [the provider stub](../../crates/nteract-identity/src/jupyterhub.rs). |
+
+On-prem compute attached to the current cloud does not move document authority
+on premises. The reference hosted application still uses Workers, Durable
+Objects, D1, and R2 ([bindings](../../apps/notebook-cloud/wrangler.toml)).
+The [AWS room-host memo](../memos/aws-rust-room-host.md) is an exploratory
+alternative, not a superseding deployment decision or a turnkey on-prem package.
+
+## Corrections made
+
+- [MCP lifecycle guidance](../adr/mcp-session-lifecycle.md) now describes live
+  daemon-incarnation reconciliation, guarded session publication, active and
+  parked peers, and current proxy handoff. The old classify/latch algorithm was
+  no longer the implementation. Sources: [daemon watcher](../../crates/runt-mcp/src/daemon_watch.rs)
+  and [activation controller](../../crates/runt-mcp/src/session_activation.rs).
+- Last-peer departure schedules kernel teardown, not immediate room removal.
+  Room reaping has a separate idle/capacity policy and durability checks.
+  UUID recovery can use the daemon's persistent path registry. UUIDs absent at
+  the daemon's availability check are refused; the check and recovery load are
+  not atomic, as the follow-up below records. Sources:
+  [teardown](../../crates/runtimed/src/notebook_sync_server/peer_eviction.rs#L107)
+  and [UUID attachment](../../crates/runtimed/src/daemon.rs#L3041).
+- [Daemon guidance](../../crates/runtimed/AGENTS.md) now describes recovery
+  journals for persistent rooms and disk-backed blobs with garbage collection,
+  rather than treating legacy snapshots and ephemeral outputs as the whole
+  persistence model. Sources: [journal loading](../../crates/runtimed/src/notebook_sync_server/room.rs#L1808),
+  [blob storage](../../crates/runtimed/src/blob_store.rs#L288), and
+  [durable execution results](../../crates/runtimed/src/daemon.rs#L2014).
+- The [progressive-connect memo](../memos/mcp-connect-initial-projection.md)
+  distinguishes implemented local projection-first connect from its historical
+  measurements and proposed response shape. Creation and background rejoin
+  still have different readiness behavior.
+- The [desktop bridge memo](../memos/desktop-cloud-daemon-bridge.md) distinguishes
+  forwarding handlers from authorized execution through the editor-only opener.
+  Two-hop connection-status composition is implemented; credential acquisition,
+  effective-scope propagation, extra document streams, and persistence remain
+  separate work.
+- The [workstation runbook](../runbooks/remote-workstation.md) now distinguishes
+  recoverable disconnects from intentional idle/replacement stops, documents
+  eligible owner-triggered resume, and describes the configured interpreter
+  instead of an unwired environment catalog.
+- The [deployment ADR](../adr/deployment-topology.md) and
+  [cloud-connected MCP ADR](../adr/cloud-connected-local-mcp.md) distinguish
+  environment-backed credential references from proposed keychain integration.
+  Workstation pairing credentials are a different path.
+
+## Automerge is already upstream
+
+| Dependency | Audited source |
+|---|---|
+| Production Rust and `runtimed-wasm` | crates.io Automerge exactly `0.11.0`, from [the workspace pin](../../Cargo.toml#L57) and `Cargo.lock`; no workspace patch override. |
+| Legacy compatibility peer | `automerge-legacy`, Rust `0.10.0`, from `nteract/automerge` revision `3fb6af5cc3af23b79f27cebfa339c8c98987e7b7`, only under [store dev-dependencies](../../crates/automerge-store/Cargo.toml#L16). |
+| Frontend | Generated Rust WASM bindings, not the JS `@automerge/automerge` package. JS release numbers are not this application's Automerge version. |
+
+Commit `ae6aef0f` ([PR #4181](https://github.com/nteract/nteract/pull/4181))
+switched production on August 26. Upstream
+[Rust `0.11.0`](https://docs.rs/crate/automerge/0.11.0), released August 12,
+is still the latest published Rust release checked on September 4.
+No production version bump or fork removal is needed at this baseline.
+
+The remaining fork is deliberate test coverage: the
+[compatibility tests](../../crates/automerge-store/tests/version_compat.rs#L282)
+exchange snapshots and encoded sync messages in both directions, including
+representative rich text. The store also tests rejection/quarantine of malformed
+legacy data without rewriting it. Removing the test dependency would require a
+replacement compatibility strategy, not just a cleaner dependency list.
+
+The [fork-patch memo](../memos/automerge-fork-patches.md) retains historical
+research but no longer calls actor validation unimplemented. Current ingress
+uses [clone-preview validation](../../crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs#L58).
+A read-only incoming-change parser is a proposed optimization, not a prerequisite
+for the existing authorization check. The disposition of every historical fork
+patch was not exhaustively mapped.
+
+## Follow-up work
+
+### Refuse missing data during UUID-only legacy recovery
+
+The [legacy snapshot branch](../../crates/runtimed/src/daemon.rs#L3122) checks
+that a persisted file exists before awaiting room creation. If that file
+vanishes and no journal is recovered, [room loading](../../crates/runtimed/src/notebook_sync_server/room.rs#L1945)
+can fall back to a fresh document. Make this recovery path refuse missing data
+instead, and add a regression test for disappearance between the availability
+check and load. Caller-side `list_rooms` checks would not close this race.
+
+### Enforce the registry's transport requirement
+
+The ADR requires HTTPS outside explicit local-development exceptions, but
+[`normalize_url_domain`](../../crates/notebook-cloud-transport/src/registry.rs#L231)
+currently accepts both HTTP and HTTPS without a loopback check. Enforce the
+requirement before attaching credentials, independently of any configuration UI.
+Add non-loopback rejection and explicit loopback-exception tests. The gap is not
+approval to configure remote cleartext endpoints.
+
+### Carry authorized scope through hosted open
+
+The daemon's hosted opener requests
+[`editor`](../../crates/runtimed/src/daemon.rs#L3572), while the
+[request gate](../../crates/runtimed/src/notebook_sync_server/peer_writer.rs#L384)
+rejects editor execution before forwarding. Hosted attachment and execution
+remain owner-only. Carry requested and server-authorized effective scope through
+open/recovery/UI, and test viewer downgrade and authorized execution end to end.
+Do not fix this by treating all editors as owners or by equating attached compute
+with permission to execute.
+
+### Define the remote embedding and deployment contracts
+
+Keep the working local Electron integration distinct from a remotely editable
+iframe. The latter needs parent/origin authorization, credential bootstrap,
+notebook selection, capability projection, output isolation, and lifecycle rules.
+Removing the hosted shell's framing restriction alone would not supply them.
+
+For on-prem work, decide whether the target is compute, the document host, or
+both. A new document host also needs deployment/storage adapters and admission
+policy. Same-origin multiple accounts and catalog aggregation remain separate
+contracts in the [federation memo](../memos/hosted-notebook-federation.md), not
+features established by the current registry and workstation agent.
+
+### Migrate the MCP SDK and test both sides of the proxy
+
+The workspace requires `rmcp = "1.4"` and locks **1.5.0**. Its default protocol
+revision is **2025-11-25**, inherited by the
+[child's server info](../../crates/runt-mcp/src/lib.rs#L413) and the proxy.
+The SDK can negotiate older revisions; that is not proof that every emitted
+application payload is suitable for every negotiated revision.
+
+Upstream [rmcp **3.2.0**](https://docs.rs/crate/rmcp/3.2.0), released August 31,
+and the [2026-07-28 MCP revision](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+need a separate migration. The newer SDK still defaults client startup to the
+legacy `initialize` flow and `2025-11-25`, while its server supports both legacy
+and modern requests. Updating the dependency alone does not choose the supported
+application lifecycle.
+
+The 2026 revision removes the initialization handshake and protocol-level
+sessions, adds per-request version/capability metadata and `server/discover`,
+and changes subscriptions and multi-round-trip requests. Application-level
+notebook selection still needs an explicit scoping contract.
+
+Test upstream-client-to-proxy and proxy-to-child behavior separately, including
+identity attribution, tool/resource schemas, notifications, reconnect, and
+explicit notebook targeting. The current harness requests `2024-11-05`; retain
+legacy-client coverage rather than treating a newer SDK pin as conformance.
+No claim of 2026-07-28 compatibility is made by this audit.
+
+## Verification
+
+These passed against the audited code. Rust commands ran from the repository root:
+
+| Command | Passed |
+|---|---:|
+| `cargo test --locked -p automerge-store --test version_compat` | 2 |
+| `cargo test --locked -p automerge-store --lib` | 13 |
+| `cargo test --locked -p automerge-recovery` | 15 |
+| `cargo test --locked -p runt-mcp --lib` | 218 |
+| `cargo test --locked -p runt-mcp-proxy --lib` | 114 |
+| `cargo test --locked -p notebook-cloud-transport --lib` | 33 |
+| `python3 scripts/mcp-connect-harness.py --self-test` | 19 checks |
+
+Host/relay/status tests: 29 passed, from the repository root:
+
+```sh
+pnpm test:run packages/notebook-host/tests/electron-host.test.ts packages/runtimed-node/tests/relay.test.ts apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
+```
+
+Workstation, identity, and authorization tests: 69 passed; selected room lifecycle
+tests: 16 passed. Both commands ran from `apps/notebook-cloud`:
+
+```sh
+node --import tsx --test test/hosted-workstation-agent.test.mjs test/identity.test.ts test/authorization.test.ts
+node --import tsx --test --test-name-pattern="resume|idle|non-owner|replacement workstation|runtime peer.*session" test/notebook-room.test.ts
+```
+
+`pnpm --dir apps/notebook-cloud typecheck` passed. Its runtime-WASM prerequisite
+reused up-to-date artifacts and verified the four document genesis assets; it
+was not a fresh WASM build. Live hosted/workstation smoke tests, live MCP fault
+scenarios, installed/deployed artifact versions, and a protocol conformance
+matrix were not tested. Passing unit tests does not establish those guarantees.

--- a/docs/memos/automerge-fork-patches.md
+++ b/docs/memos/automerge-fork-patches.md
@@ -1,21 +1,36 @@
 # Automerge Fork Patches
 
-**Status:** Memo / active register, 2026-05-21; dependency baseline updated 2026-08-26.
+**Status:** Memo / active register, 2026-05-21; dependency and validator status checked 2026-09-04.
 
-## Fork baseline update (2026-07-13)
+## Current dependency baseline (2026-09-04)
 
-`nteract/automerge:main` is a tested mirror of upstream Automerge commit
-`3fb6af5cc3af23b79f27cebfa339c8c98987e7b7`. The previous fork main is
-preserved at `archive/main-pre-upstream-sync-20260713`.
+Production Rust and `runtimed-wasm` use crates.io Automerge exactly `0.11.0`
+(`Cargo.toml:57`, `Cargo.lock:627`), adopted by `ae6aef0f` on 2026-08-26.
+The frontend does not depend on the JS `@automerge/automerge` package. There is
+no workspace Automerge patch override.
 
-Upstream already includes the stale-orphan sync correction and its
-`queued_orphan_need_does_not_block_unrelated_sync_response` regression test.
-The downstream stale-orphan PR was therefore closed as superseded rather than
-rebased: the minimal nteract-only patch set for that behavior is empty. The
-nteract workspace now pins crates.io Automerge 0.11 exactly. The mirror
-revision remains as a dev-only compatibility peer in `automerge-store`, where
-tests prove bidirectional snapshot loading and encoded sync convergence with
-the version shipped by nteract 2.7.
+`automerge-store` retains `nteract/automerge` revision
+`3fb6af5cc3af23b79f27cebfa339c8c98987e7b7` (Rust `0.10.0`) only as the
+`automerge-legacy` dev-dependency (`crates/automerge-store/Cargo.toml:17`).
+No branch is selected by that dependency. Its tests cover bidirectional
+snapshot loading and encoded sync with representative legacy data
+(`crates/automerge-store/tests/version_compat.rs:282–352`), not every deployed
+document or every historical patch.
+
+## Historical fork baseline (2026-07-13)
+
+The July record described `nteract/automerge:main` as a tested mirror of
+upstream commit `3fb6af5cc3af23b79f27cebfa339c8c98987e7b7`, with the previous
+main preserved at `archive/main-pre-upstream-sync-20260713`. These are
+historical branch observations, not current remote-ref checks.
+
+The stale-orphan sync correction and its
+`queued_orphan_need_does_not_block_unrelated_sync_response` regression are
+present in the locally cached crates.io `0.11.0` source (`src/sync.rs:170–182`,
+`tests/test.rs:3689`). The July record says the downstream stale-orphan PR was
+closed as superseded. This supports no remaining downstream patch for that
+behavior; it does not establish that all 21 patches recorded in the earlier
+`b3502d42` rebase were merged upstream.
 
 This memo tracks possible Automerge fork patches. It is not an accepted nteract
 architecture decision until a patch becomes part of the workspace contract.
@@ -23,15 +38,20 @@ architecture decision until a patch becomes part of the workspace contract.
 ## Context
 
 We retain `nteract/automerge` as a compatibility reference and possible home
-for narrowly scoped future patches, but production workspace code uses the
-crates.io release. The identity-and-trust ADR
-(`docs/adr/identity-and-trust.md`) defers per-frame actor-label validation
-because doing it cleanly requires either an upstream Automerge contribution, a
-fresh fork patch, or a throwaway-peer hack per frame. The first two are real
-options; the third is not. This memo proposes possible patches and how they
-relate to upstream.
+for narrowly scoped future patches, not as a production requirement.
 
-Sister concern: before adding new patches we want to pull the latest upstream into our fork. Rebasing on current upstream is its own little exercise (the `filters` branch and other in-flight work shift the surface around), but it's cheap and one-time. Tracked as a sibling task, not a patch.
+Actor-label validation is implemented with clone-preview: apply a non-empty
+frame to a cloned document and peer state, validate the newly applied changes,
+then mutate the real document only after admission succeeds. See
+`crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs:58–95` and
+`crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs:95`.
+The deferred work in the identity-and-trust ADR is
+reducing clone and duplicate-apply cost, not introducing validation.
+
+`sync_message_new_changes` remains a proposed API. It is absent from the
+checked crates.io `0.11.0` source and is not called by production code. Before
+implementing a new patch, recheck upstream APIs and the historical research
+below; switching production back to a fork is a separate dependency decision.
 
 ## Patches we want
 
@@ -58,7 +78,8 @@ impl Automerge {
 }
 ```
 
-Internal implementation shape:
+Historical implementation sketch; internal signatures have not been reverified
+against `0.11.0`:
 
 ```rust
 impl Automerge {
@@ -86,7 +107,7 @@ impl Automerge {
 }
 ```
 
-`ReadSyncMessageChangesError` is a public error type in `automerge::sync`. It can be constructed from the crate-private load errors internally, but it must not expose crate-private types in its public variants.
+In this proposal, `ReadSyncMessageChangesError` would be a public error type in `automerge::sync`. It could be constructed from crate-private load errors internally, but must not expose crate-private types in its public variants.
 
 Cost on the hot path: parse twice (once here, once in `receive_sync_message`). The doubled work is bounded by message size and acceptable for our scale. The method must be read-only: it cannot advance sync state, mutate the document, or accept partially parsed data. The room-host validator should fail closed if this parser errors.
 
@@ -100,9 +121,16 @@ Required fork tests:
 
 Upstream story: this is an additive public method with no behavior change to existing callers. Reasonable PR to submit upstream after we've got it working on our fork. If accepted, we drop our patch later.
 
-### 2. (Tentative) Pull the `filters` branch in
+### 2. (Historical research, tentative) Pull the `filters` branch in
 
-Upstream `origin/filters` is post-peer-review but not yet in `main`. It introduces `Filter { default, authors, actors }` with rules `Allow / AllowUpTo { heads } / Deny`. Subduction semantics: rejected changes still ingest and sync, just stop rendering. That's the right primitive for runtime revocation and post-hoc audit hiding (see the identity ADR's revocation follow-up).
+The 2026-05-21 research described upstream `origin/filters` as post-peer-review
+but not yet in `main`. Its current status was not reverified in the
+2026-09-04 local audit; the options below are historical, not a recommendation
+to cherry-pick today. The described API was
+`Filter { default, authors, actors }` with rules
+`Allow / AllowUpTo { heads } / Deny`. Subduction would retain changes for
+storage and sync while hiding them from rendering, a possible primitive for
+runtime revocation and post-hoc audit hiding.
 
 Two paths:
 
@@ -133,18 +161,18 @@ When keyhive's surface stabilizes, signed changes would let us verify cross-spac
 
 Maintaining a long-lived fork is a known cost; the patches are deliberately small and additive to keep rebases boring.
 
-## Implementation order
+## Proposed implementation order
 
-1. Pull latest upstream into our fork. Keep that as a fork-only maintenance PR unless the workspace pin changes.
-2. Implement patch 1 on a `nteract/automerge` branch with the tests above. Submit it upstream once the fork patch passes locally.
-3. Update this workspace's `Cargo.toml` and `Cargo.lock` to the fork commit. Verify at least `cargo test -p automerge-recovery`, `cargo test -p notebook-doc`, `cargo test -p runtime-doc`, and `cargo test -p notebook-sync`.
-4. Wire the pre-apply actor-label validator in the room-host extraction using `Automerge::sync_message_new_changes(&message)` before `receive_sync_message_recovering`. Identity ADR's deferred limitation closes only after this step lands.
-5. Watch the upstream filters PR. Revisit cherry-picking when revocation work begins.
+1. Recheck upstream for a suitable parser before creating a new fork patch.
+2. If still needed, prototype patch 1 with the tests above and submit it upstream.
+3. Decide separately whether a temporary production fork is justified. Any dependency change must retain legacy compatibility checks and verify at least `automerge-store`, `automerge-recovery`, `notebook-doc`, `runtime-doc`, `notebook-sync`, and WASM tests.
+4. Replace the implemented clone-preview validator with the parser only after verifying equivalent admission and rejection behavior. This addresses deferred performance work, not a missing v1 authorization boundary.
+5. Recheck the historical filters research when revocation work becomes a requirement.
 
 ## Out of scope here
 
 - The room-host crate extraction itself (separate ADR).
-- Pre-existing fork patches (whatever's on `nteract/automerge` today vs upstream `main`). The history is in the fork; this ADR is about what we want to add.
+- An exhaustive disposition of historical fork patches. The current production pin is upstream; this memo does not establish that every earlier patch was merged.
 - Whether we should switch to `automerge-repo` for any part of the sync transport (separate question, separate ADR if it ever becomes one).
 
 ## Acceptance Criteria

--- a/docs/memos/desktop-cloud-daemon-bridge.md
+++ b/docs/memos/desktop-cloud-daemon-bridge.md
@@ -60,10 +60,20 @@ Bridged docs (V1): `NotebookDoc` (read/write) and `RuntimeStateDoc`
 `CommsDoc`/`CommentsDoc` bridging and local-runtime-peer policy are deferred
 (#3861 slice 5).
 
-Execution (V1): hosted rooms do not launch local kernels. `execute_cell`
-requests from local peers are forwarded to the cloud room as hosted `Request`
-frames (`crates/runtimed/src/requests/mod.rs:217-267`); the resulting
-queue/output state arrives back via RuntimeStateDoc sync.
+Execution plumbing (V1): hosted-bridged rooms do not launch local kernels.
+Handlers in `crates/runtimed/src/requests/mod.rs` can forward `execute_cell`
+requests as hosted `Request` frames; cloud queue/output state arrives through
+RuntimeStateDoc sync. This is not an operational execution guarantee through
+the current hosted opener.
+
+**Current implementation, 2026-09-04:** `daemon.rs` requests `editor` for the
+cloud connection and assigns `editor` to local bridge peers. The request gate
+in `notebook_sync_server/peer_writer.rs` rejects editor execution before it
+reaches the forwarding handler; hosted execution also requires owner scope.
+Requested/effective scope propagation and authorized execution through the
+bridge remain open. Attaching a workstation does not grant an editor execution
+authority. See the scope contract in
+`docs/adr/cloud-connected-local-mcp.md`.
 
 Persistence (V1): none (ephemeral room). Local-first persistence for hosted
 sessions is #3600.
@@ -115,17 +125,27 @@ New connection handshake channel (`crates/notebook-protocol/src/connection/hands
 The daemon resolves the URL against the registry, creates or joins the
 hosted-bridged room, spawns the bridge if needed, and serves the connection
 like a normal `notebook_sync` peer (typed bootstrap, `NotebookConnectionInfo`
-with the daemon-local room id). Reconnect/status composition in the desktop UI
-is #3599.
+with the daemon-local room id).
+
+**Current implementation, 2026-09-04:** the bridge publishes connecting,
+connected, reconnecting, authentication-failed, and terminal-error status.
+`apps/notebook/src/lib/desktop-connection-status.ts` composes this with the
+local daemon connection, so an online first hop cannot hide an unavailable
+cloud room. This two-hop status composition is implemented and unit-tested;
+richer presence/status UX remains #3599. Status reporting does not itself
+provide credential renewal or effective-scope propagation.
 
 ## Remaining Work (see #3861)
 
 - Account-aware discovery and Notebook Home use the federation memo above; they
   are not additional responsibilities of the per-room bridge.
 - OAuth/device-flow credential acquisition and keychain storage.
+- Requested/effective hosted scope propagation and authorized execution through
+  the currently editor-only opener.
 - CommsDoc/CommentsDoc bridging; widget replay across the bridge.
 - Offering local daemon compute to the hosted room (workstation attach is a
   separate, existing flow).
 - Offline edits with later cloud rejection UX.
 - Local-first persistence of hosted sessions (#3600).
-- Richer status/presence composition in desktop UI (#3599).
+- Richer presence/status UX in desktop UI (#3599), beyond the implemented
+  daemon/bridge connection-status composition.

--- a/docs/memos/markdown-plan-documents.md
+++ b/docs/memos/markdown-plan-documents.md
@@ -231,9 +231,17 @@ Package versions checked with `npm view` and `cargo search` from this workspace:
 | `@lexical/markdown` | not installed | `0.45.0` | Ecosystem reference, not the recommended document model. |
 | `@milkdown/kit` | not installed | `7.21.2` | ProseMirror-based reference, not the recommended document model. |
 | `@markdoc/markdoc` | not installed | `0.5.7` | Safer component-tag alternative to full MDX. |
-| `@automerge/automerge` | Rust fork in repo | `3.2.6` | JS ecosystem has rich text/text APIs, but repo is pinned to nteract fork. |
+| `@automerge/automerge` | not installed | `3.2.6` | JS ecosystem reference; notebook state uses Rust WASM bindings. See the dated dependency update below. |
 | `automerge-repo` | not installed | `0.1.0` | Interesting sync reference, not a direct replacement. |
 | Rust `markdown` crate | `markdown = "1"` | `1.0.0` | Current per `cargo search markdown`. |
+
+**Automerge dependency update, 2026-09-04:** The table's JS version is the
+2026-06-12 observation, not a current release claim. Production Rust and WASM
+now use crates.io Automerge exactly `0.11.0` (`Cargo.toml:57`), adopted by
+`ae6aef0f` on 2026-08-26. Only `automerge-store` keeps `nteract/automerge`
+revision `3fb6af5cc3af23b79f27cebfa339c8c98987e7b7` (Rust `0.10.0`) as a
+legacy test peer (`crates/automerge-store/Cargo.toml:17`), not a production
+patch. See [the fork patch register](automerge-fork-patches.md).
 
 Relevant upstream docs:
 

--- a/docs/memos/mcp-connect-initial-projection.md
+++ b/docs/memos/mcp-connect-initial-projection.md
@@ -8,7 +8,68 @@ for [issue #3907](https://github.com/nteract/nteract/issues/3907).
 This memo preserves the investigation, benchmark, and original API sketch. The
 ADRs are authoritative where the original recommendation assumed a disposable
 file-backed Automerge mirror, rollback after partial loading, or one combined
-readiness state.
+readiness state. The design sections below preserve the original recommendation;
+they are not an exact description of today's response schema or a claim that
+every proposed diagnostic and acceptance scenario has shipped.
+
+## Implementation checkpoint: 2026-09-04
+
+At source baseline `6bff3e7b`, progressive local `connect_notebook` and
+same-target coalescing are implemented. The path and UUID branches attach the
+peer, fetch the room projection over an independent `PoolClient` control
+connection, retain it, and publish through an activation lease. They no longer
+wait for full local NotebookDoc/RuntimeStateDoc readiness before returning.
+See `crates/runt-mcp/src/tools/session.rs:620`, `:1332`, and `:1406`.
+
+The actual connect response has:
+
+| Field | Current shape |
+|-------|---------------|
+| `cells` | Formatted summary string containing stable cell IDs, not the proposed array |
+| `session_generation` | Installed activation generation |
+| `source_state` | Source state, using `phase` rather than the sketch's `state` |
+| `readiness` | Booleans `projection`, `document`, `runtime`, `interactive` |
+| `projection` | `heads`, `runtime_state_heads`, `completeness` |
+| `capabilities` | Booleans `read`, `mutate`, `execute` |
+| `runtime`, `dependencies`, `project_context` | Initial context derived from the daemon projection |
+
+Success is JSON text plus a notebook resource link, not structured connect
+content. The sketch's `sync` object and top-level `availability` are not the
+current connect response. See `add_progressive_session_fields` and
+`notebook_session_response` at `tools/session.rs:583`, `:808`.
+
+Readiness remains operation-specific. `get_all_cells` can return retained,
+bounded projection data before interactivity; full NotebookDoc/resource reads
+and mutations require an interactive document. Runtime reads require a
+connected, ready RuntimeStateDoc; execution additionally requires an
+interactive document and ready runtime. Kernel control need not wait for an
+already running kernel. Retained projection data never authorizes cached-source
+mutation or execution. See `crates/runt-mcp/src/session.rs:485`, `:595`,
+`crates/runt-mcp/src/tools/cell_read.rs:229`, and
+`crates/runt-mcp/src/resources.rs:285`.
+
+Same-target callers share the current activation result. A different target
+supersedes pending work, while a failed replacement leaves the installed session
+usable. Publication and later active-session access are generation-guarded;
+this is not transaction isolation for arbitrary concurrent tool calls. See
+`crates/runt-mcp/src/session_activation.rs:76`, `:225`, `:442` and
+`crates/runt-mcp/src/lib.rs:273`.
+
+Do not extend the early-return contract to `create_notebook` or background
+local rejoin: both still await session readiness (`tools/session.rs:1648`,
+`crates/runt-mcp/src/daemon_watch.rs:517`). Hosted readiness also remains a
+separate path, not the local retained-projection contract (`session.rs:415`).
+Readiness failures use codes such as `notebook_not_ready`, `runtime_not_ready`,
+and `sync_failed`; other connection failures can still be text tool errors.
+
+The current harness includes shared-generation/projection and peer-count checks
+at `scripts/mcp-connect-harness.py:1099` and a stalled-peer scenario at `:1367`.
+These source-backed capabilities do not update the measurements below. The
+2026-07-10 timings and two-peer observation remain historical, not a new
+benchmark or current concurrency result. Protocol compatibility is separately
+covered by the [lifecycle ADR](../adr/mcp-session-lifecycle.md#mcp-protocol-checkpoint)
+and [source audit](../audits/mcp-cloud-automerge-audit.md); this checkpoint does
+not claim conformance with upstream MCP `2026-07-28`.
 
 ## Summary
 
@@ -34,13 +95,13 @@ room and can produce the projection under one short document read. A cache
 would add identity aliases and invalidation rules without removing the initial
 file-load boundary.
 
-## Current coupling
+## Coupling observed on 2026-07-10
 
-The local path and UUID branches in
-`crates/runt-mcp/src/tools/session.rs` call
+At the time of the investigation, the local path and UUID branches in
+`crates/runt-mcp/src/tools/session.rs` called
 `await_session_ready_timeout(120s)` before installing the session or formatting
 the response. `SyncStatus::session_ready()` in
-`crates/notebook-sync/src/status.rs` requires all of the following:
+`crates/notebook-sync/src/status.rs` required all of the following:
 
 - `NotebookDocPhase::Interactive`;
 - `RuntimeStatePhase::Ready`;
@@ -85,7 +146,8 @@ for room or peer readiness.
 `connect_notebook` should return after **Projection ready**. It should include
 the later milestones in a `sync` object rather than waiting for both.
 
-An example response shape is:
+The original proposed response shape follows. It is preserved as an API sketch,
+not the implemented schema; see the dated checkpoint above for current fields:
 
 ```json
 {
@@ -236,11 +298,13 @@ local replica.
 
 ## Duplicate connects
 
-The current path installs its session only after the readiness wait. Concurrent
-connects can therefore create multiple peer sync tasks before any caller sees
-an active session.
+In the 2026-07-10 baseline, the path installed its session only after the
+readiness wait. Concurrent connects could therefore create multiple peer sync
+tasks before any caller saw an active session. The coalescing recommendation
+below is now implemented through `SessionActivation`; it is not an outstanding
+feature request.
 
-Coalesce connects by normalized target:
+The recommendation was to coalesce connects by normalized target:
 
 - canonical absolute path for local files;
 - notebook UUID for local resident or ephemeral rooms;
@@ -255,8 +319,10 @@ same file-backed room use the same coalescing key.
 
 ## Failure semantics and diagnostics
 
-The current 120-second generic error loses the distinction between file load,
-projection, NotebookDoc convergence, and RuntimeState convergence.
+The baseline's 120-second generic error lost the distinction between file load,
+projection, NotebookDoc convergence, and RuntimeState convergence. The following
+was the diagnostic recommendation, not a list of fields all guaranteed in the
+current MCP response.
 
 Record and surface:
 
@@ -309,18 +375,18 @@ produced:
 | Warm path open 1 | 541.0 ms | 5.0 ms | 64 of 64 |
 | Warm path open 2 | 535.3 ms | 4.8 ms | 64 of 64 |
 
-The ordinary path is correct, and this run did not reproduce `MissingOps`.
-The roughly 100x difference between the connect and immediate-read timings is
+The ordinary path was correct in this run, which did not reproduce `MissingOps`.
+The roughly 100x difference between the connect and immediate-read timings was
 consistent with connect waiting on broader peer readiness rather than the cost
 of formatting the initial projection.
 
 With two concurrent same-path connects in one MCP process, the harness observed
 `active_peers = 2` for the target room before the calls completed and the room
 settled back to one peer. Both calls returned the same notebook ID and all 64
-cell IDs. This confirms that duplicate connects currently multiply peer and
-sync-bootstrap work even when the final session state looks correct.
+cell IDs. In that baseline, duplicate connects multiplied peer and
+sync-bootstrap work even though the final session state looked correct.
 
-An implementation is ready to ship when:
+The original acceptance criteria were:
 
 1. cold path, resident path, resident UUID, and ephemeral UUID connects return
    the authoritative stable IDs in one call;
@@ -334,6 +400,10 @@ An implementation is ready to ship when:
    has been superseded.
 
 ## Adopted implementation sequence
+
+This preserves the original sequencing rationale, not a current list of
+unfinished work. The checkpoint above records the implemented MCP behavior;
+source and recovery guarantees remain owned by the linked ADRs.
 
 1. Land room-owned source state, task leases, staged immutable imports, and
    bounded projections while preserving existing MCP waiting behavior.

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -124,13 +124,23 @@ is passed through the environment (`RUNT_CLOUD_TOKEN`), never argv.
 credential for foreground `runt workstation run`; the service path uses the
 stored credential file written by `connect`.
 
-In the hosted notebook, attaching compute to a workstation dispatches an attach
-job; the agent accepts it and the runtime peer attaches to the room as
+In the hosted notebook, an owner attaching compute to a workstation dispatches
+an attach job; the agent accepts it and the runtime peer attaches to the room as
 `runtime_peer` over an outbound WebSocket. The peer reconnects with backoff
-across room evictions and network blips and keeps the kernel alive across
-reconnects; a clean room close does not tear the kernel down. If the agent
-restarts, it adopts runtime peers that are still alive (per-job pid + log files
-under the daemon cache) and reports the ones that are gone.
+across recoverable room evictions and network blips, retaining the kernel.
+Ordinary transport closes are recoverable, but an intentional room stop is not.
+
+**Current lifecycle, 2026-09-04:** after 30 minutes without queued or active
+execution, the room stops idle compute, even if viewers remain connected. Its
+`runtime idle timeout` close uses code 1000 but is treated as a terminal,
+graceful shutdown. Replacement, restart, and policy-rejection closes are also
+terminal for the old peer, not instructions to reconnect it. Owner execution
+can resume an eligible previously selected workstation as described below.
+
+If the workstation agent restarts, it adopts its runtime peers that are still
+alive using per-job pid + log files under the daemon cache, and reports the
+ones that are gone. This is recovery of nteract runtime-peer processes, not
+adoption of arbitrary existing Jupyter kernels.
 
 ## Run it as a service
 
@@ -229,10 +239,26 @@ flows.
 
 ## What the workstation offers
 
-`runtimed` maintains prewarmed environment pools (uv/conda/pixi) and captured
-per-notebook environments. The workstation endpoint projects these as the
-environments it can offer (`list_environments`), and the hosted room's
-workstation panel surfaces attachment state.
+As of 2026-09-04, the shipped workstation agent advertises **Current Python**:
+its configured interpreter, working directory, and `launch_current_python`
+capability. It launches kernels in that interpreter without installing
+packages. The hosted workstation panel surfaces registration and attachment
+state, not a catalog of every daemon-managed environment.
+
+`runtimed` also maintains prewarmed environment pools (uv/conda/pixi) and
+per-notebook environments. The `list_environments` helper in
+`crates/runtimed/src/workstation/environments.rs` projects pool state, but it is
+not wired into the hosted workstation registration/catalog path. Hosted pool
+selection and captured-environment discovery remain follow-up work.
+
+Hosted attachment and execution requests are owner-only; editing a notebook
+does not grant permission to spend compute. If an owner executes with no active
+runtime peer, an attachment already connecting can accept queued work. A
+previously selected registered workstation whose attachment is `ready`,
+`disconnected`, or `idle` can receive a resume attach job when it belongs to
+the notebook owner and passes the room's online/lease/heartbeat checks. The room rejects execution
+when no eligible attachment can connect or resume. It does not select compute
+from the room URL or fall back to an unrelated workstation.
 
 Hosted runtime controls use the workstation contract rather than browser-owned
 kernel launch state. Interrupt requests are forwarded to the active runtime


### PR DESCRIPTION
## Summary

Follow-up to #4210: check selected documentation against implementation and tests at baseline 6bff3e7b, rather than only cleaning up prose.

- Add docs/audits/mcp-cloud-automerge-audit.md with source references, embedding boundaries, dependency provenance, verification, and concrete follow-ups.
- Correct MCP concurrency, active/parked sessions, incarnation reconciliation, readiness gates, proxy handoff, and progressive-connect status.
- Correct cloud bridge execution/status claims, workstation interpreter discovery and lifecycle, credential handling, and proposed versus implemented hosting targets.
- Confirm production already uses upstream Automerge 0.11.0; retain the legacy fork as test-only compatibility coverage and correct recovery-policy guidance.
- Correct daemon recovery-journal, blob-retention, and room-teardown guidance. Preserve dated measurements and proposed API sketches as historical/proposed.

## Scope and follow-ups

Documentation and agent guidance only. No runtime, dependency, or generated-artifact changes. The rmcp 3.2 migration is being handled separately.

The audit records unresolved code work without presenting it as fixed: non-loopback HTTPS enforcement, effective hosted-scope propagation, the UUID legacy-snapshot availability/load race, and remote embedding/deployment contracts.

## Validation

- 395 Rust tests passed across Automerge store/compatibility/recovery, MCP, proxy, and cloud transport suites.
- 114 focused JavaScript/TypeScript host, relay, status, workstation, identity, authorization, and room-lifecycle tests passed.
- 19 MCP harness self-tests passed.
- Cloud typecheck and runtime-WASM prerequisite/genesis checks passed.
- cargo xtask lint --fix, documentation-reference checks, and git diff --check passed.
- Independent factual reviews completed; the atomic-recovery overstatement found in review was corrected.

Commands and coverage limits are recorded in the audit. Live hosted/workstation smoke tests, fresh WASM rebuilding, and a full MCP protocol conformance matrix were not performed.