### PR TITLE
chore(mcp): upgrade rmcp to 3.2 with legacy compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,8 +1747,18 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -1759,14 +1775,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4514,7 +4554,7 @@ dependencies = [
  "libc",
  "notify",
  "notify-debouncer-mini",
- "rmcp",
+ "rmcp 3.2.0",
  "runt-mcp-proxy",
  "runt-workspace",
  "schemars 1.2.1",
@@ -5016,7 +5056,7 @@ name = "nteract-mcp"
 version = "0.5.6"
 dependencies = [
  "dirs",
- "rmcp",
+ "rmcp 3.2.0",
  "runt-mcp-proxy",
  "runt-workspace",
  "tokio",
@@ -7360,9 +7400,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "futures",
+ "pastey",
+ "pin-project-lite",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -7375,19 +7436,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7453,7 +7515,7 @@ dependencies = [
  "notify",
  "nteract-telemetry",
  "reqwest 0.12.28",
- "rmcp",
+ "rmcp 3.2.0",
  "runt-mcp",
  "runt-publish",
  "runt-workspace",
@@ -7490,7 +7552,7 @@ dependencies = [
  "regex",
  "repr-llm",
  "reqwest 0.12.28",
- "rmcp",
+ "rmcp 3.2.0",
  "runt-workspace",
  "runtime-doc",
  "runtimed-client",
@@ -7511,7 +7573,9 @@ dependencies = [
 name = "runt-mcp-proxy"
 version = "0.5.6"
 dependencies = [
- "rmcp",
+ "rmcp 1.5.0",
+ "rmcp 3.2.0",
+ "runt-mcp",
  "serde_json",
  "tempfile",
  "tokio",
@@ -8336,7 +8400,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9036,6 +9100,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ rattler_virtual_packages = "2.3"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 reqwest-middleware = "0.4"
-rmcp = "1.4"
+rmcp = "3.2.0"
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -19,6 +19,7 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
@@ -29,9 +30,10 @@ use std::time::{Duration, Instant, SystemTime};
 
 use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, ListResourceTemplatesResult,
-    ListResourcesResult, ListToolsResult, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, DiscoverRequestMethod,
+    DiscoverResult, Implementation, ListResourceTemplatesResult, ListResourcesResult,
+    ListToolsResult, ProtocolVersion, ReadResourceRequestParams, ReadResourceResponse,
+    ReadResourceResult, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::schemars;
 use rmcp::service::{RequestContext, RoleServer};
@@ -41,6 +43,23 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{error, info, warn};
+
+const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+];
+
+fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    if context.peer.peer_info().is_none() {
+        return Err(McpError::invalid_request(
+            "initialize is required before application requests",
+            None,
+        ));
+    }
+    Ok(())
+}
 
 // ---------------------------------------------------------------------------
 // Daemon management
@@ -818,7 +837,7 @@ impl Supervisor {
 
     async fn reject_in_attach_mode(&self, operation: &str) -> Option<CallToolResult> {
         if self.current_mode().await == DevMode::Attach {
-            Some(CallToolResult::success(vec![Content::text(format!(
+            Some(CallToolResult::success(vec![ContentBlock::text(format!(
                 "{operation} is disabled in nteract-dev attach mode. Attach mode never starts, stops, rebuilds, or restarts the shared worktree daemon; use an owner-mode nteract-dev session for daemon lifecycle changes."
             ))]))
         } else {
@@ -1133,7 +1152,7 @@ impl Supervisor {
             "notebook",
         );
         if !binary.exists() {
-            return Ok(CallToolResult::success(vec![Content::text(
+            return Ok(CallToolResult::success(vec![ContentBlock::text(
                 "No notebook binary found. Run `cargo build -p notebook --no-default-features` first.",
             )]));
         }
@@ -1148,7 +1167,7 @@ impl Supervisor {
         let path = match notebook_id {
             Some(id) => {
                 if !std::path::Path::new(id).is_absolute() {
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Notebook '{id}' is untitled (not saved to disk). \
                          Use save_notebook(path) first, then call show_notebook()."
                     ))]));
@@ -1192,11 +1211,11 @@ impl Supervisor {
                 state
                     .managed
                     .insert("notebook-app".into(), ManagedProcess { child, port: None });
-                Ok(CallToolResult::success(vec![Content::text(format!(
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                     "Opened notebook in nteract (dev, Vite port {vite_port}): {path}"
                 ))]))
             }
-            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+            Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "Failed to launch notebook app: {e}"
             ))])),
         }
@@ -1394,7 +1413,7 @@ impl Supervisor {
                 "release" => true,
                 "debug" => false,
                 other => {
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "up: unknown mode '{other}'. Use 'debug' or 'release'."
                     ))]));
                 }
@@ -1445,7 +1464,7 @@ impl Supervisor {
         if params.rebuild {
             info!("[supervisor] up: rebuild requested");
             if !run_cargo_build_daemon(&project_root) {
-                return Ok(CallToolResult::success(vec![Content::text(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
                     "up: cargo build -p runtimed failed. See the supervisor logs for details.",
                 )]));
             }
@@ -1470,7 +1489,7 @@ impl Supervisor {
                         report.push("rebuild: python bindings fresh".into());
                     }
                     MaturinDevelopStatus::Failed => {
-                        return Ok(CallToolResult::success(vec![Content::text(
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(
                             "up: maturin develop failed. Daemon binary was rebuilt; \
                              Python bindings were not. See the supervisor logs.",
                         )]));
@@ -1487,7 +1506,7 @@ impl Supervisor {
             // automerge rejects on receive. Stale wasm leaves the frontend
             // stuck on "Initializing" with no surfaced error.
             if !run_xtask_wasm_ensure(&project_root) {
-                return Ok(CallToolResult::success(vec![Content::text(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
                     "up: cargo xtask wasm-ensure-runtime failed. Daemon was rebuilt; \
                      the frontend wasm bundle may be stale. See the supervisor logs.",
                 )]));
@@ -1577,7 +1596,7 @@ impl Supervisor {
                 &daemon_workspace_path,
                 Duration::from_secs(30),
             ) {
-                return Ok(CallToolResult::success(vec![Content::text(format!(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                     "up: daemon did not become ready within 30s.\n\n{}",
                     report.join("\n")
                 ))]));
@@ -1634,7 +1653,7 @@ impl Supervisor {
             report.push("child: healthy".into());
         }
 
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             report.join("\n"),
         )]))
     }
@@ -1693,7 +1712,7 @@ impl Supervisor {
             report.push("daemon: left running (pass daemon=true to stop)".into());
         }
 
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             report.join("\n"),
         )]))
     }
@@ -1854,6 +1873,38 @@ struct DownParams {
 
 /// MCP ServerHandler that proxies to the nteract child + injects supervisor tools.
 impl ServerHandler for Supervisor {
+    async fn initialize(
+        &self,
+        request: rmcp::model::InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::InitializeResult, McpError> {
+        if context.peer.peer_info().as_deref() != Some(&request) {
+            return Err(McpError::invalid_request(
+                "initialize cannot change an existing connection or follow application requests",
+                None,
+            ));
+        }
+        let mut info = self.get_info();
+        if self
+            .supported_protocol_versions()
+            .contains(&request.protocol_version)
+        {
+            info.protocol_version = request.protocol_version;
+        }
+        Ok(info)
+    }
+
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(LEGACY_PROTOCOL_VERSIONS)
+    }
+
+    async fn discover(
+        &self,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<DiscoverResult, McpError> {
+        Err(McpError::method_not_found::<DiscoverRequestMethod>())
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
             ServerCapabilities::builder()
@@ -1864,6 +1915,7 @@ impl ServerHandler for Supervisor {
                 .enable_extensions_with(mcp_apps_extension_capabilities())
                 .build(),
         )
+        .with_protocol_version(ProtocolVersion::V_2025_11_25)
         .with_server_info(Implementation::new(
             "nteract-dev",
             env!("CARGO_PKG_VERSION"),
@@ -1878,11 +1930,30 @@ impl ServerHandler for Supervisor {
         )
     }
 
+    async fn list_prompts(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::ListPromptsResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(rmcp::model::ListPromptsResult::default())
+    }
+
+    async fn complete(
+        &self,
+        _request: rmcp::model::CompleteRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::CompleteResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(rmcp::model::CompleteResult::default())
+    }
+
     async fn list_tools(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        require_legacy_handshake(&context)?;
         let mut tools = Vec::new();
 
         // Supervisor's own tools. Schema generation is fallible in principle
@@ -1952,18 +2023,15 @@ impl ServerHandler for Supervisor {
             }
         }
 
-        Ok(ListToolsResult {
-            tools,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn list_resources(
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
+        require_legacy_handshake(&context)?;
         let state = self.state.read().await;
         if let Some(ref proxy) = state.proxy {
             Ok(proxy.child_resources(request).await)
@@ -1975,8 +2043,9 @@ impl ServerHandler for Supervisor {
     async fn list_resource_templates(
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
+        require_legacy_handshake(&context)?;
         let state = self.state.read().await;
         if let Some(ref proxy) = state.proxy {
             Ok(proxy.child_resource_templates(request).await)
@@ -1988,15 +2057,30 @@ impl ServerHandler for Supervisor {
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
-        self.forward_read_resource(request).await
+        context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, McpError> {
+        require_legacy_handshake(&context)?;
+        self.forward_read_resource(request)
+            .await
+            .map(ReadResourceResponse::Complete)
     }
 
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, McpError> {
+        require_legacy_handshake(&context)?;
+        self.handle_tool_call(request)
+            .await
+            .map(CallToolResponse::Complete)
+    }
+}
+
+impl Supervisor {
+    async fn handle_tool_call(
+        &self,
+        request: CallToolRequestParams,
     ) -> Result<CallToolResult, McpError> {
         match request.name.as_ref() {
             "up" => self.handle_up(&request).await,
@@ -2007,7 +2091,7 @@ impl ServerHandler for Supervisor {
                 let status = self.status().await;
                 let json = serde_json::to_string_pretty(&status)
                     .unwrap_or_else(|e| format!("Failed to serialize status: {e}"));
-                Ok(CallToolResult::success(vec![Content::text(json)]))
+                Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
             }
             "supervisor_restart" => {
                 let target = request
@@ -2065,18 +2149,18 @@ impl ServerHandler for Supervisor {
                             &daemon_workspace_path,
                             Duration::from_secs(30),
                         ) {
-                            return Ok(CallToolResult::success(vec![Content::text(
+                            return Ok(CallToolResult::success(vec![ContentBlock::text(
                                 "Daemon restart failed — daemon did not become ready within 30s",
                             )]));
                         }
 
                         match self.restart_child().await {
-                            Ok(()) => Ok(CallToolResult::success(vec![Content::text(
+                            Ok(()) => Ok(CallToolResult::success(vec![ContentBlock::text(
                                 "Daemon and MCP server restarted successfully",
                             )])),
-                            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
-                                "Daemon restarted but MCP server failed: {e}"
-                            ))])),
+                            Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(
+                                format!("Daemon restarted but MCP server failed: {e}"),
+                            )])),
                         }
                     }
                     _ => {
@@ -2089,12 +2173,12 @@ impl ServerHandler for Supervisor {
                             }
                         }
                         match self.restart_child().await {
-                            Ok(()) => Ok(CallToolResult::success(vec![Content::text(
+                            Ok(()) => Ok(CallToolResult::success(vec![ContentBlock::text(
                                 "nteract MCP server restarted successfully",
                             )])),
-                            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
-                                "Restart failed: {e}"
-                            ))])),
+                            Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(
+                                format!("Restart failed: {e}"),
+                            )])),
                         }
                     }
                 }
@@ -2124,7 +2208,7 @@ impl ServerHandler for Supervisor {
                         // (uses bundled build or installed app) and hint that
                         // Vite is available via the supervisor
                         let mut result = self.forward_tool_call(request).await?;
-                        result.content.push(Content::text(
+                        result.content.push(ContentBlock::text(
                             "\n\nTip: Use supervisor_start_vite to start a Vite \
                              dev server for hot-reload, then show_notebook will \
                              launch with live frontend changes."
@@ -2139,10 +2223,10 @@ impl ServerHandler for Supervisor {
                     return Ok(result);
                 }
                 match self.start_vite().await {
-                    Ok(port) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Ok(port) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Vite dev server running on http://localhost:{port}"
                     ))])),
-                    Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Failed to start Vite: {e}"
                     ))])),
                 }
@@ -2158,15 +2242,15 @@ impl ServerHandler for Supervisor {
                     .and_then(Value::as_str)
                     .unwrap_or("");
                 if name.is_empty() {
-                    return Ok(CallToolResult::success(vec![Content::text(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(
                         "Missing required 'name' argument (e.g. \"vite\")",
                     )]));
                 }
                 match self.stop_managed(name).await {
-                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Ok(()) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Stopped '{name}'"
                     ))])),
-                    Err(e) => Ok(CallToolResult::success(vec![Content::text(e)])),
+                    Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(e)])),
                 }
             }
             "supervisor_rebuild" => {
@@ -2185,7 +2269,7 @@ impl ServerHandler for Supervisor {
 
                 // 1. Rebuild daemon binary and CLI (cargo build -p runtimed -p runt)
                 if !run_cargo_build_daemon(&project_root) {
-                    return Ok(CallToolResult::success(vec![Content::text(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(
                         "cargo build -p runtimed failed — check the supervisor logs for details",
                     )]));
                 }
@@ -2194,7 +2278,7 @@ impl ServerHandler for Supervisor {
                 // SKIP_MATURIN=1 is set (speeds up Rust-only iteration).
                 if std::env::var("SKIP_MATURIN").unwrap_or_default() != "1" {
                     if !run_maturin_develop(&project_root).success() {
-                        return Ok(CallToolResult::success(vec![Content::text(
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(
                             "maturin develop failed — check the supervisor logs for details\n\
                              (daemon binary was rebuilt successfully)",
                         )]));
@@ -2208,7 +2292,7 @@ impl ServerHandler for Supervisor {
                 // stale wasm here ends in stuck "Initializing" via
                 // duplicate-seq-1.
                 if !run_xtask_wasm_ensure(&project_root) {
-                    return Ok(CallToolResult::success(vec![Content::text(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(
                         "cargo xtask wasm-ensure-runtime failed — check the supervisor logs for details\n\
                          (daemon binary was rebuilt successfully; the frontend wasm bundle may be stale)",
                     )]));
@@ -2248,7 +2332,7 @@ impl ServerHandler for Supervisor {
                     &daemon_workspace_path,
                     Duration::from_secs(30),
                 ) {
-                    return Ok(CallToolResult::success(vec![Content::text(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(
                         "Rebuild succeeded but daemon did not become ready within 30s",
                     )]));
                 }
@@ -2288,10 +2372,10 @@ impl ServerHandler for Supervisor {
                     ""
                 };
                 match self.restart_child().await {
-                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Ok(()) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Rebuilt daemon + Python bindings and restarted everything successfully{version_warning}",
                     ))])),
-                    Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Err(e) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Rebuild and daemon restart succeeded but MCP server restart failed: {e}{version_warning}"
                     ))])),
                 }
@@ -2310,9 +2394,9 @@ impl ServerHandler for Supervisor {
                 match log_path {
                     Some(path) if path.exists() => {
                         let text = tail_file(&path, lines);
-                        Ok(CallToolResult::success(vec![Content::text(text)]))
+                        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
                     }
-                    _ => Ok(CallToolResult::success(vec![Content::text(
+                    _ => Ok(CallToolResult::success(vec![ContentBlock::text(
                         "No Vite log found. Start Vite first with supervisor_start_vite.",
                     )])),
                 }
@@ -2335,13 +2419,13 @@ impl ServerHandler for Supervisor {
                 match log_path {
                     Some(path) if path.exists() => {
                         let text = tail_file(&path, lines);
-                        Ok(CallToolResult::success(vec![Content::text(text)]))
+                        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
                     }
-                    Some(path) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Some(path) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Daemon log not found at {}",
                         path.display()
                     ))])),
-                    None => Ok(CallToolResult::success(vec![Content::text(
+                    None => Ok(CallToolResult::success(vec![ContentBlock::text(
                         "Could not determine daemon log path",
                     )])),
                 }
@@ -2361,7 +2445,7 @@ impl ServerHandler for Supervisor {
                     "release" => true,
                     "debug" => false,
                     other => {
-                        return Ok(CallToolResult::success(vec![Content::text(format!(
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                             "Unknown mode '{other}'. Use 'debug' or 'release'."
                         ))]));
                     }
@@ -2369,7 +2453,7 @@ impl ServerHandler for Supervisor {
 
                 let old_release = RELEASE_MODE.load(Ordering::Relaxed);
                 if old_release == new_release {
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Already in {mode} mode, no change needed."
                     ))]));
                 }
@@ -2404,7 +2488,7 @@ impl ServerHandler for Supervisor {
                     if !target_runt.exists() {
                         missing.push(format!("runt: {}", target_runt.display()));
                     }
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Cannot switch to {mode} mode — missing binaries:\n  {}\n\
                          Build them first with: cargo build {}-p runtimed -p runt",
                         missing.join("\n  "),
@@ -2456,7 +2540,7 @@ impl ServerHandler for Supervisor {
                 ) {
                     // Roll back on failure
                     RELEASE_MODE.store(old_release, Ordering::Relaxed);
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Failed to switch to {mode} mode — daemon did not become ready within 30s. \
                          Rolled back to {} mode.",
                         if old_release { "release" } else { "debug" }
@@ -2465,13 +2549,13 @@ impl ServerHandler for Supervisor {
 
                 // Restart the MCP child so it reconnects to the new daemon
                 match self.restart_child().await {
-                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    Ok(()) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "Switched to {mode} mode. Daemon and MCP server restarted."
                     ))])),
                     Err(e) => {
                         // Daemon is running in new mode but child failed — don't roll back
                         // the daemon, just report the child failure
-                        Ok(CallToolResult::success(vec![Content::text(format!(
+                        Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                             "Switched to {mode} mode. Daemon restarted but MCP server failed: {e}"
                         ))]))
                     }
@@ -2922,6 +3006,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let transport = rmcp::transport::io::stdio();
     let server = supervisor.serve(transport).await?;
+    if server.peer().peer_info().is_none() {
+        server.cancellation_token().cancel();
+        return Err("The initialize handshake is required".into());
+    }
     info!("MCP server initialized on stdio (supervisor tools available)");
 
     // Extract upstream client identity from the MCP initialize handshake.
@@ -3278,6 +3366,181 @@ mod tests {
         PathBuf::from("/repo")
     }
 
+    async fn supervisor_responses(requests: Vec<Value>) -> Vec<Value> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        let supervisor = Supervisor::new_empty(
+            dir.path().to_path_buf(),
+            DevMode::Attach,
+            dir.path().to_path_buf(),
+            None,
+            tx,
+        );
+        let (server_side, client_side) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            if let Ok(service) = supervisor.serve(server_side).await {
+                let _ = service.waiting().await;
+            }
+        });
+        let mut client = BufReader::new(client_side);
+        let mut responses = Vec::new();
+        for request in requests {
+            let mut encoded = serde_json::to_vec(&request).unwrap();
+            encoded.push(b'\n');
+            client.get_mut().write_all(&encoded).await.unwrap();
+            let mut response = String::new();
+            tokio::time::timeout(Duration::from_secs(5), client.read_line(&mut response))
+                .await
+                .expect("request should receive a response")
+                .unwrap();
+            responses.push(serde_json::from_str(&response).unwrap());
+        }
+        server.abort();
+        responses
+    }
+
+    #[tokio::test]
+    async fn supervisor_preserves_legacy_handshakes_and_tool_response_shape() {
+        for version in LEGACY_PROTOCOL_VERSIONS {
+            let responses = supervisor_responses(vec![
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": version,
+                        "capabilities": {},
+                        "clientInfo": { "name": "test-client", "version": "1" }
+                    }
+                }),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": { "name": "up", "arguments": {} }
+                }),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "prompts/list"
+                }),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "completion/complete",
+                    "params": {
+                        "ref": { "type": "ref/prompt", "name": "test" },
+                        "argument": { "name": "test", "value": "" }
+                    }
+                }),
+            ])
+            .await;
+            assert_eq!(responses[0]["result"]["protocolVersion"], version.as_str());
+            assert_eq!(responses[0]["result"]["serverInfo"]["name"], "nteract-dev");
+            let result = &responses[1]["result"];
+            assert_eq!(result["content"][0]["type"], "text");
+            assert!(result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("disabled in nteract-dev attach mode"));
+            assert!(result.get("resultType").is_none(), "{result}");
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_repeated_initialize_cannot_change_protocol_or_identity() {
+        for version in LEGACY_PROTOCOL_VERSIONS {
+            let initialize = serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "protocolVersion": version, "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1"}
+                }
+            });
+            for patch in [
+                serde_json::json!({"protocolVersion": "2026-07-28"}),
+                serde_json::json!({"clientInfo": {"name": "replacement-client", "version": "1"}}),
+                serde_json::json!({"capabilities": {"roots": {"listChanged": true}}}),
+            ] {
+                let mut changed = initialize.clone();
+                changed["id"] = serde_json::json!(2);
+                changed["params"]
+                    .as_object_mut()
+                    .unwrap()
+                    .extend(patch.as_object().unwrap().clone());
+                let responses = supervisor_responses(vec![
+                    initialize.clone(), changed,
+                    serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "up", "arguments": {}}}),
+                    initialize.clone(),
+                ]).await;
+                assert_eq!(responses[1]["error"]["code"], -32600);
+                assert!(responses[2]["result"]["content"].is_array());
+                assert!(responses[2]["result"].get("resultType").is_none());
+                assert_eq!(responses[3]["result"]["protocolVersion"], version.as_str());
+            }
+        }
+    }
+
+    fn request_without_handshake(method: &str, version: &str) -> Value {
+        let mut params = serde_json::json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": version,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        });
+        match method {
+            "tools/call" => params["name"] = serde_json::json!("up"),
+            "resources/read" => params["uri"] = serde_json::json!("test://resource"),
+            "completion/complete" => {
+                params["ref"] = serde_json::json!({ "type": "ref/prompt", "name": "test" });
+                params["argument"] = serde_json::json!({ "name": "test", "value": "" });
+            }
+            _ => {}
+        }
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params
+        })
+    }
+
+    #[tokio::test]
+    async fn supervisor_rejects_modern_requests_without_a_handshake() {
+        for method in [
+            "server/discover",
+            "tools/list",
+            "tools/call",
+            "resources/read",
+        ] {
+            let responses =
+                supervisor_responses(vec![request_without_handshake(method, "2026-07-28")]).await;
+            assert_eq!(responses[0]["error"]["code"], -32022, "{}", responses[0]);
+            assert!(responses[0].get("result").is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_requires_handshake_even_with_legacy_request_metadata() {
+        for method in [
+            "server/discover",
+            "tools/list",
+            "tools/call",
+            "resources/list",
+            "resources/templates/list",
+            "resources/read",
+            "prompts/list",
+            "completion/complete",
+        ] {
+            let responses =
+                supervisor_responses(vec![request_without_handshake(method, "2025-11-25")]).await;
+            assert!(responses[0].get("error").is_some(), "{}", responses[0]);
+            assert!(responses[0].get("result").is_none());
+        }
+    }
+
     #[test]
     fn supervisor_server_info_advertises_mcp_apps_extension() {
         let (tool_list_changed_tx, _tool_list_changed_rx) = mpsc::channel(1);
@@ -3285,6 +3548,11 @@ mod tests {
             Supervisor::new_empty(root(), DevMode::Attach, root(), None, tool_list_changed_tx);
         let info = supervisor.get_info();
 
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
+        assert_eq!(
+            supervisor.supported_protocol_versions().as_ref(),
+            LEGACY_PROTOCOL_VERSIONS
+        );
         assert!(info.capabilities.extensions.as_ref().is_some_and(
             |extensions| extensions.contains_key(runt_mcp_proxy::MCP_APPS_EXTENSION_ID)
         ));

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -270,6 +270,11 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    if server.peer().peer_info().is_none() {
+        error!("The initialize handshake is required");
+        server.cancellation_token().cancel();
+        return ExitCode::FAILURE;
+    }
 
     // Extract upstream client identity
     let (upstream_name, upstream_title) = server
@@ -380,6 +385,32 @@ mod tests {
         );
         assert_eq!(config.server_name, runt_workspace::desktop_product_name());
         assert_eq!(config.monitor_poll_interval_ms, 500);
+    }
+
+    #[test]
+    fn proxy_preserves_legacy_protocol_and_compiled_server_identity() {
+        use rmcp::model::ProtocolVersion;
+        use rmcp::ServerHandler;
+
+        let mut config = proxy_config_for_channel("nightly".to_string());
+        config.cache_dir = None;
+        let proxy = McpProxy::new(config, None);
+        let info = proxy.get_info();
+
+        assert_eq!(
+            info.server_info.name,
+            runt_workspace::desktop_product_name()
+        );
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
+        assert_eq!(
+            proxy.supported_protocol_versions().as_ref(),
+            &[
+                ProtocolVersion::V_2024_11_05,
+                ProtocolVersion::V_2025_03_26,
+                ProtocolVersion::V_2025_06_18,
+                ProtocolVersion::V_2025_11_25,
+            ]
+        );
     }
 
     #[test]

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -15,6 +15,8 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+rmcp_legacy = { package = "rmcp", version = "=1.5.0", default-features = false, features = ["server", "client", "transport-io"] }
+runt-mcp = { path = "../runt-mcp" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -5,8 +5,8 @@ use std::future::Future;
 use std::path::Path;
 use std::process::{ExitStatus, Stdio};
 
-use rmcp::model::Implementation;
-use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::model::{Implementation, ProtocolVersion};
+use rmcp::service::{ClientCacheConfig, RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::{async_rw::AsyncRwTransport, Transport};
 use rmcp::{ClientHandler, ServiceExt};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -30,6 +30,7 @@ impl ClientHandler for ChildClientHandler {
         let mut impl_info = Implementation::new(&self.upstream_name, env!("CARGO_PKG_VERSION"));
         impl_info.title = self.upstream_title.clone();
         rmcp::model::ClientInfo::new(Default::default(), impl_info)
+            .with_protocol_version(ProtocolVersion::V_2025_11_25)
     }
 }
 
@@ -236,6 +237,10 @@ pub async fn spawn_child(
         .serve(transport)
         .await
         .map_err(|e| format!("Failed to initialize child MCP client: {e}"))?;
+    client
+        .peer()
+        .set_response_cache_config(ClientCacheConfig::disabled())
+        .await;
 
     Ok(SpawnedChild {
         client,
@@ -262,6 +267,23 @@ mod tests {
     use super::*;
     use rmcp::{ServerHandler, ServiceExt};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn child_info_preserves_identity_with_legacy_version_and_empty_capabilities() {
+        let handler = ChildClientHandler {
+            upstream_name: "codex-mcp-client".to_string(),
+            upstream_title: Some("Codex".to_string()),
+        };
+        let info = handler.get_info();
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
+        assert_eq!(info.client_info.name, "codex-mcp-client");
+        assert_eq!(info.client_info.title.as_deref(), Some("Codex"));
+        assert_eq!(info.client_info.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            serde_json::to_value(info.capabilities).unwrap(),
+            serde_json::json!({})
+        );
+    }
 
     /// Minimal `ServerHandler` — all methods use rmcp's defaults.
     struct NoopServer;

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -10,9 +10,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, ListResourceTemplatesResult,
-    ListResourcesResult, ListToolsResult, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, ProtocolVersion,
+    ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::service::{NotificationContext, Peer, RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
@@ -81,7 +82,8 @@ fn circuit_breaker_allows_restart(
 /// reachable when the child started — the proxy degrades to a generic
 /// "child restarted" reconnection banner in that case.
 fn extract_daemon_version(client: &child::RunningChild) -> Option<String> {
-    let title = client.peer_info()?.server_info.title.as_deref()?;
+    let peer_info = client.peer_info()?;
+    let title = peer_info.server_info.as_ref()?.title.as_deref()?;
     // Title format: "nteract (daemon X.Y.Z)".
     let open = title.find("(daemon ")?;
     let close = title.rfind(')')?;
@@ -920,10 +922,12 @@ impl McpProxy {
         let generation = snapshot.generation;
         let start = Instant::now();
 
-        let result =
-            snapshot.peer.call_tool(params.clone()).await.map_err(|e| {
-                McpError::internal_error(format!("Child tool call failed: {e}"), None)
-            });
+        let result = snapshot
+            .peer
+            .call_tool_once(params.clone())
+            .await
+            .map_err(|e| McpError::internal_error(format!("Child tool call failed: {e}"), None))
+            .and_then(complete_tool_response);
         self.log_child_call_if_slow(
             "call_tool",
             Some(params.name.as_ref()),
@@ -944,11 +948,10 @@ impl McpProxy {
 
         let result = snapshot
             .peer
-            .read_resource(params.clone())
+            .read_resource_once(params.clone())
             .await
-            .map_err(|e| {
-                McpError::internal_error(format!("Child resource read failed: {e}"), None)
-            });
+            .map_err(|e| McpError::internal_error(format!("Child resource read failed: {e}"), None))
+            .and_then(complete_resource_response);
         self.log_child_call_if_slow(
             "read_resource",
             Some(params.uri.as_ref()),
@@ -1003,7 +1006,7 @@ impl McpProxy {
             // Prepend the reconnection notice before the actual tool result
             result
                 .content
-                .insert(0, Content::text(format!("[nteract] {msg}\n")));
+                .insert(0, ContentBlock::text(format!("[nteract] {msg}\n")));
         }
     }
 
@@ -1095,6 +1098,38 @@ struct ChildPeerSnapshot {
     generation: u64,
 }
 
+fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    if context.peer.peer_info().is_none() {
+        return Err(McpError::invalid_request(
+            "initialize is required before application requests",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn complete_tool_response(response: CallToolResponse) -> Result<CallToolResult, McpError> {
+    match response {
+        CallToolResponse::Complete(result) => Ok(result),
+        _ => Err(McpError::internal_error(
+            "Child returned a non-final tool response on a legacy MCP connection",
+            None,
+        )),
+    }
+}
+
+fn complete_resource_response(
+    response: ReadResourceResponse,
+) -> Result<ReadResourceResult, McpError> {
+    match response {
+        ReadResourceResponse::Complete(result) => Ok(result),
+        _ => Err(McpError::internal_error(
+            "Child returned a non-final resource response on a legacy MCP connection",
+            None,
+        )),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ServerHandler — used when McpProxy is the top-level MCP server (nteract-mcp)
 // ---------------------------------------------------------------------------
@@ -1103,6 +1138,37 @@ struct ChildPeerSnapshot {
 /// IS the MCP server. The supervisor wraps this with its own ServerHandler that
 /// adds supervisor_* tools.
 impl ServerHandler for McpProxy {
+    async fn initialize(
+        &self,
+        request: rmcp::model::InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::InitializeResult, McpError> {
+        if context.peer.peer_info().as_deref() != Some(&request) {
+            return Err(McpError::invalid_request(
+                "initialize cannot change an existing connection or follow application requests",
+                None,
+            ));
+        }
+        let mut info = self.get_info();
+        if self
+            .supported_protocol_versions()
+            .contains(&request.protocol_version)
+        {
+            info.protocol_version = request.protocol_version;
+        }
+        Ok(info)
+    }
+
+    fn supported_protocol_versions(&self) -> std::borrow::Cow<'static, [ProtocolVersion]> {
+        const VERSIONS: &[ProtocolVersion] = &[
+            ProtocolVersion::V_2024_11_05,
+            ProtocolVersion::V_2025_03_26,
+            ProtocolVersion::V_2025_06_18,
+            ProtocolVersion::V_2025_11_25,
+        ];
+        std::borrow::Cow::Borrowed(VERSIONS)
+    }
+
     fn get_info(&self) -> ServerInfo {
         // list_tools serves the cached tool set synchronously so the first
         // client response is fast, then on_initialized spawns the child and
@@ -1119,6 +1185,7 @@ impl ServerHandler for McpProxy {
                 .enable_extensions_with(crate::mcp_apps_extension_capabilities())
                 .build(),
         )
+        .with_protocol_version(ProtocolVersion::V_2025_11_25)
         .with_server_info(Implementation::new(
             &self.config.server_name,
             env!("CARGO_PKG_VERSION"),
@@ -1132,11 +1199,39 @@ impl ServerHandler for McpProxy {
         )
     }
 
+    async fn discover(
+        &self,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::DiscoverResult, McpError> {
+        Err(McpError::method_not_found::<
+            rmcp::model::DiscoverRequestMethod,
+        >())
+    }
+
+    async fn list_prompts(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::ListPromptsResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(rmcp::model::ListPromptsResult::default())
+    }
+
+    async fn complete(
+        &self,
+        _request: rmcp::model::CompleteRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::CompleteResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(rmcp::model::CompleteResult::default())
+    }
+
     async fn list_tools(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        require_legacy_handshake(&context)?;
         // Serve tools optimistically: if the child is connected, query it live;
         // otherwise return the cached/built-in tool definitions immediately.
         // This avoids blocking the MCP client during async child initialization.
@@ -1152,47 +1247,47 @@ impl ServerHandler for McpProxy {
             cached
         };
         tools.push(reconnect_tool());
-        Ok(ListToolsResult {
-            tools,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn list_resources(
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
+        require_legacy_handshake(&context)?;
         Ok(self.child_resources(request).await)
     }
 
     async fn list_resource_templates(
         &self,
         request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
+        require_legacy_handshake(&context)?;
         Ok(self.child_resource_templates(request).await)
     }
 
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
-        self.forward_read_resource(request).await
+        context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, McpError> {
+        require_legacy_handshake(&context)?;
+        self.forward_read_resource(request).await.map(Into::into)
     }
 
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, McpError> {
+        require_legacy_handshake(&context)?;
         // Intercept the built-in reconnect tool before waiting on child
         // readiness — reconnect is the escape hatch when the child is
         // wedged, so it must not block on child readiness itself.
         if request.name == RECONNECT_TOOL_NAME {
-            return self.handle_reconnect().await;
+            return self.handle_reconnect().await.map(Into::into);
         }
 
         // Wait for child if not ready
@@ -1206,13 +1301,16 @@ impl ServerHandler for McpProxy {
             let _ = tokio::time::timeout(Duration::from_secs(60), notified).await;
         }
 
-        self.forward_tool_call(request).await
+        self.forward_tool_call(request).await.map(Into::into)
     }
 
     // Spawn the child only after the client has sent `notifications/initialized`.
     // Once the child is up, send tools/list_changed and resources/list_changed
     // so the client re-queries and replaces the cached list with the live one.
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+        if context.peer.peer_info().is_none() {
+            return;
+        }
         if self.state.read().await.child_client.is_some() {
             return;
         }
@@ -1286,7 +1384,7 @@ impl McpProxy {
         let pending = self.state.write().await.reconnection_message.take();
         let detail = pending.unwrap_or_else(|| "Child restarted.".to_string());
         let body = format!("{detail}\n\nRestart #{restart_count} (was #{prior_restart_count}).");
-        Ok(CallToolResult::success(vec![Content::text(body)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(body)]))
     }
 }
 
@@ -1297,7 +1395,6 @@ impl McpProxy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::Content;
     use std::collections::HashMap;
 
     fn test_config() -> ProxyConfig {
@@ -1309,6 +1406,74 @@ mod tests {
             cache_dir: None,
             monitor_poll_interval_ms: 500,
             recovery_hint: "Test recovery hint.".to_string(),
+        }
+    }
+
+    async fn first_request_response(request: serde_json::Value) -> serde_json::Value {
+        use rmcp::ServiceExt;
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let proxy = McpProxy::new(test_config(), None);
+        let (server_side, mut client_side) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            if let Ok(service) = proxy.serve(server_side).await {
+                let _ = service.waiting().await;
+            }
+        });
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        client_side.write_all(&encoded).await.unwrap();
+        let mut response = String::new();
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            BufReader::new(client_side).read_line(&mut response),
+        )
+        .await
+        .expect("first request should receive a response")
+        .unwrap();
+        server.abort();
+        serde_json::from_str(&response).unwrap()
+    }
+
+    #[tokio::test]
+    async fn legacy_initialize_negotiates_each_supported_version() {
+        let proxy = McpProxy::new(test_config(), None);
+        let versions = proxy.supported_protocol_versions();
+        assert_eq!(versions.len(), 4);
+        for version in versions.iter() {
+            let response = first_request_response(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": version,
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "1" }
+                }
+            }))
+            .await;
+            assert_eq!(response["result"]["protocolVersion"], version.as_str());
+            assert!(response.get("error").is_none(), "{response}");
+        }
+    }
+
+    #[tokio::test]
+    async fn modern_first_requests_are_rejected_before_dispatch() {
+        for method in ["server/discover", "tools/list"] {
+            let response = first_request_response(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientCapabilities": {}
+                    }
+                }
+            }))
+            .await;
+            assert_eq!(response["error"]["code"], -32022, "{response}");
+            assert!(response.get("result").is_none(), "{response}");
         }
     }
 
@@ -1570,25 +1735,101 @@ mod tests {
             Some("Daemon upgraded (2.1.2 → 2.1.3)".to_string());
 
         // Create a tool result
-        let mut result = CallToolResult::success(vec![Content::text("tool output")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("tool output")]);
 
         // Prepend should add the message
         proxy.prepend_reconnection_message(&mut result).await;
 
         assert_eq!(result.content.len(), 2);
         // First content should be the reconnection notice
-        let first_text = result.content[0]
-            .raw
-            .as_text()
-            .expect("first content should be text");
+        let ContentBlock::Text(first_text) = &result.content[0] else {
+            panic!("first content should be text");
+        };
         assert!(first_text.text.contains("Daemon upgraded"));
         assert!(first_text.text.starts_with("[nteract]"));
         // Second should be the original
-        let second_text = result.content[1]
-            .raw
-            .as_text()
-            .expect("second content should be text");
+        let ContentBlock::Text(second_text) = &result.content[1] else {
+            panic!("second content should be text");
+        };
         assert_eq!(second_text.text, "tool output");
+    }
+
+    #[tokio::test]
+    async fn complete_tool_response_preserves_metadata_and_content_after_reconnection() {
+        use rmcp::model::{MetaObject, Resource};
+
+        let proxy = McpProxy::new(test_config(), None);
+        proxy.state.write().await.reconnection_message = Some("Child restarted".to_string());
+        let mut meta = MetaObject::new();
+        meta.insert(
+            "ui".to_string(),
+            serde_json::json!({"resourceUri": "ui://notebook"}),
+        );
+        let annotations = serde_json::from_value(serde_json::json!({
+            "audience": ["user"],
+            "priority": 0.8
+        }))
+        .unwrap();
+        let resource = Resource::new("ui://notebook", "notebook")
+            .with_meta(meta.clone())
+            .with_annotations(annotations);
+        let original_content = vec![
+            ContentBlock::text("tool output"),
+            ContentBlock::resource_link(resource),
+            ContentBlock::image("aW1hZ2U=", "image/png"),
+        ];
+        let mut result = CallToolResult::success(original_content.clone());
+        result.structured_content = Some(serde_json::json!({"notebook_id": "notebook-id"}));
+        result.meta = Some(meta.clone());
+        result.is_error = Some(true);
+        let expected_structured = result.structured_content.clone();
+
+        let mut result = complete_tool_response(result.into()).unwrap();
+        proxy.prepend_reconnection_message(&mut result).await;
+        let result = complete_tool_response(result.into()).unwrap();
+
+        assert_eq!(&result.content[1..], original_content.as_slice());
+        assert_eq!(result.meta, Some(meta));
+        assert_eq!(result.structured_content, expected_structured);
+        assert_eq!(result.is_error, Some(true));
+        let wire = serde_json::to_value(&result).unwrap();
+        assert_eq!(
+            wire["content"][2]["annotations"]["audience"],
+            serde_json::json!(["user"])
+        );
+        assert_eq!(
+            wire["content"][2]["_meta"]["ui"]["resourceUri"],
+            "ui://notebook"
+        );
+    }
+
+    #[test]
+    fn complete_resource_response_preserves_contents_and_metadata() {
+        let wire = serde_json::json!({
+            "contents": [{
+                "uri": "ui://notebook",
+                "mimeType": "text/html;profile=mcp-app",
+                "text": "<main>Notebook</main>",
+                "_meta": {"ui": {"prefersBorder": true}}
+            }],
+            "_meta": {"source": "child"}
+        });
+        let result: ReadResourceResult = serde_json::from_value(wire.clone()).unwrap();
+        let result = complete_resource_response(result.into()).unwrap();
+        assert_eq!(serde_json::to_value(result).unwrap(), wire);
+    }
+
+    #[test]
+    fn non_final_child_responses_are_rejected() {
+        let input = rmcp::model::InputRequiredResult::from_request_state("state");
+        let tool_error =
+            complete_tool_response(CallToolResponse::InputRequired(input.clone())).unwrap_err();
+        let resource_error =
+            complete_resource_response(ReadResourceResponse::InputRequired(input)).unwrap_err();
+        assert!(tool_error.message.contains("non-final tool response"));
+        assert!(resource_error
+            .message
+            .contains("non-final resource response"));
     }
 
     #[tokio::test]
@@ -1597,7 +1838,7 @@ mod tests {
 
         proxy.state.write().await.reconnection_message = Some("test message".to_string());
 
-        let mut result = CallToolResult::success(vec![Content::text("output")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("output")]);
         proxy.prepend_reconnection_message(&mut result).await;
 
         // Message should be consumed
@@ -1609,7 +1850,7 @@ mod tests {
         let proxy = McpProxy::new(test_config(), None);
 
         // No reconnection message set
-        let mut result = CallToolResult::success(vec![Content::text("output")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("output")]);
         let original_len = result.content.len();
 
         proxy.prepend_reconnection_message(&mut result).await;
@@ -1622,12 +1863,12 @@ mod tests {
         let proxy = McpProxy::new(test_config(), None);
         proxy.state.write().await.reconnection_message = Some("upgraded".to_string());
 
-        let mut result1 = CallToolResult::success(vec![Content::text("first")]);
+        let mut result1 = CallToolResult::success(vec![ContentBlock::text("first")]);
         proxy.prepend_reconnection_message(&mut result1).await;
         assert_eq!(result1.content.len(), 2);
 
         // Second call should not prepend anything
-        let mut result2 = CallToolResult::success(vec![Content::text("second")]);
+        let mut result2 = CallToolResult::success(vec![ContentBlock::text("second")]);
         proxy.prepend_reconnection_message(&mut result2).await;
         assert_eq!(result2.content.len(), 1);
     }
@@ -1643,7 +1884,7 @@ mod tests {
             "arguments": { "path": "/tmp/test.ipynb" }
         }))
         .unwrap();
-        let result = CallToolResult::success(vec![Content::text("ok")]);
+        let result = CallToolResult::success(vec![ContentBlock::text("ok")]);
 
         proxy.track_session(&params, &result).await;
 
@@ -1664,7 +1905,7 @@ mod tests {
         proxy
             .track_session(
                 &params1,
-                &CallToolResult::success(vec![Content::text("ok")]),
+                &CallToolResult::success(vec![ContentBlock::text("ok")]),
             )
             .await;
 
@@ -1677,7 +1918,7 @@ mod tests {
         proxy
             .track_session(
                 &params2,
-                &CallToolResult::success(vec![Content::text("ok")]),
+                &CallToolResult::success(vec![ContentBlock::text("ok")]),
             )
             .await;
 
@@ -1700,7 +1941,7 @@ mod tests {
         proxy
             .track_session(
                 &create,
-                &CallToolResult::success(vec![Content::text(
+                &CallToolResult::success(vec![ContentBlock::text(
                     r#"{"notebook_id":"38582ef2-a117-4ce6-83d2-20c2c45d33d7"}"#,
                 )]),
             )
@@ -1714,7 +1955,7 @@ mod tests {
         proxy
             .track_session(
                 &save,
-                &CallToolResult::success(vec![Content::text(
+                &CallToolResult::success(vec![ContentBlock::text(
                     r#"{"path":"/tmp/analysis.ipynb","notebook_id":"38582ef2-a117-4ce6-83d2-20c2c45d33d7"}"#,
                 )]),
             )
@@ -1741,7 +1982,7 @@ mod tests {
         proxy
             .track_session(
                 &save,
-                &CallToolResult::success(vec![Content::text(
+                &CallToolResult::success(vec![ContentBlock::text(
                     r#"{"path":"/tmp/analysis.ipynb","notebook_id":"01KTZA152886TK1WAHYA48G7HJ"}"#,
                 )]),
             )
@@ -1771,7 +2012,7 @@ mod tests {
         proxy
             .track_session(
                 &disconnect,
-                &CallToolResult::success(vec![Content::text("ok")]),
+                &CallToolResult::success(vec![ContentBlock::text("ok")]),
             )
             .await;
 
@@ -1797,7 +2038,7 @@ mod tests {
         proxy
             .track_session(
                 &disconnect,
-                &CallToolResult::success(vec![Content::text("ok")]),
+                &CallToolResult::success(vec![ContentBlock::text("ok")]),
             )
             .await;
 
@@ -1817,7 +2058,10 @@ mod tests {
         .unwrap();
 
         proxy
-            .track_session(&params, &CallToolResult::success(vec![Content::text("ok")]))
+            .track_session(
+                &params,
+                &CallToolResult::success(vec![ContentBlock::text("ok")]),
+            )
             .await;
 
         let state = proxy.state.read().await;
@@ -1833,7 +2077,7 @@ mod tests {
             "arguments": { "path": "/tmp/test.ipynb" }
         }))
         .unwrap();
-        let mut result = CallToolResult::success(vec![Content::text("error")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("error")]);
         result.is_error = Some(true);
 
         proxy.track_session(&params, &result).await;
@@ -2113,7 +2357,10 @@ mod tests {
                 let text: String = call_result
                     .content
                     .iter()
-                    .filter_map(|c| c.raw.as_text().map(|t| t.text.clone()))
+                    .filter_map(|content| match content {
+                        ContentBlock::Text(text) => Some(text.text.clone()),
+                        _ => None,
+                    })
                     .collect::<Vec<_>>()
                     .join("\n");
                 assert!(

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -3,7 +3,7 @@
 //! can seed the new child's `NTERACT_MCP_REJOIN_NOTEBOOK` env var and let the
 //! child's `daemon_watch` loop re-join on its first `Connected` event.
 
-use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use serde_json::Value;
 
 /// Track a durable notebook target from session-establishing or persistence calls.
@@ -94,7 +94,7 @@ pub fn extract_session_id(
 /// file-backed connect/create responses).
 fn extract_notebook_path_from_result(result: &CallToolResult) -> Option<String> {
     for content in &result.content {
-        if let Some(text) = content.raw.as_text() {
+        if let ContentBlock::Text(text) = content {
             if let Ok(json) = serde_json::from_str::<Value>(&text.text) {
                 if let Some(path) = json.get("notebook_path").and_then(Value::as_str) {
                     return Some(path.to_string());
@@ -108,7 +108,7 @@ fn extract_notebook_path_from_result(result: &CallToolResult) -> Option<String> 
 /// Parse the canonical `path` returned by `save_notebook`.
 fn extract_path_from_result(result: &CallToolResult) -> Option<String> {
     for content in &result.content {
-        if let Some(text) = content.raw.as_text() {
+        if let ContentBlock::Text(text) = content {
             if let Ok(json) = serde_json::from_str::<Value>(&text.text) {
                 if let Some(path) = json.get("path").and_then(Value::as_str) {
                     return Some(path.to_string());
@@ -128,7 +128,7 @@ pub(crate) fn is_hosted_session_target(target: &str) -> bool {
 /// Parse notebook_id from a tool result's text content (JSON response body).
 pub(crate) fn extract_notebook_id_from_result(result: &CallToolResult) -> Option<String> {
     for content in &result.content {
-        if let Some(text) = content.raw.as_text() {
+        if let ContentBlock::Text(text) = content {
             if let Ok(json) = serde_json::from_str::<Value>(&text.text) {
                 if let Some(id) = json.get("notebook_id").and_then(Value::as_str) {
                     return Some(id.to_string());
@@ -161,7 +161,6 @@ fn hosted_notebook_target(domain: &str, notebook_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::Content;
 
     fn make_params(name: &str, args: serde_json::Value) -> CallToolRequestParams {
         serde_json::from_value(serde_json::json!({
@@ -172,11 +171,11 @@ mod tests {
     }
 
     fn success_result() -> CallToolResult {
-        CallToolResult::success(vec![Content::text("ok")])
+        CallToolResult::success(vec![ContentBlock::text("ok")])
     }
 
     fn error_result() -> CallToolResult {
-        let mut result = CallToolResult::success(vec![Content::text("error")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("error")]);
         result.is_error = Some(true);
         result
     }
@@ -278,7 +277,7 @@ mod tests {
             "connect_notebook",
             serde_json::json!({"notebook_id": "550e8400-e29b-41d4-a716-446655440000"}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "550e8400-e29b-41d4-a716-446655440000", "notebook_path": "/Users/me/fasty.ipynb", "connected": true}"#,
         )]);
         assert_eq!(
@@ -295,7 +294,7 @@ mod tests {
             "connect_notebook",
             serde_json::json!({"notebook_id": "550e8400-e29b-41d4-a716-446655440000"}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "550e8400-e29b-41d4-a716-446655440000", "connected": true}"#,
         )]);
         assert_eq!(
@@ -315,7 +314,7 @@ mod tests {
                 "domain": "https://preview.runt.run/"
             }),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "01KTZA152886TK1WAHYA48G7HJ", "notebook_path": "/Users/me/local.ipynb"}"#,
         )]);
         assert_eq!(
@@ -332,7 +331,7 @@ mod tests {
             "connect_notebook",
             serde_json::json!({"target": "550e8400-e29b-41d4-a716-446655440000"}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "550e8400-e29b-41d4-a716-446655440000", "notebook_path": "/Users/me/fasty.ipynb"}"#,
         )]);
         assert_eq!(
@@ -363,7 +362,7 @@ mod tests {
             "connect_notebook",
             serde_json::json!({"path": "~/fasty.ipynb"}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "550e8400-e29b-41d4-a716-446655440000", "path": "/Users/me/fasty.ipynb", "notebook_path": "/Users/me/fasty.ipynb"}"#,
         )]);
         assert_eq!(
@@ -401,7 +400,7 @@ mod tests {
     #[test]
     fn tracks_create_notebook_from_response() {
         let params = make_params("create_notebook", serde_json::json!({}));
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "8540eb53-8609-471d-88f4-5c3e92c3b396", "runtime": {"language": "python"}}"#,
         )]);
         assert_eq!(
@@ -411,12 +410,38 @@ mod tests {
     }
 
     #[test]
+    fn session_tracking_skips_non_text_blocks_and_preserves_annotated_text() {
+        let params = make_params("create_notebook", serde_json::json!({}));
+        let text: ContentBlock = serde_json::from_value(serde_json::json!({
+            "type": "text",
+            "text": "{\"notebook_id\":\"notebook-id\",\"notebook_path\":\"/tmp/analysis.ipynb\"}",
+            "annotations": {"audience": ["assistant"]},
+            "_meta": {"source": "child"}
+        }))
+        .unwrap();
+        let result = CallToolResult::success(vec![
+            ContentBlock::image("aW1hZ2U=", "image/png"),
+            ContentBlock::text("[nteract] Child restarted"),
+            text,
+        ]);
+
+        assert_eq!(
+            extract_session_id(&params, &result).as_deref(),
+            Some("/tmp/analysis.ipynb")
+        );
+        assert_eq!(
+            extract_notebook_id_from_result(&result).as_deref(),
+            Some("notebook-id")
+        );
+    }
+
+    #[test]
     fn tracks_create_notebook_with_deps_from_response() {
         let params = make_params(
             "create_notebook",
             serde_json::json!({"dependencies": ["numpy", "pandas"]}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"notebook_id": "abc-123", "runtime": {"language": "python"}, "dependencies": ["numpy", "pandas"], "package_manager": "uv"}"#,
         )]);
         assert_eq!(
@@ -439,7 +464,7 @@ mod tests {
             "save_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),
         );
-        let result = CallToolResult::success(vec![Content::text(
+        let result = CallToolResult::success(vec![ContentBlock::text(
             r#"{"path": "/private/tmp/test.ipynb", "notebook_id": "abc-123"}"#,
         )]);
         assert_eq!(
@@ -496,7 +521,7 @@ mod tests {
             "connect_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),
         );
-        let mut result = CallToolResult::success(vec![Content::text("ok")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("ok")]);
         result.is_error = None;
         assert_eq!(
             extract_session_id(&params, &result),

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -289,6 +289,25 @@ mod tests {
     }
 
     #[test]
+    fn tool_cache_preserves_mcp_apps_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cached = tool("notebook");
+        let mut meta = rmcp::model::MetaObject::new();
+        meta.insert(
+            "ui".to_string(),
+            serde_json::json!({"resourceUri": "ui://notebook", "visibility": ["model", "app"]}),
+        );
+        cached.meta = Some(meta);
+        let expected = serde_json::to_value(&cached).unwrap();
+
+        save_tool_cache(dir.path(), &[cached]);
+        let loaded = load_cached_tools(dir.path()).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(serde_json::to_value(&loaded[0]).unwrap(), expected);
+    }
+
+    #[test]
     fn load_falls_back_to_builtin_when_no_cache_file() {
         let dir = tempfile::tempdir().unwrap();
         // With no cache file on disk, should fall back to built-in cache

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+
+use rmcp_legacy::model::{
+    CallToolRequestParams, CallToolResult, ClientInfo, ListResourceTemplatesResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ServerInfo,
+};
+use rmcp_legacy::service::{NotificationContext, RequestContext, RoleServer};
+use rmcp_legacy::{ClientHandler, ErrorData, ServerHandler};
+use serde_json::json;
+
+pub const CHILD_MODE: &str = "NTERACT_COMPATIBILITY_CHILD";
+pub const READY: &str = "nteract-compatibility-fixture-ready";
+
+pub fn child_args() -> Vec<String> {
+    [
+        "--exact",
+        "compatibility_child_process",
+        "--nocapture",
+        "--quiet",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect()
+}
+
+pub fn child_env(dir: &Path, mode: &str) -> HashMap<String, String> {
+    HashMap::from([
+        (CHILD_MODE.into(), mode.into()),
+        (
+            "NTERACT_COMPATIBILITY_ROOT".into(),
+            dir.to_string_lossy().into_owned(),
+        ),
+        ("HOME".into(), dir.to_string_lossy().into_owned()),
+        ("USERPROFILE".into(), dir.to_string_lossy().into_owned()),
+        (
+            "XDG_CACHE_HOME".into(),
+            dir.join("cache").to_string_lossy().into_owned(),
+        ),
+        (
+            "XDG_CONFIG_HOME".into(),
+            dir.join("config").to_string_lossy().into_owned(),
+        ),
+        (
+            "XDG_DATA_HOME".into(),
+            dir.join("data").to_string_lossy().into_owned(),
+        ),
+        ("TMPDIR".into(), dir.to_string_lossy().into_owned()),
+        ("TEMP".into(), dir.to_string_lossy().into_owned()),
+        ("TMP".into(), dir.to_string_lossy().into_owned()),
+        ("RUNTIMED_DEV".into(), "0".into()),
+        (
+            "RUNTIMED_WORKSPACE_PATH".into(),
+            dir.to_string_lossy().into_owned(),
+        ),
+        (
+            "RUNTIMED_SOCKET_PATH".into(),
+            dir.join("daemon.sock").to_string_lossy().into_owned(),
+        ),
+        ("NTERACT_MCP_REJOIN_NOTEBOOK".into(), String::new()),
+        (
+            "NTERACT_MCP_OPERATOR_CLIENT".into(),
+            "compatibility-client".into(),
+        ),
+        (
+            "NTERACT_MCP_OPERATOR_SESSION".into(),
+            "compatibility-session".into(),
+        ),
+    ])
+}
+
+pub struct LegacyClient(pub &'static str);
+
+impl ClientHandler for LegacyClient {
+    fn get_info(&self) -> ClientInfo {
+        serde_json::from_value(json!({
+            "protocolVersion": self.0,
+            "capabilities": {},
+            "clientInfo": {"name": "rmcp-1.5-client", "version": "1.5.0", "title": "Legacy Client"}
+        }))
+        .expect("legacy client info")
+    }
+}
+
+struct LegacyChild {
+    initialized: std::sync::atomic::AtomicBool,
+}
+
+impl ServerHandler for LegacyChild {
+    fn get_info(&self) -> ServerInfo {
+        serde_json::from_value(json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {"tools": {}, "resources": {}},
+            "serverInfo": {"name": "rmcp-1.5-child", "version": "1.5.0"}
+        }))
+        .expect("legacy child server info")
+    }
+
+    async fn on_initialized(&self, _context: NotificationContext<RoleServer>) {
+        self.initialized
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        Ok(serde_json::from_value(json!({
+            "tools": [{"name": "compatibility_echo", "description": "Pinned SDK fixture", "inputSchema": {"type": "object", "properties": {"message": {"type": "string"}}}}]
+        })).expect("legacy tool definitions"))
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        Ok(serde_json::from_value(json!({
+            "resources": [{"uri": "compatibility://resource", "name": "legacy-resource", "mimeType": "text/plain"}]
+        })).expect("legacy resource definitions"))
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        Ok(serde_json::from_value(json!({
+            "resourceTemplates": [{"uriTemplate": "compatibility://{id}", "name": "legacy-template"}]
+        })).expect("legacy resource templates"))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        if request.uri != "compatibility://resource" {
+            return Err(ErrorData::resource_not_found(
+                "Missing fixture resource",
+                None,
+            ));
+        }
+        Ok(serde_json::from_value(json!({
+            "contents": [{"uri": request.uri, "mimeType": "text/plain", "text": "legacy resource\nλ", "_meta": {"compatibility/preserved": true}}]
+        })).expect("legacy resource result"))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if request.name != "compatibility_echo" {
+            return Err(ErrorData::invalid_params("Unknown fixture tool", None));
+        }
+        let info = context
+            .peer
+            .peer_info()
+            .expect("legacy child must have initialized peer info");
+        let payload = json!({
+            "arguments": request.arguments,
+            "clientInfo": info.client_info,
+            "protocolVersion": info.protocol_version,
+            "capabilities": info.capabilities,
+            "operatorSession": std::env::var("NTERACT_MCP_OPERATOR_SESSION").expect("operator session"),
+            "operatorClient": std::env::var("NTERACT_MCP_OPERATOR_CLIENT").expect("operator client"),
+            "initialized": self.initialized.load(std::sync::atomic::Ordering::Acquire)
+        });
+        Ok(serde_json::from_value(json!({
+            "content": [{"type": "text", "text": payload.to_string()}],
+            "structuredContent": payload,
+            "isError": false,
+            "_meta": {"compatibility/preserved": true}
+        }))
+        .expect("legacy tool result"))
+    }
+}
+
+pub fn run_child_if_requested() {
+    let Ok(mode) = std::env::var(CHILD_MODE) else {
+        return;
+    };
+    let root = std::path::PathBuf::from(
+        std::env::var("NTERACT_COMPATIBILITY_ROOT").expect("controlled child root"),
+    );
+    assert_eq!(
+        std::env::var_os("HOME").expect("controlled HOME"),
+        root.as_os_str()
+    );
+    assert_eq!(
+        std::env::var_os("RUNTIMED_SOCKET_PATH").expect("controlled socket"),
+        root.join("daemon.sock").as_os_str()
+    );
+    assert_eq!(
+        std::env::var("NTERACT_MCP_REJOIN_NOTEBOOK").expect("controlled rejoin"),
+        ""
+    );
+    std::fs::write(root.join("child-started"), std::process::id().to_string())
+        .expect("record fixture spawn");
+    println!("{READY}");
+    std::io::stdout()
+        .flush()
+        .expect("flush fixture readiness marker");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("fixture runtime");
+    runtime.block_on(async {
+        match mode.as_str() {
+            "legacy" => {
+                use rmcp_legacy::ServiceExt;
+                LegacyChild {
+                    initialized: std::sync::atomic::AtomicBool::new(false),
+                }
+                .serve(rmcp_legacy::transport::stdio())
+                .await
+                .expect("serve pinned legacy child")
+                .waiting()
+                .await
+                .expect("legacy child service");
+            }
+            "new" => {
+                use rmcp::ServiceExt;
+                runt_mcp::NteractMcp::new_no_show(
+                    root.join("daemon.sock"),
+                    None,
+                    Some(root.join("blobs")),
+                )
+                .with_execution_store_path(Some(root.join("executions")))
+                .serve(rmcp::transport::stdio())
+                .await
+                .expect("serve production new child")
+                .waiting()
+                .await
+                .expect("new child service");
+            }
+            _ => panic!("unknown compatibility fixture mode"),
+        }
+    });
+    std::process::exit(0);
+}

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -1,0 +1,557 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod fixtures;
+#[path = "../../runt-mcp/tests/support/mod.rs"]
+mod support;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use runt_mcp_proxy::{McpProxy, ProxyConfig};
+use serde_json::{json, Value};
+use support::{
+    assert_initialize, assert_unsupported, legacy_result, modern_meta, modern_requests, Wire,
+    DEADLINE, LEGACY_VERSIONS,
+};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::time::timeout;
+
+#[test]
+fn compatibility_child_process() {
+    fixtures::run_child_if_requested();
+}
+
+fn isolated_proxy() -> (tempfile::TempDir, McpProxy, Arc<AtomicUsize>) {
+    let dir = tempfile::tempdir().expect("isolated proxy directory");
+    runt_mcp_proxy::tools::save_tool_cache(
+        dir.path(),
+        &[rmcp::model::Tool::new(
+            "cached_compatibility_tool",
+            "Cached fixture",
+            serde_json::from_value::<serde_json::Map<String, Value>>(json!({"type": "object"}))
+                .expect("tool schema"),
+        )],
+    );
+    let executable = std::env::current_exe().expect("test executable");
+    let resolves = Arc::new(AtomicUsize::new(0));
+    let count = resolves.clone();
+    let proxy = McpProxy::new(
+        ProxyConfig {
+            resolve_child_command: Box::new(move || {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(executable.clone())
+            }),
+            child_args: fixtures::child_args(),
+            child_env: fixtures::child_env(dir.path(), "legacy"),
+            server_name: "compatibility-proxy".into(),
+            cache_dir: Some(dir.path().to_path_buf()),
+            monitor_poll_interval_ms: 60_000,
+            recovery_hint: "Compatibility test fixture only".into(),
+        },
+        None,
+    );
+    (dir, proxy, resolves)
+}
+
+async fn assert_no_child(proxy: &McpProxy, resolves: &AtomicUsize, dir: &std::path::Path) {
+    let state = proxy.state.read().await;
+    assert!(state.child_client.is_none());
+    assert_eq!(state.child_generation, 0);
+    assert_eq!(state.restart_count, 0);
+    assert!(state.child_spawn_time.is_none());
+    assert!(state.last_restart_time.is_none());
+    assert!(state.last_notebook_id.is_none());
+    assert!(state.reconnection_message.is_none());
+    assert!(!state.should_exit);
+    assert_eq!(resolves.load(Ordering::SeqCst), 0);
+    assert!(!dir.join("child-started").exists());
+}
+
+async fn stop_child(proxy: &McpProxy) {
+    let child = {
+        let mut state = proxy.state.write().await;
+        state.child_client.take()
+    };
+    if let Some(child) = child {
+        timeout(DEADLINE, child.cancel())
+            .await
+            .expect("child cancellation timed out")
+            .expect("cancel child");
+    }
+}
+
+async fn legacy_proxy_wire(version: &str) {
+    let (dir, proxy, resolves) = isolated_proxy();
+    proxy
+        .set_upstream_identity(
+            "compatibility-client".into(),
+            Some("Compatibility Client".into()),
+        )
+        .await;
+    let mut wire = Wire::start(proxy.clone());
+    assert_eq!(
+        legacy_result(&wire.request(0, "ping", None).await),
+        &json!({})
+    );
+    let initialized = wire.request(1, "initialize", Some(json!({
+        "protocolVersion": version,
+        "capabilities": {"roots": {"listChanged": true}},
+        "clientInfo": {"name": "compatibility-client", "title": "Compatibility Client", "version": "1"}
+    }))).await;
+    assert_initialize(&initialized, version, "compatibility-proxy");
+
+    let response = wire.request(2, "tools/list", None).await;
+    let tools = legacy_result(&response)["tools"]
+        .as_array()
+        .expect("cached tool list");
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0]["name"], "cached_compatibility_tool");
+    assert_eq!(tools[1]["name"], "reconnect");
+    assert!(tools
+        .iter()
+        .all(|tool| tool["inputSchema"]["type"] == "object"));
+    assert_eq!(
+        legacy_result(&wire.request(3, "resources/list", None).await)["resources"],
+        json!([])
+    );
+    assert_eq!(
+        legacy_result(&wire.request(4, "resources/templates/list", None).await)
+            ["resourceTemplates"],
+        json!([])
+    );
+    assert_no_child(&proxy, &resolves, dir.path()).await;
+    assert!(wire.notifications.is_empty());
+
+    wire.initialized().await;
+    wire.notification("notifications/tools/list_changed").await;
+    wire.notification("notifications/resources/list_changed")
+        .await;
+    assert_eq!(resolves.load(Ordering::SeqCst), 1);
+    assert!(dir.path().join("child-started").exists());
+
+    let response = wire.request(5, "tools/list", None).await;
+    let tools = legacy_result(&response)["tools"]
+        .as_array()
+        .expect("live old SDK tools");
+    assert!(tools
+        .iter()
+        .any(|tool| tool["name"] == "compatibility_echo"));
+    assert!(!tools
+        .iter()
+        .any(|tool| tool["name"] == "cached_compatibility_tool"));
+    assert!(tools.iter().any(|tool| tool["name"] == "reconnect"));
+
+    let response = wire.request(6, "tools/call", Some(json!({"name": "compatibility_echo", "arguments": {"message": "new proxy → old child\nλ"}}))).await;
+    let result = legacy_result(&response);
+    assert_eq!(result["isError"], false);
+    assert_eq!(result["_meta"]["compatibility/preserved"], true);
+    let payload: Value = serde_json::from_str(
+        result["content"][0]["text"]
+            .as_str()
+            .expect("legacy text content"),
+    )
+    .expect("fixture payload");
+    assert_eq!(payload, result["structuredContent"]);
+    assert_eq!(payload["arguments"]["message"], "new proxy → old child\nλ");
+    assert_eq!(payload["clientInfo"]["name"], "compatibility-client");
+    assert_eq!(payload["clientInfo"]["title"], "Compatibility Client");
+    assert_eq!(payload["protocolVersion"], "2025-11-25");
+    assert_eq!(payload["initialized"], true);
+    assert_eq!(payload["capabilities"], json!({}));
+    assert_eq!(payload["operatorClient"], "compatibility-client");
+    assert!(!payload["operatorSession"]
+        .as_str()
+        .expect("operator session")
+        .is_empty());
+
+    let response = wire.request(7, "resources/list", None).await;
+    assert_eq!(
+        legacy_result(&response)["resources"][0]["uri"],
+        "compatibility://resource"
+    );
+    let response = wire.request(8, "resources/templates/list", None).await;
+    assert_eq!(
+        legacy_result(&response)["resourceTemplates"][0]["uriTemplate"],
+        "compatibility://{id}"
+    );
+    let response = wire
+        .request(
+            9,
+            "resources/read",
+            Some(json!({"uri": "compatibility://resource"})),
+        )
+        .await;
+    let result = legacy_result(&response);
+    assert_eq!(result["contents"][0]["text"], "legacy resource\nλ");
+    assert_eq!(
+        result["contents"][0]["_meta"]["compatibility/preserved"],
+        true
+    );
+    let response = wire
+        .request(
+            10,
+            "resources/read",
+            Some(json!({"uri": "compatibility://missing"})),
+        )
+        .await;
+    assert_eq!(response["error"]["code"], -32603);
+    assert!(response["error"]["message"]
+        .as_str()
+        .expect("forwarded resource error")
+        .contains("Missing fixture resource"));
+
+    wire.initialized().await;
+    assert_eq!(
+        legacy_result(&wire.request(11, "ping", None).await),
+        &json!({})
+    );
+    assert_eq!(resolves.load(Ordering::SeqCst), 1);
+    timeout(DEADLINE, proxy.restart_child())
+        .await
+        .expect("restart timed out")
+        .expect("restart legacy child");
+    let response = wire
+        .request(
+            12,
+            "tools/call",
+            Some(json!({"name": "compatibility_echo", "arguments": {"message": "after restart"}})),
+        )
+        .await;
+    let restarted = legacy_result(&response);
+    assert_eq!(
+        restarted["structuredContent"]["operatorSession"],
+        payload["operatorSession"]
+    );
+    assert_eq!(
+        restarted["structuredContent"]["operatorClient"],
+        payload["operatorClient"]
+    );
+    assert_eq!(
+        restarted["structuredContent"]["clientInfo"],
+        payload["clientInfo"]
+    );
+    assert_eq!(restarted["structuredContent"]["capabilities"], json!({}));
+    assert_eq!(resolves.load(Ordering::SeqCst), 2);
+    let child_peer = {
+        let state = proxy.state.read().await;
+        state
+            .child_client
+            .as_ref()
+            .expect("restarted child")
+            .peer()
+            .clone()
+    };
+    assert!(!child_peer.response_cache_config().await.enabled);
+    assert!(wire.finish().await);
+    stop_child(&proxy).await;
+}
+
+macro_rules! legacy_test {
+    ($name:ident, $version:literal) => {
+        #[tokio::test]
+        async fn $name() {
+            legacy_proxy_wire($version).await;
+        }
+    };
+}
+
+legacy_test!(version_skew_new_proxy_to_old_child_2024_11_05, "2024-11-05");
+legacy_test!(version_skew_new_proxy_to_old_child_2025_03_26, "2025-03-26");
+legacy_test!(version_skew_new_proxy_to_old_child_2025_06_18, "2025-06-18");
+legacy_test!(version_skew_new_proxy_to_old_child_2025_11_25, "2025-11-25");
+
+async fn reject_modern_without_handshake(anonymous: bool) {
+    for version in ["2026-07-28", "2099-01-01"] {
+        for (method, mut params) in modern_requests() {
+            let (dir, proxy, resolves) = isolated_proxy();
+            let cached = std::fs::read(dir.path().join("tool-cache.json")).expect("cached tools");
+            let mut wire = Wire::start(proxy.clone());
+            params["_meta"] = modern_meta(version, anonymous);
+            assert_unsupported(&wire.request(42, method, Some(params)).await, version);
+            assert_no_child(&proxy, &resolves, dir.path()).await;
+            assert_eq!(proxy.state.read().await.upstream_name, "unknown");
+            assert_eq!(
+                std::fs::read(dir.path().join("tool-cache.json")).expect("unchanged cache"),
+                cached
+            );
+            assert!(wire.notifications.is_empty());
+            assert!(wire.finish().await);
+        }
+    }
+}
+
+#[tokio::test]
+async fn modern_named_requests_rejected_without_handshake_or_child_side_effects() {
+    reject_modern_without_handshake(false).await;
+}
+
+#[tokio::test]
+async fn modern_anonymous_requests_rejected_without_handshake_or_child_side_effects() {
+    reject_modern_without_handshake(true).await;
+}
+
+#[tokio::test]
+async fn missing_modern_metadata_rejected_before_child_dispatch() {
+    for params in [
+        json!({"name": "reconnect", "arguments": {}}),
+        json!({"name": "reconnect", "arguments": {}, "_meta": {"io.modelcontextprotocol/protocolVersion": "2026-07-28"}}),
+        json!({"name": "reconnect", "arguments": {}, "_meta": {"protocolVersion": "2026-07-28", "clientCapabilities": {}}}),
+    ] {
+        let (dir, proxy, resolves) = isolated_proxy();
+        let mut wire = Wire::start(proxy.clone());
+        assert_eq!(
+            wire.request(1, "tools/call", Some(params)).await["error"]["code"],
+            -32602
+        );
+        assert_no_child(&proxy, &resolves, dir.path()).await;
+        assert!(!wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn modern_metadata_cannot_upgrade_legacy_proxy_or_trigger_reconnect() {
+    let (dir, proxy, resolves) = isolated_proxy();
+    let mut wire = Wire::start(proxy.clone());
+    assert_initialize(
+        &wire.initialize("2025-11-25").await,
+        "2025-11-25",
+        "compatibility-proxy",
+    );
+    let response = wire.request(2, "tools/call", Some(json!({"name": "reconnect", "arguments": {}, "_meta": modern_meta("2026-07-28", true)}))).await;
+    assert_unsupported(&response, "2026-07-28");
+    let response = wire.request(3, "tools/list", None).await;
+    assert_eq!(
+        legacy_result(&response)["tools"][0]["name"],
+        "cached_compatibility_tool"
+    );
+    assert_no_child(&proxy, &resolves, dir.path()).await;
+    assert!(wire.finish().await);
+}
+
+#[tokio::test]
+async fn initialize_never_negotiates_a_modern_no_handshake_revision() {
+    for version in ["2026-07-28", "2099-01-01"] {
+        let (dir, proxy, resolves) = isolated_proxy();
+        let mut wire = Wire::start(proxy.clone());
+        assert_initialize(
+            &wire.initialize(version).await,
+            "2025-11-25",
+            "compatibility-proxy",
+        );
+        let response = wire.request(2, "tools/list", None).await;
+        assert!(legacy_result(&response)["tools"].is_array());
+        assert_no_child(&proxy, &resolves, dir.path()).await;
+        assert!(wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn repeated_initialize_cannot_change_proxy_protocol_or_identity() {
+    for version in LEGACY_VERSIONS {
+        let (dir, proxy, resolves) = isolated_proxy();
+        let mut wire = Wire::start(proxy.clone());
+        assert_initialize(
+            &wire.initialize(version).await,
+            version,
+            "compatibility-proxy",
+        );
+        support::assert_reinitialize_preserves_legacy_peer(&mut wire, version).await;
+        assert_no_child(&proxy, &resolves, dir.path()).await;
+        assert!(wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn legacy_inline_metadata_and_initialized_notification_cannot_start_a_child() {
+    for anonymous in [false, true] {
+        for version in ["2025-11-25", "2026-07-28"] {
+            let (dir, proxy, resolves) = isolated_proxy();
+            let mut wire = Wire::start(proxy.clone());
+            let response = wire
+                .request(
+                    1,
+                    "tools/list",
+                    Some(json!({"_meta": modern_meta(version, anonymous)})),
+                )
+                .await;
+            assert_eq!(
+                response["error"]["code"],
+                if version == "2025-11-25" {
+                    -32600
+                } else {
+                    -32022
+                }
+            );
+            wire.initialized().await;
+            for (index, (method, mut params)) in modern_requests().into_iter().enumerate() {
+                params["_meta"] = modern_meta("2025-11-25", anonymous);
+                let response = wire.request(index as u64 + 2, method, Some(params)).await;
+                assert!(response.get("error").is_some(), "{response}");
+                assert_no_child(&proxy, &resolves, dir.path()).await;
+                assert!(wire.notifications.is_empty());
+            }
+            assert!(wire.finish().await);
+        }
+    }
+}
+
+#[tokio::test]
+async fn version_skew_old_rmcp_client_to_new_production_child() {
+    use rmcp_legacy::ServiceExt;
+    use std::process::Stdio;
+
+    for version in LEGACY_VERSIONS {
+        let dir = tempfile::tempdir().expect("isolated new child directory");
+        let mut child =
+            tokio::process::Command::new(std::env::current_exe().expect("test executable"))
+                .args(fixtures::child_args())
+                .env_clear()
+                .envs(fixtures::child_env(dir.path(), "new"))
+                .current_dir(dir.path())
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .kill_on_drop(true)
+                .spawn()
+                .expect("spawn production child fixture");
+        let stdin = child.stdin.take().expect("child stdin");
+        let mut stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+        timeout(DEADLINE, async {
+            loop {
+                let mut line = String::new();
+                assert_ne!(
+                    stdout
+                        .read_line(&mut line)
+                        .await
+                        .expect("fixture readiness line"),
+                    0,
+                    "fixture exited before readiness"
+                );
+                if line.trim() == fixtures::READY {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("fixture startup timed out");
+        let client = timeout(
+            DEADLINE,
+            fixtures::LegacyClient(version).serve((stdout, stdin)),
+        )
+        .await
+        .expect("legacy client handshake timed out")
+        .expect("pinned rmcp 1.5 handshake with new child");
+        assert_eq!(
+            client
+                .peer_info()
+                .expect("server info")
+                .protocol_version
+                .as_str(),
+            version
+        );
+        assert_eq!(
+            client.peer_info().expect("server info").server_info.name,
+            "nteract"
+        );
+
+        let tools = timeout(DEADLINE, client.list_tools(None))
+            .await
+            .expect("tools timeout")
+            .expect("legacy tools/list");
+        assert!(tools
+            .tools
+            .iter()
+            .any(|tool| tool.name == "create_notebook"));
+        assert!(!tools.tools.iter().any(|tool| tool.name == "show_notebook"));
+        let resources = timeout(DEADLINE, client.list_resources(None))
+            .await
+            .expect("resources timeout")
+            .expect("legacy resources/list");
+        assert!(resources
+            .resources
+            .iter()
+            .any(|resource| resource.uri == "ui://nteract/output.html"));
+        let templates = timeout(DEADLINE, client.list_resource_templates(None))
+            .await
+            .expect("templates timeout")
+            .expect("legacy templates/list");
+        assert!(!templates.resource_templates.is_empty());
+        let read = serde_json::from_value(json!({"uri": "ui://nteract/output.html"}))
+            .expect("legacy read params");
+        let resource = timeout(DEADLINE, client.read_resource(read))
+            .await
+            .expect("read timeout")
+            .expect("legacy resource content");
+        let resource = serde_json::to_value(resource).expect("resource JSON");
+        assert!(!resource["contents"][0]["text"]
+            .as_str()
+            .expect("HTML resource")
+            .is_empty());
+        let call = serde_json::from_value(json!({"name": "disconnect_notebook", "arguments": {}}))
+            .expect("legacy tool params");
+        let result = timeout(DEADLINE, client.call_tool(call))
+            .await
+            .expect("call timeout")
+            .expect("legacy tool result");
+        assert_eq!(result.is_error, Some(true));
+        let result = serde_json::to_value(result).expect("tool JSON");
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .expect("legacy text content")
+            .contains("No active session"));
+        timeout(DEADLINE, client.cancel())
+            .await
+            .expect("client cancellation timeout")
+            .expect("cancel legacy client");
+        assert!(timeout(DEADLINE, child.wait())
+            .await
+            .expect("new child exit timeout")
+            .expect("reap new child")
+            .success());
+        assert!(!dir.path().join("daemon.sock").exists());
+        assert!(!dir.path().join("executions").exists());
+    }
+}
+
+#[tokio::test]
+async fn version_skew_production_spawn_child_pins_legacy_and_reaps_old_sdk_child() {
+    let dir = tempfile::tempdir().expect("isolated old child directory");
+    let spawned = timeout(
+        DEADLINE,
+        runt_mcp_proxy::child::spawn_child(
+            &std::env::current_exe().expect("test executable"),
+            &fixtures::child_args(),
+            &fixtures::child_env(dir.path(), "legacy"),
+            "spawn-child-client",
+            Some("Spawn Child Client"),
+        ),
+    )
+    .await
+    .expect("spawn child timeout")
+    .expect("production spawn_child initializes pinned old SDK");
+    assert!(!spawned.client.peer().response_cache_config().await.enabled);
+    let info = spawned.client.peer_info().expect("old child info");
+    assert_eq!(info.protocol_version.as_str(), "2025-11-25");
+    assert_eq!(
+        info.server_info.as_ref().expect("old server identity").name,
+        "rmcp-1.5-child"
+    );
+    let mut exit_status = spawned.exit_status;
+    timeout(DEADLINE, spawned.client.cancel())
+        .await
+        .expect("child cancellation timeout")
+        .expect("cancel old child");
+    timeout(DEADLINE, async {
+        loop {
+            if exit_status.borrow().is_some() {
+                break;
+            }
+            exit_status
+                .changed()
+                .await
+                .expect("child exit owner remained alive");
+        }
+    })
+    .await
+    .expect("production child owner did not reap the old SDK fixture");
+}

--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -15,7 +15,7 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use rmcp::model::{Content, Role};
+use rmcp::model::{Annotations, ContentBlock, Role, TextContent};
 use runtimed_outputs::output_resolver::{content_ref_meta, CONTENT_PRIORITY};
 use runtimed_outputs::resolved_output::{DataValue, Output};
 
@@ -27,8 +27,11 @@ use runtimed_outputs::resolved_output::{DataValue, Output};
 /// token-optimized. Annotating agent-channel text with the assistant audience
 /// lets renderers drop it from human views without guessing. Resource-link
 /// content items stay unannotated — both audiences navigate by them.
-pub fn assistant_text(text: impl Into<String>) -> Content {
-    Content::text(text.into()).with_audience(vec![Role::Assistant])
+pub fn assistant_text(text: impl Into<String>) -> ContentBlock {
+    ContentBlock::Text(
+        TextContent::new(text)
+            .with_annotations(Annotations::default().with_audience(vec![Role::Assistant])),
+    )
 }
 
 /// ANSI escape code regex — matches color codes, cursor movement, OSC sequences.
@@ -143,8 +146,8 @@ pub fn format_outputs_text(outputs: &[Output]) -> String {
 /// so agents know execution produced output they can't see.
 ///
 /// All text items are agent-channel content, annotated `audience: [assistant]`.
-pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content> {
-    let mut items: Vec<rmcp::model::Content> = Vec::new();
+pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<ContentBlock> {
+    let mut items: Vec<ContentBlock> = Vec::new();
     let mut omitted_count = 0usize;
     let mut omitted_mimes: Vec<String> = Vec::new();
 
@@ -718,8 +721,33 @@ mod tests {
     #[test]
     fn assistant_text_sets_assistant_audience() {
         let item = assistant_text("hello");
-        assert_eq!(item.audience(), Some(&vec![Role::Assistant]));
+        assert_eq!(
+            item.as_text()
+                .expect("text content")
+                .annotations
+                .as_ref()
+                .expect("text annotations")
+                .audience
+                .as_ref(),
+            Some(&vec![Role::Assistant])
+        );
         assert_eq!(item.as_text().expect("text content").text, "hello");
+    }
+
+    #[test]
+    fn assistant_text_round_trips_flat_mcp_content() {
+        let item = assistant_text("hello\nnotebook");
+        let wire = serde_json::to_value(&item).expect("serialize text content");
+        assert_eq!(
+            wire,
+            serde_json::json!({
+                "type": "text",
+                "text": "hello\nnotebook",
+                "annotations": { "audience": ["assistant"] }
+            })
+        );
+        let decoded: ContentBlock = serde_json::from_value(wire).expect("deserialize text content");
+        assert_eq!(decoded, item);
     }
 
     #[test]
@@ -733,7 +761,16 @@ mod tests {
         let items = outputs_to_content_items(&outputs);
         assert_eq!(items.len(), 2);
         for item in &items {
-            assert_eq!(item.audience(), Some(&vec![Role::Assistant]));
+            assert_eq!(
+                item.as_text()
+                    .expect("text content")
+                    .annotations
+                    .as_ref()
+                    .expect("text annotations")
+                    .audience
+                    .as_ref(),
+                Some(&vec![Role::Assistant])
+            );
         }
     }
 

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -6,15 +6,17 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Implementation, ListResourceTemplatesResult,
-    ListResourcesResult, ListToolsResult, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResponse, CallToolResult, CompleteRequestParams, CompleteResult,
+    DiscoverRequestMethod, DiscoverResult, Implementation, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, ProtocolVersion,
+    ReadResourceRequestParams, ReadResourceResponse, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
@@ -40,6 +42,12 @@ use session::{
 use session_activation::SessionActivation;
 
 const SLOW_MCP_TOOL_CALL: Duration = Duration::from_secs(30);
+const LEGACY_PROTOCOL_VERSIONS: [ProtocolVersion; 4] = [
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+];
 /// Client names are untrusted handshake input. Keep the derived operator slug
 /// compact enough for actor labels, logs, and UI while retaining useful brand
 /// names in full.
@@ -391,7 +399,67 @@ impl NteractMcp {
     }
 }
 
+fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    if context.peer.peer_info().is_none() {
+        return Err(McpError::invalid_request(
+            "initialize is required before application requests",
+            None,
+        ));
+    }
+    Ok(())
+}
+
 impl ServerHandler for NteractMcp {
+    async fn initialize(
+        &self,
+        request: rmcp::model::InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::InitializeResult, McpError> {
+        if context.peer.peer_info().as_deref() != Some(&request) {
+            return Err(McpError::invalid_request(
+                "initialize cannot change an existing connection or follow application requests",
+                None,
+            ));
+        }
+        let mut info = self.get_info();
+        if self
+            .supported_protocol_versions()
+            .contains(&request.protocol_version)
+        {
+            info.protocol_version = request.protocol_version;
+        }
+        Ok(info)
+    }
+
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(&LEGACY_PROTOCOL_VERSIONS)
+    }
+
+    async fn discover(
+        &self,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<DiscoverResult, McpError> {
+        Err(McpError::method_not_found::<DiscoverRequestMethod>())
+    }
+
+    async fn list_prompts(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(ListPromptsResult::default())
+    }
+
+    async fn complete(
+        &self,
+        _request: CompleteRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CompleteResult, McpError> {
+        require_legacy_handshake(&context)?;
+        Ok(CompleteResult::default())
+    }
+
     fn get_info(&self) -> ServerInfo {
         // Advertise MCP Apps extension for output rendering
         let mut extensions = rmcp::model::ExtensionCapabilities::new();
@@ -417,6 +485,7 @@ impl ServerHandler for NteractMcp {
                 .enable_extensions_with(extensions)
                 .build(),
         )
+        .with_protocol_version(ProtocolVersion::V_2025_11_25)
         .with_server_info(impl_info)
         .with_instructions(
             "nteract MCP server for Jupyter notebooks. \
@@ -432,35 +501,35 @@ impl ServerHandler for NteractMcp {
 
     /// Accept logging/setLevel requests (no-op — we don't change log level dynamically).
     /// Without this, MCP Jam gets an error on connect.
+    #[allow(deprecated)]
     async fn set_level(
         &self,
         _request: rmcp::model::SetLevelRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
         Ok(())
     }
 
     async fn list_tools(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        require_legacy_handshake(&context)?;
         let mut tools = tools::all_tools();
         if self.no_show {
             tools.retain(|t| t.name.as_ref() != "show_notebook");
         }
-        Ok(ListToolsResult {
-            tools,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
+        require_legacy_handshake(&context)?;
         // Sniff client name on first call for use as the notebook peer label.
         // The title (e.g., "Claude Desktop") is preferred over the raw
         // implementation name ("claude-ai"), then known names are canonicalized.
@@ -498,30 +567,35 @@ impl ServerHandler for NteractMcp {
         if tracing::enabled!(tracing::Level::DEBUG) {
             log_mcp_response(&request.name, elapsed, &result);
         }
-        result
+        result.map(Into::into)
     }
 
     async fn list_resources(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
+        require_legacy_handshake(&context)?;
         resources::list_resources(self).await
     }
 
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
-        resources::read_resource(self, &request).await
+        context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, McpError> {
+        require_legacy_handshake(&context)?;
+        resources::read_resource(self, &request)
+            .await
+            .map(Into::into)
     }
 
     async fn list_resource_templates(
         &self,
         _request: Option<rmcp::model::PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
+        require_legacy_handshake(&context)?;
         Ok(resources::list_resource_templates())
     }
 }
@@ -622,7 +696,133 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::{CallToolResult, Content};
+    use rmcp::model::{CallToolResult, ContentBlock};
+
+    #[test]
+    fn server_advertises_only_legacy_protocol_versions() {
+        let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None);
+        assert_eq!(
+            server.get_info().protocol_version,
+            ProtocolVersion::V_2025_11_25
+        );
+        assert_eq!(
+            server
+                .supported_protocol_versions()
+                .iter()
+                .map(ProtocolVersion::as_str)
+                .collect::<Vec<_>>(),
+            ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+        );
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn application_handlers_require_handshake_even_with_legacy_inline_metadata() {
+        use rmcp::model::{
+            ArgumentInfo, ClientInfo, ErrorCode, LoggingLevel, Reference, RequestMetaObject,
+            SetLevelRequestParams,
+        };
+
+        for initialized in [false, true] {
+            let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None);
+            let (_client_transport, server_transport) = tokio::io::duplex(4096);
+            let client_info =
+                ClientInfo::default().with_protocol_version(ProtocolVersion::V_2025_11_25);
+            let mut running = rmcp::service::serve_directly(
+                server,
+                server_transport,
+                initialized.then_some(client_info.clone()),
+            );
+            let context = || {
+                let mut context = RequestContext::new(
+                    rmcp::model::NumberOrString::Number(1),
+                    running.peer().clone(),
+                );
+                context.meta = RequestMetaObject::with_client_context(
+                    ProtocolVersion::V_2025_11_25,
+                    client_info.client_info.clone(),
+                    client_info.capabilities.clone(),
+                );
+                context
+            };
+            let server = running.service();
+            let results = [
+                server.list_tools(None, context()).await.map(|_| ()),
+                server
+                    .call_tool(CallToolRequestParams::new("interrupt_kernel"), context())
+                    .await
+                    .map(|_| ()),
+                server.list_resources(None, context()).await.map(|_| ()),
+                server
+                    .list_resource_templates(None, context())
+                    .await
+                    .map(|_| ()),
+                server
+                    .read_resource(
+                        ReadResourceRequestParams::new("ui://nteract/output.html"),
+                        context(),
+                    )
+                    .await
+                    .map(|_| ()),
+                server
+                    .set_level(SetLevelRequestParams::new(LoggingLevel::Info), context())
+                    .await,
+                server.list_prompts(None, context()).await.map(|result| {
+                    assert!(result.prompts.is_empty());
+                }),
+                server
+                    .complete(
+                        CompleteRequestParams::new(
+                            Reference::for_prompt("unused"),
+                            ArgumentInfo::new("name", ""),
+                        ),
+                        context(),
+                    )
+                    .await
+                    .map(|result| assert!(result.completion.values.is_empty())),
+            ];
+            for result in results {
+                if initialized {
+                    result.expect("initialized application request");
+                } else {
+                    let error = result.expect_err("application request without initialize");
+                    assert_eq!(error.code, ErrorCode::INVALID_REQUEST);
+                    assert_eq!(
+                        error.message,
+                        "initialize is required before application requests"
+                    );
+                }
+            }
+            let error = server
+                .discover(context())
+                .await
+                .expect_err("discovery is unsupported");
+            assert_eq!(error.code, ErrorCode::METHOD_NOT_FOUND);
+            running.close().await.expect("close test service");
+        }
+    }
+
+    #[test]
+    fn complete_tool_responses_preserve_content_errors_and_metadata() {
+        for is_error in [false, true] {
+            let content = vec![crate::formatting::assistant_text("notebook result")];
+            let mut result = if is_error {
+                CallToolResult::error(content)
+            } else {
+                CallToolResult::success(content)
+            };
+            result.structured_content = Some(serde_json::json!({
+                "notebook_id": "nb-1", "execution_id": "exec-1"
+            }));
+            let expected = serde_json::to_value(&result).expect("serialize tool result");
+            let response: CallToolResponse = result.into();
+            assert!(matches!(response, CallToolResponse::Complete(_)));
+            let wire = serde_json::to_value(rmcp::model::ServerResult::from(response))
+                .expect("serialize complete tool response");
+            assert_eq!(wire, expected);
+            assert_eq!(wire.get("isError"), Some(&serde_json::json!(is_error)));
+        }
+    }
 
     #[test]
     fn seeded_operator_identity_matches_handshake_identity() {
@@ -794,8 +994,8 @@ mod tests {
     /// Build a text content item whose JSON serialization exceeds `min_bytes`,
     /// with multi-byte characters (em-dashes) placed densely near the cut point
     /// so the truncation is guaranteed to land inside one.
-    fn content_with_multibyte_near(min_bytes: usize) -> Content {
-        // JSON overhead for Content::text is ~30-40 bytes. Use em-dashes
+    fn content_with_multibyte_near(min_bytes: usize) -> ContentBlock {
+        // JSON overhead for ContentBlock::text is ~30-40 bytes. Use em-dashes
         // (3 bytes each) densely from byte ~(min_bytes - 50) onward to
         // guarantee the cut point hits mid-character regardless of exact overhead.
         let safe_prefix = min_bytes.saturating_sub(50);
@@ -805,7 +1005,7 @@ mod tests {
         for _ in 0..emdash_count {
             text.push('—');
         }
-        Content::text(text)
+        ContentBlock::text(text)
     }
 
     #[test]
@@ -831,11 +1031,11 @@ mod tests {
         }
         let structured = serde_json::json!({ "data": text });
 
-        let mut result = CallToolResult::success(vec![Content::text("ok")]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text("ok")]);
         result.structured_content = Some(serde_json::from_value(structured).unwrap());
         // Force the warn path (which logs structured_content) by injecting a null byte
         // into the main content so null_bytes > 0.
-        result.content = vec![Content::text("has\0null")];
+        result.content = vec![ContentBlock::text("has\0null")];
         let elapsed = Duration::from_millis(1);
 
         log_mcp_response("test_tool", elapsed, &Ok(result));
@@ -849,7 +1049,7 @@ mod tests {
         for _ in 0..40 {
             text.push_str("╔═══╗\n║ x ║\n╚═══╝\n");
         }
-        let result = CallToolResult::success(vec![Content::text(text)]);
+        let result = CallToolResult::success(vec![ContentBlock::text(text)]);
         let elapsed = Duration::from_millis(1);
 
         log_mcp_response("test_tool", elapsed, &Ok(result));

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -1,8 +1,9 @@
 //! MCP resource serving (output.html, notebook cells, status).
 
 use rmcp::model::{
-    Annotated, ListResourceTemplatesResult, ListResourcesResult, Meta, RawResource,
-    RawResourceTemplate, ReadResourceRequestParams, ReadResourceResult, ResourceContents, Role,
+    Annotations, ListResourceTemplatesResult, ListResourcesResult, MetaObject,
+    ReadResourceRequestParams, ReadResourceResult, Resource, ResourceContents, ResourceTemplate,
+    Role,
 };
 use rmcp::ErrorData as McpError;
 
@@ -46,7 +47,7 @@ const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
 /// Claude Desktop; advertising this metadata is only the host permission layer.
 ///
 /// Claude Desktop requires `localhost` (not `127.0.0.1`) for domain allowlists.
-fn resource_ui_meta(blob_base_url: &Option<String>) -> Meta {
+fn resource_ui_meta(blob_base_url: &Option<String>) -> MetaObject {
     let mut ui = serde_json::Map::new();
     ui.insert("prefersBorder".to_string(), serde_json::json!(false));
 
@@ -63,7 +64,7 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> Meta {
 
     let mut meta = serde_json::Map::new();
     meta.insert("ui".to_string(), serde_json::Value::Object(ui));
-    Meta(meta)
+    MetaObject(meta)
 }
 
 /// List available MCP resources.
@@ -97,11 +98,7 @@ pub async fn list_resources(server: &NteractMcp) -> Result<ListResourcesResult, 
         ));
     }
 
-    Ok(ListResourcesResult {
-        resources,
-        next_cursor: None,
-        meta: None,
-    })
+    Ok(ListResourcesResult::with_all_items(resources))
 }
 
 /// List available dynamic MCP resource templates.
@@ -133,11 +130,7 @@ pub fn list_resource_templates() -> ListResourceTemplatesResult {
         ),
     ];
 
-    ListResourceTemplatesResult {
-        resource_templates: templates,
-        next_cursor: None,
-        meta: None,
-    }
+    ListResourceTemplatesResult::with_all_items(templates)
 }
 
 /// Read an MCP resource by URI.
@@ -199,17 +192,14 @@ fn resource(
     description: impl Into<String>,
     mime_type: impl Into<String>,
     icon: IconKind,
-    meta: Option<Meta>,
-) -> Annotated<RawResource> {
-    let mut raw = RawResource::new(uri, name);
+    meta: Option<MetaObject>,
+) -> Resource {
+    let mut raw = Resource::new(uri, name);
     raw.description = Some(description.into());
     raw.mime_type = Some(mime_type.into());
     raw.icons = Some(icons::icons(icon));
     raw.meta = meta;
-    Annotated {
-        raw,
-        annotations: None,
-    }
+    raw
 }
 
 fn assistant_resource(
@@ -219,10 +209,12 @@ fn assistant_resource(
     mime_type: impl Into<String>,
     icon: IconKind,
     priority: f32,
-) -> Annotated<RawResource> {
-    resource(uri, name, description, mime_type, icon, None)
-        .with_audience(vec![Role::Assistant])
-        .with_priority(priority)
+) -> Resource {
+    resource(uri, name, description, mime_type, icon, None).with_annotations(
+        Annotations::default()
+            .with_audience(vec![Role::Assistant])
+            .with_priority(priority),
+    )
 }
 
 fn resource_template(
@@ -231,15 +223,12 @@ fn resource_template(
     description: impl Into<String>,
     mime_type: impl Into<String>,
     icon: IconKind,
-) -> Annotated<RawResourceTemplate> {
-    let mut raw = RawResourceTemplate::new(uri_template, name);
+) -> ResourceTemplate {
+    let mut raw = ResourceTemplate::new(uri_template, name);
     raw.description = Some(description.into());
     raw.mime_type = Some(mime_type.into());
     raw.icons = Some(icons::icons(icon));
-    Annotated {
-        raw,
-        annotations: None,
-    }
+    raw
 }
 
 fn assistant_resource_template(
@@ -249,10 +238,12 @@ fn assistant_resource_template(
     mime_type: impl Into<String>,
     icon: IconKind,
     priority: f32,
-) -> Annotated<RawResourceTemplate> {
-    resource_template(uri_template, name, description, mime_type, icon)
-        .with_audience(vec![Role::Assistant])
-        .with_priority(priority)
+) -> ResourceTemplate {
+    resource_template(uri_template, name, description, mime_type, icon).with_annotations(
+        Annotations::default()
+            .with_audience(vec![Role::Assistant])
+            .with_priority(priority),
+    )
 }
 
 async fn active_notebooks_json(server: &NteractMcp) -> Result<String, McpError> {
@@ -513,8 +504,8 @@ pub(crate) fn notebook_resources_json(notebook_id: &str) -> serde_json::Value {
     })
 }
 
-pub(crate) fn notebook_cells_resource_link(notebook_id: &str) -> RawResource {
-    let mut resource = RawResource::new(
+pub(crate) fn notebook_cells_resource_link(notebook_id: &str) -> Resource {
+    let mut resource = Resource::new(
         notebook_cells_uri(notebook_id),
         format!("nteract cells {notebook_id}"),
     );
@@ -524,8 +515,8 @@ pub(crate) fn notebook_cells_resource_link(notebook_id: &str) -> RawResource {
     resource
 }
 
-pub(crate) fn notebook_cell_resource_link(notebook_id: &str, cell_id: &str) -> RawResource {
-    let mut resource = RawResource::new(
+pub(crate) fn notebook_cell_resource_link(notebook_id: &str, cell_id: &str) -> Resource {
+    let mut resource = Resource::new(
         notebook_cell_uri(notebook_id, cell_id),
         format!("nteract cell {cell_id}"),
     );
@@ -581,13 +572,13 @@ mod tests {
     use std::path::PathBuf;
 
     use rmcp::model::{
-        Annotations, CallToolResult, Content, Meta, ReadResourceRequestParams, Role,
+        Annotations, CallToolResult, ContentBlock, MetaObject, ReadResourceRequestParams, Role,
     };
 
     use super::*;
     use crate::NteractMcp;
 
-    fn ui_meta(meta: &Meta) -> &serde_json::Value {
+    fn ui_meta(meta: &MetaObject) -> &serde_json::Value {
         meta.0.get("ui").expect("ui metadata")
     }
 
@@ -658,14 +649,40 @@ mod tests {
 
         let result = list_resources(&server).await.expect("list resources");
         let resource = result.resources.first().expect("output resource");
-        let meta = resource.raw.meta.as_ref().expect("resource metadata");
+        let meta = resource.meta.as_ref().expect("resource metadata");
         let ui = ui_meta(meta);
 
-        assert_eq!(resource.raw.uri, OUTPUT_RESOURCE_URI);
+        assert_eq!(resource.uri, OUTPUT_RESOURCE_URI);
         assert!(resource.annotations.is_none());
-        assert_light_dark_icons(resource.raw.icons.as_deref().expect("resource icons"));
+        assert_light_dark_icons(resource.icons.as_deref().expect("resource icons"));
         assert_eq!(ui.get("prefersBorder"), Some(&serde_json::json!(false)));
         assert!(ui.get("csp").is_some());
+    }
+
+    #[tokio::test]
+    async fn resource_list_round_trips_flat_descriptors() {
+        let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None);
+        let result = list_resources(&server).await.expect("list resources");
+        let wire = serde_json::to_value(&result).expect("serialize resource list");
+        assert!(wire.get("nextCursor").is_none());
+        assert!(wire.get("ttlMs").is_none());
+        assert!(wire.get("cacheScope").is_none());
+        assert_eq!(
+            wire.pointer("/resources/0/_meta/ui/prefersBorder"),
+            Some(&serde_json::json!(false))
+        );
+        assert_eq!(
+            wire.pointer("/resources/1/annotations/audience"),
+            Some(&serde_json::json!(["assistant"]))
+        );
+        assert_eq!(
+            wire.pointer("/resources/1/annotations/priority"),
+            Some(&serde_json::json!(NOTEBOOK_CONTEXT_PRIORITY))
+        );
+        assert!(wire.pointer("/resources/0/raw").is_none());
+        let decoded: ListResourcesResult =
+            serde_json::from_value(wire).expect("deserialize resource list");
+        assert_eq!(decoded, result);
     }
 
     #[tokio::test]
@@ -682,7 +699,11 @@ mod tests {
         )
         .await
         .expect("read output resource");
-        let wire = serde_json::to_value(result).expect("serialize resource result");
+        let expected = serde_json::to_value(&result).expect("serialize resource result");
+        let response: rmcp::model::ReadResourceResponse = result.into();
+        let wire = serde_json::to_value(rmcp::model::ServerResult::from(response))
+            .expect("serialize resource response");
+        assert_eq!(wire, expected);
         let content = wire
             .pointer("/contents/0")
             .expect("serialized output resource content");
@@ -718,7 +739,7 @@ mod tests {
         let resource = result
             .resources
             .iter()
-            .find(|resource| resource.raw.uri == NOTEBOOKS_RESOURCE_URI)
+            .find(|resource| resource.uri == NOTEBOOKS_RESOURCE_URI)
             .expect("notebook collection resource");
 
         assert_assistant_context_annotations(
@@ -727,7 +748,7 @@ mod tests {
                 .as_ref()
                 .expect("notebook resource annotations"),
         );
-        assert_light_dark_icons(resource.raw.icons.as_deref().expect("resource icons"));
+        assert_light_dark_icons(resource.icons.as_deref().expect("resource icons"));
     }
 
     #[test]
@@ -737,7 +758,7 @@ mod tests {
         let templates: Vec<_> = result
             .resource_templates
             .iter()
-            .map(|template| template.raw.uri_template.as_str())
+            .map(|template| template.uri_template.as_str())
             .collect();
 
         assert!(templates.contains(&"nteract://notebooks/{notebook_id}/cells"));
@@ -750,7 +771,7 @@ mod tests {
                     .as_ref()
                     .expect("notebook resource template annotations"),
             );
-            assert_light_dark_icons(template.raw.icons.as_deref().expect("template icons"));
+            assert_light_dark_icons(template.icons.as_deref().expect("template icons"));
         }
     }
 
@@ -837,7 +858,7 @@ mod tests {
     #[test]
     fn notebook_resource_link_content_round_trips_mcp_wire_format() {
         let expected_uri = "nteract://notebooks/nb%201/cells/cell%2Fwith%2Fslash";
-        let result = CallToolResult::success(vec![Content::resource_link(
+        let result = CallToolResult::success(vec![ContentBlock::resource_link(
             notebook_cell_resource_link("nb 1", "cell/with/slash"),
         )]);
         let value = serde_json::to_value(&result).expect("serialize resource link");

--- a/crates/runt-mcp/src/session_activation.rs
+++ b/crates/runt-mcp/src/session_activation.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use tokio::sync::watch;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -348,7 +348,7 @@ pub fn activation_error(
             "target": target.as_str(),
         }
     });
-    let mut result = CallToolResult::error(vec![Content::text(details.to_string())]);
+    let mut result = CallToolResult::error(vec![ContentBlock::text(details.to_string())]);
     result.structured_content = Some(details);
     result
 }
@@ -384,7 +384,7 @@ mod tests {
     }
 
     fn success(value: &str) -> CallToolResult {
-        CallToolResult::success(vec![Content::text(value.to_string())])
+        CallToolResult::success(vec![ContentBlock::text(value.to_string())])
     }
 
     #[tokio::test]

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -404,7 +404,7 @@ fn cell_resource_success(
 ) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![
         crate::formatting::assistant_text(message),
-        Content::resource_link(crate::resources::notebook_cell_resource_link(
+        ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
             notebook_id,
             cell_id,
         )),
@@ -420,7 +420,7 @@ fn cell_resource_json_success(
         crate::formatting::assistant_text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         ),
-        Content::resource_link(crate::resources::notebook_cell_resource_link(
+        ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
             notebook_id,
             cell_id,
         )),
@@ -435,7 +435,7 @@ fn cells_resource_json_success(
         crate::formatting::assistant_text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         ),
-        Content::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
     ]))
 }
 

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use rmcp::ErrorData as McpError;
 use runtimed_outputs::output_resolver;
 use schemars::JsonSchema;
@@ -17,7 +17,7 @@ use super::{arg_bool, arg_str, assert_cell_exists, tool_error};
 fn cells_resource_result(message: String, notebook_id: &str) -> CallToolResult {
     CallToolResult::success(vec![
         formatting::assistant_text(message),
-        Content::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
     ])
 }
 
@@ -241,7 +241,7 @@ pub async fn run_all_cells(
     let comms = runtime_state.as_ref().map(|rs| &rs.comms);
     let mut content_items = vec![
         formatting::assistant_text(header.clone()),
-        rmcp::model::Content::resource_link(crate::resources::notebook_cells_resource_link(
+        rmcp::model::ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(
             handle.notebook_id(),
         )),
     ];

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Meta, Tool, ToolAnnotations};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ContentBlock, MetaObject, Tool, ToolAnnotations,
+};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -39,27 +41,27 @@ const OUTPUT_RESOURCE_URI: &str = "ui://nteract/output.html";
 
 /// Build `_meta` for tools that produce structured content for the MCP Apps widget.
 /// Wire format: `{ "ui": { "resourceUri": "ui://nteract/output.html" } }`
-fn app_tool_meta() -> Meta {
+fn app_tool_meta() -> MetaObject {
     let mut meta = serde_json::Map::new();
     meta.insert(
         "ui".to_string(),
         serde_json::json!({ "resourceUri": OUTPUT_RESOURCE_URI }),
     );
-    Meta(meta)
+    MetaObject(meta)
 }
 
 /// Build `_meta` that opts a tool out of deferred-tool lists in Claude clients.
 /// Claude Code / Desktop / Cowork defer all MCP tools by default; setting
 /// `"anthropic/alwaysLoad": true` makes the tool immediately available
 /// without requiring a ToolSearch round-trip.
-fn always_load_meta() -> Meta {
+fn always_load_meta() -> MetaObject {
     let mut meta = serde_json::Map::new();
     meta.insert("anthropic/alwaysLoad".to_string(), serde_json::json!(true));
-    Meta(meta)
+    MetaObject(meta)
 }
 
-fn cell_resource_content(notebook_id: &str, cell_id: &str) -> Content {
-    Content::resource_link(crate::resources::notebook_cell_resource_link(
+fn cell_resource_content(notebook_id: &str, cell_id: &str) -> ContentBlock {
+    ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
         notebook_id,
         cell_id,
     ))
@@ -783,6 +785,28 @@ mod tests {
     }
 
     #[test]
+    fn tool_descriptors_round_trip_app_and_discovery_metadata() {
+        for (name, expected_meta) in [
+            (
+                "execute_cell",
+                serde_json::json!({ "ui": { "resourceUri": OUTPUT_RESOURCE_URI } }),
+            ),
+            (
+                "connect_notebook",
+                serde_json::json!({ "anthropic/alwaysLoad": true }),
+            ),
+        ] {
+            let tool = registered_tool(name);
+            let wire = serde_json::to_value(&tool).expect("serialize tool descriptor");
+            assert_eq!(wire.get("_meta"), Some(&expected_meta));
+            assert!(wire.get("inputSchema").is_some());
+            assert!(wire.get("meta").is_none());
+            let decoded: Tool = serde_json::from_value(wire).expect("deserialize tool descriptor");
+            assert_eq!(decoded, tool);
+        }
+    }
+
+    #[test]
     fn registered_tools_advertise_mcp_icons() {
         for tool in all_tools() {
             assert_light_dark_icons(&tool);
@@ -971,7 +995,7 @@ mod tests {
         );
         assert!(value.get("mime_type").is_none());
 
-        let decoded: Content = serde_json::from_value(value).expect("deserialize content");
+        let decoded: ContentBlock = serde_json::from_value(value).expect("deserialize content");
         let link = decoded.as_resource_link().expect("resource link");
         assert_eq!(link.uri, expected_uri);
         assert_eq!(link.mime_type.as_deref(), Some("application/json"));
@@ -983,13 +1007,27 @@ mod tests {
         // annotation lets renderers drop it from human views.
         let ok = tool_success("done").unwrap();
         assert_eq!(
-            ok.content[0].audience(),
+            ok.content[0]
+                .as_text()
+                .unwrap()
+                .annotations
+                .as_ref()
+                .unwrap()
+                .audience
+                .as_ref(),
             Some(&vec![rmcp::model::Role::Assistant])
         );
 
         let err = tool_error("boom").unwrap();
         assert_eq!(
-            err.content[0].audience(),
+            err.content[0]
+                .as_text()
+                .unwrap()
+                .annotations
+                .as_ref()
+                .unwrap()
+                .audience
+                .as_ref(),
             Some(&vec![rmcp::model::Role::Assistant])
         );
     }
@@ -997,7 +1035,7 @@ mod tests {
     #[test]
     fn resource_links_stay_unannotated_for_both_audiences() {
         let content = cell_resource_content("nb", "cell");
-        assert!(content.annotations.is_none());
+        assert!(content.as_resource_link().unwrap().annotations.is_none());
     }
 
     #[test]

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -800,7 +800,7 @@ fn add_created_notebook_recovery(mut result: CallToolResult, notebook_id: &str) 
         "tool": "connect_notebook",
         "notebook_id": notebook_id,
     });
-    result.content = vec![Content::text(details.to_string())];
+    result.content = vec![ContentBlock::text(details.to_string())];
     result.structured_content = Some(details);
     result
 }
@@ -808,13 +808,13 @@ fn add_created_notebook_recovery(mut result: CallToolResult, notebook_id: &str) 
 fn notebook_session_response(mut response: serde_json::Value, notebook_id: &str) -> CallToolResult {
     response["resources"] = crate::resources::notebook_resources_json(notebook_id);
     CallToolResult::success(vec![
-        Content::text(serde_json::to_string_pretty(&response).unwrap_or_default()),
-        Content::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        ContentBlock::text(serde_json::to_string_pretty(&response).unwrap_or_default()),
+        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
     ])
 }
 
 fn notebook_json_response(response: serde_json::Value) -> CallToolResult {
-    CallToolResult::success(vec![Content::text(
+    CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string_pretty(&response).unwrap_or_default(),
     )])
 }

--- a/crates/runt-mcp/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp/tests/protocol_compatibility.rs
@@ -1,0 +1,283 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod support;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use runt_mcp::NteractMcp;
+use serde_json::json;
+use support::{
+    assert_initialize, assert_unsupported, legacy_result, modern_meta, modern_requests, Wire,
+};
+
+fn isolated_server() -> (tempfile::TempDir, Arc<NteractMcp>) {
+    let dir = tempfile::tempdir().expect("isolated MCP directory");
+    let server = NteractMcp::new_no_show(
+        dir.path().join("daemon.sock"),
+        None,
+        Some(dir.path().join("blobs")),
+    )
+    .with_execution_store_path(Some(dir.path().join("executions")));
+    (dir, Arc::new(server))
+}
+
+async fn legacy_wire(version: &str) {
+    let (_dir, server) = isolated_server();
+    let mut wire = Wire::start(server.clone());
+    let ping = wire.request(0, "ping", None).await;
+    assert_eq!(legacy_result(&ping), &json!({}));
+    assert_initialize(&wire.initialize(version).await, version, "nteract");
+
+    let response = wire.request(2, "tools/list", None).await;
+    let tools = legacy_result(&response)["tools"]
+        .as_array()
+        .expect("tool list");
+    assert!(tools.iter().any(|tool| tool["name"] == "create_notebook"));
+    assert!(!tools.iter().any(|tool| tool["name"] == "show_notebook"));
+    assert!(tools
+        .iter()
+        .all(|tool| tool["inputSchema"]["type"] == "object"));
+    assert!(server.session().read().await.is_none());
+    assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 0);
+
+    wire.initialized().await;
+    let response = wire.request(3, "resources/list", None).await;
+    let resources = legacy_result(&response)["resources"]
+        .as_array()
+        .expect("resource list");
+    assert!(resources
+        .iter()
+        .any(|resource| resource["uri"] == "ui://nteract/output.html"));
+    let response = wire.request(4, "resources/templates/list", None).await;
+    assert!(legacy_result(&response)["resourceTemplates"]
+        .as_array()
+        .is_some_and(|templates| !templates.is_empty()));
+
+    let response = wire
+        .request(
+            5,
+            "resources/read",
+            Some(json!({"uri": "ui://nteract/output.html"})),
+        )
+        .await;
+    let contents = legacy_result(&response)["contents"]
+        .as_array()
+        .expect("legacy resource contents");
+    assert_eq!(contents.len(), 1);
+    assert_eq!(contents[0]["uri"], "ui://nteract/output.html");
+    assert_eq!(contents[0]["mimeType"], "text/html;profile=mcp-app");
+    assert!(!contents[0]["text"].as_str().expect("HTML text").is_empty());
+    assert_eq!(contents[0]["_meta"]["ui"]["prefersBorder"], false);
+
+    let response = wire
+        .request(
+            6,
+            "tools/call",
+            Some(json!({"name": "disconnect_notebook", "arguments": {}})),
+        )
+        .await;
+    let result = legacy_result(&response);
+    assert_eq!(result["isError"], true);
+    assert_eq!(result["content"][0]["type"], "text");
+    assert!(result["content"][0]["text"]
+        .as_str()
+        .expect("tool error text")
+        .contains("No active session"));
+    assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 1);
+
+    let response = wire
+        .request(
+            7,
+            "resources/read",
+            Some(json!({"uri": "missing://compatibility"})),
+        )
+        .await;
+    assert_eq!(response["error"]["code"], -32002);
+    let response = wire
+        .request(
+            8,
+            "tools/call",
+            Some(json!({"name": "missing_compatibility_tool", "arguments": {}})),
+        )
+        .await;
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(
+        legacy_result(&wire.request(9, "ping", None).await),
+        &json!({})
+    );
+    assert!(server.session().read().await.is_none());
+    assert!(wire.finish().await);
+}
+
+macro_rules! legacy_test {
+    ($name:ident, $version:literal) => {
+        #[tokio::test]
+        async fn $name() {
+            legacy_wire($version).await;
+        }
+    };
+}
+
+legacy_test!(legacy_2024_11_05_newline_wire, "2024-11-05");
+legacy_test!(legacy_2025_03_26_newline_wire, "2025-03-26");
+legacy_test!(legacy_2025_06_18_newline_wire, "2025-06-18");
+legacy_test!(legacy_2025_11_25_newline_wire, "2025-11-25");
+
+async fn reject_modern_without_handshake(anonymous: bool) {
+    for version in ["2026-07-28", "2099-01-01"] {
+        for (method, mut params) in modern_requests() {
+            let (dir, server) = isolated_server();
+            let label = server.peer_label_shared().read().await.clone();
+            let operator = server.operator_shared().read().await.clone();
+            let mut wire = Wire::start(server.clone());
+            params["_meta"] = modern_meta(version, anonymous);
+            let response = wire.request(42, method, Some(params)).await;
+            assert_unsupported(&response, version);
+            assert!(server.session().read().await.is_none(), "{method}");
+            assert!(server.parked_sessions().read().await.is_empty(), "{method}");
+            assert!(
+                server.last_session_drop().read().await.is_none(),
+                "{method}"
+            );
+            assert_eq!(
+                server.session_intent_epoch().load(Ordering::Acquire),
+                0,
+                "{method}"
+            );
+            assert_eq!(*server.peer_label_shared().read().await, label, "{method}");
+            assert_eq!(*server.operator_shared().read().await, operator, "{method}");
+            assert_eq!(
+                std::fs::read_dir(dir.path())
+                    .expect("isolated directory")
+                    .count(),
+                0
+            );
+            assert!(wire.finish().await);
+        }
+    }
+}
+
+#[tokio::test]
+async fn modern_named_requests_rejected_without_handshake_or_notebook_side_effects() {
+    reject_modern_without_handshake(false).await;
+}
+
+#[tokio::test]
+async fn modern_anonymous_requests_rejected_without_handshake_or_notebook_side_effects() {
+    reject_modern_without_handshake(true).await;
+}
+
+#[tokio::test]
+async fn missing_modern_metadata_rejected_before_notebook_dispatch() {
+    for params in [
+        json!({"name": "disconnect_notebook", "arguments": {}}),
+        json!({"name": "disconnect_notebook", "arguments": {}, "_meta": {"io.modelcontextprotocol/protocolVersion": "2026-07-28"}}),
+        json!({"name": "disconnect_notebook", "arguments": {}, "_meta": {"protocolVersion": "2026-07-28", "clientCapabilities": {}}}),
+    ] {
+        let (_dir, server) = isolated_server();
+        let mut wire = Wire::start(server.clone());
+        let response = wire.request(1, "tools/call", Some(params)).await;
+        assert_eq!(response["error"]["code"], -32602);
+        assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 0);
+        assert!(server.session().read().await.is_none());
+        assert!(!wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn modern_metadata_cannot_upgrade_a_legacy_session() {
+    let (_dir, server) = isolated_server();
+    let mut wire = Wire::start(server.clone());
+    assert_initialize(
+        &wire.initialize("2025-11-25").await,
+        "2025-11-25",
+        "nteract",
+    );
+    wire.initialized().await;
+    let response = wire.request(2, "tools/call", Some(json!({
+        "name": "disconnect_notebook", "arguments": {}, "_meta": modern_meta("2026-07-28", true)
+    }))).await;
+    assert_unsupported(&response, "2026-07-28");
+    assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 0);
+    let response = wire.request(3, "tools/list", None).await;
+    assert!(legacy_result(&response)["tools"].is_array());
+    assert!(wire.finish().await);
+}
+
+#[tokio::test]
+async fn repeated_initialize_cannot_change_notebook_protocol_or_identity() {
+    for version in support::LEGACY_VERSIONS {
+        let (_dir, server) = isolated_server();
+        let mut wire = Wire::start(server.clone());
+        assert_initialize(&wire.initialize(version).await, version, "nteract");
+        support::assert_reinitialize_preserves_legacy_peer(&mut wire, version).await;
+        let response = wire
+            .request(
+                121,
+                "tools/call",
+                Some(json!({"name": "disconnect_notebook", "arguments": {}})),
+            )
+            .await;
+        assert_eq!(legacy_result(&response)["isError"], true);
+        assert_eq!(
+            *server.peer_label_shared().read().await,
+            "Compatibility Client"
+        );
+        assert!(server
+            .operator_shared()
+            .read()
+            .await
+            .starts_with("agent:compatibility-client:"));
+        assert!(wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn legacy_inline_metadata_cannot_bypass_notebook_handshake() {
+    for anonymous in [false, true] {
+        let (dir, server) = isolated_server();
+        let label = server.peer_label_shared().read().await.clone();
+        let operator = server.operator_shared().read().await.clone();
+        let mut wire = Wire::start(server.clone());
+        let response = wire
+            .request(
+                1,
+                "tools/list",
+                Some(json!({"_meta": modern_meta("2025-11-25", anonymous)})),
+            )
+            .await;
+        assert_eq!(response["error"]["code"], -32600);
+        wire.initialized().await;
+        for (index, (method, mut params)) in modern_requests().into_iter().enumerate() {
+            params["_meta"] = modern_meta("2025-11-25", anonymous);
+            let response = wire.request(index as u64 + 2, method, Some(params)).await;
+            assert!(response.get("error").is_some(), "{response}");
+            assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 0);
+            assert!(server.session().read().await.is_none());
+            assert!(server.parked_sessions().read().await.is_empty());
+            assert_eq!(*server.peer_label_shared().read().await, label);
+            assert_eq!(*server.operator_shared().read().await, operator);
+            assert_eq!(
+                std::fs::read_dir(dir.path())
+                    .expect("isolated directory")
+                    .count(),
+                0
+            );
+            assert!(wire.notifications.is_empty());
+        }
+        assert!(wire.finish().await);
+    }
+}
+
+#[tokio::test]
+async fn initialize_never_negotiates_a_modern_no_handshake_revision() {
+    for version in ["2026-07-28", "2099-01-01"] {
+        let (_dir, server) = isolated_server();
+        let mut wire = Wire::start(server);
+        assert_initialize(&wire.initialize(version).await, "2025-11-25", "nteract");
+        let response = wire.request(2, "tools/list", None).await;
+        assert!(legacy_result(&response)["tools"].is_array());
+        assert!(wire.finish().await);
+    }
+}

--- a/crates/runt-mcp/tests/support/mod.rs
+++ b/crates/runt-mcp/tests/support/mod.rs
@@ -1,0 +1,262 @@
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use rmcp::{ServerHandler, ServiceExt};
+use serde_json::{json, Value};
+use tokio::io::{
+    AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream, Lines, ReadHalf, WriteHalf,
+};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+pub const LEGACY_VERSIONS: [&str; 4] = ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
+pub const DEADLINE: Duration = Duration::from_secs(10);
+
+pub struct Wire {
+    reader: Lines<BufReader<ReadHalf<DuplexStream>>>,
+    writer: WriteHalf<DuplexStream>,
+    task: JoinHandle<Result<bool, String>>,
+    pub notifications: Vec<Value>,
+}
+
+impl Wire {
+    pub fn start<S: ServerHandler + Send + Sync + 'static>(handler: S) -> Self {
+        let (server, client) = tokio::io::duplex(64 * 1024);
+        let task = tokio::spawn(async move {
+            match handler.serve(server).await {
+                Ok(service) => service
+                    .waiting()
+                    .await
+                    .map(|_| true)
+                    .map_err(|e| e.to_string()),
+                Err(_) => Ok(false),
+            }
+        });
+        let (reader, writer) = tokio::io::split(client);
+        Self {
+            reader: BufReader::new(reader).lines(),
+            writer,
+            task,
+            notifications: Vec::new(),
+        }
+    }
+
+    pub async fn send(&mut self, message: Value) {
+        let mut bytes = serde_json::to_vec(&message).expect("serialize JSON-RPC message");
+        bytes.push(b'\n');
+        timeout(DEADLINE, self.writer.write_all(&bytes))
+            .await
+            .expect("wire write timed out")
+            .expect("write newline-delimited JSON");
+    }
+
+    pub async fn receive(&mut self) -> Value {
+        let line = timeout(DEADLINE, self.reader.next_line())
+            .await
+            .expect("wire response timed out")
+            .expect("read JSON-RPC line")
+            .expect("unexpected EOF before JSON-RPC response");
+        let message: Value = serde_json::from_str(&line).expect("response must be a JSON line");
+        assert_eq!(message["jsonrpc"], "2.0");
+        message
+    }
+
+    pub async fn request(&mut self, id: u64, method: &str, params: Option<Value>) -> Value {
+        let mut message = json!({"jsonrpc": "2.0", "id": id, "method": method});
+        if let Some(params) = params {
+            message["params"] = params;
+        }
+        self.send(message).await;
+        loop {
+            let response = self.receive().await;
+            if response.get("id").is_none() {
+                assert!(response["method"].is_string());
+                self.notifications.push(response);
+                continue;
+            }
+            assert_eq!(response["id"], id, "response IDs must be preserved");
+            assert_ne!(
+                response.get("result").is_some(),
+                response.get("error").is_some()
+            );
+            return response;
+        }
+    }
+
+    pub async fn initialize(&mut self, version: &str) -> Value {
+        self.request(
+            1,
+            "initialize",
+            Some(json!({
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {"name": "compatibility-client", "version": "1.0", "title": "Compatibility Client"}
+            })),
+        )
+        .await
+    }
+
+    pub async fn initialized(&mut self) {
+        self.send(json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+            .await;
+    }
+
+    pub async fn notification(&mut self, method: &str) {
+        timeout(DEADLINE, async {
+            loop {
+                if self
+                    .notifications
+                    .iter()
+                    .any(|message| message["method"] == method)
+                {
+                    return;
+                }
+                let message = self.receive().await;
+                assert!(
+                    message.get("id").is_none(),
+                    "unexpected response: {message}"
+                );
+                self.notifications.push(message);
+            }
+        })
+        .await
+        .expect("expected initialized notification did not arrive");
+    }
+
+    pub async fn finish(mut self) -> bool {
+        self.writer.shutdown().await.expect("close client writer");
+        timeout(DEADLINE, &mut self.task)
+            .await
+            .expect("server did not stop after EOF")
+            .expect("server task panicked")
+            .expect("server service failed")
+    }
+}
+
+impl Drop for Wire {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub async fn assert_reinitialize_preserves_legacy_peer(wire: &mut Wire, version: &str) {
+    let original = json!({
+        "protocolVersion": version,
+        "capabilities": {},
+        "clientInfo": {"name": "compatibility-client", "version": "1.0", "title": "Compatibility Client"}
+    });
+    let mut changes = Vec::new();
+    for new_version in [
+        "2026-07-28",
+        if version == "2024-11-05" {
+            "2025-11-25"
+        } else {
+            "2024-11-05"
+        },
+    ] {
+        let mut changed = original.clone();
+        changed["protocolVersion"] = json!(new_version);
+        changes.push(changed);
+    }
+    let mut changed = original.clone();
+    changed["clientInfo"]["name"] = json!("replacement-client");
+    changes.push(changed);
+    let mut changed = original.clone();
+    changed["clientInfo"]["title"] = json!("Replacement Client");
+    changes.push(changed);
+    let mut changed = original.clone();
+    changed["capabilities"] = json!({"roots": {"listChanged": true}});
+    changes.push(changed);
+    for (index, params) in changes.into_iter().enumerate() {
+        let id = 100 + index as u64 * 2;
+        let response = wire.request(id, "initialize", Some(params)).await;
+        assert_eq!(response["error"]["code"], -32600, "{response}");
+        let response = wire.request(id + 1, "tools/list", None).await;
+        assert!(legacy_result(&response)["tools"].is_array());
+    }
+    let response = wire.request(120, "initialize", Some(original)).await;
+    assert_eq!(legacy_result(&response)["protocolVersion"], version);
+}
+
+pub fn legacy_result(response: &Value) -> &Value {
+    assert!(
+        response.get("error").is_none(),
+        "unexpected error: {response}"
+    );
+    let result = response.get("result").expect("JSON-RPC result");
+    assert!(result.is_object());
+    for modern_field in ["resultType", "requestState", "inputRequests"] {
+        assert!(
+            result.get(modern_field).is_none(),
+            "modern field in legacy result: {response}"
+        );
+    }
+    result
+}
+
+pub fn assert_initialize(response: &Value, version: &str, server_name: &str) {
+    let result = legacy_result(response);
+    assert_eq!(result["protocolVersion"], version);
+    assert_eq!(result["serverInfo"]["name"], server_name);
+    assert!(result["serverInfo"]["version"].is_string());
+    assert!(result["capabilities"]["tools"].is_object());
+    assert!(result["capabilities"]["resources"].is_object());
+    assert_eq!(
+        result["capabilities"]["extensions"]["io.modelcontextprotocol/ui"],
+        json!({})
+    );
+    assert!(result["capabilities"].get("tasks").is_none());
+}
+
+pub fn modern_meta(version: &str, anonymous: bool) -> Value {
+    let mut meta = json!({
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientCapabilities": {}
+    });
+    if !anonymous {
+        meta["io.modelcontextprotocol/clientInfo"] =
+            json!({"name": "modern-client", "version": "3.2"});
+    }
+    meta
+}
+
+pub fn modern_requests() -> Vec<(&'static str, Value)> {
+    vec![
+        ("server/discover", json!({})),
+        ("tools/list", json!({})),
+        ("resources/list", json!({})),
+        ("resources/templates/list", json!({})),
+        ("resources/read", json!({"uri": "ui://nteract/output.html"})),
+        (
+            "tools/call",
+            json!({"name": "create_notebook", "arguments": {"ephemeral": true}}),
+        ),
+        (
+            "tools/call",
+            json!({"name": "disconnect_notebook", "arguments": {}}),
+        ),
+        ("tools/call", json!({"name": "reconnect", "arguments": {}})),
+        (
+            "subscriptions/listen",
+            json!({"notifications": {"toolsListChanged": true}}),
+        ),
+    ]
+}
+
+pub fn assert_unsupported(response: &Value, version: &str) {
+    assert!(
+        response.get("result").is_none(),
+        "modern request unexpectedly succeeded: {response}"
+    );
+    assert_eq!(response["error"]["code"], -32022, "{response}");
+    assert_eq!(response["error"]["data"]["requested"], version);
+    let mut supported: Vec<_> = response["error"]["data"]["supported"]
+        .as_array()
+        .expect("supported versions in error")
+        .iter()
+        .map(|value| value.as_str().expect("protocol version string"))
+        .collect();
+    supported.sort_unstable();
+    assert_eq!(supported, LEGACY_VERSIONS);
+}

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -756,6 +756,10 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
 
     let transport = rmcp::transport::io::stdio();
     let handle = server.serve(transport).await?;
+    if handle.peer().peer_info().is_none() {
+        handle.cancel().await?;
+        return Ok(());
+    }
 
     // Grab a cancellation token before `waiting()` moves ownership of `handle`.
     // Used to gracefully close the MCP transport on daemon upgrade so the

--- a/crates/runt/src/notebook_cli.rs
+++ b/crates/runt/src/notebook_cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand};
-use rmcp::model::{CallToolRequestParams, CallToolResult, RawContent, ResourceContents};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, ResourceContents};
 use serde_json::{Map, Value};
 
 #[derive(Subcommand)]
@@ -310,22 +310,23 @@ fn print_result(result: &CallToolResult, json: bool) -> Result<()> {
 
     let mut printed = false;
     for content in &result.content {
-        match &content.raw {
-            RawContent::Text(text) => {
+        match content {
+            ContentBlock::Text(text) => {
                 print_block(&text.text, &mut printed);
             }
-            RawContent::ResourceLink(resource) => {
+            ContentBlock::ResourceLink(resource) => {
                 print_block(&format!("Resource: {}", resource.uri), &mut printed);
             }
-            RawContent::Resource(resource) => match &resource.resource {
+            ContentBlock::Resource(resource) => match &resource.resource {
                 ResourceContents::TextResourceContents { uri, text, .. } => {
                     print_block(&format!("Resource: {uri}\n{text}"), &mut printed);
                 }
                 ResourceContents::BlobResourceContents { uri, .. } => {
                     print_block(&format!("Resource: {uri}"), &mut printed);
                 }
+                _ => print_block(&serde_json::to_string(&resource.resource)?, &mut printed),
             },
-            RawContent::Image(image) => {
+            ContentBlock::Image(image) => {
                 print_block(
                     &format!(
                         "[image {}: {} base64 bytes]",
@@ -335,7 +336,7 @@ fn print_result(result: &CallToolResult, json: bool) -> Result<()> {
                     &mut printed,
                 );
             }
-            RawContent::Audio(audio) => {
+            ContentBlock::Audio(audio) => {
                 print_block(
                     &format!(
                         "[audio {}: {} base64 bytes]",
@@ -345,6 +346,7 @@ fn print_result(result: &CallToolResult, json: bool) -> Result<()> {
                     &mut printed,
                 );
             }
+            _ => print_block(&serde_json::to_string(content)?, &mut printed),
         }
     }
 
@@ -371,19 +373,23 @@ fn print_block(text: &str, printed: &mut bool) {
 fn result_text(result: &CallToolResult) -> String {
     let mut parts = Vec::new();
     for content in &result.content {
-        match &content.raw {
-            RawContent::Text(text) => parts.push(text.text.clone()),
-            RawContent::ResourceLink(resource) => parts.push(format!("Resource: {}", resource.uri)),
-            RawContent::Resource(resource) => match &resource.resource {
+        match content {
+            ContentBlock::Text(text) => parts.push(text.text.clone()),
+            ContentBlock::ResourceLink(resource) => {
+                parts.push(format!("Resource: {}", resource.uri))
+            }
+            ContentBlock::Resource(resource) => match &resource.resource {
                 ResourceContents::TextResourceContents { uri, text, .. } => {
                     parts.push(format!("Resource: {uri}\n{text}"));
                 }
                 ResourceContents::BlobResourceContents { uri, .. } => {
                     parts.push(format!("Resource: {uri}"));
                 }
+                _ => parts.push(serde_json::to_string(&resource.resource).unwrap_or_default()),
             },
-            RawContent::Image(image) => parts.push(format!("[image {}]", image.mime_type)),
-            RawContent::Audio(audio) => parts.push(format!("[audio {}]", audio.mime_type)),
+            ContentBlock::Image(image) => parts.push(format!("[image {}]", image.mime_type)),
+            ContentBlock::Audio(audio) => parts.push(format!("[audio {}]", audio.mime_type)),
+            _ => parts.push(serde_json::to_string(content).unwrap_or_default()),
         }
     }
     parts.join("\n")
@@ -400,7 +406,7 @@ fn result_notebook_id(result: &CallToolResult) -> Option<String> {
     }
 
     for content in &result.content {
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             continue;
         };
         let Ok(value) = serde_json::from_str::<Value>(&text.text) else {
@@ -412,4 +418,49 @@ fn result_notebook_id(result: &CallToolResult) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_result_content_preserves_cli_text_and_notebook_identity() -> Result<()> {
+        let wire = serde_json::json!({
+            "content": [
+                { "type": "text", "text": "{\"notebook_id\":\"nb-1\"}",
+                  "annotations": { "audience": ["assistant"] } },
+                { "type": "resource_link", "uri": "nteract://notebooks/nb-1/cells",
+                  "name": "notebook cells", "mimeType": "application/json" },
+                { "type": "resource", "resource": {
+                    "uri": "nteract://notebooks/nb-1/cells/cell-1", "text": "cell snapshot" } },
+                { "type": "resource", "resource": {
+                    "uri": "nteract://blob/output", "blob": "AA==" } },
+                { "type": "image", "data": "AA==", "mimeType": "image/png" },
+                { "type": "audio", "data": "AA==", "mimeType": "audio/wav" }
+            ],
+            "isError": false
+        });
+        let result: CallToolResult = serde_json::from_value(wire.clone())?;
+        assert_eq!(result_notebook_id(&result).as_deref(), Some("nb-1"));
+        assert_eq!(
+            result_text(&result),
+            "{\"notebook_id\":\"nb-1\"}\nResource: nteract://notebooks/nb-1/cells\nResource: nteract://notebooks/nb-1/cells/cell-1\ncell snapshot\nResource: nteract://blob/output\n[image image/png]\n[audio audio/wav]"
+        );
+        assert_eq!(serde_json::to_value(result)?, wire);
+        Ok(())
+    }
+
+    #[test]
+    fn structured_notebook_identity_takes_precedence_over_text() {
+        let mut result = CallToolResult::success(vec![ContentBlock::text(
+            "{\"notebook_id\":\"text-notebook\"}",
+        )]);
+        result.structured_content =
+            Some(serde_json::json!({ "notebook_id": "structured-notebook" }));
+        assert_eq!(
+            result_notebook_id(&result).as_deref(),
+            Some("structured-notebook")
+        );
+    }
 }

--- a/crates/runt/tests/mcp_startup.rs
+++ b/crates/runt/tests/mcp_startup.rs
@@ -1,0 +1,119 @@
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::time::timeout;
+
+#[tokio::test]
+async fn rejected_first_request_does_not_start_notebook_recovery() {
+    for (method, version, expected_code) in [
+        ("tools/list", "2026-07-28", -32022),
+        ("tools/list", "2025-11-25", -32600),
+        ("server/discover", "2025-11-25", -32601),
+    ] {
+        let dir = tempfile::tempdir().expect("isolated runt MCP directory");
+        let notebook = dir.path().join("rejoin.ipynb");
+        let source = r#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+        std::fs::write(&notebook, source).expect("write rejoin fixture");
+        let socket = dir.path().join("s");
+        let listener = tokio::net::UnixListener::bind(&socket).expect("bind isolated daemon probe");
+        let (connections, mut observed) = tokio::sync::mpsc::unbounded_channel();
+        let probe = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                if connections.send(()).is_err() {
+                    break;
+                }
+                drop(stream);
+            }
+        });
+        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_runt"))
+            .arg("mcp")
+            .env_clear()
+            .env("HOME", dir.path())
+            .env("USERPROFILE", dir.path())
+            .env("XDG_CONFIG_HOME", dir.path().join("config"))
+            .env("XDG_CACHE_HOME", dir.path().join("cache"))
+            .env("XDG_DATA_HOME", dir.path().join("data"))
+            .env("RUNTIMED_DEV", "1")
+            .env("RUNTIMED_WORKSPACE_PATH", dir.path())
+            .env("RUNTIMED_SOCKET_PATH", &socket)
+            .env("NTERACT_MCP_REJOIN_NOTEBOOK", &notebook)
+            .current_dir(dir.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn actual runt mcp entrypoint");
+        let mut stdin = child.stdin.take().expect("child stdin");
+        let mut stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+        stdin
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"ping\"}\n")
+            .await
+            .expect("write pre-init ping");
+        let mut ping = String::new();
+        timeout(Duration::from_secs(10), stdout.read_line(&mut ping))
+            .await
+            .expect("ping timed out")
+            .expect("read ping response");
+        assert_eq!(
+            serde_json::from_str::<Value>(&ping).expect("ping JSON")["result"],
+            json!({})
+        );
+        let mut startup_queries = 0;
+        while observed.try_recv().is_ok() {
+            startup_queries += 1;
+        }
+        assert_eq!(
+            startup_queries, 2,
+            "blob metadata and daemon version queries"
+        );
+        let request = json!({
+            "jsonrpc": "2.0", "id": 1, "method": method,
+            "params": {"_meta": {
+                "io.modelcontextprotocol/protocolVersion": version,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }}
+        });
+        let mut encoded = serde_json::to_vec(&request).expect("encode request");
+        encoded.push(b'\n');
+        stdin
+            .write_all(&encoded)
+            .await
+            .expect("write first application request");
+        let mut response = String::new();
+        timeout(Duration::from_secs(10), stdout.read_line(&mut response))
+            .await
+            .expect("first response timed out")
+            .expect("read first response");
+        let response: Value = serde_json::from_str(&response).expect("JSON-RPC error response");
+        assert_eq!(response["id"], 1);
+        assert_eq!(response["error"]["code"], expected_code, "{response}");
+        assert!(response.get("result").is_none());
+        assert!(
+            timeout(Duration::from_millis(500), observed.recv())
+                .await
+                .is_err(),
+            "rejected request started daemon recovery traffic"
+        );
+        stdin.shutdown().await.expect("close client stdin");
+        drop(stdin);
+        let status = timeout(Duration::from_secs(10), child.wait())
+            .await
+            .expect("uninitialized runt mcp did not stop after EOF")
+            .expect("reap runt mcp");
+        assert!(status.success(), "{status}");
+        let mut remaining = String::new();
+        assert_eq!(stdout.read_line(&mut remaining).await.expect("read EOF"), 0);
+        assert_eq!(
+            std::fs::read_to_string(&notebook).expect("rejoin fixture remains"),
+            source
+        );
+        probe.abort();
+        let _ = probe.await;
+    }
+}

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -674,7 +674,15 @@ async def smoke(
     opencode_model: str | None,
     opencode_timeout_secs: float,
 ) -> None:
-    params = StdioServerParameters(command=str(runt_exe), args=["mcp"])
+    params = StdioServerParameters(
+        command=str(runt_exe),
+        args=["mcp"],
+        env={
+            key: os.environ[key]
+            for key in ("RUNTIMED_DEV", "RUNTIMED_WORKSPACE_PATH", "RUNTIMED_SOCKET_PATH")
+            if key in os.environ
+        },
+    )
 
     async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
         await session.initialize()


### PR DESCRIPTION
## Summary

Upgrade the production rmcp SDK and macros from locked 1.5.0 to 3.2.0 while deliberately retaining the legacy initialization lifecycle. This is the SDK-only first step, not native MCP 2026 support or an HTTP/embedding redesign.

- Explicitly support `2024-11-05`, `2025-03-26`, `2025-06-18`, and `2025-11-25` in the notebook server, standalone proxy, and development supervisor.
- Reject discovery and application requests without an initialize exchange. A protocol allowlist alone is insufficient: rmcp 3.2 permits inline metadata selecting a legacy revision. Also ignore an initialized notification from a peer with no handshake.
- Preserve the negotiated protocol, client identity, and capabilities on repeated initialize requests; reject attempts to replace them. Do not start child recovery or telemetry for an uninitialized connection.
- Keep the child hop on legacy initialization with an explicit `2025-11-25` version and its own empty client capabilities. Disable the SDK response cache so the proxy retains cache/restart ownership.
- Migrate content, resources, metadata, and completed-response boundaries without changing notebook targeting, session parking, synced-cell execution, tool schemas, MCP Apps metadata, or generated tool caches. Reject non-final child responses rather than introducing MRTR handling.
- Add raw newline JSON-RPC coverage, pinned rmcp 1.5 client/child fixtures, restart-stable attribution checks, and metadata/content serialization regressions. Existing raw 2024 harnesses remain unchanged.
- Forward explicit daemon-routing environment variables in the Python smoke client, allowing the independent `mcp>=1.0,<2` check to target an isolated worktree daemon.

Automerge and its historical compatibility test dependency are unchanged. The concurrent documentation audit is not included.

## Verification

Passed in the isolated implementation worktree:

- `cargo xtask artifacts ensure all`
- `cargo check --locked --all-targets -p runt-mcp -p runt-mcp-proxy -p nteract-mcp -p mcp-supervisor -p runt`
- `cargo test --locked -p runt-mcp -p runt-mcp-proxy -p nteract-mcp -p mcp-supervisor -p runt`: **440 passed**, including 25 compatibility-suite tests and an actual `runt mcp` startup/recovery regression test on Unix
- `cargo clippy --locked --all-targets -p runt-mcp -p runt-mcp-proxy -p nteract-mcp -p mcp-supervisor -p runt -- -D warnings`
- `cargo test --locked -p runtimed --test tokio_mutex_lint`: **2 passed**
- `cargo xtask sync-tool-cache --check`: unchanged, 23 tools / 1452 description bytes
- `python3 scripts/mcp-connect-harness.py --self-test`: **19 passed**
- `cargo xtask lint --fix`
- Raw-client progressive suite: 64-cell fixture, 3 samples, 2 concurrent connects; target switching, degraded source, and stalled-peer gating passed
- Python `mcp>=1.0,<2` smoke: basic execution and Polars passes succeeded against the worktree daemon
- `pnpm --filter notebook-ui test:e2e:browser execute-cell-output.spec.ts`: Chromium test passed with a clean command exit using separately managed worktree Vite. An earlier run passed the test but hung in the wrapper's Vite shutdown; no unrelated runner code was changed.

Additional manual version-skew validation used the **actual historical proxy implementation** at `6bff3e7b0a6e27b89c9ee3e700c6e7ffd6100885`, with rmcp/macros 1.5.0, in a separate temporary Cargo project. It negotiated each of the four legacy upstream versions, listed tools/resources, ran `print(1+1)` through the new child with exact output `2`, read the UI resource, disconnected, and left no child processes. This manual check uses compatible freshly resolved transitive dependencies rather than the entire historical lockfile and is not an installed-artifact or restart test. It is kept out of workspace dependencies to avoid making `cargo -p runt-mcp-proxy` ambiguous.

No installed desktop daemon or GUI was used. No live hosted/on-prem deployment matrix was run.

## Native 2026 follow-up: clients and actors

Old clients can remain supported alongside native 2026 clients. Their attribution sources differ:

- Legacy clients provide `clientInfo` during initialize. Native clients can provide it in request metadata through `RequestContext::client_info()`; it is optional, so anonymous clients must remain usable.
- Preserve one logical owner per stdio connection, the existing proxy-stable operator-session seed, and the separation between friendly presence labels and durable actor identifiers. Client name/title are self-reported attribution, not authentication; the daemon's principal remains authoritative.
- Resolve that owner before spawning/rejoining the child, using a shared single-flight startup gate. Native first requests run before `.serve()` returns and never send `notifications/initialized`, so launcher post-serve setup cannot be the native startup path. Discovery must not attach a notebook.
- Keep downstream capabilities distinct. Add modern result normalization, zero-TTL private list/read responses, and cancellable list-change subscriptions before advertising `2026-07-28`. Defer MRTR/Tasks, HTTP hosting, and independent-client multiplexing.

These are follow-up design directions, not behavior enabled by this PR.
