### PR TITLE
docs(agents): use conversational language in guidance

### DIFF
--- a/.agents/reviewers/nteract-code-review-rubric.md
+++ b/.agents/reviewers/nteract-code-review-rubric.md
@@ -5,10 +5,10 @@ passes. It is reviewer guidance, not general implementation guidance.
 
 ## Operating Mode
 
-Review as a senior nteract code reviewer. Stay read-only. Inspect the diff
-first, then the nearest owning code, tests, `AGENTS.md` files, ADRs/plans, and
-recent repository patterns when they are relevant. Be terse, adversarial, and
-evidence-backed.
+Stay read-only. Inspect the diff first, then the nearest owning code, tests,
+`AGENTS.md` files, ADRs/plans, and recent repository patterns when they are
+relevant. Challenge assumptions and check claims against the implementation.
+Explain each finding with enough evidence for the author to assess and fix it.
 
 Primary goals:
 
@@ -60,11 +60,11 @@ Prefer at most 12 findings.
 - Tests: require focused tests at the changed boundary. Treat deleted tests as
   suspicious unless the behavior was removed and replacement coverage exists.
 - Comment and doc claims: module headers and doc comments state what is true
-  now. Flag past-tense history narration AND speculative future-consumer
+  now. Flag past-tense history narration and speculative future-consumer
   claims - naming hosts, surfaces, or integrations that do not consume the
-  module. Claims about other subsystems deserve extra suspicion because the
-  diff cannot verify them (example: the MCP surface is Rust by design, so TS
-  store docs must never list it as a consumer). Carried-forward prose in a
+  module. Verify claims about other subsystems against their actual consumers
+  rather than relying on the diff (example: the MCP surface is Rust by design,
+  so TS store docs must never list it as a consumer). Carried-forward prose in a
   touched header is in scope, not grandfathered.
 
 ## Finding Contract

--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -232,7 +232,8 @@ work:
 | Batch→Incremental | Bloom filter exchange → live sync frames | Fingerprint reconciliation → subscription push | Same as raw automerge |
 | Testability | Async, needs mocks | Pure sans-IO functions | Async select! loop |
 
-**nteract's `required_heads` is novel:** request-scoped causal gating where the daemon defers one request until preconditions are met while sync continues unblocked. Neither automerge-repo nor samod gates actions on causal preconditions this way.
+nteract implements `required_heads` in its daemon: it defers one request until
+its causal preconditions are met while sync continues unblocked.
 
 ### Settings Sync
 

--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: daemon-dev
 description: >
-  Develop, debug, and manage the runtimed daemon, Python bindings, build system,
-  and Python bindings. Use when working on daemon code, kernel issues,
+  Develop, debug, and manage the runtimed daemon, Python bindings, and build
+  system. Use when working on daemon code, kernel issues,
   maturin builds, or xtask workflows.
 ---
 

--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -214,54 +214,56 @@ in a module-level `ObservableStore` singleton, follow Decision 8
 (`docs/adr/frontend-sync-bridge.md`). The store outlives every component, so
 each async completion is a stale-write risk:
 
-- **Domain hooks are the API; the binding is plumbing.** Components import
+- **Components consume named domain hooks.** Components import
   `useCloudAuthState`/`useHostedCatalogAuth`/`useCloudWorkstationsRegistry`, never
   `store.select(...)` inline in a render body and never
-  `observable-binding.ts` directly. One binding, shared desktop and cloud.
-- **Singletons for lifetime, context for consumption.** The store stays a module
-  singleton (boot, drivers, instant-paint snapshot reads), but each domain hook
+  `observable-binding.ts` directly. Desktop and cloud share one binding.
+- **Resolve store instances through context.** The store stays a module
+  singleton for boot, drivers, and initial snapshot reads, but each domain hook
   resolves its instance from `useCloudStores()` (`cloud-stores-context.ts`),
-  whose default is the singleton bundle. Production mounts no provider, so it is
-  byte-identical; a test or Elements fixture mounts `CloudStoresProvider` with
-  its own instances and the subtree reads those. The provider overrides
+  whose default is the singleton bundle. Production mounts no provider and uses
+  those same instances; a test or Elements fixture mounts `CloudStoresProvider`
+  with its own instances and the subtree reads those. The provider overrides
   consumption, never activation - its owner activates the instances it supplies.
   A controller that dispatches actions on the same store reads it from the same
   context too, so an override gets a coherent store.
-- **Capture at issue, drop at apply for every completion.** Poll ticks AND
+- **Check request identity after every await.** Poll ticks and
   imperative actions capture `{epoch, auth reference, endpoint}` when the
   request starts; after every `await` (success, error, and any follow-up
-  refetch), the result is discarded if the identity moved. A guarded first
-  await followed by an unguarded second await is the recurring hole.
-- **Invalidation covers bookkeeping, not just visible state.** `dispose`,
+  refetch), discard the result if the identity changed. Checking only the
+  first await leaves later completions able to write stale state.
+- **Invalidate pending work and clear its indicators.** `dispose`,
   `reset`, and a signed-out closed gate bump the activation epoch so captured
-  issues die with them (a transient `loading` gate is a recoverable dip and
+  requests become stale (a transient `loading` gate is recoverable and
   keeps in-flight work alive); a dropped completion also clears any indicator
   it wrote (by object-reference ownership, so it can never clobber a newer
   identity's own state).
-- **After-settle loops re-arm on settle, never on emission.** A self-scheduling
+- **Restart after-settle polls on completion.** A self-scheduling
   poll re-arms via `repeat()` on completion, so a swallowed inner rejection
   cannot kill the loop. Keep `catchError` on the inner fetch.
-- **One in-flight guard, one `exhaustMap`.** Fixed-rate triggers that must
+- **Route fixed-rate triggers through one `exhaustMap`.** Triggers that must
   not overlap (interval tick, visibility rise, manual wakeup) feed a single
   `exhaustMap`; do not give each trigger its own guard. After-settle stores
   instead serialize manual refresh and mutation refetches through a dedicated
-  `concatMap` action stream off the poll loop, so the coupling stays ordered
-  and the cadence unperturbed.
+  `concatMap` action stream outside the poll loop, preserving action order
+  and polling cadence.
 - **Inject every clock.** `scheduler`, `now`, and the network operations are
   `activate(deps)` arguments, so tests run entirely on virtual time and the
-  suite proves cadence, gates, aborts, and stale drops deterministically.
-- **Named comparators with the manifest tripwire.** `distinctUntilChanged`
+  suite checks cadence, gates, aborts, and discarded stale results
+  deterministically.
+- **List every field in the comparator's manifest.** `distinctUntilChanged`
   uses a named `fooEquals(a, b)` with a colocated
   `satisfies Record<keyof T, true>` manifest. The manifest forces every key to
   be *listed* when the type grows; it does not prove every key is *compared* -
   treat a break as a prompt to revisit the comparator body, not proof of
   correctness. A projection that allocates an array or object each tick needs
   a structural comparator (length plus per-element identity/fields); a
-  reference check on a re-allocated value dedups nothing. The manifest break
-  surfaces as a tsc error (`pnpm --dir apps/notebook-cloud typecheck`); the
+  reference check on a newly allocated value deduplicates nothing. A missing
+  manifest key surfaces as a tsc error (`pnpm --dir apps/notebook-cloud typecheck`); the
   node test script alone will not catch it.
-- **`loaded$` gates readiness, not state.** The state subject emits its seeded
-  default before the gate opens (state emits first, then the gate); a consumer
+- **Read `loaded$` to distinguish loading from loaded empty state.** The state
+  subject emits its seeded default before the gate opens (state emits first,
+  then the gate); a consumer
   that must tell "loading" from "loaded empty" reads `loaded$`, never infers
   from an empty snapshot.
 

--- a/.agents/skills/nteract-diagnostics/SKILL.md
+++ b/.agents/skills/nteract-diagnostics/SKILL.md
@@ -82,13 +82,19 @@ date -u -d "@$(jq -r '.[0].results[0].created_at' upload-row.json)"
 date -u -d "@$(jq -r '.[0].results[0].uploaded_at' upload-row.json)"
 ```
 
-## Report Shape
+## Reporting the diagnosis
 
-Return:
+Keep `upload-row.json` and `entries.txt` with the investigation artifacts so
+the upload metadata (excluding the token) and complete archive inventory remain
+available. In the reply, explain the likely cause with short evidence snippets
+and file references. Include metadata and archive entries that help assess the
+incident, and link the saved artifacts when useful. If the archive does not
+cover the reported time window, say what is missing and which check comes next.
 
-- Upload metadata from `upload-row.json`, excluding the token.
-- Archive entries from `entries.txt`.
-- Likely cause, with short evidence snippets and file references.
-- Missing evidence or the next check if the archive does not cover the reported time window.
+For example, when logs start after the incident:
+
+> The daemon was healthy when these logs were captured, but `runtimed.log`
+> starts after the reported freeze. This archive can't establish its cause.
+> The next check is the rotated `runtimed.log.1` from that time window.
 
 Do not overfit to the first scary error. Check whether the daemon was healthy at capture time, whether the logs include the reported timestamp, and whether later user messages make an earlier error a red herring.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -48,11 +48,16 @@ For CRDT/doc changes: `create_notebook` → `create_cell` → `get_cell` (verify
 
 For kernel-env changes: `up rebuild=true` → `create_notebook` → execute `import sys; print(sys.executable)` → verify Python path.
 
-### Confidence Levels
+### Reporting verification
 
-- **HIGH**: Narrow tests passed AND MCP live verification passed
-- **MEDIUM**: Narrow tests passed, MCP verification skipped
-- **LOW**: Only compilation checked
+State which checks ran and what they established. Distinguish compilation,
+narrow tests, and MCP live verification; name skipped or blocked checks and
+the behavior they leave unverified.
+
+For example, after narrow tests pass but a live check is unavailable:
+
+> The daemon tests passed. I couldn't run the MCP check because nteract-dev
+> wasn't available, so live cell execution is still unverified.
 
 Always run `cargo xtask lint --fix` before committing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 <!-- This file is canonical. CLAUDE.md is a symlink to AGENTS.md. -->
 
+## Communication
+
+Write like you're talking with a colleague you know. Use everyday language and
+precise technical terms where they help. Contractions, humor, and a little
+informality are welcome when they fit. Give the explanation enough room to make
+sense. Let the conversation determine the structure, and use the user's examples
+as guidance rather than a script.
+
+Keep shared writing guidance here; subsystem instructions should add only what
+their task needs. Templates for saved technical records and structured tool
+outputs retain their required fields. Chat replies should fit the question,
+with evidence and limitations that matter to the answer.
+
 ## Start here
 
 - Confirm the worktree, branch, and existing diff before editing.

--- a/packages/runtimed/AGENTS.md
+++ b/packages/runtimed/AGENTS.md
@@ -11,21 +11,21 @@ projections). Mechanism only - no React and no
 
 ## Invariants
 
-- **`ObservableStore` emission order is load-bearing.** `setState` emits state
+- **Preserve `ObservableStore` emission order.** `setState` emits state
   before the `loaded$` gate; `resetState` flips the gate false before the
   default state lands. A subscriber combining the two must never see
   `loaded=true` alongside a not-yet-applied state.
 - **`createPoll` after-settle re-arms on completion (`repeat`), never on
   emission.** A rejected fetch is swallowed to `EMPTY` and emits nothing; if
   re-arm depended on emission, one transient error would kill the loop.
-- **`createPoll` fixed-rate funnels every trigger through ONE `exhaustMap`.**
+- **`createPoll` fixed-rate funnels every trigger through one `exhaustMap`.**
   Interval tick, gate rise, and wakeups share a single in-flight guard; a
   trigger landing mid-fetch is dropped, never a concurrent request.
-- **`interval$` is the teardown lever.** A new cadence (or `null`) tears down
+- **Use `interval$` to change or stop polling.** A new cadence (or `null`) tears down
   the running loop and aborts the in-flight fetch via `finalize`. Model dynamic
   cadence policy as this stream; do not add a second stop mechanism.
 - **Every timer takes an injectable `SchedulerLike`.** New pipelines here must
-  be virtual-time-total; tests never sleep on the wall clock.
+  run entirely on virtual time in tests; tests never sleep on the wall clock.
 - **Comparators are named and manifest-backed.** `distinctUntilChanged` uses
   named field-by-field `fooEquals` functions carrying a colocated
   `satisfies Record<keyof T, true>` manifest (keys listed, not proven
@@ -33,6 +33,6 @@ projections). Mechanism only - no React and no
 - **The barrel uses explicit re-exports.** A new export must be added to
   `src/index.ts` or the `pnpm --dir apps/notebook build` tsc gate fails.
 
-Decision record: `docs/adr/frontend-sync-bridge.md` Decision 8. How-to depth:
-frontend-dev skill, "Module-Singleton Source Stores". Rust daemon guidance is
-separate: `crates/runtimed/AGENTS.md`.
+Decision record: `docs/adr/frontend-sync-bridge.md` Decision 8. See the
+frontend-dev skill's "Module-Singleton Source Stores" section for implementation
+guidance and `crates/runtimed/AGENTS.md` for Rust daemon guidance.

--- a/src/components/notebook/AGENTS.md
+++ b/src/components/notebook/AGENTS.md
@@ -1,10 +1,10 @@
 # Notebook state stores
 
 Scope: `src/components/notebook/state/**` - the shared store layer between
-WASM/host sources and notebook UI. Two store idioms live here; the boundary is
-a Decision 8 call, not an accident (`docs/adr/frontend-sync-bridge.md`).
+WASM/host sources and notebook UI. Decision 8 in
+`docs/adr/frontend-sync-bridge.md` defines when to use each store pattern.
 
-## Two store idioms
+## Choosing a store pattern
 
 - **Hand-rolled `Map`/`Set` pub/sub** (`cell-store.ts`, `execution-store.ts`,
   `output-store.ts`, `rail-ui-state.ts`, ...): synchronous per-entity fan-out
@@ -15,7 +15,7 @@ a Decision 8 call, not an accident (`docs/adr/frontend-sync-bridge.md`).
   `AbortController`. `runtime-state-store.ts` in `packages/runtimed` extends
   `ObservableStore` (frontend-sync-bridge Decision 8).
 
-## Binding is plumbing
+## React binding
 
 - `observable-binding.ts` is the single tearing-safe `useSyncExternalStore`
   binding, shared by desktop and cloud store-hook modules. Its file header is
@@ -24,5 +24,5 @@ a Decision 8 call, not an accident (`docs/adr/frontend-sync-bridge.md`).
   (`useRuntimeState`, `useCloudAuthState`, ...). Inline `select()` creates a
   fresh Observable per render and defeats the binding cache.
 - Reset/reconnect paths invalidate stale async writes by epoch, not just
-  visible state. How-to depth: frontend-dev skill, "Module-Singleton Source
-  Stores".
+  visible state. See the frontend-dev skill's "Module-Singleton Source Stores"
+  section for implementation guidance.


### PR DESCRIPTION
Agent guidance currently asks reviewers to be “terse, adversarial,” requires diagnostics replies to reproduce complete archive inventories, and reports test confidence with HIGH/MEDIUM/LOW labels. Put the agreed conversational writing guidance in the root `AGENTS.md`, then make subsystem reporting describe the evidence and uncertainty the reader needs. Saved records and structured tool outputs keep their required fields.

Replace several store-guidance slogans with concrete instructions, remove an unsupported claim of Automerge protocol novelty, and fix a duplicated skill-description phrase. Diagnostics and verification examples demonstrate ordinary prose. Technical commands, code examples, schemas, ownership rules, authorization boundaries, and review/testing requirements are preserved. This changes nine Markdown files and makes no measured claim about model behavior.

Validation on `e5d82ffbc`: `cargo xtask lint --fix`; changed-path docs/link checks (9 files); skill validation (5 skills); `git diff --check`; unchanged fenced code and preserved inline technical literals; verified canonical instruction symlinks. Rebased onto current main while retaining the recent prose cleanup and technical documentation audit.

Kilo review completed on the final commit with Claude Sonnet 4.6 (correctness) and Gemini 3.8 Flash (maintainability); both source-integrity checks passed. No actionable findings remained after independent verification. The correctness suggestions concerned normal Markdown soft wrapping, restoring an unverified third-party novelty claim, and hypothetical weighting of bullets versus prose. The mechanism and nteract ownership remain explicit; token secrecy and saved diagnostic evidence remain required. Reviewer-allowlist restrictions blocked some diagnostic commands; the independent local checks above passed.

[CI passed](https://github.com/nteract/nteract/actions/runs/34085266848) on the same commit: Docs & Agent Guidance, Lint & Format, JS Tests & Benchmarks, Browser E2E, shared UI build, Linux Rust Tests, and Linux Rust Clippy. Other platform/package lanes were skipped by the workflow.
