### PR TITLE
fix(mcp): avoid replaying mutations after response loss

### DIFF
--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -654,37 +654,60 @@ impl McpProxy {
         });
     }
 
-    /// Forward a tool call to the child, restarting if the child has disconnected.
+    /// Forward a tool call, recovering a disconnected child without replaying
+    /// mutations whose outcome may have been lost with the response.
     ///
     /// Prepends any pending reconnection message to the result.
     pub async fn forward_tool_call(
         &self,
         params: CallToolRequestParams,
     ) -> Result<CallToolResult, McpError> {
+        // Record release intent before sending: a lost disconnect reply must
+        // not cause the replacement child to rejoin the notebook just released.
+        if params.name.as_ref() == "disconnect_notebook" {
+            self.clear_disconnect_handoff(&params).await;
+        }
         // First attempt
-        match self.try_forward_tool_call(&params).await {
+        let failure = match self.try_forward_tool_call(&params).await {
             Ok(mut result) => {
                 self.track_session(&params, &result).await;
                 self.prepend_reconnection_message(&mut result).await;
                 return Ok(result);
             }
-            Err(e) => {
-                let state = self.state.read().await;
-                let child_alive = state
+            Err(failure) => {
+                if !failure.transport_closed {
+                    if failure.may_have_run && !tool_can_be_replayed(&params.name) {
+                        return Ok(unknown_tool_outcome(&params.name, &failure, None));
+                    }
+                    return Err(failure.error);
+                }
+                failure
+            }
+        };
+
+        // Judge the transport used for this call, not a replacement that a
+        // background monitor may already have installed. Do not restart that
+        // healthy replacement merely because the old call failed.
+        let replacement_ready = {
+            let state = self.state.read().await;
+            failure.generation != Some(state.child_generation)
+                && state
                     .child_client
                     .as_ref()
-                    .is_some_and(|c| !c.is_transport_closed());
-                drop(state);
-                if child_alive {
-                    warn!("Tool call failed but child still connected, not restarting: {e}");
-                    return Err(e);
-                }
-                warn!("Tool call failed and child transport closed, attempting restart: {e}");
-            }
+                    .is_some_and(|c| !c.is_transport_closed())
+        };
+        let recovery = if replacement_ready {
+            Ok(())
+        } else {
+            self.restart_child().await
+        };
+
+        if failure.may_have_run && !tool_can_be_replayed(&params.name) {
+            return Ok(unknown_tool_outcome(&params.name, &failure, recovery.err()));
         }
 
-        // Child is gone — restart and retry once
-        if let Err(e) = self.restart_child().await {
+        // No request was dispatched, or the operation is explicitly read-only.
+        if let Err(e) = recovery {
             return Err(McpError::internal_error(
                 format!("Child restart failed: {e}"),
                 None,
@@ -708,7 +731,13 @@ impl McpProxy {
         }
 
         // Second attempt after restart
-        let mut result = self.try_forward_tool_call(&params).await?;
+        let mut result = match self.try_forward_tool_call(&params).await {
+            Ok(result) => result,
+            Err(failure) if failure.may_have_run && !tool_can_be_replayed(&params.name) => {
+                return Ok(unknown_tool_outcome(&params.name, &failure, None));
+            }
+            Err(failure) => return Err(failure.error),
+        };
         self.track_session(&params, &result).await;
         self.prepend_reconnection_message(&mut result).await;
         Ok(result)
@@ -917,17 +946,52 @@ impl McpProxy {
     async fn try_forward_tool_call(
         &self,
         params: &CallToolRequestParams,
-    ) -> Result<CallToolResult, McpError> {
-        let snapshot = self.child_peer_snapshot().await?;
+    ) -> Result<CallToolResult, ForwardToolFailure> {
+        let snapshot = self
+            .child_peer_snapshot()
+            .await
+            .map_err(|error| ForwardToolFailure {
+                error,
+                generation: None,
+                transport_closed: true,
+                may_have_run: false,
+            })?;
         let generation = snapshot.generation;
+        if snapshot.peer.is_transport_closed() {
+            return Err(ForwardToolFailure {
+                error: McpError::internal_error("Child transport was closed before dispatch", None),
+                generation: Some(generation),
+                transport_closed: true,
+                may_have_run: false,
+            });
+        }
         let start = Instant::now();
 
-        let result = snapshot
-            .peer
-            .call_tool_once(params.clone())
-            .await
-            .map_err(|e| McpError::internal_error(format!("Child tool call failed: {e}"), None))
-            .and_then(complete_tool_response);
+        let result = match snapshot.peer.call_tool_once(params.clone()).await {
+            Ok(response) => complete_tool_response(response).map_err(|error| ForwardToolFailure {
+                error,
+                generation: Some(generation),
+                transport_closed: false,
+                may_have_run: true,
+            }),
+            Err(rmcp::service::ServiceError::McpError(error)) => Err(ForwardToolFailure {
+                error,
+                generation: Some(generation),
+                transport_closed: false,
+                may_have_run: false,
+            }),
+            Err(error) => Err(ForwardToolFailure {
+                transport_closed: snapshot.peer.is_transport_closed()
+                    || matches!(
+                        error,
+                        rmcp::service::ServiceError::TransportClosed
+                            | rmcp::service::ServiceError::TransportSend(_)
+                    ),
+                error: McpError::internal_error(format!("Child tool call failed: {error}"), None),
+                generation: Some(generation),
+                may_have_run: true,
+            }),
+        };
         self.log_child_call_if_slow(
             "call_tool",
             Some(params.name.as_ref()),
@@ -962,22 +1026,26 @@ impl McpProxy {
         result
     }
 
+    async fn clear_disconnect_handoff(&self, params: &CallToolRequestParams) {
+        let requested_id = params
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("notebook_id"))
+            .and_then(serde_json::Value::as_str);
+        let mut state = self.state.write().await;
+        let disconnected_active = requested_id.is_none()
+            || requested_id == state.last_notebook_id.as_deref()
+            || requested_id == state.last_notebook_session_id.as_deref();
+        if disconnected_active {
+            info!("Clearing notebook handoff target for explicit disconnect intent");
+            state.last_notebook_id = None;
+            state.last_notebook_session_id = None;
+        }
+    }
+
     async fn track_session(&self, params: &CallToolRequestParams, result: &CallToolResult) {
         if params.name.as_ref() == "disconnect_notebook" && result.is_error != Some(true) {
-            let requested_id = params
-                .arguments
-                .as_ref()
-                .and_then(|args| args.get("notebook_id"))
-                .and_then(serde_json::Value::as_str);
-            let mut state = self.state.write().await;
-            let disconnected_active = requested_id.is_none()
-                || requested_id == state.last_notebook_id.as_deref()
-                || requested_id == state.last_notebook_session_id.as_deref();
-            if disconnected_active {
-                info!("Clearing notebook handoff target after explicit disconnect");
-                state.last_notebook_id = None;
-                state.last_notebook_session_id = None;
-            }
+            self.clear_disconnect_handoff(params).await;
             return;
         }
 
@@ -1096,6 +1164,57 @@ impl McpProxy {
 struct ChildPeerSnapshot {
     peer: Peer<child::RoleChild>,
     generation: u64,
+}
+
+#[derive(Debug)]
+struct ForwardToolFailure {
+    error: McpError,
+    /// The peer generation acquired for this attempt, if any.
+    generation: Option<u64>,
+    transport_closed: bool,
+    /// A send was attempted and no definitive tool or protocol result arrived.
+    may_have_run: bool,
+}
+
+/// This is a local contract, not an interpretation of a child's tool hints.
+/// Unknown tools, session changes, and execution are deliberately excluded.
+fn tool_can_be_replayed(name: &str) -> bool {
+    matches!(
+        name,
+        "list_active_notebooks"
+            | "list_notebooks"
+            | "get_cell"
+            | "get_all_cells"
+            | "get_results"
+            | "get_dependencies"
+    )
+}
+
+fn unknown_tool_outcome(
+    name: &str,
+    failure: &ForwardToolFailure,
+    recovery_error: Option<String>,
+) -> CallToolResult {
+    warn!(event = "tool_outcome_unknown", tool = name, generation = failure.generation, error = %failure.error, recovery_error = ?recovery_error, "Tool response lost; mutation was not replayed");
+    let mut message = format!(
+        "No definitive response arrived after '{name}' was sent. The operation may already have \
+         completed, so it was not retried. Inspect notebook state or execution results \
+         before deciding whether to repeat it."
+    );
+    if let Some(error) = &recovery_error {
+        message.push_str(&format!(" Recovery also failed: {error}"));
+    }
+    let mut result = CallToolResult::error(vec![ContentBlock::text(message.clone())]);
+    result.structured_content = Some(serde_json::json!({
+        "error": {
+            "code": "outcome_unknown",
+            "message": message,
+            "tool": name,
+            "retry_safe": false,
+            "recovery_error": recovery_error,
+        }
+    }));
+    result
 }
 
 fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
@@ -2099,7 +2218,8 @@ mod tests {
         let result = proxy.try_forward_tool_call(&params).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.message.contains("not running"));
+        assert!(err.error.message.contains("not running"));
+        assert!(err.generation.is_none());
     }
 
     #[tokio::test]

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -86,6 +86,7 @@ impl ClientHandler for LegacyClient {
 
 struct LegacyChild {
     initialized: std::sync::atomic::AtomicBool,
+    lose_first_response: bool,
 }
 
 impl ServerHandler for LegacyChild {
@@ -108,6 +109,17 @@ impl ServerHandler for LegacyChild {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
+        if self.lose_first_response {
+            return Ok(serde_json::from_value(json!({
+                "tools": (["execute_cell", "get_results", "future_mutation", "disconnect_notebook", "definitive_error"].map(|name| json!({
+                    "name": name,
+                    "description": "Accept a call, then lose the first response",
+                    "inputSchema": {"type": "object"},
+                    "annotations": {"readOnlyHint": true, "idempotentHint": true}
+                })))
+            }))
+            .expect("response-loss fixture tools"));
+        }
         Ok(serde_json::from_value(json!({
             "tools": [{"name": "compatibility_echo", "description": "Pinned SDK fixture", "inputSchema": {"type": "object", "properties": {"message": {"type": "string"}}}}]
         })).expect("legacy tool definitions"))
@@ -154,6 +166,35 @@ impl ServerHandler for LegacyChild {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
+        if self.lose_first_response {
+            if request.name == "definitive_error" {
+                return Err(ErrorData::invalid_params(
+                    "Definitive fixture rejection",
+                    None,
+                ));
+            }
+            let root = std::path::PathBuf::from(
+                std::env::var("NTERACT_COMPATIBILITY_ROOT").expect("fixture root"),
+            );
+            let path = root.join("accepted-calls");
+            let first = !path.exists();
+            let mut log = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .expect("call acceptance log");
+            writeln!(log, "{}", request.name).expect("record accepted call");
+            log.sync_all()
+                .expect("persist acceptance before losing response");
+            if first {
+                // The accepted effect survives the child. No JSON-RPC response
+                // reaches the proxy; this is the uncertainty boundary under test.
+                std::process::exit(75);
+            }
+            return Ok(CallToolResult::success(vec![
+                rmcp_legacy::model::Content::text("accepted"),
+            ]));
+        }
         if request.name != "compatibility_echo" {
             return Err(ErrorData::invalid_params("Unknown fixture tool", None));
         }
@@ -211,10 +252,11 @@ pub fn run_child_if_requested() {
         .expect("fixture runtime");
     runtime.block_on(async {
         match mode.as_str() {
-            "legacy" => {
+            "legacy" | "response-loss" => {
                 use rmcp_legacy::ServiceExt;
                 LegacyChild {
                     initialized: std::sync::atomic::AtomicBool::new(false),
+                    lose_first_response: mode == "response-loss",
                 }
                 .serve(rmcp_legacy::transport::stdio())
                 .await

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -22,6 +22,10 @@ fn compatibility_child_process() {
 }
 
 fn isolated_proxy() -> (tempfile::TempDir, McpProxy, Arc<AtomicUsize>) {
+    isolated_proxy_with_mode("legacy")
+}
+
+fn isolated_proxy_with_mode(mode: &str) -> (tempfile::TempDir, McpProxy, Arc<AtomicUsize>) {
     let dir = tempfile::tempdir().expect("isolated proxy directory");
     runt_mcp_proxy::tools::save_tool_cache(
         dir.path(),
@@ -35,14 +39,18 @@ fn isolated_proxy() -> (tempfile::TempDir, McpProxy, Arc<AtomicUsize>) {
     let executable = std::env::current_exe().expect("test executable");
     let resolves = Arc::new(AtomicUsize::new(0));
     let count = resolves.clone();
+    let fail_resolution = dir.path().join("fail-resolution");
     let proxy = McpProxy::new(
         ProxyConfig {
             resolve_child_command: Box::new(move || {
                 count.fetch_add(1, Ordering::SeqCst);
+                if fail_resolution.exists() {
+                    return Err("Fixture binary unavailable; restart your MCP session".into());
+                }
                 Ok(executable.clone())
             }),
             child_args: fixtures::child_args(),
-            child_env: fixtures::child_env(dir.path(), "legacy"),
+            child_env: fixtures::child_env(dir.path(), mode),
             server_name: "compatibility-proxy".into(),
             cache_dir: Some(dir.path().to_path_buf()),
             monitor_poll_interval_ms: 60_000,
@@ -51,6 +59,156 @@ fn isolated_proxy() -> (tempfile::TempDir, McpProxy, Arc<AtomicUsize>) {
         None,
     );
     (dir, proxy, resolves)
+}
+
+#[tokio::test]
+async fn lost_mutation_response_is_not_replayed_even_with_read_only_hints() {
+    for name in ["execute_cell", "future_mutation"] {
+        let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+        proxy.init_child().await.expect("start response-loss child");
+        let request = serde_json::from_value(json!({"name": name, "arguments": {}})).unwrap();
+        let result = timeout(DEADLINE, proxy.forward_tool_call(request))
+            .await
+            .expect("bounded recovery")
+            .expect("actionable tool result");
+        assert_eq!(result.is_error, Some(true));
+        let details = result
+            .structured_content
+            .as_ref()
+            .expect("structured recovery guidance");
+        assert_eq!(details["error"]["code"], "outcome_unknown");
+        assert_eq!(details["error"]["retry_safe"], false);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+            format!("{name}\n")
+        );
+
+        let read = serde_json::from_value(json!({"name": "get_results", "arguments": {}})).unwrap();
+        let next = timeout(DEADLINE, proxy.forward_tool_call(read))
+            .await
+            .expect("recovered child responds")
+            .expect("read recovered state");
+        assert_ne!(next.is_error, Some(true));
+        stop_child(&proxy).await;
+    }
+}
+
+#[tokio::test]
+async fn lost_read_response_is_retried_once() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.expect("start response-loss child");
+    let request = serde_json::from_value(json!({"name": "get_results", "arguments": {}})).unwrap();
+    let result = timeout(DEADLINE, proxy.forward_tool_call(request))
+        .await
+        .expect("bounded recovery")
+        .expect("read retry");
+    assert_ne!(result.is_error, Some(true));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+        "get_results\nget_results\n"
+    );
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
+async fn mutation_can_run_once_when_the_stored_child_was_already_closed() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.unwrap();
+    let mut child = proxy.state.write().await.child_client.take().unwrap();
+    child.close().await.unwrap();
+    proxy.state.write().await.child_client = Some(child);
+    // Disable the fault for the replacement: no request has been accepted.
+    std::fs::write(dir.path().join("accepted-calls"), "").unwrap();
+    let request = serde_json::from_value(json!({"name":"execute_cell","arguments":{}})).unwrap();
+    let result = timeout(DEADLINE, proxy.forward_tool_call(request))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_ne!(result.is_error, Some(true));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+        "execute_cell\n"
+    );
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
+async fn definitive_protocol_error_is_preserved_without_restarting() {
+    let (dir, proxy, resolves) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.unwrap();
+    let request =
+        serde_json::from_value(json!({"name":"definitive_error","arguments":{}})).unwrap();
+    let error = proxy.forward_tool_call(request).await.unwrap_err();
+    assert_eq!(error.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert_eq!(error.message, "Definitive fixture rejection");
+    assert_eq!(resolves.load(Ordering::SeqCst), 1);
+    assert!(!dir.path().join("accepted-calls").exists());
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
+async fn unknown_outcome_includes_failed_recovery_in_text() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.unwrap();
+    std::fs::write(dir.path().join("fail-resolution"), "fail").unwrap();
+    let request = serde_json::from_value(json!({"name":"execute_cell","arguments":{}})).unwrap();
+    let result = proxy.forward_tool_call(request).await.unwrap();
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["error"]["code"],
+        "outcome_unknown"
+    );
+    let contents = serde_json::to_value(&result.content).unwrap();
+    assert!(contents[0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("restart your MCP session"));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+        "execute_cell\n"
+    );
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
+async fn lost_disconnect_response_does_not_restore_the_release_target() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.unwrap();
+    proxy.state.write().await.last_notebook_id = Some("released-notebook".into());
+    let request =
+        serde_json::from_value(json!({"name":"disconnect_notebook","arguments":{}})).unwrap();
+    let result = proxy.forward_tool_call(request).await.unwrap();
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["error"]["code"],
+        "outcome_unknown"
+    );
+    assert!(proxy.state.read().await.last_notebook_id.is_none());
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+        "disconnect_notebook\n"
+    );
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
+async fn mutation_sent_after_initial_child_recovery_still_reports_lost_response() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    // No previously advertised catalog: exercise startup, not incompatible
+    // replacement of the deliberately unrelated optimistic test cache.
+    proxy.state.write().await.cached_tools = None;
+    let request = serde_json::from_value(json!({"name": "execute_cell", "arguments": {}})).unwrap();
+    let result = timeout(DEADLINE, proxy.forward_tool_call(request))
+        .await
+        .expect("bounded startup")
+        .expect("actionable result");
+    assert_eq!(
+        result.structured_content.unwrap()["error"]["code"],
+        "outcome_unknown"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("accepted-calls")).unwrap(),
+        "execute_cell\n"
+    );
+    stop_child(&proxy).await;
 }
 
 async fn assert_no_child(proxy: &McpProxy, resolves: &AtomicUsize, dir: &std::path::Path) {

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -79,9 +79,15 @@ restored as a group.
 See `crates/runt-mcp-proxy/src/proxy.rs:310`, `:962`, and
 `crates/runt-mcp-proxy/src/session.rs:17`. The proxy's `reconnect` tool replaces
 the child, not the daemon (`proxy.rs:1268`). A requested rejoin is not proof of
-a ready notebook. Forwarding retries once after a closed child transport
-(`proxy.rs:658`), so transparent restart is not an exactly-once mutation
-contract.
+a ready notebook. Forwarding may retry once when no request was dispatched or
+the tool is on the proxy's explicit read-only replay allowlist. A mutation
+whose response was lost returns a tool error with `error.code: outcome_unknown`
+and `error.retry_safe: false` in structured content. It is never automatically
+replayed. The text asks the agent to inspect notebook state or execution results
+before deciding whether to repeat the action, and includes recovery failures.
+This prevents duplicate dispatch during recovery; it does not establish
+exactly-once execution. Explicit disconnect intent clears the matching rejoin
+target before dispatch, so losing its reply cannot restore the released session.
 
 ## Decision 2: Proxy modes are policy, not state
 
@@ -509,10 +515,12 @@ already implemented separate-child/shared-daemon model.
    a separate compatibility policy. Recovery hints are already caller-specific:
    installed wrapper at `crates/nteract-mcp/src/main.rs:204`, dev supervisor at
    `crates/mcp-supervisor/src/main.rs:3159`.
-5. **Retry and protocol compatibility.** The proxy's one retry after a closed
-   child transport does not establish exactly-once execution. Define any
-   stronger retry guarantee and migration to the newer upstream protocol
-   explicitly; do not infer either from transparent restart or SDK version.
+5. **Recovery concurrency and protocol compatibility.** Concurrent callers
+   currently skip a restart already in progress rather than await its result.
+   A retry can therefore race replacement startup. Shared restart completion
+   and migration to the newer upstream protocol need explicit lifecycle work;
+   neither exactly-once execution nor native protocol support follows from
+   transparent restart or the SDK version.
 
 Already-absent UUID refusal and file-backed UUID registry recovery are
 implemented; the snapshot-disappearance race in Decision 8 remains a separate


### PR DESCRIPTION
A child can accept a notebook mutation and die before its MCP response reaches the proxy. Previously, recovery retried that call and could execute the mutation twice. The proxy now recovers the connection and returns an `outcome_unknown` tool error with `retry_safe: false`, asking the agent to inspect notebook or execution state before repeating the action.

Calls that provably were never dispatched can still run once. An explicit local allowlist permits one replay of read-only tools; child-provided hints cannot authorize replay. Definitive protocol errors keep their original code/message. Recovery failures appear in both text and structured content, and an explicit disconnect clears its matching rejoin target before dispatch.

Validation: 122 proxy library tests, 21 protocol compatibility tests, `cargo clippy --locked -p runt-mcp-proxy --all-targets -- -D warnings`, and `cargo xtask lint --fix` passed. Subprocess fixtures persist call acceptance before exiting without a reply, verifying dispatch counts for mutations and reads, pre-dispatch child death, failed recovery, and disconnect intent. Kilo Opus 5 and GPT-5.6 Sol reviewed the initial patch; follow-up correctness review of the fixes found no actionable issues.

This is the recovery-safety slice of the MCP observation work. The existing concurrent-restart early-return race is documented and remains for the shared lifecycle work; this PR does not claim exactly-once execution or introduce subscriptions/native protocol support. Live daemon execution and desktop UX are not established by the subprocess fixtures.
