### PR TITLE
feat(mcp): observe notebook changes with bounded waits and subscriptions

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2084,9 +2084,20 @@ impl ServerHandler for Supervisor {
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
         require_legacy_handshake(&context)?;
-        let proxy = {
-            let state = self.state.read().await;
-            Self::get_proxy(&state)?.clone()
+        let ready = self.child_ready.notified();
+        let proxy = { self.state.read().await.proxy.clone() };
+        let proxy = match proxy {
+            Some(proxy) => proxy,
+            None => {
+                tokio::select! {
+                    _ = context.ct.cancelled() => return Err(McpError::internal_error("Subscription cancelled during startup", None)),
+                    result = tokio::time::timeout(Duration::from_secs(30), ready) => {
+                        result.map_err(|_| McpError::internal_error("MCP startup timed out; retry after startup completes", None))?;
+                    }
+                }
+                let state = self.state.read().await;
+                Self::get_proxy(&state)?.clone()
+            }
         };
         proxy.forward_subscribe(request.uri, context.peer).await
     }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1911,6 +1911,7 @@ impl ServerHandler for Supervisor {
                 .enable_tools()
                 .enable_tool_list_changed()
                 .enable_resources()
+                .enable_resources_subscribe()
                 .enable_resources_list_changed()
                 .enable_extensions_with(mcp_apps_extension_capabilities())
                 .build(),
@@ -2074,6 +2075,37 @@ impl ServerHandler for Supervisor {
         self.handle_tool_call(request)
             .await
             .map(CallToolResponse::Complete)
+    }
+
+    #[allow(deprecated)]
+    async fn subscribe(
+        &self,
+        request: rmcp::model::SubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        let proxy = {
+            let state = self.state.read().await;
+            Self::get_proxy(&state)?.clone()
+        };
+        proxy.forward_subscribe(request.uri, context.peer).await
+    }
+
+    #[allow(deprecated)]
+    async fn unsubscribe(
+        &self,
+        request: rmcp::model::UnsubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        let proxy = {
+            let state = self.state.read().await;
+            state.proxy.clone()
+        };
+        if let Some(proxy) = proxy {
+            proxy.forward_unsubscribe(request.uri).await?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -67,8 +67,17 @@ impl ExecutionWatcher {
         cell_id: impl Into<String>,
         execution_id: impl Into<String>,
     ) -> Self {
+        Self::from_receiver(handle.subscribe_runtime_state(), cell_id, execution_id)
+    }
+
+    /// Observe a runtime snapshot stream without retaining a sync handle.
+    pub fn from_receiver(
+        rx: watch::Receiver<RuntimeState>,
+        cell_id: impl Into<String>,
+        execution_id: impl Into<String>,
+    ) -> Self {
         Self {
-            rx: handle.subscribe_runtime_state(),
+            rx,
             cell_id: cell_id.into(),
             execution_id: execution_id.into(),
             prev: None,

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -856,6 +856,7 @@ impl DocHandle {
                 None,
                 &created_at,
             )?;
+            state.publish_comments_snapshot();
         }
 
         // Notify sync task that CommentsDoc changed
@@ -885,6 +886,7 @@ impl DocHandle {
                 after_message_id.as_deref(),
                 &created_at,
             )?;
+            state.publish_comments_snapshot();
         }
 
         // Notify sync task that CommentsDoc changed
@@ -900,6 +902,7 @@ impl DocHandle {
         {
             let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
             state.comments_doc.resolve_thread(thread_id, &resolved_at)?;
+            state.publish_comments_snapshot();
         }
 
         // Notify sync task that CommentsDoc changed
@@ -913,6 +916,7 @@ impl DocHandle {
         {
             let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
             state.comments_doc.reopen_thread(thread_id)?;
+            state.publish_comments_snapshot();
         }
 
         // Notify sync task that CommentsDoc changed
@@ -926,6 +930,18 @@ impl DocHandle {
         let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
         let projection = state.comments_doc.read_projection(None)?;
         Ok(projection)
+    }
+
+    /// Observe local and remote comments without retaining a notebook peer.
+    /// Subscribe before taking a baseline; the retained projection and watch
+    /// registration are captured under the same document lock. `None` means
+    /// comments identity/projection is not available yet.
+    pub fn subscribe_comments(
+        &self,
+    ) -> Result<watch::Receiver<Option<Arc<comments_doc::CommentsProjection>>>, SyncError> {
+        let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        state.publish_comments_snapshot();
+        Ok(state.comments_tx.subscribe())
     }
 
     fn readiness_error(status: &SyncStatus) -> Option<SyncError> {
@@ -1217,7 +1233,7 @@ fn document_contains_heads(
 }
 
 /// Read the execution_id for a cell directly from a raw AutoCommit document.
-fn read_execution_id(doc: &AutoCommit, cell_id: &str) -> Option<String> {
+pub(crate) fn read_execution_id(doc: &AutoCommit, cell_id: &str) -> Option<String> {
     let (_, cells_id) = doc.get(&automerge::ROOT, "cells").ok().flatten()?;
     let (_, cell_obj) = doc.get(&cells_id, cell_id).ok().flatten()?;
     let (value, _) = doc.get(&cell_obj, "execution_id").ok().flatten()?;
@@ -1277,6 +1293,113 @@ mod tests {
             status_rx,
             "test-notebook".to_string(),
         )
+    }
+
+    #[test]
+    fn comments_watch_covers_local_crud_and_does_not_retain_handle() {
+        let handle = test_handle();
+        handle.set_actor("agent:test").unwrap();
+        let mut comments = handle.subscribe_comments().unwrap();
+        assert!(comments
+            .borrow_and_update()
+            .as_ref()
+            .unwrap()
+            .threads
+            .is_empty());
+        let thread = handle
+            .create_comment_thread(
+                CommentAnchor::Cell {
+                    cell_id: "cell-1".into(),
+                    observed_cell_position: None,
+                },
+                "first".into(),
+            )
+            .unwrap();
+        assert!(comments.has_changed().unwrap());
+        assert_eq!(
+            comments.borrow_and_update().as_ref().unwrap().threads[0]
+                .messages
+                .len(),
+            1
+        );
+        handle.reply_to_comment(&thread, "second".into()).unwrap();
+        assert_eq!(
+            comments.borrow_and_update().as_ref().unwrap().threads[0]
+                .messages
+                .len(),
+            2
+        );
+        handle.resolve_comment_thread(&thread).unwrap();
+        assert!(comments.has_changed().unwrap());
+        comments.borrow_and_update();
+        handle.reopen_comment_thread(&thread).unwrap();
+        assert!(comments.has_changed().unwrap());
+        comments.borrow_and_update();
+        // A second observer neither generates a false update nor retains a
+        // command channel after the session releases the last handle.
+        let _second = handle.subscribe_comments().unwrap();
+        assert!(!comments.has_changed().unwrap());
+        drop(handle);
+        assert!(comments.has_changed().is_err());
+    }
+
+    #[test]
+    fn comments_watch_publishes_remote_sync_and_suppresses_negotiation_frames() {
+        let source = test_handle();
+        source.set_actor("agent:source").unwrap();
+        source
+            .create_comment_thread(
+                CommentAnchor::Cell {
+                    cell_id: "cell-1".into(),
+                    observed_cell_position: None,
+                },
+                "remote comment".into(),
+            )
+            .unwrap();
+        let target = test_handle();
+        target.doc.lock().unwrap().comments_doc = comments_doc::CommentsDoc::new_empty_for_sync();
+        let mut comments = target.subscribe_comments().unwrap();
+        assert!(comments.borrow_and_update().is_none());
+        for _ in 0..10 {
+            let from_source = source
+                .doc
+                .lock()
+                .unwrap()
+                .generate_comments_sync_message_recovering("test-send")
+                .unwrap();
+            let from_target = target
+                .doc
+                .lock()
+                .unwrap()
+                .generate_comments_sync_message_recovering("test-reply")
+                .unwrap();
+            if from_source.is_none() && from_target.is_none() {
+                break;
+            }
+            if let Some(message) = from_source {
+                target
+                    .doc
+                    .lock()
+                    .unwrap()
+                    .receive_comments_sync_message_recovering(message, "test-receive")
+                    .unwrap();
+            }
+            if let Some(message) = from_target {
+                source
+                    .doc
+                    .lock()
+                    .unwrap()
+                    .receive_comments_sync_message_recovering(message, "test-receive")
+                    .unwrap();
+            }
+        }
+        assert_eq!(
+            comments.borrow_and_update().as_ref().unwrap().threads[0].messages[0].body,
+            "remote comment"
+        );
+        let state = target.doc.lock().unwrap();
+        state.publish_comments_snapshot();
+        assert!(!comments.has_changed().unwrap());
     }
 
     #[test]

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -16,6 +16,8 @@ use comments_doc::CommentsDoc;
 use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::{CommsDoc, RuntimeStateDoc};
+use std::sync::Arc;
+use tokio::sync::watch;
 
 /// The shared state behind `Arc<Mutex<SharedDocState>>`.
 ///
@@ -53,6 +55,10 @@ pub struct SharedDocState {
     /// Automerge sync protocol state for the CommentsDoc peer.
     pub(crate) comments_peer_state: sync::State,
 
+    /// Retained comments projection. Receivers own no sync command sender, so
+    /// observing comments cannot keep a notebook peer connected.
+    pub(crate) comments_tx: watch::Sender<Option<Arc<comments_doc::CommentsProjection>>>,
+
     #[cfg(test)]
     panic_on_next_doc_sync: bool,
     #[cfg(test)]
@@ -83,6 +89,7 @@ impl SharedDocState {
             comms_peer_state: sync::State::new(),
             comments_doc,
             comments_peer_state: sync::State::new(),
+            comments_tx: watch::channel(None).0,
             #[cfg(test)]
             panic_on_next_doc_sync: false,
             #[cfg(test)]
@@ -295,6 +302,7 @@ impl SharedDocState {
         &mut self,
         message: sync::Message,
     ) -> Result<(), automerge::AutomergeError> {
+        let before = self.comments_doc.doc_mut().get_heads();
         self.comments_doc
             .doc_mut()
             .sync()
@@ -309,7 +317,22 @@ impl SharedDocState {
                 self.notebook_id, err
             );
         }
+        if before != self.comments_doc.doc_mut().get_heads() {
+            self.publish_comments_snapshot();
+        }
         Ok(())
+    }
+
+    pub(crate) fn publish_comments_snapshot(&self) {
+        let projection = self.comments_doc.read_projection(None).ok().map(Arc::new);
+        self.comments_tx.send_if_modified(|current| {
+            if *current == projection {
+                false
+            } else {
+                *current = projection;
+                true
+            }
+        });
     }
 
     pub(crate) fn receive_comments_sync_message_recovering(

--- a/crates/notebook-sync/src/snapshot.rs
+++ b/crates/notebook-sync/src/snapshot.rs
@@ -4,6 +4,7 @@
 //! (local or remote). Readers access the latest state without acquiring
 //! the document mutex — they just borrow from the watch channel.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use notebook_doc::metadata::NotebookMetadataSnapshot;
@@ -23,6 +24,10 @@ pub struct NotebookSnapshot {
     /// Parsed notebook metadata (kernelspec, language_info, runt config).
     /// `None` if the document has no metadata yet.
     pub notebook_metadata: Option<NotebookMetadataSnapshot>,
+
+    /// Current execution pointers captured under the same document lock as
+    /// cells. Runtime entries alone cannot identify a cell's selected execution.
+    pub execution_pointers: Arc<BTreeMap<String, String>>,
 }
 
 impl NotebookSnapshot {
@@ -30,9 +35,17 @@ impl NotebookSnapshot {
     pub fn from_doc(doc: &automerge::AutoCommit) -> Self {
         use notebook_doc::{get_cells_from_doc, get_metadata_snapshot_from_doc};
 
+        let cells = get_cells_from_doc(doc);
+        let execution_pointers = cells
+            .iter()
+            .filter_map(|cell| {
+                crate::handle::read_execution_id(doc, &cell.id).map(|id| (cell.id.clone(), id))
+            })
+            .collect();
         Self {
-            cells: Arc::new(get_cells_from_doc(doc)),
+            cells: Arc::new(cells),
             notebook_metadata: get_metadata_snapshot_from_doc(doc),
+            execution_pointers: Arc::new(execution_pointers),
         }
     }
 
@@ -41,6 +54,7 @@ impl NotebookSnapshot {
         Self {
             cells: Arc::new(Vec::new()),
             notebook_metadata: None,
+            execution_pointers: Arc::new(BTreeMap::new()),
         }
     }
 

--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -76,6 +76,7 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
             { "name": "save_notebook", "description": "Save notebook to disk. For notebooks created with create_notebook(), you must provide a path." },
             { "name": "show_notebook", "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason." },
             { "name": "disconnect_notebook", "description": "Release a notebook session's peer connection. Omit notebook_id to disconnect the active session." },
+            { "name": "wait_for_notebook_change", "description": "Wait for notebook changes or an exact execution." },
             { "name": "get_cell", "description": "Get a cell by ID, including execution status/id and compact output summaries." },
             { "name": "get_all_cells", "description": "Get all cells as summary, json, or rich format with compact execution/output summaries." },
             { "name": "create_cell", "description": "Create a cell anchored by after_cell_id; omit after_cell_id to append." },

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -23,9 +23,18 @@ pub type RoleChild = rmcp::service::RoleClient;
 pub struct ChildClientHandler {
     pub upstream_name: String,
     pub upstream_title: Option<String>,
+    pub notifications:
+        tokio::sync::broadcast::Sender<rmcp::model::ResourceUpdatedNotificationParam>,
 }
 
 impl ClientHandler for ChildClientHandler {
+    async fn on_resource_updated(
+        &self,
+        params: rmcp::model::ResourceUpdatedNotificationParam,
+        _: rmcp::service::NotificationContext<RoleChild>,
+    ) {
+        let _ = self.notifications.send(params);
+    }
     fn get_info(&self) -> rmcp::model::ClientInfo {
         let mut impl_info = Implementation::new(&self.upstream_name, env!("CARGO_PKG_VERSION"));
         impl_info.title = self.upstream_title.clone();
@@ -231,6 +240,7 @@ pub async fn spawn_child(
     let handler = ChildClientHandler {
         upstream_name: upstream_name.to_string(),
         upstream_title: upstream_title.map(|s| s.to_string()),
+        notifications: tokio::sync::broadcast::channel(256).0,
     };
 
     let client = handler
@@ -273,6 +283,7 @@ mod tests {
         let handler = ChildClientHandler {
             upstream_name: "codex-mcp-client".to_string(),
             upstream_title: Some("Codex".to_string()),
+            notifications: tokio::sync::broadcast::channel(256).0,
         };
         let info = handler.get_info();
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
@@ -305,6 +316,7 @@ mod tests {
         let handler = ChildClientHandler {
             upstream_name: "test".to_string(),
             upstream_title: None,
+            notifications: tokio::sync::broadcast::channel(256).0,
         };
         let client = handler
             .serve(client_side)

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod child;
 pub mod circuit_breaker;
+mod observation_bridge;
 pub mod proxy;
 pub mod session;
 pub mod tools;

--- a/crates/runt-mcp-proxy/src/observation_bridge.rs
+++ b/crates/runt-mcp-proxy/src/observation_bridge.rs
@@ -1,0 +1,240 @@
+//! Legacy invalidation relay bound to one child transport per watch.
+//!
+//! A connection actor orders subscribe/unsubscribe operations, including their
+//! child acknowledgments. Concurrent duplicates cannot report success before
+//! the original subscription succeeds or unsubscribe a replacement watch.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use rmcp::model::{
+    ResourceUpdatedNotificationParam, SubscribeRequestParams, UnsubscribeRequestParams,
+};
+use rmcp::service::{Peer, RoleClient, RoleServer};
+use rmcp::ErrorData as McpError;
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+type Reply = oneshot::Sender<Result<(), McpError>>;
+enum Operation {
+    Subscribe {
+        uri: String,
+        child: Peer<RoleClient>,
+        notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
+        upstream: Peer<RoleServer>,
+        reply: Reply,
+    },
+    Unsubscribe {
+        uri: String,
+        reply: Reply,
+    },
+}
+struct Worker {
+    sender: mpsc::Sender<Operation>,
+    task: tokio::task::JoinHandle<()>,
+}
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+struct Watch {
+    child: Peer<RoleClient>,
+    upstream: Peer<RoleServer>,
+    task: tokio::task::JoinHandle<()>,
+}
+impl Drop for Watch {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ObservationBridge {
+    worker: Mutex<Option<Worker>>,
+}
+impl ObservationBridge {
+    fn sender(&self) -> Result<mpsc::Sender<Operation>, McpError> {
+        let mut worker = self
+            .worker
+            .lock()
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        Ok(worker
+            .get_or_insert_with(|| {
+                let (sender, receiver) = mpsc::channel(128);
+                Worker {
+                    sender,
+                    task: tokio::spawn(run(receiver)),
+                }
+            })
+            .sender
+            .clone())
+    }
+
+    pub(crate) async fn subscribe(
+        &self,
+        uri: String,
+        child: Peer<RoleClient>,
+        notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
+        upstream: Peer<RoleServer>,
+    ) -> Result<(), McpError> {
+        let (reply, response) = oneshot::channel();
+        self.sender()?
+            .send(Operation::Subscribe {
+                uri,
+                child,
+                notifications,
+                upstream,
+                reply,
+            })
+            .await
+            .map_err(|_| unavailable())?;
+        response.await.map_err(|_| unavailable())?
+    }
+
+    pub(crate) async fn unsubscribe(&self, uri: String) -> Result<(), McpError> {
+        let (reply, response) = oneshot::channel();
+        self.sender()?
+            .send(Operation::Unsubscribe { uri, reply })
+            .await
+            .map_err(|_| unavailable())?;
+        response.await.map_err(|_| unavailable())?
+    }
+}
+fn unavailable() -> McpError {
+    McpError::internal_error("Resource subscription relay is unavailable", None)
+}
+fn child_error(error: rmcp::service::ServiceError) -> McpError {
+    match error {
+        rmcp::service::ServiceError::McpError(error) => error,
+        error => McpError::internal_error(error.to_string(), None),
+    }
+}
+
+#[allow(deprecated)]
+async fn run(mut operations: mpsc::Receiver<Operation>) {
+    let mut watches: HashMap<String, Watch> = HashMap::new();
+    while let Some(operation) = operations.recv().await {
+        let closed: Vec<_> = watches
+            .iter()
+            .filter(|(_, watch)| watch.child.is_transport_closed())
+            .map(|(uri, _)| uri.clone())
+            .collect();
+        for uri in closed {
+            if let Some(watch) = watches.remove(&uri) {
+                // The actor may observe closure before the relay's next tick.
+                let _ = watch
+                    .upstream
+                    .notify_resource_updated(ResourceUpdatedNotificationParam::new(uri))
+                    .await;
+            }
+        }
+        watches.retain(|_, watch| !watch.task.is_finished());
+        match operation {
+            Operation::Subscribe {
+                uri,
+                child,
+                notifications,
+                upstream,
+                reply,
+            } => {
+                if reply.is_closed() {
+                    continue;
+                }
+                if watches.contains_key(&uri) {
+                    let _ = reply.send(Ok(()));
+                    continue;
+                }
+                if watches.len() >= 128 {
+                    let _ = reply.send(Err(McpError::invalid_request(
+                        "At most 128 resource watches may be active",
+                        None,
+                    )));
+                    continue;
+                }
+                let result = child
+                    .subscribe(SubscribeRequestParams::new(&uri))
+                    .await
+                    .map_err(child_error);
+                match result {
+                    Ok(_) => {
+                        if reply.send(Ok(())).is_err() {
+                            let _ = child.unsubscribe(UnsubscribeRequestParams::new(uri)).await;
+                            continue;
+                        }
+                        let task = tokio::spawn(relay(
+                            uri.clone(),
+                            child.clone(),
+                            notifications,
+                            upstream.clone(),
+                        ));
+                        watches.insert(
+                            uri,
+                            Watch {
+                                child,
+                                upstream,
+                                task,
+                            },
+                        );
+                    }
+                    Err(error) => {
+                        let _ = reply.send(Err(error));
+                    }
+                }
+            }
+            Operation::Unsubscribe { uri, reply } => {
+                let result = if let Some(watch) = watches.remove(&uri) {
+                    watch.task.abort();
+                    watch
+                        .child
+                        .unsubscribe(UnsubscribeRequestParams::new(uri))
+                        .await
+                        .map(|_| ())
+                        .map_err(child_error)
+                } else {
+                    Ok(())
+                };
+                let _ = reply.send(result);
+            }
+        }
+    }
+}
+
+async fn relay(
+    uri: String,
+    child: Peer<RoleClient>,
+    mut notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
+    upstream: Peer<RoleServer>,
+) {
+    let mut tick = tokio::time::interval(Duration::from_millis(100));
+    loop {
+        if upstream.is_transport_closed() {
+            break;
+        }
+        if child.is_transport_closed() {
+            let _ = upstream
+                .notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri))
+                .await;
+            break;
+        }
+        let update = tokio::select! {
+            event = notifications.recv() => match event {
+                Ok(event) => event.uri == uri,
+                Err(broadcast::error::RecvError::Lagged(_)) => true,
+                Err(broadcast::error::RecvError::Closed) => {
+                    let _ = upstream.notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri)).await;
+                    break;
+                },
+            },
+            _ = tick.tick() => false,
+        };
+        if update
+            && upstream
+                .notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri))
+                .await
+                .is_err()
+        {
+            break;
+        }
+    }
+}

--- a/crates/runt-mcp-proxy/src/observation_bridge.rs
+++ b/crates/runt-mcp-proxy/src/observation_bridge.rs
@@ -20,6 +20,7 @@ enum Operation {
     Subscribe {
         uri: String,
         child: Peer<RoleClient>,
+        generation: u64,
         notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
         upstream: Peer<RoleServer>,
         reply: Reply,
@@ -40,6 +41,7 @@ impl Drop for Worker {
 }
 struct Watch {
     child: Peer<RoleClient>,
+    generation: u64,
     upstream: Peer<RoleServer>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -59,6 +61,12 @@ impl ObservationBridge {
             .worker
             .lock()
             .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        if worker
+            .as_ref()
+            .is_some_and(|worker| worker.task.is_finished())
+        {
+            worker.take();
+        }
         Ok(worker
             .get_or_insert_with(|| {
                 let (sender, receiver) = mpsc::channel(128);
@@ -75,30 +83,40 @@ impl ObservationBridge {
         &self,
         uri: String,
         child: Peer<RoleClient>,
+        generation: u64,
         notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
         upstream: Peer<RoleServer>,
     ) -> Result<(), McpError> {
         let (reply, response) = oneshot::channel();
-        self.sender()?
-            .send(Operation::Subscribe {
-                uri,
-                child,
-                notifications,
-                upstream,
-                reply,
-            })
-            .await
-            .map_err(|_| unavailable())?;
-        response.await.map_err(|_| unavailable())?
+        let operation = async {
+            self.sender()?
+                .send(Operation::Subscribe {
+                    uri,
+                    child,
+                    generation,
+                    notifications,
+                    upstream,
+                    reply,
+                })
+                .await
+                .map_err(|_| unavailable())?;
+            response.await.map_err(|_| unavailable())?
+        };
+        tokio::time::timeout(Duration::from_secs(10), operation).await.map_err(|_| McpError::internal_error("Resource subscription timed out; obtain a fresh notebook baseline before retrying", None))?
     }
 
     pub(crate) async fn unsubscribe(&self, uri: String) -> Result<(), McpError> {
         let (reply, response) = oneshot::channel();
-        self.sender()?
-            .send(Operation::Unsubscribe { uri, reply })
+        let operation = async {
+            self.sender()?
+                .send(Operation::Unsubscribe { uri, reply })
+                .await
+                .map_err(|_| unavailable())?;
+            response.await.map_err(|_| unavailable())?
+        };
+        tokio::time::timeout(Duration::from_secs(10), operation)
             .await
-            .map_err(|_| unavailable())?;
-        response.await.map_err(|_| unavailable())?
+            .map_err(|_| McpError::internal_error("Resource unsubscribe timed out", None))?
     }
 }
 fn unavailable() -> McpError {
@@ -114,7 +132,13 @@ fn child_error(error: rmcp::service::ServiceError) -> McpError {
 #[allow(deprecated)]
 async fn run(mut operations: mpsc::Receiver<Operation>) {
     let mut watches: HashMap<String, Watch> = HashMap::new();
-    while let Some(operation) = operations.recv().await {
+    let mut cleanup = tokio::time::interval(Duration::from_secs(1));
+    cleanup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        let operation = tokio::select! {
+            operation = operations.recv() => match operation { Some(operation) => Some(operation), None => break },
+            _ = cleanup.tick() => None,
+        };
         let closed: Vec<_> = watches
             .iter()
             .filter(|(_, watch)| watch.child.is_transport_closed())
@@ -122,18 +146,26 @@ async fn run(mut operations: mpsc::Receiver<Operation>) {
             .collect();
         for uri in closed {
             if let Some(watch) = watches.remove(&uri) {
-                // The actor may observe closure before the relay's next tick.
-                let _ = watch
-                    .upstream
-                    .notify_resource_updated(ResourceUpdatedNotificationParam::new(uri))
-                    .await;
+                // Transport closure can precede the callback channel closing.
+                let _ = tokio::time::timeout(
+                    Duration::from_millis(250),
+                    watch
+                        .upstream
+                        .notify_resource_updated(ResourceUpdatedNotificationParam::new(uri)),
+                )
+                .await;
             }
         }
-        watches.retain(|_, watch| !watch.task.is_finished());
+        watches
+            .retain(|_, watch| !watch.task.is_finished() && !watch.upstream.is_transport_closed());
+        let Some(operation) = operation else {
+            continue;
+        };
         match operation {
             Operation::Subscribe {
                 uri,
                 child,
+                generation,
                 notifications,
                 upstream,
                 reply,
@@ -141,9 +173,21 @@ async fn run(mut operations: mpsc::Receiver<Operation>) {
                 if reply.is_closed() {
                     continue;
                 }
-                if watches.contains_key(&uri) {
+                if watches
+                    .get(&uri)
+                    .is_some_and(|watch| watch.generation == generation)
+                {
                     let _ = reply.send(Ok(()));
                     continue;
+                }
+                if let Some(previous) = watches.remove(&uri) {
+                    let _ = tokio::time::timeout(
+                        Duration::from_millis(250),
+                        previous
+                            .upstream
+                            .notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri)),
+                    )
+                    .await;
                 }
                 if watches.len() >= 128 {
                     let _ = reply.send(Err(McpError::invalid_request(
@@ -152,14 +196,23 @@ async fn run(mut operations: mpsc::Receiver<Operation>) {
                     )));
                     continue;
                 }
-                let result = child
-                    .subscribe(SubscribeRequestParams::new(&uri))
-                    .await
-                    .map_err(child_error);
+                let result = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    child.subscribe(SubscribeRequestParams::new(&uri)),
+                )
+                .await
+                .map_err(|_| {
+                    McpError::internal_error("Child resource subscription timed out", None)
+                })
+                .and_then(|result| result.map_err(child_error));
                 match result {
                     Ok(_) => {
                         if reply.send(Ok(())).is_err() {
-                            let _ = child.unsubscribe(UnsubscribeRequestParams::new(uri)).await;
+                            let _ = tokio::time::timeout(
+                                Duration::from_secs(5),
+                                child.unsubscribe(UnsubscribeRequestParams::new(uri)),
+                            )
+                            .await;
                             continue;
                         }
                         let task = tokio::spawn(relay(
@@ -172,6 +225,7 @@ async fn run(mut operations: mpsc::Receiver<Operation>) {
                             uri,
                             Watch {
                                 child,
+                                generation,
                                 upstream,
                                 task,
                             },
@@ -185,12 +239,15 @@ async fn run(mut operations: mpsc::Receiver<Operation>) {
             Operation::Unsubscribe { uri, reply } => {
                 let result = if let Some(watch) = watches.remove(&uri) {
                     watch.task.abort();
-                    watch
-                        .child
-                        .unsubscribe(UnsubscribeRequestParams::new(uri))
-                        .await
-                        .map(|_| ())
-                        .map_err(child_error)
+                    tokio::time::timeout(
+                        Duration::from_secs(5),
+                        watch.child.unsubscribe(UnsubscribeRequestParams::new(uri)),
+                    )
+                    .await
+                    .map_err(|_| {
+                        McpError::internal_error("Child resource unsubscribe timed out", None)
+                    })
+                    .and_then(|result| result.map(|_| ()).map_err(child_error))
                 } else {
                     Ok(())
                 };
@@ -206,7 +263,6 @@ async fn relay(
     mut notifications: broadcast::Receiver<ResourceUpdatedNotificationParam>,
     upstream: Peer<RoleServer>,
 ) {
-    let mut tick = tokio::time::interval(Duration::from_millis(100));
     loop {
         if upstream.is_transport_closed() {
             break;
@@ -217,16 +273,15 @@ async fn relay(
                 .await;
             break;
         }
-        let update = tokio::select! {
-            event = notifications.recv() => match event {
-                Ok(event) => event.uri == uri,
-                Err(broadcast::error::RecvError::Lagged(_)) => true,
-                Err(broadcast::error::RecvError::Closed) => {
-                    let _ = upstream.notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri)).await;
-                    break;
-                },
-            },
-            _ = tick.tick() => false,
+        let update = match notifications.recv().await {
+            Ok(event) => event.uri == uri,
+            Err(broadcast::error::RecvError::Lagged(_)) => true,
+            Err(broadcast::error::RecvError::Closed) => {
+                let _ = upstream
+                    .notify_resource_updated(ResourceUpdatedNotificationParam::new(&uri))
+                    .await;
+                break;
+            }
         };
         if update
             && upstream

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -182,6 +182,7 @@ pub struct McpProxy {
     /// Stable across child generations so automatic rejoin retains the exact
     /// operator used by the explicit connect in the previous child.
     operator_session: String,
+    observation_bridge: Arc<crate::observation_bridge::ObservationBridge>,
 }
 
 impl McpProxy {
@@ -223,6 +224,7 @@ impl McpProxy {
             exit_signal: Arc::new(Notify::new()),
             restart_in_progress: Arc::new(Mutex::new(false)),
             operator_session: uuid::Uuid::new_v4().simple().to_string()[..8].to_string(),
+            observation_bridge: Arc::default(),
         }
     }
 
@@ -237,6 +239,32 @@ impl McpProxy {
             self.operator_session.clone(),
         );
         child_env
+    }
+
+    /// Set the upstream client identity (from MCP initialize handshake).
+    pub async fn forward_subscribe(
+        &self,
+        uri: String,
+        upstream: Peer<RoleServer>,
+    ) -> Result<(), McpError> {
+        let (peer, notifications) = {
+            let state = self.state.read().await;
+            let client = state
+                .child_client
+                .as_ref()
+                .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
+            (
+                client.peer().clone(),
+                client.service().notifications.subscribe(),
+            )
+        };
+        self.observation_bridge
+            .subscribe(uri, peer, notifications, upstream)
+            .await
+    }
+
+    pub async fn forward_unsubscribe(&self, uri: String) -> Result<(), McpError> {
+        self.observation_bridge.unsubscribe(uri).await
     }
 
     /// Set the upstream client identity (from MCP initialize handshake).
@@ -1187,6 +1215,7 @@ fn tool_can_be_replayed(name: &str) -> bool {
             | "get_all_cells"
             | "get_results"
             | "get_dependencies"
+            | "wait_for_notebook_change"
     )
 }
 
@@ -1300,6 +1329,7 @@ impl ServerHandler for McpProxy {
                 .enable_tools()
                 .enable_tool_list_changed()
                 .enable_resources()
+                .enable_resources_subscribe()
                 .enable_resources_list_changed()
                 .enable_extensions_with(crate::mcp_apps_extension_capabilities())
                 .build(),
@@ -1394,6 +1424,26 @@ impl ServerHandler for McpProxy {
     ) -> Result<ReadResourceResponse, McpError> {
         require_legacy_handshake(&context)?;
         self.forward_read_resource(request).await.map(Into::into)
+    }
+
+    #[allow(deprecated)]
+    async fn subscribe(
+        &self,
+        request: rmcp::model::SubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        self.forward_subscribe(request.uri, context.peer).await
+    }
+
+    #[allow(deprecated)]
+    async fn unsubscribe(
+        &self,
+        request: rmcp::model::UnsubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        self.forward_unsubscribe(request.uri).await
     }
 
     async fn call_tool(

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -241,26 +241,87 @@ impl McpProxy {
         child_env
     }
 
-    /// Set the upstream client identity (from MCP initialize handshake).
+    /// Subscribe only after child startup, with one recovery for a closed child.
     pub async fn forward_subscribe(
         &self,
         uri: String,
         upstream: Peer<RoleServer>,
     ) -> Result<(), McpError> {
-        let (peer, notifications) = {
-            let state = self.state.read().await;
-            let client = state
-                .child_client
-                .as_ref()
-                .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
-            (
-                client.peer().clone(),
-                client.service().notifications.subscribe(),
-            )
-        };
-        self.observation_bridge
-            .subscribe(uri, peer, notifications, upstream)
-            .await
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut recovered = false;
+        loop {
+            let ready = self.child_ready.notified();
+            let snapshot = {
+                let state = self.state.read().await;
+                state.child_client.as_ref().map(|client| {
+                    (
+                        client.peer().clone(),
+                        state.child_generation,
+                        client.service().notifications.subscribe(),
+                    )
+                })
+            };
+            let Some((peer, generation, notifications)) = snapshot else {
+                tokio::time::timeout_at(deadline, ready)
+                    .await
+                    .map_err(|_| {
+                        McpError::internal_error(
+                            "Notebook MCP child did not become ready for subscription",
+                            None,
+                        )
+                    })?;
+                continue;
+            };
+            if peer.is_transport_closed() {
+                if recovered {
+                    return Err(McpError::internal_error(
+                        "Notebook MCP child closed during subscription recovery",
+                        None,
+                    ));
+                }
+                recovered = true;
+                let proxy = self.clone();
+                // A caller timeout must not abandon the restart's ownership flag.
+                let recovery = tokio::spawn(async move {
+                    let replacement_ready = {
+                        let state = proxy.state.read().await;
+                        state.child_generation != generation
+                            && state
+                                .child_client
+                                .as_ref()
+                                .is_some_and(|child| !child.is_transport_closed())
+                    };
+                    if replacement_ready {
+                        Ok(())
+                    } else {
+                        proxy.restart_child().await
+                    }
+                });
+                tokio::time::timeout_at(deadline, recovery)
+                    .await
+                    .map_err(|_| McpError::internal_error("Subscription recovery timed out", None))?
+                    .map_err(|error| McpError::internal_error(error.to_string(), None))?
+                    .map_err(|error| McpError::internal_error(error, None))?;
+                continue;
+            }
+            let result = self
+                .observation_bridge
+                .subscribe(
+                    uri.clone(),
+                    peer.clone(),
+                    generation,
+                    notifications,
+                    upstream.clone(),
+                )
+                .await;
+            if result.is_err() && peer.is_transport_closed() && !recovered {
+                continue;
+            }
+            if self.state.read().await.child_generation != generation {
+                return Err(McpError::internal_error("Notebook MCP child changed during subscription; read a fresh baseline and subscribe again", None));
+            }
+            return result;
+        }
     }
 
     pub async fn forward_unsubscribe(&self, uri: String) -> Result<(), McpError> {

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -161,6 +161,35 @@ impl ServerHandler for LegacyChild {
         })).expect("legacy resource result"))
     }
 
+    async fn subscribe(
+        &self,
+        request: rmcp_legacy::model::SubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        if request.uri == "compatibility://missing" {
+            return Err(ErrorData::resource_not_found(
+                "Missing fixture resource",
+                None,
+            ));
+        }
+        context
+            .peer
+            .notify_resource_updated(rmcp_legacy::model::ResourceUpdatedNotificationParam {
+                uri: request.uri,
+            })
+            .await
+            .unwrap();
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        _: rmcp_legacy::model::UnsubscribeRequestParams,
+        _: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        Ok(())
+    }
+
     async fn call_tool(
         &self,
         request: CallToolRequestParams,

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -166,12 +166,22 @@ impl ServerHandler for LegacyChild {
         request: rmcp_legacy::model::SubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), ErrorData> {
+        if request.uri == "compatibility://stalled" {
+            std::future::pending::<()>().await;
+        }
         if request.uri == "compatibility://missing" {
             return Err(ErrorData::resource_not_found(
                 "Missing fixture resource",
                 None,
             ));
         }
+        let root = std::path::PathBuf::from(std::env::var("NTERACT_COMPATIBILITY_ROOT").unwrap());
+        let mut log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(root.join("subscription-calls"))
+            .unwrap();
+        writeln!(log, "{}", request.uri).unwrap();
         context
             .peer
             .notify_resource_updated(rmcp_legacy::model::ResourceUpdatedNotificationParam {

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -239,6 +239,80 @@ async fn stop_child(proxy: &McpProxy) {
 }
 
 #[tokio::test]
+async fn stalled_subscription_does_not_block_later_watches() {
+    let (_dir, proxy, _) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    let response = wire
+        .request(
+            2,
+            "resources/subscribe",
+            Some(json!({"uri":"compatibility://stalled"})),
+        )
+        .await;
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("timed out"));
+    assert_eq!(
+        legacy_result(
+            &wire
+                .request(
+                    3,
+                    "resources/subscribe",
+                    Some(json!({"uri":"compatibility://resource"}))
+                )
+                .await
+        ),
+        &json!({})
+    );
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn subscriptions_wait_for_startup_and_rebind_after_child_replacement() {
+    let (_dir, proxy, resolves) = isolated_proxy();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    let uri = "compatibility://resource";
+    assert_eq!(
+        legacy_result(
+            &wire
+                .request(2, "resources/subscribe", Some(json!({"uri":uri})))
+                .await
+        ),
+        &json!({})
+    );
+    wire.notification("notifications/resources/updated").await;
+    wire.notifications.clear();
+    proxy.restart_child().await.unwrap();
+    assert_eq!(
+        legacy_result(
+            &wire
+                .request(3, "resources/subscribe", Some(json!({"uri":uri})))
+                .await
+        ),
+        &json!({})
+    );
+    assert_eq!(resolves.load(Ordering::SeqCst), 2);
+    // The new child's subscribe emits an update before its acknowledgment.
+    // Checking its call log distinguishes this from the old child's invalidation.
+    assert_eq!(
+        std::fs::read_to_string(_dir.path().join("subscription-calls"))
+            .unwrap()
+            .lines()
+            .count(),
+        2
+    );
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
 async fn resource_subscriptions_relay_early_notifications_and_invalidate_on_child_loss() {
     let (_dir, proxy, _) = isolated_proxy();
     proxy.init_child().await.unwrap();

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -238,6 +238,53 @@ async fn stop_child(proxy: &McpProxy) {
     }
 }
 
+#[tokio::test]
+async fn resource_subscriptions_relay_early_notifications_and_invalidate_on_child_loss() {
+    let (_dir, proxy, _) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    let info = wire.initialize("2025-11-25").await;
+    assert_eq!(
+        legacy_result(&info)["capabilities"]["resources"]["subscribe"],
+        true
+    );
+    wire.initialized().await;
+    let uri = "compatibility://resource";
+    let subscribed = wire
+        .request(2, "resources/subscribe", Some(json!({"uri":uri})))
+        .await;
+    assert_eq!(legacy_result(&subscribed), &json!({}));
+    wire.notification("notifications/resources/updated").await;
+    assert!(wire
+        .notifications
+        .iter()
+        .any(|notification| notification["params"]["uri"] == uri));
+    wire.notifications.clear();
+    let duplicate = wire
+        .request(3, "resources/subscribe", Some(json!({"uri":uri})))
+        .await;
+    assert_eq!(legacy_result(&duplicate), &json!({}));
+    let rejected = wire
+        .request(
+            4,
+            "resources/subscribe",
+            Some(json!({"uri":"compatibility://missing"})),
+        )
+        .await;
+    assert_eq!(rejected["error"]["code"], -32002);
+    stop_child(&proxy).await;
+    wire.notification("notifications/resources/updated").await;
+    assert!(wire
+        .notifications
+        .iter()
+        .any(|notification| notification["params"]["uri"] == uri));
+    let unsubscribed = wire
+        .request(5, "resources/unsubscribe", Some(json!({"uri":uri})))
+        .await;
+    assert_eq!(legacy_result(&unsubscribed), &json!({}));
+    wire.finish().await;
+}
+
 async fn legacy_proxy_wire(version: &str) {
     let (dir, proxy, resolves) = isolated_proxy();
     proxy

--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -212,6 +212,51 @@
     "name": "disconnect_notebook"
   },
   {
+    "annotations": {
+      "openWorldHint": false,
+      "readOnlyHint": true
+    },
+    "description": "Wait for notebook changes or an exact execution.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "description": "Opaque cursor from a prior read or wait. Omit with no execution_id for an immediate baseline.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "execution_id": {
+          "description": "Wait for this exact execution to finish, including trailing output, even if its cell is rerun.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notebook_handle": {
+          "description": "Attachment handle returned by connect_notebook or create_notebook.",
+          "type": "string"
+        },
+        "timeout_secs": {
+          "description": "Maximum wait in seconds. Default 25; must be between 0 and 50.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "notebook_handle"
+      ],
+      "title": "WaitForNotebookChangeParams",
+      "type": "object"
+    },
+    "name": "wait_for_notebook_change"
+  },
+  {
     "_meta": {
       "ui": {
         "resourceUri": "ui://nteract/output.html"

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -39,6 +39,7 @@ url = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
+rmcp = { workspace = true, features = ["client"] }
 futures-util = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/runt-mcp/src/icons.rs
+++ b/crates/runt-mcp/src/icons.rs
@@ -49,7 +49,7 @@ pub(crate) fn tool_icon(name: &str) -> Option<IconKind> {
         "move_cell" => IconKind::MoveCell,
         "execute_cell" => IconKind::RunCell,
         "run_all_cells" => IconKind::RunAllCells,
-        "get_results" => IconKind::GetResults,
+        "get_results" | "wait_for_notebook_change" => IconKind::GetResults,
         "interrupt_kernel" => IconKind::InterruptKernel,
         "restart_kernel" => IconKind::RestartKernel,
         "manage_dependencies" => IconKind::ManageDependencies,

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -28,12 +28,14 @@ pub mod editing;
 pub mod execution;
 pub mod formatting;
 mod icons;
+pub mod observation;
 pub mod presence;
 pub mod project_file;
 mod resources;
 mod session;
 mod session_activation;
 mod structured;
+mod subscriptions;
 pub mod tools;
 
 use session::{
@@ -139,6 +141,8 @@ pub struct NteractMcp {
     /// the room doesn't hit the eviction timer. On switch-back, the parked
     /// session is resumed instead of creating a new connection.
     parked_sessions: Arc<RwLock<std::collections::HashMap<String, NotebookSession>>>,
+    observation_waits: tokio::sync::Semaphore,
+    resource_subscriptions: Arc<subscriptions::ResourceSubscriptions>,
     /// Context from the most recently dropped session — allows error messages
     /// to tell agents *why* the session was lost and *which notebook_id* to
     /// reconnect to, instead of the generic "No active notebook session".
@@ -166,6 +170,38 @@ pub struct NteractMcp {
 }
 
 impl NteractMcp {
+    pub(crate) async fn observer_for_handle(
+        &self,
+        notebook_handle: &str,
+    ) -> Result<Option<(String, observation::ObservationReader)>, McpError> {
+        let capture = |session: &NotebookSession| {
+            session
+                .access(session::SessionRequirement::DocumentRead)
+                .map_err(resources::resource_session_access_error)?;
+            session
+                .observer()
+                .map(|observer| Some((session.notebook_id.clone(), observer)))
+                .map_err(|error| McpError::internal_error(error, None))
+        };
+        {
+            let active = self.session.read().await;
+            if let Some(session) = active
+                .as_ref()
+                .filter(|session| session.notebook_handle == notebook_handle)
+            {
+                return capture(session);
+            }
+        }
+        let parked = self.parked_sessions.read().await;
+        match parked
+            .values()
+            .find(|session| session.notebook_handle == notebook_handle)
+        {
+            Some(session) => capture(session),
+            None => Ok(None),
+        }
+    }
+
     /// Create a new MCP server instance.
     pub fn new(
         socket_path: PathBuf,
@@ -183,6 +219,8 @@ impl NteractMcp {
             session_intent_epoch: Arc::new(AtomicU64::new(0)),
             session_activation: Arc::new(SessionActivation::default()),
             parked_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            observation_waits: tokio::sync::Semaphore::new(8),
+            resource_subscriptions: Arc::default(),
             last_session_drop: Arc::new(RwLock::new(None)),
             peer_label: Arc::new(RwLock::new("Inkwell".to_string())),
             operator: Arc::new(RwLock::new(agent_operator(
@@ -482,6 +520,7 @@ impl ServerHandler for NteractMcp {
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
+                .enable_resources_subscribe()
                 .enable_extensions_with(extensions)
                 .build(),
         )
@@ -495,7 +534,14 @@ impl ServerHandler for NteractMcp {
              Calling these again switches your active session. \
              Read cells through MCP resources: \
              nteract://notebooks/{notebook_id}/cells and \
-             nteract://notebooks/{notebook_id}/cells/{cell_id}.",
+             nteract://notebooks/{notebook_id}/cells/{cell_id}. \
+             Connect/create also return a notebook_handle for that exact attachment; \
+             use its nteract://sessions/{notebook_handle}/cells or /comments resource. \
+             Reads return a cursor. Use wait_for_notebook_change with that handle \
+             and cursor for a bounded wait, or supply execution_id to wait for an \
+             exact execution and its settled output. Canceling a wait only stops \
+             observation; interrupt_kernel explicitly stops computation. A released \
+             attachment needs a new connect and handle.",
         )
     }
 
@@ -597,6 +643,47 @@ impl ServerHandler for NteractMcp {
     ) -> Result<ListResourceTemplatesResult, McpError> {
         require_legacy_handshake(&context)?;
         Ok(resources::list_resource_templates())
+    }
+
+    #[allow(deprecated)]
+    async fn subscribe(
+        &self,
+        request: rmcp::model::SubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        let target = resources::parse_notebook_resource_uri(&request.uri)
+            .map_err(|message| McpError::resource_not_found(message, None))?;
+        let notebook_id = match &target {
+            resources::NotebookResourceUri::Cells { notebook_id }
+            | resources::NotebookResourceUri::Cell { notebook_id, .. }
+            | resources::NotebookResourceUri::Comments { notebook_id } => notebook_id,
+            resources::NotebookResourceUri::Notebooks => {
+                return Err(McpError::invalid_params(
+                    "Subscribe to a connected notebook's cells or comments resource",
+                    None,
+                ))
+            }
+        };
+        let (_, _, handle, observer) = resources::resource_session(
+            self,
+            notebook_id,
+            request.uri.starts_with("nteract://sessions/"),
+        )
+        .await?;
+        drop(handle);
+        self.resource_subscriptions
+            .subscribe(request.uri, target, observer, context.peer)
+    }
+
+    #[allow(deprecated)]
+    async fn unsubscribe(
+        &self,
+        request: rmcp::model::UnsubscribeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        require_legacy_handshake(&context)?;
+        self.resource_subscriptions.unsubscribe(&request.uri)
     }
 }
 

--- a/crates/runt-mcp/src/observation.rs
+++ b/crates/runt-mcp/src/observation.rs
@@ -1,0 +1,668 @@
+//! Bounded notebook change observation over the existing sync peer.
+//!
+//! An owner follows an active or parked session. Readers contain snapshots and
+//! watch receivers, never a `DocHandle` or sync command sender. Dropping the
+//! owner invalidates readers even if a client keeps a pending wait alive.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use comments_doc::CommentsProjection;
+use notebook_sync::status::{ConnectionState, SyncStatus};
+use notebook_sync::{DocHandle, NotebookSnapshot, SyncError};
+use runtime_doc::RuntimeState;
+use serde::Serialize;
+use tokio::sync::watch;
+
+const RETAINED_BATCHES: usize = 256;
+const COALESCE: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Debug)]
+pub struct ObservedNotebook {
+    pub notebook: Arc<NotebookSnapshot>,
+    pub runtime: Arc<RuntimeState>,
+    pub comments: Option<Arc<CommentsProjection>>,
+    pub status: SyncStatus,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeKind {
+    Cells,
+    NotebookMetadata,
+    Runtime,
+    Executions,
+    Outputs,
+    Comments,
+    Status,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct NotebookChanges {
+    pub kinds: BTreeSet<ChangeKind>,
+    pub cell_ids: BTreeSet<String>,
+    pub execution_ids: BTreeSet<String>,
+    pub comment_thread_ids: BTreeSet<String>,
+}
+
+impl NotebookChanges {
+    fn merge(&mut self, other: &Self) {
+        self.kinds.extend(&other.kinds);
+        self.cell_ids.extend(other.cell_ids.iter().cloned());
+        self.execution_ids
+            .extend(other.execution_ids.iter().cloned());
+        self.comment_thread_ids
+            .extend(other.comment_thread_ids.iter().cloned());
+    }
+
+    fn between(before: &ObservedNotebook, after: &ObservedNotebook) -> Self {
+        let mut changes = Self::default();
+        if before.notebook.cells.iter().map(|cell| &cell.id).ne(after
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| &cell.id))
+        {
+            changes.kinds.insert(ChangeKind::Cells);
+        }
+        let old_cells: BTreeMap<_, _> = before
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| (&cell.id, cell))
+            .collect();
+        let new_cells: BTreeMap<_, _> = after
+            .notebook
+            .cells
+            .iter()
+            .map(|cell| (&cell.id, cell))
+            .collect();
+        for id in old_cells.keys().chain(new_cells.keys()) {
+            if old_cells.get(id) != new_cells.get(id) {
+                changes.cell_ids.insert((*id).clone());
+                changes.kinds.insert(ChangeKind::Cells);
+            }
+        }
+        for id in before
+            .notebook
+            .execution_pointers
+            .keys()
+            .chain(after.notebook.execution_pointers.keys())
+        {
+            let old = before.notebook.execution_pointers.get(id);
+            let new = after.notebook.execution_pointers.get(id);
+            if old != new {
+                changes.kinds.insert(ChangeKind::Executions);
+                changes.kinds.insert(ChangeKind::Outputs);
+                changes.cell_ids.insert(id.clone());
+                changes
+                    .execution_ids
+                    .extend(old.into_iter().chain(new).cloned());
+            }
+        }
+        if before.notebook.notebook_metadata != after.notebook.notebook_metadata {
+            changes.kinds.insert(ChangeKind::NotebookMetadata);
+        }
+        if before.runtime != after.runtime {
+            changes.kinds.insert(ChangeKind::Runtime);
+            for id in before
+                .runtime
+                .executions
+                .keys()
+                .chain(after.runtime.executions.keys())
+            {
+                let old = before.runtime.executions.get(id);
+                let new = after.runtime.executions.get(id);
+                if old != new {
+                    changes.kinds.insert(ChangeKind::Executions);
+                    changes.execution_ids.insert(id.clone());
+                    if old.map(|execution| &execution.outputs)
+                        != new.map(|execution| &execution.outputs)
+                    {
+                        changes.kinds.insert(ChangeKind::Outputs);
+                    }
+                    for execution in old.into_iter().chain(new) {
+                        if let Some(cell_id) = &execution.cell_id {
+                            changes.cell_ids.insert(cell_id.clone());
+                        }
+                    }
+                }
+            }
+        }
+        if before.comments != after.comments {
+            changes.kinds.insert(ChangeKind::Comments);
+            let old: BTreeMap<_, _> = before
+                .comments
+                .iter()
+                .flat_map(|projection| &projection.threads)
+                .map(|thread| (&thread.id, thread))
+                .collect();
+            let new: BTreeMap<_, _> = after
+                .comments
+                .iter()
+                .flat_map(|projection| &projection.threads)
+                .map(|thread| (&thread.id, thread))
+                .collect();
+            for id in old.keys().chain(new.keys()) {
+                if old.get(id) != new.get(id) {
+                    changes.comment_thread_ids.insert((*id).clone());
+                }
+            }
+        }
+        if before.status != after.status {
+            changes.kinds.insert(ChangeKind::Status);
+        }
+        changes
+    }
+}
+
+struct Inputs {
+    notebook: watch::Receiver<NotebookSnapshot>,
+    runtime: watch::Receiver<RuntimeState>,
+    comments: watch::Receiver<Option<Arc<CommentsProjection>>>,
+    status: watch::Receiver<SyncStatus>,
+}
+
+impl Inputs {
+    fn current(&mut self, previous: Option<&ObservedNotebook>) -> ObservedNotebook {
+        let notebook = match previous {
+            Some(previous) if !self.notebook.has_changed().unwrap_or(true) => {
+                previous.notebook.clone()
+            }
+            _ => Arc::new(self.notebook.borrow_and_update().clone()),
+        };
+        let runtime = match previous {
+            Some(previous) if !self.runtime.has_changed().unwrap_or(true) => {
+                previous.runtime.clone()
+            }
+            _ => Arc::new(self.runtime.borrow_and_update().clone()),
+        };
+        let mut status = self.status.borrow_and_update().clone();
+        if self.status.has_changed().is_err() {
+            status.connection = ConnectionState::Disconnected;
+        }
+        ObservedNotebook {
+            notebook,
+            runtime,
+            comments: self.comments.borrow_and_update().clone(),
+            status,
+        }
+    }
+}
+
+struct Journal {
+    generation: String,
+    sequence: u64,
+    view: ObservedNotebook,
+    history: VecDeque<(u64, NotebookChanges)>,
+    released: bool,
+}
+
+impl Journal {
+    fn cursor(&self) -> String {
+        format!("{}:{}", self.generation, self.sequence)
+    }
+
+    fn record(&mut self, next: ObservedNotebook) -> bool {
+        let changes = NotebookChanges::between(&self.view, &next);
+        self.view = next;
+        if changes.kinds.is_empty() {
+            return false;
+        }
+        self.sequence = match self.sequence.checked_add(1) {
+            Some(sequence) => sequence,
+            None => {
+                self.generation = uuid::Uuid::new_v4().to_string();
+                self.history.clear();
+                1
+            }
+        };
+        self.history.push_back((self.sequence, changes));
+        if self.history.len() > RETAINED_BATCHES {
+            self.history.pop_front();
+        }
+        true
+    }
+
+    fn since(&self, after: Option<&str>) -> ChangeRead {
+        let mut result = ChangeRead {
+            outcome: ChangeOutcome::Baseline,
+            cursor: self.cursor(),
+            changes: NotebookChanges::default(),
+            snapshot: self.view.clone(),
+        };
+        if self.released || self.view.status.connection == ConnectionState::Disconnected {
+            result.outcome = ChangeOutcome::Unavailable;
+            return result;
+        }
+        let Some(after) = after else {
+            return result;
+        };
+        let parsed = after.rsplit_once(':').and_then(|(generation, sequence)| {
+            (generation == self.generation)
+                .then_some(sequence)?
+                .parse::<u64>()
+                .ok()
+        });
+        let oldest = self
+            .history
+            .front()
+            .map_or(self.sequence, |(sequence, _)| sequence - 1);
+        let Some(sequence) =
+            parsed.filter(|sequence| *sequence >= oldest && *sequence <= self.sequence)
+        else {
+            result.outcome = ChangeOutcome::ResyncRequired;
+            return result;
+        };
+        result.outcome = if sequence == self.sequence {
+            ChangeOutcome::Unchanged
+        } else {
+            ChangeOutcome::Changed
+        };
+        for (_, changes) in self.history.iter().filter(|(entry, _)| *entry > sequence) {
+            result.changes.merge(changes);
+        }
+        result
+    }
+}
+
+struct State {
+    inputs: Inputs,
+    journal: Journal,
+    changed: watch::Sender<u64>,
+}
+
+/// Own this alongside a session; move it when parking or resuming the session.
+pub struct ObservationOwner {
+    reader: ObservationReader,
+    task: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+pub struct ObservationReader {
+    state: Arc<Mutex<State>>,
+    changed: watch::Receiver<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeOutcome {
+    Baseline,
+    Changed,
+    Unchanged,
+    TimedOut,
+    ResyncRequired,
+    Unavailable,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChangeRead {
+    pub outcome: ChangeOutcome,
+    pub cursor: String,
+    pub changes: NotebookChanges,
+    /// Snapshot paired with this cursor. Resource reads must use this snapshot
+    /// rather than independently sampling a later document version.
+    pub snapshot: ObservedNotebook,
+}
+
+impl ObservationOwner {
+    /// Requires a Tokio runtime. Subscribe to every source before capturing
+    /// the baseline, so a concurrent local/remote edit cannot disappear.
+    pub fn new(handle: &DocHandle) -> Result<Self, Box<SyncError>> {
+        Self::from_inputs(Inputs {
+            notebook: handle.subscribe(),
+            runtime: handle.subscribe_runtime_state(),
+            comments: handle.subscribe_comments()?,
+            status: handle.subscribe_status(),
+        })
+    }
+
+    fn from_inputs(mut inputs: Inputs) -> Result<Self, Box<SyncError>> {
+        let view = inputs.current(None);
+        let journal = Journal {
+            generation: uuid::Uuid::new_v4().to_string(),
+            sequence: 0,
+            view,
+            history: VecDeque::new(),
+            released: false,
+        };
+        let mut notebook = inputs.notebook.clone();
+        let mut runtime = inputs.runtime.clone();
+        let mut comments = inputs.comments.clone();
+        let mut status = inputs.status.clone();
+        let (changed, receiver) = watch::channel(0);
+        let reader = ObservationReader {
+            state: Arc::new(Mutex::new(State {
+                inputs,
+                journal,
+                changed,
+            })),
+            changed: receiver,
+        };
+        let worker = reader.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let closed = tokio::select! {
+                    result = notebook.changed() => result.is_err(),
+                    result = runtime.changed() => result.is_err(),
+                    result = comments.changed() => result.is_err(),
+                    result = status.changed() => result.is_err(),
+                };
+                if closed {
+                    worker.invalidate();
+                    return;
+                }
+                tokio::time::sleep(COALESCE).await;
+                // A closed channel is observed on the next iteration. The
+                // public read path also sees disconnected status immediately.
+                if worker.read(None).is_err() {
+                    return;
+                }
+            }
+        });
+        Ok(Self { reader, task })
+    }
+
+    pub fn reader(&self) -> ObservationReader {
+        self.reader.clone()
+    }
+}
+
+impl Drop for ObservationOwner {
+    fn drop(&mut self) {
+        self.reader.invalidate();
+        self.task.abort();
+    }
+}
+
+impl ObservationReader {
+    pub(crate) fn same_attachment(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+
+    pub fn execution_watcher(
+        &self,
+        execution_id: &str,
+    ) -> Result<notebook_sync::execution_watch::ExecutionWatcher, Box<SyncError>> {
+        let state = self.state.lock().map_err(|_| SyncError::LockPoisoned)?;
+        let cell_id = state
+            .inputs
+            .runtime
+            .borrow()
+            .executions
+            .get(execution_id)
+            .and_then(|execution| execution.cell_id.clone())
+            .unwrap_or_default();
+        Ok(
+            notebook_sync::execution_watch::ExecutionWatcher::from_receiver(
+                state.inputs.runtime.clone(),
+                cell_id,
+                execution_id,
+            ),
+        )
+    }
+
+    pub fn read(&self, after: Option<&str>) -> Result<ChangeRead, Box<SyncError>> {
+        let mut state = self.state.lock().map_err(|_| SyncError::LockPoisoned)?;
+        if !state.journal.released {
+            let State {
+                inputs,
+                journal,
+                changed,
+            } = &mut *state;
+            let view = inputs.current(Some(&journal.view));
+            if journal.record(view) {
+                changed.send_replace(journal.sequence);
+            }
+        }
+        Ok(state.journal.since(after))
+    }
+
+    fn invalidate(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        state.journal.released = true;
+        state
+            .changed
+            .send_modify(|sequence| *sequence = sequence.wrapping_add(1));
+    }
+
+    /// A cancellation only drops this future; it cannot send kernel requests.
+    pub async fn wait(&self, after: &str, timeout: Duration) -> Result<ChangeRead, Box<SyncError>> {
+        let mut changed = self.changed.clone();
+        let ready = tokio::time::timeout(timeout, async {
+            loop {
+                changed.borrow_and_update();
+                let result = self.read(Some(after))?;
+                if result.outcome != ChangeOutcome::Unchanged {
+                    return Ok(result);
+                }
+                if changed.changed().await.is_err() {
+                    self.invalidate();
+                }
+            }
+        })
+        .await;
+        match ready {
+            Ok(result) => result,
+            Err(_) => {
+                let mut result = self.read(Some(after))?;
+                if result.outcome == ChangeOutcome::Unchanged {
+                    result.outcome = ChangeOutcome::TimedOut;
+                }
+                Ok(result)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    pub(crate) struct Fixture {
+        pub(crate) owner: ObservationOwner,
+        pub(crate) notebook: watch::Sender<NotebookSnapshot>,
+        pub(crate) runtime: watch::Sender<RuntimeState>,
+        _comments: watch::Sender<Option<Arc<CommentsProjection>>>,
+        _status: watch::Sender<SyncStatus>,
+    }
+
+    pub(crate) fn fixture() -> Fixture {
+        let (notebook, notebook_rx) = watch::channel(NotebookSnapshot::empty());
+        let (runtime, runtime_rx) = watch::channel(RuntimeState::default());
+        let (comments, comments_rx) = watch::channel(None);
+        let (status, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let owner = ObservationOwner::from_inputs(Inputs {
+            notebook: notebook_rx,
+            runtime: runtime_rx,
+            comments: comments_rx,
+            status: status_rx,
+        })
+        .unwrap();
+        Fixture {
+            owner,
+            notebook,
+            runtime,
+            _comments: comments,
+            _status: status,
+        }
+    }
+
+    pub(crate) fn edited(source: &str) -> NotebookSnapshot {
+        let mut doc = notebook_doc::NotebookDoc::new("observed-notebook");
+        doc.add_cell_after("cell-1", "code", None).unwrap();
+        doc.update_source("cell-1", source).unwrap();
+        NotebookSnapshot::from_doc(&doc.into_inner())
+    }
+
+    #[tokio::test]
+    async fn edits_between_baseline_and_wait_are_returned_with_the_matching_snapshot() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        fixture.notebook.send_replace(edited("print(2)"));
+        let changed = reader
+            .wait(&baseline.cursor, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(changed.outcome, ChangeOutcome::Changed);
+        assert_eq!(changed.snapshot.notebook.cells[0].source, "print(2)");
+        assert_eq!(changed.changes.cell_ids, BTreeSet::from(["cell-1".into()]));
+        assert_eq!(
+            reader.read(Some(&changed.cursor)).unwrap().outcome,
+            ChangeOutcome::Unchanged
+        );
+    }
+
+    #[tokio::test]
+    async fn burst_changes_coalesce_without_copying_source_into_the_history() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        for index in 0..20 {
+            fixture
+                .notebook
+                .send_replace(edited(&format!("print({index})")));
+        }
+        let changed = reader
+            .wait(&baseline.cursor, Duration::from_secs(1))
+            .await
+            .unwrap();
+        let state = reader.state.lock().unwrap();
+        assert_eq!(state.journal.sequence, 1);
+        assert_eq!(state.journal.history.len(), 1);
+        assert_eq!(changed.snapshot.notebook.cells[0].source, "print(19)");
+        assert!(!serde_json::to_string(&changed.changes)
+            .unwrap()
+            .contains("print"));
+    }
+
+    #[tokio::test]
+    async fn expired_foreign_and_future_cursors_require_rebaseline() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        let mut first_cursor = String::new();
+        for index in 0..=RETAINED_BATCHES {
+            fixture.notebook.send_replace(edited(&index.to_string()));
+            let change = reader.read(None).unwrap();
+            if index == 0 {
+                first_cursor = change.cursor;
+            }
+        }
+        assert_eq!(
+            reader.state.lock().unwrap().journal.history.len(),
+            RETAINED_BATCHES
+        );
+        assert_eq!(
+            reader.read(Some(&baseline.cursor)).unwrap().outcome,
+            ChangeOutcome::ResyncRequired
+        );
+        assert_eq!(
+            reader.read(Some(&first_cursor)).unwrap().outcome,
+            ChangeOutcome::Changed
+        );
+        assert_eq!(
+            reader.read(Some("foreign:0")).unwrap().outcome,
+            ChangeOutcome::ResyncRequired
+        );
+        let future = format!("{}:999999", reader.state.lock().unwrap().journal.generation);
+        assert_eq!(
+            reader.read(Some(&future)).unwrap().outcome,
+            ChangeOutcome::ResyncRequired
+        );
+    }
+
+    #[tokio::test]
+    async fn releasing_session_wakes_pending_wait_and_invalidates_retained_reader() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        let pending = {
+            let reader = reader.clone();
+            tokio::spawn(
+                async move { reader.wait(&baseline.cursor, Duration::from_secs(30)).await },
+            )
+        };
+        drop(fixture.owner);
+        let result = tokio::time::timeout(Duration::from_secs(1), pending)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.outcome, ChangeOutcome::Unavailable);
+        assert_eq!(
+            reader.read(None).unwrap().outcome,
+            ChangeOutcome::Unavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_wait_does_not_destroy_observation_and_timeout_is_explicit() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        let pending = {
+            let reader = reader.clone();
+            let cursor = baseline.cursor.clone();
+            tokio::spawn(async move { reader.wait(&cursor, Duration::from_secs(30)).await })
+        };
+        pending.abort();
+        let timeout = reader
+            .wait(&baseline.cursor, Duration::from_millis(1))
+            .await
+            .unwrap();
+        assert_eq!(timeout.outcome, ChangeOutcome::TimedOut);
+        fixture.notebook.send_replace(edited("still connected"));
+        assert_eq!(
+            reader
+                .wait(&baseline.cursor, Duration::from_secs(1))
+                .await
+                .unwrap()
+                .outcome,
+            ChangeOutcome::Changed
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_pointer_changes_are_visible_even_without_a_runtime_update() {
+        let fixture = fixture();
+        fixture.notebook.send_replace(edited("pass"));
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        fixture.notebook.send_modify(|snapshot| {
+            Arc::make_mut(&mut snapshot.execution_pointers).insert("cell-1".into(), "run-2".into());
+        });
+        let change = reader.read(Some(&baseline.cursor)).unwrap();
+        assert_eq!(
+            change.changes.execution_ids,
+            BTreeSet::from(["run-2".into()])
+        );
+        assert!(change.changes.kinds.contains(&ChangeKind::Outputs));
+        assert_eq!(
+            change.snapshot.notebook.execution_pointers["cell-1"],
+            "run-2"
+        );
+    }
+
+    #[tokio::test]
+    async fn output_updates_keep_the_exact_execution_and_cell_identity() {
+        let fixture = fixture();
+        let reader = fixture.owner.reader();
+        let baseline = reader.read(None).unwrap();
+        fixture.runtime.send_modify(|runtime| {
+            runtime.executions.insert("run-1".into(), serde_json::from_value(serde_json::json!({"status":"done","cell_id":"cell-1","outputs":[{"output_type":"stream","text":"done"}]})).unwrap());
+        });
+        let changed = reader
+            .wait(&baseline.cursor, Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(
+            changed.changes.execution_ids,
+            BTreeSet::from(["run-1".into()])
+        );
+        assert_eq!(changed.changes.cell_ids, BTreeSet::from(["cell-1".into()]));
+        assert!(changed.changes.kinds.contains(&ChangeKind::Outputs));
+    }
+}

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -8,6 +8,7 @@ use rmcp::model::{
 use rmcp::ErrorData as McpError;
 
 use crate::icons::{self, IconKind};
+use crate::observation::{ChangeOutcome, ChangeRead, ObservationReader, ObservedNotebook};
 use crate::NteractMcp;
 
 const OUTPUT_RESOURCE_URI: &str = "ui://nteract/output.html";
@@ -103,7 +104,7 @@ pub async fn list_resources(server: &NteractMcp) -> Result<ListResourcesResult, 
 
 /// List available dynamic MCP resource templates.
 pub fn list_resource_templates() -> ListResourceTemplatesResult {
-    let templates = vec![
+    let mut templates = vec![
         assistant_resource_template(
             "nteract://notebooks/{notebook_id}/cells",
             "nteract notebook cells",
@@ -130,6 +131,18 @@ pub fn list_resource_templates() -> ListResourceTemplatesResult {
         ),
     ];
 
+    let attachment_templates: Vec<_> = templates
+        .iter()
+        .cloned()
+        .map(|mut template| {
+            template.uri_template = template
+                .uri_template
+                .replace("notebooks/{notebook_id}", "sessions/{notebook_handle}");
+            template.name = format!("{} by attachment", template.name);
+            template
+        })
+        .collect();
+    templates.extend(attachment_templates);
     ListResourceTemplatesResult::with_all_items(templates)
 }
 
@@ -159,29 +172,39 @@ pub async fn read_resource(
             Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
         }
         NotebookResourceUri::Cells { notebook_id } => {
-            let handle = handle_for_notebook(server, &notebook_id).await?;
-            let text = cells_json(&notebook_id, &handle);
-            Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
+            let (notebook_id, handle_id, _handle, observer) =
+                resource_session(server, &notebook_id, uri.starts_with("nteract://sessions/"))
+                    .await?;
+            let snapshot = observed_read(&observer)?;
+            let text = cells_json(&notebook_id, &snapshot.snapshot, &handle_id);
+            observed_resource(uri, text, &handle_id, &snapshot)
         }
         NotebookResourceUri::Cell {
             notebook_id,
             cell_id,
         } => {
-            let handle = handle_for_notebook(server, &notebook_id).await?;
-            let text = cell_json(&notebook_id, &handle, &cell_id)?;
-            Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
+            let (notebook_id, handle_id, _handle, observer) =
+                resource_session(server, &notebook_id, uri.starts_with("nteract://sessions/"))
+                    .await?;
+            let snapshot = observed_read(&observer)?;
+            let text = cell_json(&notebook_id, &snapshot.snapshot, &cell_id, &handle_id)?;
+            observed_resource(uri, text, &handle_id, &snapshot)
         }
         NotebookResourceUri::Comments { notebook_id } => {
-            let handle = handle_for_notebook(server, &notebook_id).await?;
+            let (_notebook_id, handle_id, handle, observer) =
+                resource_session(server, &notebook_id, uri.starts_with("nteract://sessions/"))
+                    .await?;
             // Settle pending comments/state frames so a read right after join
             // does not race the daemon's initial CommentsDocSync.
             let _ = handle.confirm_state_sync().await;
-            let projection = handle
-                .get_comments_projection()
-                .map_err(|e| McpError::internal_error(format!("read comments: {e}"), None))?;
+            let snapshot = observed_read(&observer)?;
+            let projection =
+                snapshot.snapshot.comments.as_ref().ok_or_else(|| {
+                    McpError::internal_error("Comments are not available yet", None)
+                })?;
             let text = serde_json::to_string_pretty(&projection)
                 .map_err(|e| McpError::internal_error(format!("serialize comments: {e}"), None))?;
-            Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
+            observed_resource(uri, text, &handle_id, &snapshot)
         }
     }
 }
@@ -273,23 +296,62 @@ async fn known_session_notebook_ids(server: &NteractMcp) -> Vec<String> {
     notebook_ids
 }
 
-async fn handle_for_notebook(
+pub(crate) async fn resource_session(
     server: &NteractMcp,
     notebook_id: &str,
-) -> Result<notebook_sync::handle::DocHandle, McpError> {
-    if let Some(session) = server.session.read().await.as_ref() {
-        if session.notebook_id == notebook_id {
-            return session
-                .access(crate::session::SessionRequirement::DocumentRead)
-                .map(|access| access.handle)
-                .map_err(resource_session_access_error);
+    by_handle: bool,
+) -> Result<
+    (
+        String,
+        String,
+        notebook_sync::handle::DocHandle,
+        ObservationReader,
+    ),
+    McpError,
+> {
+    let capture = |session: &crate::session::NotebookSession| {
+        let access = session
+            .access(crate::session::SessionRequirement::DocumentRead)
+            .map_err(resource_session_access_error)?;
+        let observer = session
+            .observer()
+            .map_err(|error| McpError::internal_error(error, None))?;
+        Ok((
+            session.notebook_id.clone(),
+            session.notebook_handle.clone(),
+            access.handle,
+            observer,
+        ))
+    };
+    let matches = |session: &crate::session::NotebookSession| {
+        if by_handle {
+            session.notebook_handle == notebook_id
+        } else {
+            session.notebook_id == notebook_id
+        }
+    };
+    let mut found = {
+        let active = server.session.read().await;
+        active
+            .as_ref()
+            .filter(|session| matches(session))
+            .map(capture)
+            .transpose()?
+    };
+    {
+        let parked = server.parked_sessions.read().await;
+        for session in parked.values().filter(|session| matches(session)) {
+            if let Some((_, handle, _, _)) = &found {
+                if *handle == session.notebook_handle {
+                    continue;
+                }
+                return Err(McpError::invalid_params("Ambiguous notebook ID; read its nteract://sessions/{notebook_handle} resource instead", None));
+            }
+            found = Some(capture(session)?);
         }
     }
-    if let Some(session) = server.parked_sessions.read().await.get(notebook_id) {
-        return session
-            .access(crate::session::SessionRequirement::DocumentRead)
-            .map(|access| access.handle)
-            .map_err(resource_session_access_error);
+    if let Some(found) = found {
+        return Ok(found);
     }
     Err(McpError::resource_not_found(
         format!(
@@ -300,7 +362,37 @@ async fn handle_for_notebook(
     ))
 }
 
-fn resource_session_access_error(error: crate::session::SessionAccessError) -> McpError {
+fn observed_read(observer: &ObservationReader) -> Result<ChangeRead, McpError> {
+    let read = observer
+        .read(None)
+        .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+    if read.outcome == ChangeOutcome::Unavailable {
+        return Err(McpError::resource_not_found(
+            "Notebook attachment is no longer available",
+            None,
+        ));
+    }
+    Ok(read)
+}
+
+fn observed_resource(
+    uri: &str,
+    text: String,
+    handle: &str,
+    read: &ChangeRead,
+) -> Result<ReadResourceResult, McpError> {
+    let mut data: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+    data["cursor"] = serde_json::json!(read.cursor);
+    data["notebook_handle"] = serde_json::json!(handle);
+    Ok(
+        ReadResourceResult::new(vec![json_resource(uri, data.to_string())])
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private),
+    )
+}
+
+pub(crate) fn resource_session_access_error(error: crate::session::SessionAccessError) -> McpError {
     McpError::internal_error(
         serde_json::json!({
             "error": {
@@ -323,30 +415,26 @@ fn json_resource(uri: &str, text: String) -> ResourceContents {
     }
 }
 
-fn cells_json(notebook_id: &str, handle: &notebook_sync::handle::DocHandle) -> String {
-    let status_by_cell = crate::tools::cell_read::build_cell_status_map(handle);
-    let execution_count_by_cell = crate::tools::cell_read::build_cell_execution_count_map(handle);
-    let outputs_by_cell = handle.get_all_outputs();
-    let cells = handle.get_cells();
+fn cells_json(notebook_id: &str, view: &ObservedNotebook, notebook_handle: &str) -> String {
+    let cells = view.notebook.cells();
     let cell_entries: Vec<_> = cells
         .iter()
         .enumerate()
         .map(|(index, cell)| {
-            let execution_id = handle.get_cell_execution_id(&cell.id);
-            let status = status_by_cell.get(&cell.id).cloned().or_else(|| {
-                (cell.cell_type == "code" && execution_id.is_none()).then(|| "never_run".into())
-            });
+            let execution_id = view.notebook.execution_pointers.get(&cell.id);
+            let execution = execution_id.and_then(|id| view.runtime.executions.get(id));
+            let status = observed_cell_status(view, cell);
             serde_json::json!({
                 "cell_id": cell.id,
-                "uri": notebook_cell_uri(notebook_id, &cell.id),
+                "uri": attachment_cell_uri(notebook_handle, &cell.id),
                 "cell_type": cell.cell_type,
-                "previous_cell_id": previous_cell_id(&cells, index),
-                "next_cell_id": next_cell_id(&cells, index),
+                "previous_cell_id": previous_cell_id(cells, index),
+                "next_cell_id": next_cell_id(cells, index),
                 "source_preview": source_preview(&cell.source, 160),
                 "execution_id": execution_id,
-                "execution_count": execution_count_by_cell.get(&cell.id),
+                "execution_count": execution.and_then(|entry| entry.execution_count).map(|count| count.to_string()),
                 "status": status,
-                "outputs": summarize_outputs(outputs_by_cell.get(&cell.id).map(Vec::as_slice).unwrap_or(&[])),
+                "outputs": summarize_outputs(execution.map(|entry| entry.outputs.as_slice()).unwrap_or(&[])),
             })
         })
         .collect();
@@ -370,31 +458,33 @@ fn next_cell_id(cells: &[notebook_doc::CellSnapshot], index: usize) -> Option<&s
 
 fn cell_json(
     notebook_id: &str,
-    handle: &notebook_sync::handle::DocHandle,
+    view: &ObservedNotebook,
     cell_id: &str,
+    notebook_handle: &str,
 ) -> Result<String, McpError> {
-    let cell = handle
+    let cell = view
+        .notebook
         .get_cell(cell_id)
         .ok_or_else(|| McpError::resource_not_found(format!("Cell not found: {cell_id}"), None))?;
-    let execution_id = handle.get_cell_execution_id(cell_id);
-    let execution_count =
-        crate::tools::cell_read::get_cell_execution_count_from_runtime(handle, cell_id);
-    let status_by_cell = crate::tools::cell_read::build_cell_status_map(handle);
-    let status = status_by_cell.get(cell_id).cloned().or_else(|| {
-        (cell.cell_type == "code" && execution_id.is_none()).then(|| "never_run".into())
-    });
-    let outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
-    let execution_count = (!execution_count.is_empty()).then_some(execution_count);
-    let cells = handle.get_cells();
+    let execution_id = view.notebook.execution_pointers.get(cell_id);
+    let execution = execution_id.and_then(|id| view.runtime.executions.get(id));
+    let execution_count = execution
+        .and_then(|entry| entry.execution_count)
+        .map(|count| count.to_string());
+    let status = observed_cell_status(view, cell);
+    let outputs = execution
+        .map(|entry| entry.outputs.as_slice())
+        .unwrap_or(&[]);
+    let cells = view.notebook.cells();
     let cell_index = cells.iter().position(|candidate| candidate.id == cell_id);
-    let previous_cell_id = cell_index.and_then(|index| previous_cell_id(&cells, index));
-    let next_cell_id = cell_index.and_then(|index| next_cell_id(&cells, index));
+    let previous_cell_id = cell_index.and_then(|index| previous_cell_id(cells, index));
+    let next_cell_id = cell_index.and_then(|index| next_cell_id(cells, index));
 
     Ok(serde_json::to_string_pretty(&serde_json::json!({
         "notebook_id": notebook_id,
         "cell": {
             "cell_id": cell.id,
-            "uri": notebook_cell_uri(notebook_id, cell_id),
+            "uri": attachment_cell_uri(notebook_handle, cell_id),
             "cell_type": cell.cell_type,
             "previous_cell_id": previous_cell_id,
             "next_cell_id": next_cell_id,
@@ -407,10 +497,42 @@ fn cell_json(
             "execution_id": execution_id,
             "execution_count": execution_count,
             "status": status,
-            "outputs": summarize_outputs(&outputs),
+            "outputs": summarize_outputs(outputs),
         }
     }))
     .unwrap_or_else(|_| "{}".into()))
+}
+
+fn observed_cell_status<'a>(
+    view: &'a ObservedNotebook,
+    cell: &notebook_doc::CellSnapshot,
+) -> Option<&'a str> {
+    let Some(id) = view.notebook.execution_pointers.get(&cell.id) else {
+        return (cell.cell_type == "code").then_some("never_run");
+    };
+    if view
+        .runtime
+        .queue
+        .executing
+        .as_ref()
+        .is_some_and(|entry| &entry.execution_id == id)
+    {
+        return Some("running");
+    }
+    if view
+        .runtime
+        .queue
+        .queued
+        .iter()
+        .any(|entry| &entry.execution_id == id)
+    {
+        return Some("queued");
+    }
+    view.runtime
+        .executions
+        .get(id)
+        .map(|entry| entry.status.as_str())
+        .filter(|status| matches!(*status, "done" | "error" | "cancelled"))
 }
 
 fn summarize_outputs(outputs: &[serde_json::Value]) -> Vec<serde_json::Value> {
@@ -444,7 +566,7 @@ fn source_preview(source: &str, max_chars: usize) -> String {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum NotebookResourceUri {
+pub(crate) enum NotebookResourceUri {
     Notebooks,
     Cells {
         notebook_id: String,
@@ -458,12 +580,15 @@ enum NotebookResourceUri {
     },
 }
 
-fn parse_notebook_resource_uri(uri: &str) -> Result<NotebookResourceUri, String> {
+pub(crate) fn parse_notebook_resource_uri(uri: &str) -> Result<NotebookResourceUri, String> {
     if uri == NOTEBOOKS_RESOURCE_URI {
         return Ok(NotebookResourceUri::Notebooks);
     }
 
-    let Some(rest) = uri.strip_prefix("nteract://notebooks/") else {
+    let Some(rest) = uri
+        .strip_prefix("nteract://notebooks/")
+        .or_else(|| uri.strip_prefix("nteract://sessions/"))
+    else {
         return Err(format!("Unknown nteract resource URI: {uri}"));
     };
     let parts: Vec<&str> = rest.split('/').collect();
@@ -480,6 +605,27 @@ fn parse_notebook_resource_uri(uri: &str) -> Result<NotebookResourceUri, String>
         }),
         _ => Err(format!("Unknown nteract resource URI: {uri}")),
     }
+}
+
+pub(crate) fn attachment_cells_uri(notebook_handle: &str) -> String {
+    format!(
+        "nteract://sessions/{}/cells",
+        encode_segment(notebook_handle)
+    )
+}
+
+pub(crate) fn attachment_cells_resource_link(notebook_handle: &str) -> Resource {
+    let mut resource = notebook_cells_resource_link(notebook_handle);
+    resource.uri = attachment_cells_uri(notebook_handle);
+    resource
+}
+
+fn attachment_cell_uri(notebook_handle: &str, cell_id: &str) -> String {
+    format!(
+        "{}/{}",
+        attachment_cells_uri(notebook_handle),
+        encode_segment(cell_id)
+    )
 }
 
 pub(crate) fn notebook_cells_uri(notebook_id: &str) -> String {
@@ -824,6 +970,43 @@ mod tests {
                 notebook_id: "nb 1".to_string(),
                 cell_id: "cell/with/slash".to_string()
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn resource_body_keeps_its_snapshot_cursor_and_execution_pointer() {
+        let fixture = crate::observation::tests::fixture();
+        fixture
+            .notebook
+            .send_replace(crate::observation::tests::edited("old source"));
+        fixture.notebook.send_modify(|notebook| {
+            std::sync::Arc::make_mut(&mut notebook.execution_pointers)
+                .insert("cell-1".into(), "run-1".into());
+        });
+        fixture.runtime.send_modify(|runtime| {
+            runtime.executions.insert("run-1".into(), serde_json::from_value(serde_json::json!({"status":"done","execution_count":3,"outputs":[{"output_type":"stream","text":{"inline":"old output"}}]})).unwrap());
+            runtime.executions.insert("run-2".into(), serde_json::from_value(serde_json::json!({"status":"running","execution_count":4,"outputs":[]})).unwrap());
+        });
+        let observer = fixture.owner.reader();
+        let selected = observed_read(&observer).unwrap();
+        fixture
+            .notebook
+            .send_replace(crate::observation::tests::edited("new source"));
+        let uri = attachment_cell_uri("attachment", "cell-1");
+        let body = cell_json("notebook", &selected.snapshot, "cell-1", "attachment").unwrap();
+        let resource = observed_resource(&uri, body, "attachment", &selected).unwrap();
+        let data = serde_json::to_value(resource).unwrap();
+        let body: serde_json::Value =
+            serde_json::from_str(data["contents"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(body["cursor"], selected.cursor);
+        assert_eq!(body["cell"]["source"], "old source");
+        assert_eq!(body["cell"]["execution_id"], "run-1");
+        assert_eq!(body["cell"]["execution_count"], "3");
+        assert_eq!(body["cell"]["status"], "done");
+        assert_eq!(body["cell"]["outputs"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            observer.read(Some(&selected.cursor)).unwrap().outcome,
+            ChangeOutcome::Changed
         );
     }
 

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -2,7 +2,7 @@
 
 use std::future::Future;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -189,6 +189,10 @@ pub struct SessionAccessError {
 
 /// An active notebook session connected via the daemon.
 pub struct NotebookSession {
+    /// Opaque identity of this concrete attachment. Parking preserves it;
+    /// reconnecting creates a new handle.
+    pub notebook_handle: String,
+    observation: OnceLock<Result<crate::observation::ObservationOwner, String>>,
     /// The Automerge document handle for this notebook.
     pub handle: DocHandle,
     /// The notebook ID (always a UUID).
@@ -211,6 +215,17 @@ pub struct NotebookSession {
 }
 
 impl NotebookSession {
+    pub fn observer(&self) -> Result<crate::observation::ObservationReader, String> {
+        self.observation
+            .get_or_init(|| {
+                crate::observation::ObservationOwner::new(&self.handle)
+                    .map_err(|error| error.to_string())
+            })
+            .as_ref()
+            .map(|owner| owner.reader())
+            .map_err(Clone::clone)
+    }
+
     pub fn local(
         handle: DocHandle,
         notebook_id: String,
@@ -219,6 +234,8 @@ impl NotebookSession {
     ) -> Self {
         let activation_target = format!("local:id:{notebook_id}");
         Self {
+            notebook_handle: uuid::Uuid::new_v4().to_string(),
+            observation: OnceLock::new(),
             handle,
             notebook_id,
             notebook_path,
@@ -240,6 +257,8 @@ impl NotebookSession {
         daemon_incarnation: Option<DaemonIncarnation>,
     ) -> Self {
         Self {
+            notebook_handle: uuid::Uuid::new_v4().to_string(),
+            observation: OnceLock::new(),
             handle,
             notebook_id,
             notebook_path,
@@ -256,6 +275,8 @@ impl NotebookSession {
     pub fn hosted(handle: DocHandle, notebook_id: String, domain: String) -> Self {
         let activation_target = crate::cloud::hosted_notebook_url(&domain, &notebook_id);
         Self {
+            notebook_handle: uuid::Uuid::new_v4().to_string(),
+            observation: OnceLock::new(),
             handle,
             notebook_id,
             notebook_path: None,
@@ -275,6 +296,8 @@ impl NotebookSession {
         activation_target: CanonicalNotebookTarget,
     ) -> Self {
         Self {
+            notebook_handle: uuid::Uuid::new_v4().to_string(),
+            observation: OnceLock::new(),
             handle,
             notebook_id,
             notebook_path: None,

--- a/crates/runt-mcp/src/subscriptions.rs
+++ b/crates/runt-mcp/src/subscriptions.rs
@@ -1,0 +1,299 @@
+//! Connection-owned invalidation watches. Tasks retain observers, never sync peers.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rmcp::model::ResourceUpdatedNotificationParam;
+use rmcp::service::{Peer, RoleServer};
+use rmcp::ErrorData as McpError;
+
+use crate::observation::{ChangeKind, ChangeOutcome, NotebookChanges, ObservationReader};
+use crate::resources::NotebookResourceUri;
+
+const MAX_WATCHES: usize = 128;
+type ResourceWatch = (uuid::Uuid, ObservationReader, tokio::task::JoinHandle<()>);
+
+#[derive(Default)]
+pub(crate) struct ResourceSubscriptions {
+    tasks: Mutex<HashMap<String, ResourceWatch>>,
+}
+
+impl Drop for ResourceSubscriptions {
+    fn drop(&mut self) {
+        if let Ok(tasks) = self.tasks.get_mut() {
+            for (_, (_, _, task)) in tasks.drain() {
+                task.abort();
+            }
+        }
+    }
+}
+
+impl ResourceSubscriptions {
+    pub(crate) fn subscribe(
+        self: &Arc<Self>,
+        uri: String,
+        target: NotebookResourceUri,
+        observer: ObservationReader,
+        peer: Peer<RoleServer>,
+    ) -> Result<(), McpError> {
+        let baseline = observer
+            .read(None)
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        if baseline.outcome == ChangeOutcome::Unavailable {
+            return Err(McpError::resource_not_found(
+                "Notebook attachment is no longer available",
+                None,
+            ));
+        }
+        let mut tasks = self
+            .tasks
+            .lock()
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        if tasks.get(&uri).is_some_and(|(_, existing, task)| {
+            existing.same_attachment(&observer) && !task.is_finished()
+        }) {
+            return Ok(());
+        }
+        if let Some((_, _, task)) = tasks.remove(&uri) {
+            task.abort();
+        }
+        if tasks.len() >= MAX_WATCHES {
+            return Err(McpError::invalid_request(
+                "At most 128 resource watches may be active on this connection",
+                None,
+            ));
+        }
+        let weak = Arc::downgrade(self);
+        let id = uuid::Uuid::new_v4();
+        let task_uri = uri.clone();
+        let attachment = observer.clone();
+        let task = tokio::spawn(async move {
+            let mut cursor = baseline.cursor;
+            loop {
+                let Ok(change) = observer.wait(&cursor, Duration::from_secs(50)).await else {
+                    break;
+                };
+                cursor = change.cursor;
+                let invalidated = matches!(
+                    change.outcome,
+                    ChangeOutcome::Unavailable | ChangeOutcome::ResyncRequired
+                );
+                if (invalidated || affects(&target, &change.changes))
+                    && peer
+                        .notify_resource_updated(ResourceUpdatedNotificationParam::new(&task_uri))
+                        .await
+                        .is_err()
+                {
+                    break;
+                }
+                if change.outcome == ChangeOutcome::Unavailable {
+                    break;
+                }
+            }
+            if let Some(registry) = weak.upgrade() {
+                if let Ok(mut tasks) = registry.tasks.lock() {
+                    if tasks
+                        .get(&task_uri)
+                        .is_some_and(|(current, _, _)| *current == id)
+                    {
+                        tasks.remove(&task_uri);
+                    }
+                }
+            }
+        });
+        tasks.insert(uri, (id, attachment, task));
+        Ok(())
+    }
+
+    pub(crate) fn unsubscribe(&self, uri: &str) -> Result<(), McpError> {
+        let mut tasks = self
+            .tasks
+            .lock()
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        if let Some((_, _, task)) = tasks.remove(uri) {
+            task.abort();
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn affects(target: &NotebookResourceUri, changes: &NotebookChanges) -> bool {
+    if changes.kinds.contains(&ChangeKind::Status) {
+        return true;
+    }
+    match target {
+        NotebookResourceUri::Cells { .. } => changes.kinds.iter().any(|kind| {
+            matches!(
+                kind,
+                ChangeKind::Cells
+                    | ChangeKind::Executions
+                    | ChangeKind::Outputs
+                    | ChangeKind::Runtime
+            )
+        }),
+        // Reordering or removing another cell changes this cell's neighbor links.
+        NotebookResourceUri::Cell { cell_id, .. } => {
+            changes.kinds.contains(&ChangeKind::Cells)
+                || changes.cell_ids.contains(cell_id)
+                || changes.kinds.contains(&ChangeKind::Runtime)
+        }
+        NotebookResourceUri::Comments { .. } => changes.kinds.contains(&ChangeKind::Comments),
+        NotebookResourceUri::Notebooks => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::tests::{edited, fixture};
+    use rmcp::model::*;
+    use rmcp::service::{NotificationContext, RequestContext, RoleClient};
+    use rmcp::{ClientHandler, ServerHandler, ServiceExt};
+
+    struct Notifications(tokio::sync::mpsc::UnboundedSender<String>);
+    impl ClientHandler for Notifications {
+        async fn on_resource_updated(
+            &self,
+            params: ResourceUpdatedNotificationParam,
+            _: NotificationContext<RoleClient>,
+        ) {
+            let _ = self.0.send(params.uri);
+        }
+    }
+    struct Server {
+        registry: Arc<ResourceSubscriptions>,
+        observer: ObservationReader,
+    }
+    impl ServerHandler for Server {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(
+                ServerCapabilities::builder()
+                    .enable_resources()
+                    .enable_resources_subscribe()
+                    .build(),
+            )
+        }
+        #[allow(deprecated)]
+        async fn subscribe(
+            &self,
+            params: SubscribeRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> Result<(), McpError> {
+            let target = crate::resources::parse_notebook_resource_uri(&params.uri)
+                .map_err(|e| McpError::invalid_params(e, None))?;
+            self.registry
+                .subscribe(params.uri, target, self.observer.clone(), context.peer)
+        }
+        #[allow(deprecated)]
+        async fn unsubscribe(
+            &self,
+            params: UnsubscribeRequestParams,
+            _: RequestContext<RoleServer>,
+        ) -> Result<(), McpError> {
+            self.registry.unsubscribe(&params.uri)
+        }
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn subscribe_unsubscribe_and_session_release_use_real_protocol_notifications() {
+        let fixture = fixture();
+        let registry = Arc::new(ResourceSubscriptions::default());
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let server = Server {
+            registry: registry.clone(),
+            observer: fixture.owner.reader(),
+        };
+        let task = tokio::spawn(async move { server.serve(server_pipe).await.unwrap() });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut client = Notifications(tx).serve(client_pipe).await.unwrap();
+        let mut server = task.await.unwrap();
+        let cells = "nteract://sessions/attachment/cells";
+        let comments = "nteract://sessions/attachment/comments";
+        client
+            .subscribe(SubscribeRequestParams::new(cells))
+            .await
+            .unwrap();
+        client
+            .subscribe(SubscribeRequestParams::new(cells))
+            .await
+            .unwrap();
+        client
+            .subscribe(SubscribeRequestParams::new(comments))
+            .await
+            .unwrap();
+        assert_eq!(registry.tasks.lock().unwrap().len(), 2);
+        fixture.notebook.send_replace(edited("first edit"));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            cells
+        );
+        assert!(rx.try_recv().is_err());
+        client
+            .unsubscribe(UnsubscribeRequestParams::new(cells))
+            .await
+            .unwrap();
+        fixture.notebook.send_replace(edited("second edit"));
+        assert!(tokio::time::timeout(Duration::from_millis(150), rx.recv())
+            .await
+            .is_err());
+        drop(fixture.owner);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            comments
+        );
+        assert!(tokio::time::timeout(Duration::from_millis(150), rx.recv())
+            .await
+            .is_err());
+        assert!(registry.tasks.lock().unwrap().is_empty());
+        client.close().await.unwrap();
+        server.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn watch_limit_is_enforced_on_the_wire_and_unsubscribe_frees_a_slot() {
+        let fixture = fixture();
+        let registry = Arc::new(ResourceSubscriptions::default());
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let server = Server {
+            registry,
+            observer: fixture.owner.reader(),
+        };
+        let task = tokio::spawn(async move { server.serve(server_pipe).await.unwrap() });
+        let mut client = ().serve(client_pipe).await.unwrap();
+        let mut server = task.await.unwrap();
+        for index in 0..MAX_WATCHES {
+            client
+                .subscribe(SubscribeRequestParams::new(format!(
+                    "nteract://sessions/attachment/cells/cell-{index}"
+                )))
+                .await
+                .unwrap();
+        }
+        let extra = "nteract://sessions/attachment/comments";
+        assert!(client
+            .subscribe(SubscribeRequestParams::new(extra))
+            .await
+            .is_err());
+        client
+            .unsubscribe(UnsubscribeRequestParams::new(
+                "nteract://sessions/attachment/cells/cell-0",
+            ))
+            .await
+            .unwrap();
+        client
+            .subscribe(SubscribeRequestParams::new(extra))
+            .await
+            .unwrap();
+        client.close().await.unwrap();
+        server.close().await.unwrap();
+    }
+}

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -450,7 +450,7 @@ pub async fn get_results(
     ))
 }
 
-async fn render_execution_result(
+pub(super) async fn render_execution_result(
     server: &NteractMcp,
     execution_id: &str,
     exec: &runtime_doc::ExecutionState,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -75,6 +75,7 @@ mod deps;
 mod editing;
 mod execution;
 mod kernel;
+mod observation;
 mod session;
 
 /// Helper to generate a tool's input schema from a type.
@@ -156,6 +157,12 @@ pub fn all_tools() -> Vec<Tool> {
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         // -- Cell CRUD --
+        Tool::new(
+            "wait_for_notebook_change",
+            "Wait for notebook changes or an exact execution.",
+            schema_for::<observation::WaitForNotebookChangeParams>(),
+        )
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         Tool::new(
             "create_cell",
             "Create a cell anchored by after_cell_id; omit after_cell_id to append.",
@@ -357,6 +364,7 @@ pub async fn dispatch(
         "save_notebook" => session::save_notebook(server, request).await,
         "show_notebook" | "launch_app" => session::show_notebook(server, request).await,
         "disconnect_notebook" => session::disconnect_notebook(server, request).await,
+        "wait_for_notebook_change" => observation::wait_for_notebook_change(server, request).await,
         // Cell read. Hidden from tool listing but still callable for backwards compat;
         // resource-aware clients should read nteract://notebooks/{notebook_id}/cells.
         "get_cell" => cell_read::get_cell(server, request).await,

--- a/crates/runt-mcp/src/tools/observation.rs
+++ b/crates/runt-mcp/src/tools/observation.rs
@@ -71,6 +71,7 @@ async fn run_wait(
     observer: &ObservationReader,
     timeout: Duration,
 ) -> Result<CallToolResult, McpError> {
+    let deadline = tokio::time::Instant::now() + timeout;
     let initial = observer.read(params.after.as_deref()).map_err(sync_error)?;
     if matches!(
         initial.outcome,
@@ -111,7 +112,7 @@ async fn run_wait(
         }
     };
     let progress = tokio::select! {
-        result = tokio::time::timeout(timeout, terminal) => result.ok().flatten(),
+        result = tokio::time::timeout_at(deadline, terminal) => result.ok().flatten(),
         unavailable = unavailable => return Ok(change_result(params, notebook_id, unavailable?, None)),
     };
     let mut latest = observer
@@ -133,10 +134,21 @@ async fn run_wait(
             ExecutionTerminalReason::Done
                 | ExecutionTerminalReason::Error
                 | ExecutionTerminalReason::Cancelled
+                | ExecutionTerminalReason::Interrupted
         )
     ) {
-        latest.outcome = ChangeOutcome::Unavailable;
-        return Ok(change_result(params, notebook_id, latest, None));
+        let reason = progress
+            .terminal_reason
+            .as_ref()
+            .map(ExecutionTerminalReason::as_str)
+            .unwrap_or("execution_unavailable");
+        return Ok(change_result_details(
+            params,
+            notebook_id,
+            latest,
+            None,
+            Some(reason),
+        ));
     }
     let Some(exec) = latest.snapshot.runtime.executions.get(execution_id) else {
         latest.outcome = ChangeOutcome::ResyncRequired;
@@ -156,6 +168,7 @@ async fn run_wait(
         .cell_id
         .as_ref()
         .map(|id| std::collections::HashMap::from([(execution_id.to_owned(), id.clone())]));
+    let source_available = exec.source.is_some();
     let rendered = super::execution::render_execution_result(
         server,
         execution_id,
@@ -164,8 +177,39 @@ async fn run_wait(
         cell,
         mapping,
         false,
-    )
-    .await?;
+    );
+    let mut rendered = match tokio::time::timeout_at(deadline, rendered).await {
+        Ok(result) => result?,
+        Err(_) => {
+            let mut latest = observer
+                .read(Some(params.after.as_deref().unwrap_or(&initial.cursor)))
+                .map_err(sync_error)?;
+            if !matches!(
+                latest.outcome,
+                ChangeOutcome::Unavailable | ChangeOutcome::ResyncRequired
+            ) {
+                latest.outcome = ChangeOutcome::TimedOut;
+            }
+            return Ok(change_result(params, notebook_id, latest, None));
+        }
+    };
+    if !source_available {
+        if let Some(cell) = rendered
+            .structured_content
+            .as_mut()
+            .and_then(|data| data.get_mut("cell"))
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            cell.remove("source");
+            cell.insert(
+                "execution_source_available".into(),
+                serde_json::json!(false),
+            );
+        }
+        rendered.content.push(crate::formatting::assistant_text(
+            "The executed source was not recorded.",
+        ));
+    }
     // Rendering may await blob resolution. Do not return a successful attachment
     // result after its owning session was released during that work.
     if observer.read(None).map_err(sync_error)?.outcome == ChangeOutcome::Unavailable {
@@ -181,7 +225,19 @@ fn change_result(
     change: ChangeRead,
     execution: Option<CallToolResult>,
 ) -> CallToolResult {
-    let outcome = if execution.is_some() {
+    change_result_details(params, notebook_id, change, execution, None)
+}
+
+fn change_result_details(
+    params: &WaitForNotebookChangeParams,
+    notebook_id: &str,
+    change: ChangeRead,
+    execution: Option<CallToolResult>,
+    kernel_reason: Option<&str>,
+) -> CallToolResult {
+    let outcome = if kernel_reason.is_some() {
+        "unavailable".into()
+    } else if execution.is_some() {
         "completed".into()
     } else {
         serde_json::to_value(change.outcome).unwrap_or_default()
@@ -192,6 +248,9 @@ fn change_result(
         "execution_id":params.execution_id,
         "execution_status":params.execution_id.as_ref().and_then(|id| change.snapshot.runtime.executions.get(id)).map(|execution| &execution.status),
         "execution":execution.as_ref().and_then(|result| result.structured_content.as_ref()),
+        "reason":kernel_reason,
+        "message":kernel_reason.map(|_| "The kernel stopped before this execution produced a settled result. The notebook attachment is still available; inspect its cells or use restart_kernel before executing again."),
+        "attachment_available":change.outcome != ChangeOutcome::Unavailable,
     });
     let mut content = vec![crate::formatting::assistant_text(payload.to_string())];
     if let Some(execution) = execution {
@@ -375,5 +434,132 @@ mod tests {
                 .unwrap()["outcome"],
             "unavailable"
         );
+    }
+
+    #[tokio::test]
+    async fn interrupted_execution_completes_without_losing_the_attachment() {
+        let fixture = fixture();
+        fixture.runtime.send_modify(|state| {
+            state.executions.insert(
+                "interrupted".into(),
+                serde_json::from_value(json!({"status":"error","outputs":[]})).unwrap(),
+            );
+        });
+        let mut params = params();
+        params.execution_id = Some("interrupted".into());
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &fixture.owner.reader(),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let payload = result.structured_content.unwrap();
+        assert_eq!(payload["outcome"], "completed");
+        assert_eq!(payload["execution_status"], "error");
+        assert_eq!(payload["attachment_available"], true);
+        assert!(serde_json::to_string(&result.content)
+            .unwrap()
+            .contains("nteract://sessions/attachment/cells"));
+    }
+
+    #[tokio::test]
+    async fn kernel_failure_retains_notebook_context_and_explains_recovery() {
+        let fixture = fixture();
+        fixture.runtime.send_modify(|state| {
+            state.kernel.lifecycle = runtime_doc::RuntimeLifecycle::Error;
+            state.executions.insert(
+                "pending".into(),
+                serde_json::from_value(json!({"status":"running","outputs":[]})).unwrap(),
+            );
+        });
+        let mut params = params();
+        params.execution_id = Some("pending".into());
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &fixture.owner.reader(),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let payload = result.structured_content.unwrap();
+        assert_eq!(payload["outcome"], "unavailable");
+        assert_eq!(payload["reason"], "kernel_failed");
+        assert_eq!(payload["attachment_available"], true);
+        assert!(payload["message"]
+            .as_str()
+            .unwrap()
+            .contains("restart_kernel"));
+        assert!(serde_json::to_string(&result.content)
+            .unwrap()
+            .contains("nteract://sessions/attachment/cells"));
+    }
+
+    #[tokio::test]
+    async fn missing_execution_source_is_explicit_and_never_uses_a_later_edit() {
+        let fixture = fixture();
+        fixture.notebook.send_replace(edited("a later edit"));
+        fixture.runtime.send_modify(|state| { state.executions.insert("old".into(), serde_json::from_value(json!({"cell_id":"cell-1","status":"done","outputs":[{"output_type":"display_data","data":{"text/plain":{"inline":"old output"}}}]})).unwrap()); });
+        let mut params = params();
+        params.execution_id = Some("old".into());
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &fixture.owner.reader(),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let cell = &result.structured_content.as_ref().unwrap()["execution"]["cell"];
+        assert_eq!(cell["execution_source_available"], false);
+        assert!(cell.get("source").is_none());
+        assert!(!serde_json::to_string(&result.content)
+            .unwrap()
+            .contains("a later edit"));
+    }
+
+    #[tokio::test]
+    async fn output_resolution_shares_the_wait_deadline() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (accepted, mut connected) = tokio::sync::oneshot::channel();
+        let stall = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            let _ = accepted.send(());
+            std::future::pending::<()>().await;
+        });
+        let fixture = fixture();
+        fixture.runtime.send_modify(|state| { state.executions.insert("blob".into(), serde_json::from_value(json!({"status":"done","outputs":[{"output_type":"display_data","data":{"text/plain":{"blob":"unreachable-output","size":10}}}]})).unwrap()); });
+        let mut params = params();
+        params.execution_id = Some("blob".into());
+        let server = NteractMcp::new(
+            "unused.sock".into(),
+            Some(format!("http://{address}")),
+            None,
+        );
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_wait(
+                &server,
+                &params,
+                "notebook",
+                &fixture.owner.reader(),
+                Duration::from_millis(200),
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(
+            connected.try_recv().is_ok(),
+            "fixture must reach the stalled blob server"
+        );
+        assert_eq!(result.structured_content.unwrap()["outcome"], "timed_out");
+        stall.abort();
     }
 }

--- a/crates/runt-mcp/src/tools/observation.rs
+++ b/crates/runt-mcp/src/tools/observation.rs
@@ -1,0 +1,379 @@
+use std::time::Duration;
+
+use notebook_sync::execution_watch::ExecutionTerminalReason;
+use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::observation::{ChangeOutcome, ChangeRead, ObservationReader};
+use crate::NteractMcp;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WaitForNotebookChangeParams {
+    /// Attachment handle returned by connect_notebook or create_notebook.
+    pub notebook_handle: String,
+    /// Opaque cursor from a prior read or wait. Omit with no execution_id for an immediate baseline.
+    pub after: Option<String>,
+    /// Wait for this exact execution to finish, including trailing output, even if its cell is rerun.
+    pub execution_id: Option<String>,
+    /// Maximum wait in seconds. Default 25; must be between 0 and 50.
+    pub timeout_secs: Option<f64>,
+}
+
+fn sync_error(error: Box<notebook_sync::SyncError>) -> McpError {
+    McpError::internal_error(error.to_string(), None)
+}
+
+pub async fn wait_for_notebook_change(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let params: WaitForNotebookChangeParams = serde_json::from_value(serde_json::Value::Object(
+        request.arguments.clone().unwrap_or_default(),
+    ))
+    .map_err(|error| McpError::invalid_params(error.to_string(), None))?;
+    let seconds = params.timeout_secs.unwrap_or(25.0);
+    if !seconds.is_finite() || !(0.0..=50.0).contains(&seconds) {
+        return Err(McpError::invalid_params(
+            "timeout_secs must be between 0 and 50",
+            None,
+        ));
+    }
+    let _permit = server.observation_waits.try_acquire().map_err(|_| {
+        McpError::invalid_request(
+            "At most eight notebook waits may be active on this connection",
+            None,
+        )
+    })?;
+    let Some((notebook_id, observer)) = server.observer_for_handle(&params.notebook_handle).await?
+    else {
+        return Ok(CallToolResult::structured(serde_json::json!({
+            "outcome":"unavailable", "notebook_handle":params.notebook_handle,
+            "message":"This notebook attachment is no longer available. Connect again and obtain a new handle."
+        })));
+    };
+    run_wait(
+        server,
+        &params,
+        &notebook_id,
+        &observer,
+        Duration::from_secs_f64(seconds),
+    )
+    .await
+}
+
+async fn run_wait(
+    server: &NteractMcp,
+    params: &WaitForNotebookChangeParams,
+    notebook_id: &str,
+    observer: &ObservationReader,
+    timeout: Duration,
+) -> Result<CallToolResult, McpError> {
+    let initial = observer.read(params.after.as_deref()).map_err(sync_error)?;
+    if matches!(
+        initial.outcome,
+        ChangeOutcome::Unavailable | ChangeOutcome::ResyncRequired
+    ) || (params.after.is_none() && params.execution_id.is_none())
+    {
+        return Ok(change_result(params, notebook_id, initial, None));
+    }
+    let Some(execution_id) = params.execution_id.as_deref() else {
+        let change = observer
+            .wait(params.after.as_deref().unwrap_or(&initial.cursor), timeout)
+            .await
+            .map_err(sync_error)?;
+        return Ok(change_result(params, notebook_id, change, None));
+    };
+    let mut watcher = observer
+        .execution_watcher(execution_id)
+        .map_err(sync_error)?;
+    let terminal = async {
+        while let Some(progress) = watcher.next().await {
+            if progress.terminal {
+                return Some(progress);
+            }
+        }
+        None
+    };
+    let unavailable = async {
+        let mut cursor = initial.cursor.clone();
+        loop {
+            let changed = observer
+                .wait(&cursor, Duration::from_secs(50))
+                .await
+                .map_err(sync_error)?;
+            if changed.outcome == ChangeOutcome::Unavailable {
+                return Ok::<_, McpError>(changed);
+            }
+            cursor = changed.cursor;
+        }
+    };
+    let progress = tokio::select! {
+        result = tokio::time::timeout(timeout, terminal) => result.ok().flatten(),
+        unavailable = unavailable => return Ok(change_result(params, notebook_id, unavailable?, None)),
+    };
+    let mut latest = observer
+        .read(Some(params.after.as_deref().unwrap_or(&initial.cursor)))
+        .map_err(sync_error)?;
+    if matches!(
+        latest.outcome,
+        ChangeOutcome::Unavailable | ChangeOutcome::ResyncRequired
+    ) {
+        return Ok(change_result(params, notebook_id, latest, None));
+    }
+    let Some(progress) = progress else {
+        latest.outcome = ChangeOutcome::TimedOut;
+        return Ok(change_result(params, notebook_id, latest, None));
+    };
+    if !matches!(
+        progress.terminal_reason,
+        Some(
+            ExecutionTerminalReason::Done
+                | ExecutionTerminalReason::Error
+                | ExecutionTerminalReason::Cancelled
+        )
+    ) {
+        latest.outcome = ChangeOutcome::Unavailable;
+        return Ok(change_result(params, notebook_id, latest, None));
+    }
+    let Some(exec) = latest.snapshot.runtime.executions.get(execution_id) else {
+        latest.outcome = ChangeOutcome::ResyncRequired;
+        return Ok(change_result(params, notebook_id, latest, None));
+    };
+    let cell = exec
+        .cell_id
+        .as_deref()
+        .and_then(|id| latest.snapshot.notebook.get_cell(id))
+        .cloned()
+        .map(|mut cell| {
+            // Notebook source can already belong to a later edit or rerun.
+            cell.source = exec.source.clone().unwrap_or_default();
+            cell
+        });
+    let mapping = exec
+        .cell_id
+        .as_ref()
+        .map(|id| std::collections::HashMap::from([(execution_id.to_owned(), id.clone())]));
+    let rendered = super::execution::render_execution_result(
+        server,
+        execution_id,
+        exec,
+        Some(&latest.snapshot.runtime.comms),
+        cell,
+        mapping,
+        false,
+    )
+    .await?;
+    // Rendering may await blob resolution. Do not return a successful attachment
+    // result after its owning session was released during that work.
+    if observer.read(None).map_err(sync_error)?.outcome == ChangeOutcome::Unavailable {
+        latest.outcome = ChangeOutcome::Unavailable;
+        return Ok(change_result(params, notebook_id, latest, None));
+    }
+    Ok(change_result(params, notebook_id, latest, Some(rendered)))
+}
+
+fn change_result(
+    params: &WaitForNotebookChangeParams,
+    notebook_id: &str,
+    change: ChangeRead,
+    execution: Option<CallToolResult>,
+) -> CallToolResult {
+    let outcome = if execution.is_some() {
+        "completed".into()
+    } else {
+        serde_json::to_value(change.outcome).unwrap_or_default()
+    };
+    let payload = serde_json::json!({
+        "outcome":outcome, "notebook_handle":params.notebook_handle, "notebook_id":notebook_id,
+        "cursor":change.cursor, "changes":change.changes,
+        "execution_id":params.execution_id,
+        "execution_status":params.execution_id.as_ref().and_then(|id| change.snapshot.runtime.executions.get(id)).map(|execution| &execution.status),
+        "execution":execution.as_ref().and_then(|result| result.structured_content.as_ref()),
+    });
+    let mut content = vec![crate::formatting::assistant_text(payload.to_string())];
+    if let Some(execution) = execution {
+        content.extend(execution.content);
+    }
+    if change.outcome != ChangeOutcome::Unavailable {
+        content.push(ContentBlock::resource_link(
+            crate::resources::attachment_cells_resource_link(&params.notebook_handle),
+        ));
+    }
+    let mut result = CallToolResult::success(content);
+    result.structured_content = Some(payload);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::tests::{edited, fixture};
+    use serde_json::json;
+
+    fn server() -> NteractMcp {
+        NteractMcp::new("unused.sock".into(), None, None)
+    }
+    fn params() -> WaitForNotebookChangeParams {
+        WaitForNotebookChangeParams {
+            notebook_handle: "attachment".into(),
+            after: None,
+            execution_id: None,
+            timeout_secs: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn baseline_then_edit_returns_a_compact_change_and_attachment_link() {
+        let fixture = fixture();
+        let observer = fixture.owner.reader();
+        let mut params = params();
+        let baseline = run_wait(&server(), &params, "notebook", &observer, Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(
+            baseline.structured_content.as_ref().unwrap()["outcome"],
+            "baseline"
+        );
+        params.after = Some(
+            baseline.structured_content.unwrap()["cursor"]
+                .as_str()
+                .unwrap()
+                .into(),
+        );
+        fixture
+            .notebook
+            .send_replace(edited("secret notebook content"));
+        let changed = run_wait(&server(), &params, "notebook", &observer, Duration::ZERO)
+            .await
+            .unwrap();
+        let data = changed.structured_content.unwrap();
+        assert_eq!(data["outcome"], "changed");
+        assert!(!data.to_string().contains("secret notebook content"));
+        assert!(serde_json::to_string(&changed.content)
+            .unwrap()
+            .contains("nteract://sessions/attachment/cells"));
+    }
+
+    #[tokio::test]
+    async fn execution_wait_follows_requested_run_through_rerun_and_trailing_output() {
+        let fixture = fixture();
+        fixture.notebook.send_replace(edited("print('new run')"));
+        fixture.notebook.send_modify(|view| {
+            std::sync::Arc::make_mut(&mut view.execution_pointers)
+                .insert("cell-1".into(), "new-run".into());
+        });
+        fixture.runtime.send_modify(|state| {
+            state.executions.insert("old-run".into(), serde_json::from_value(json!({"cell_id":"cell-1","source":"print('old run')","status":"running","outputs":[]})).unwrap());
+            state.executions.insert("new-run".into(), serde_json::from_value(json!({"cell_id":"cell-1","status":"done","outputs":[]})).unwrap());
+        });
+        let observer = fixture.owner.reader();
+        let mut params = params();
+        params.execution_id = Some("old-run".into());
+        let publisher = fixture.runtime.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            publisher.send_modify(|state| {
+                let execution = state.executions.get_mut("old-run").unwrap();
+                execution.status = "done".into();
+                execution.outputs.push(
+                    json!({"output_type":"stream","name":"stdout","text":{"inline":"first"}}),
+                );
+            });
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            publisher.send_modify(|state| {
+                state.executions.get_mut("old-run").unwrap().outputs.push(
+                    json!({"output_type":"stream","name":"stdout","text":{"inline":"trailing"}}),
+                )
+            });
+        });
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &observer,
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["outcome"],
+            "completed"
+        );
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["execution_id"],
+            "old-run"
+        );
+        let text = serde_json::to_string(&result.content).unwrap();
+        assert!(text.contains("trailing"));
+        assert!(!text.contains("print('new run')"));
+    }
+
+    #[tokio::test]
+    async fn unrelated_completion_does_not_finish_wait_and_release_is_unavailable() {
+        let fixture = fixture();
+        let observer = fixture.owner.reader();
+        let mut params = params();
+        params.execution_id = Some("pending-run".into());
+        fixture.runtime.send_modify(|state| {
+            state.executions.insert(
+                "other-run".into(),
+                serde_json::from_value(json!({"status":"done","outputs":[]})).unwrap(),
+            );
+        });
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &observer,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.structured_content.unwrap()["outcome"], "timed_out");
+        drop(fixture.owner);
+        let result = run_wait(
+            &server(),
+            &params,
+            "notebook",
+            &observer,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.structured_content.unwrap()["outcome"], "unavailable");
+    }
+
+    #[tokio::test]
+    async fn bounded_waits_reject_invalid_parameters_and_saturation() {
+        let server = server();
+        for seconds in [-1.0, 51.0] {
+            let request = CallToolRequestParams::new("wait_for_notebook_change").with_arguments(
+                json!({"notebook_handle":"missing","timeout_secs":seconds})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            );
+            assert!(wait_for_notebook_change(&server, &request).await.is_err());
+        }
+        let request = CallToolRequestParams::new("wait_for_notebook_change").with_arguments(
+            json!({"notebook_handle":"missing"})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let permits = server.observation_waits.acquire_many(8).await.unwrap();
+        assert!(wait_for_notebook_change(&server, &request).await.is_err());
+        drop(permits);
+        assert_eq!(
+            wait_for_notebook_change(&server, &request)
+                .await
+                .unwrap()
+                .structured_content
+                .unwrap()["outcome"],
+            "unavailable"
+        );
+    }
+}

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -581,6 +581,7 @@ fn format_projected_cell_summaries(cells: &[NotebookCellProjection]) -> String {
 }
 
 fn add_progressive_session_fields(response: &mut serde_json::Value, session: &NotebookSession) {
+    response["notebook_handle"] = serde_json::json!(session.notebook_handle);
     let readiness = session.readiness();
     response["session_generation"] = serde_json::json!(readiness.session_generation);
     response["source_state"] = readiness.source_state.clone();
@@ -807,9 +808,19 @@ fn add_created_notebook_recovery(mut result: CallToolResult, notebook_id: &str) 
 
 fn notebook_session_response(mut response: serde_json::Value, notebook_id: &str) -> CallToolResult {
     response["resources"] = crate::resources::notebook_resources_json(notebook_id);
+    let link = if let Some(handle) = response["notebook_handle"].as_str().map(str::to_owned) {
+        let cells = crate::resources::attachment_cells_uri(&handle);
+        response["resources"] = serde_json::json!({
+            "cells": cells, "cell_template": format!("{cells}/{{cell_id}}"),
+            "comments": format!("nteract://sessions/{handle}/comments"),
+        });
+        crate::resources::attachment_cells_resource_link(&handle)
+    } else {
+        crate::resources::notebook_cells_resource_link(notebook_id)
+    };
     CallToolResult::success(vec![
         ContentBlock::text(serde_json::to_string_pretty(&response).unwrap_or_default()),
-        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        ContentBlock::resource_link(link),
     ])
 }
 

--- a/crates/runt-mcp/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp/tests/protocol_compatibility.rs
@@ -42,6 +42,24 @@ async fn legacy_wire(version: &str) {
     assert_eq!(server.session_intent_epoch().load(Ordering::Acquire), 0);
 
     wire.initialized().await;
+    for (index, uri) in ["nteract://notebooks", "nteract://sessions/expired/cells"]
+        .into_iter()
+        .enumerate()
+    {
+        let response = wire
+            .request(
+                200 + index as u64,
+                "resources/subscribe",
+                Some(json!({"uri":uri})),
+            )
+            .await;
+        assert!(response.get("error").is_some(), "{response}");
+    }
+    let response = wire.request(202, "tools/call", Some(json!({"name":"wait_for_notebook_change","arguments":{"notebook_handle":"expired"}}))).await;
+    assert_eq!(
+        legacy_result(&response)["structuredContent"]["outcome"],
+        "unavailable"
+    );
     let response = wire.request(3, "resources/list", None).await;
     let resources = legacy_result(&response)["resources"]
         .as_array()

--- a/crates/runt-mcp/tests/support/mod.rs
+++ b/crates/runt-mcp/tests/support/mod.rs
@@ -229,6 +229,18 @@ pub fn modern_requests() -> Vec<(&'static str, Value)> {
         ("resources/templates/list", json!({})),
         ("resources/read", json!({"uri": "ui://nteract/output.html"})),
         (
+            "resources/subscribe",
+            json!({"uri":"nteract://sessions/expired/cells"}),
+        ),
+        (
+            "resources/unsubscribe",
+            json!({"uri":"nteract://sessions/expired/cells"}),
+        ),
+        (
+            "tools/call",
+            json!({"name":"wait_for_notebook_change","arguments":{"notebook_handle":"expired"}}),
+        ),
+        (
             "tools/call",
             json!({"name": "create_notebook", "arguments": {"ephemeral": true}}),
         ),

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -146,6 +146,48 @@ See `crates/runt-mcp/src/lib.rs:119`, `:273`,
 `crates/runt-mcp/src/tools/session.rs:74`, `:742`, `:949`, `:1200`, and
 `crates/runt-mcp/src/resources.rs:285`.
 
+## Notebook observation
+
+Connect and create responses return an opaque `notebook_handle` for the exact
+attachment. Handle-qualified `nteract://sessions/{notebook_handle}/cells`,
+`/cells/{cell_id}`, and `/comments` resources also work while that session is
+parked. A replacement or release invalidates its handle. A reconnect must return
+a new handle; an old handle never silently binds to the new peer. Legacy
+notebook-ID resource URIs remain readable, but ambiguous IDs require a handle.
+
+Each observed session owns one observer of NotebookDoc snapshots (including
+execution pointers), RuntimeStateDoc, CommentsDoc, and sync status. Observers
+subscribe before reading their baseline. Resource reads return the cursor for
+the exact snapshot they serialize. The journal retains 256 compact change
+batches, coalescing background updates over 100 ms. Reads flush pending changes
+before selecting their cursor. The journal stores IDs and change kinds, not
+copies of cell source or output bodies. Expired or foreign cursors require a
+fresh baseline. Mutable notebook reads use private caching with a zero TTL.
+
+Legacy `resources/subscribe` watches emit URI invalidations. A connection can
+hold 128 watches; unsubscribing is idempotent. The proxy orders subscription
+operations and forwards child notifications, invalidating watches when that
+child transport ends. Watches retain snapshot receivers rather than DocHandle
+command senders, so they do not independently keep notebook peers or kernels
+alive. Releasing a session wakes pending observers as unavailable.
+
+`wait_for_notebook_change` is the bounded fallback for hosts that do not make
+resource notifications available to agents. It requires a notebook handle,
+accepts an optional cursor and execution ID, and waits 25 seconds by default
+(50 seconds maximum, eight simultaneous waits per connection). Without a
+cursor or execution ID it returns an immediate baseline. An execution wait
+follows that exact execution, including trailing stream output, independently
+of later edits or reruns of its cell. Completion uses the existing output
+formatter and the execution's captured source. Cancellation ends observation;
+it does not interrupt the kernel. The tool returns baseline, changed, completed,
+timed_out, resync_required, or unavailable, with compact changes and resource
+links. Neither notification delivery nor a progress callback proves that a host
+has refreshed model context.
+
+This observation layer does not by itself enable the native `2026-07-28`
+lifecycle or `subscriptions/listen`; those require their own transport and
+discovery support at every entrypoint.
+
 ## Decision 4: Tool intent and guarded publication are the convergence point
 
 Recovery connects outside the session lock. It captures `session_intent_epoch`

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -89,6 +89,10 @@
       "name": "disconnect_notebook"
     },
     {
+      "description": "Wait for notebook changes or an exact execution.",
+      "name": "wait_for_notebook_change"
+    },
+    {
       "description": "Create a cell anchored by after_cell_id; omit after_cell_id to append.",
       "name": "create_cell"
     },

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -89,6 +89,10 @@
       "name": "disconnect_notebook"
     },
     {
+      "description": "Wait for notebook changes or an exact execution.",
+      "name": "wait_for_notebook_change"
+    },
+    {
       "description": "Create a cell anchored by after_cell_id; omit after_cell_id to append.",
       "name": "create_cell"
     },


### PR DESCRIPTION
An agent watching a notebook needs a consistent way to notice collaborator edits, comments, and execution output. This adds a session-owned observation journal, cursor-bearing resource reads, legacy resource subscriptions through the child/proxy/supervisor, and `wait_for_notebook_change` for hosts that do not refresh model context from notifications.

Connect/create return an opaque attachment handle that also addresses parked sessions. Watches and waits retain snapshot receivers, so releasing the attachment invalidates them without independently keeping a notebook peer or kernel alive. Exact-execution waits follow the requested run through later cell edits/reruns and settle trailing output before returning the existing formatted results. Observation cancellation does not interrupt computation.

The journal retains 256 compact batches with 100 ms background coalescing. Each connection permits 128 resource watches and eight bounded waits (25 seconds by default, 50 maximum). Mutable resource reads use private caching with a zero TTL. Generated fallback catalogs and MCPB manifests include the new tool.

Validation:
- notebook-sync: 94 passed, seven existing ignored tests.
- runt-mcp: 242 unit tests, including exact execution/rerun output, snapshot/cursor pairing, cursor expiry, attachment release, cancellation, and watch/wait bounds; 11 protocol tests passed.
- runt-mcp-proxy: 122 unit and 24 process-level protocol tests passed, including early notification forwarding and child-loss invalidation.
- mcp-supervisor: 29 tests passed; affected crates pass Clippy with warnings denied.
- `cargo xtask lint --fix`, release `runt` build, and tool catalog generation passed (1,500 description bytes).
- Independent Kilo correctness and architecture reviews completed. Verified deadline, kernel-recovery, source-attribution, and subscription lifecycle findings were fixed and re-reviewed. A follow-up classification concern was not reproduced in the new API: terminal failures return execution_status=error; completed describes the observation, not successful code execution. All CI checks passed or were appropriately skipped, including Browser E2E.

This builds on #4214. Native `2026-07-28` discovery/listen and request-scoped progress are separate follow-ups. Desktop host behavior has not been inferred from the CLI probe results in #4215.
