### PR TITLE
feat(mcp): scope progress and cancellation to requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,6 +4552,7 @@ version = "0.6.6"
 dependencies = [
  "dirs",
  "libc",
+ "mcp-transport",
  "notify",
  "notify-debouncer-mini",
  "rmcp 3.2.0",
@@ -4564,6 +4565,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "mcp-transport"
+version = "0.1.0"
+dependencies = [
+ "rmcp 3.2.0",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5056,6 +5066,7 @@ name = "nteract-mcp"
 version = "0.5.6"
 dependencies = [
  "dirs",
+ "mcp-transport",
  "rmcp 3.2.0",
  "runt-mcp-proxy",
  "runt-workspace",
@@ -7510,6 +7521,7 @@ dependencies = [
  "flate2",
  "kernel-env",
  "libc",
+ "mcp-transport",
  "notebook-doc",
  "notebook-sync",
  "notify",
@@ -7544,6 +7556,7 @@ dependencies = [
  "fancy-regex 0.14.0",
  "futures-util",
  "mcp-client-branding",
+ "mcp-transport",
  "notebook-cloud-transport",
  "notebook-doc",
  "notebook-protocol",
@@ -7573,6 +7586,7 @@ dependencies = [
 name = "runt-mcp-proxy"
 version = "0.5.6"
 dependencies = [
+ "mcp-transport",
  "rmcp 1.5.0",
  "rmcp 3.2.0",
  "runt-mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/runtimed-py",
     "crates/runtimed-wasm",
     "crates/mcp-client-branding",
+    "crates/mcp-transport",
     "crates/mcp-supervisor",
     "crates/nteract-markdown-engine",
     "crates/nteract-markdown-wasm",

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -12,6 +12,7 @@ name = "mcp-supervisor"
 path = "src/main.rs"
 
 [dependencies]
+mcp-transport = { path = "../mcp-transport" }
 rmcp = { workspace = true, features = ["server", "client", "transport-child-process", "transport-io"] }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2072,7 +2072,7 @@ impl ServerHandler for Supervisor {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
         require_legacy_handshake(&context)?;
-        self.handle_tool_call(request)
+        runt_mcp_proxy::request_scope::scope(context, self.handle_tool_call(request))
             .await
             .map(CallToolResponse::Complete)
     }
@@ -3047,7 +3047,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tool_list_changed_tx,
     );
 
-    let transport = rmcp::transport::io::stdio();
+    let transport = mcp_transport::server(rmcp::transport::io::stdio());
     let server = supervisor.serve(transport).await?;
     if server.peer().peer_info().is_none() {
         server.cancellation_token().cancel();

--- a/crates/mcp-transport/Cargo.toml
+++ b/crates/mcp-transport/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-rmcp = { workspace = true, features = ["server"] }
+rmcp = { workspace = true, features = ["server", "client"] }
 tokio-util = "0.7"
 tokio = { workspace = true, features = ["macros"] }
 

--- a/crates/mcp-transport/Cargo.toml
+++ b/crates/mcp-transport/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mcp-transport"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+rmcp = { workspace = true, features = ["server"] }
+tokio-util = "0.7"
+tokio = { workspace = true, features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/mcp-transport/src/lib.rs
+++ b/crates/mcp-transport/src/lib.rs
@@ -4,7 +4,7 @@
 //! Attach a separate connection token before dispatch so observation can end
 //! immediately, while daemon-owned execution continues independently.
 
-use rmcp::model::{GetExtensions, JsonRpcMessage};
+use rmcp::model::{GetExtensions, GetMeta, JsonRpcMessage};
 use rmcp::service::{RequestContext, RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::{IntoTransport, Transport};
 use std::future::Future;
@@ -12,6 +12,14 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
 struct ConnectionClosed(CancellationToken);
+
+pub fn cancellation_error() -> rmcp::ErrorData {
+    rmcp::ErrorData::new(
+        rmcp::model::ErrorCode(-32800),
+        "Request observation cancelled; daemon execution may continue",
+        None,
+    )
+}
 
 /// Wait for either explicit request cancellation or transport teardown.
 pub async fn cancelled(context: &RequestContext<RoleServer>) {
@@ -81,5 +89,157 @@ impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
     async fn close(&mut self) -> Result<(), Self::Error> {
         self.closed.cancel();
         self.inner.close().await
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ConnectionLifetime(CancellationToken);
+#[derive(Clone)]
+struct SuppressProgress;
+/// Override the SDK's automatic private token when the upstream did not opt in.
+pub fn suppress_progress(request: &mut rmcp::model::ClientRequest) {
+    request.extensions_mut().insert(SuppressProgress);
+}
+impl ConnectionLifetime {
+    pub async fn closed(&self) {
+        self.0.cancelled().await;
+    }
+}
+
+/// Expose private-child EOF without relying on the SDK's later response drain.
+pub fn client<T, E, A>(
+    transport: T,
+) -> (
+    impl Transport<rmcp::service::RoleClient, Error = E>,
+    ConnectionLifetime,
+)
+where
+    T: IntoTransport<rmcp::service::RoleClient, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let lifetime = ConnectionLifetime::default();
+    (
+        ClientTransport {
+            inner: transport.into_transport(),
+            lifetime: lifetime.clone(),
+        },
+        lifetime,
+    )
+}
+struct ClientTransport<T> {
+    inner: T,
+    lifetime: ConnectionLifetime,
+}
+impl<T> Drop for ClientTransport<T> {
+    fn drop(&mut self) {
+        self.lifetime.0.cancel();
+    }
+}
+impl<T: Transport<rmcp::service::RoleClient>> Transport<rmcp::service::RoleClient>
+    for ClientTransport<T>
+{
+    type Error = T::Error;
+    fn send(
+        &mut self,
+        mut message: TxJsonRpcMessage<rmcp::service::RoleClient>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        if let JsonRpcMessage::Request(request) = &mut message {
+            if request
+                .request
+                .extensions()
+                .get::<SuppressProgress>()
+                .is_some()
+            {
+                request.request.get_meta_mut().remove("progressToken");
+            }
+        }
+        let send = self.inner.send(message);
+        let lifetime = self.lifetime.clone();
+        async move {
+            let result = send.await;
+            if result.is_err() {
+                lifetime.0.cancel();
+            }
+            result
+        }
+    }
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<rmcp::service::RoleClient>> {
+        let result = self.inner.receive().await;
+        if result.is_none() {
+            self.lifetime.0.cancel();
+        }
+        result
+    }
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        self.lifetime.0.cancel();
+        self.inner.close().await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rmcp::model::*;
+    struct Mock {
+        next: Option<RxJsonRpcMessage<RoleServer>>,
+        fail_write: bool,
+    }
+    impl Transport<RoleServer> for Mock {
+        type Error = std::io::Error;
+        fn send(
+            &mut self,
+            _: TxJsonRpcMessage<RoleServer>,
+        ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+            let fail = self.fail_write;
+            async move {
+                if fail {
+                    Err(std::io::Error::other("fixture write failure"))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+        async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+            self.next.take()
+        }
+        async fn close(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+    #[tokio::test]
+    async fn request_lifetime_ends_on_failed_write_close_drop_and_eof() {
+        for ending in ["write", "close", "drop", "eof"] {
+            let mut transport = server(Mock {
+                next: Some(JsonRpcMessage::request(
+                    ClientRequest::PingRequest(PingRequest::default()),
+                    RequestId::Number(1),
+                )),
+                fail_write: ending == "write",
+            });
+            let Some(JsonRpcMessage::Request(request)) = transport.receive().await else {
+                panic!("expected request")
+            };
+            let closed = request
+                .request
+                .extensions()
+                .get::<ConnectionClosed>()
+                .unwrap()
+                .clone();
+            assert!(!closed.0.is_cancelled());
+            match ending {
+                "write" => assert!(transport
+                    .send(JsonRpcMessage::response(
+                        ServerResult::empty(()),
+                        RequestId::Number(1)
+                    ))
+                    .await
+                    .is_err()),
+                "close" => transport.close().await.unwrap(),
+                "eof" => assert!(transport.receive().await.is_none()),
+                _ => drop(transport),
+            }
+            assert!(closed.0.is_cancelled(), "{ending}");
+        }
     }
 }

--- a/crates/mcp-transport/src/lib.rs
+++ b/crates/mcp-transport/src/lib.rs
@@ -1,0 +1,85 @@
+//! Connection lifetime for stdio MCP request handlers.
+//!
+//! rmcp drains in-flight handlers on EOF without cancelling their request tokens.
+//! Attach a separate connection token before dispatch so observation can end
+//! immediately, while daemon-owned execution continues independently.
+
+use rmcp::model::{GetExtensions, JsonRpcMessage};
+use rmcp::service::{RequestContext, RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::{IntoTransport, Transport};
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+struct ConnectionClosed(CancellationToken);
+
+/// Wait for either explicit request cancellation or transport teardown.
+pub async fn cancelled(context: &RequestContext<RoleServer>) {
+    let connection = context.extensions.get::<ConnectionClosed>();
+    match connection {
+        Some(connection) => {
+            tokio::select! {
+                _ = context.ct.cancelled() => {},
+                _ = connection.0.cancelled() => {},
+            }
+        }
+        None => context.ct.cancelled().await,
+    }
+}
+
+/// Apply once at each server entry point, including in-memory wire tests.
+pub fn server<T, E, A>(transport: T) -> impl Transport<RoleServer, Error = E>
+where
+    T: IntoTransport<RoleServer, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    ServerTransport {
+        inner: transport.into_transport(),
+        closed: CancellationToken::new(),
+    }
+}
+
+struct ServerTransport<T> {
+    inner: T,
+    closed: CancellationToken,
+}
+impl<T> Drop for ServerTransport<T> {
+    fn drop(&mut self) {
+        self.closed.cancel();
+    }
+}
+impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
+    type Error = T::Error;
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleServer>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let sent = self.inner.send(item);
+        let closed = self.closed.clone();
+        async move {
+            let result = sent.await;
+            if result.is_err() {
+                closed.cancel();
+            }
+            result
+        }
+    }
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        let mut message = self.inner.receive().await;
+        match &mut message {
+            Some(JsonRpcMessage::Request(request)) => {
+                request
+                    .request
+                    .extensions_mut()
+                    .insert(ConnectionClosed(self.closed.clone()));
+            }
+            None => self.closed.cancel(),
+            _ => {}
+        }
+        message
+    }
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        self.closed.cancel();
+        self.inner.close().await
+    }
+}

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -12,6 +12,7 @@ name = "nteract-mcp"
 path = "src/main.rs"
 
 [dependencies]
+mcp-transport = { path = "../mcp-transport" }
 runt-mcp-proxy = { path = "../runt-mcp-proxy" }
 runt-workspace = { path = "../runt-workspace" }
 rmcp = { workspace = true, features = ["transport-io"] }

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -262,7 +262,7 @@ async fn main() -> ExitCode {
     let proxy = McpProxy::new(config, None);
 
     // Start the MCP server on stdio immediately
-    let transport = rmcp::transport::io::stdio();
+    let transport = mcp_transport::server(rmcp::transport::io::stdio());
     let server = match proxy.serve(transport).await {
         Ok(s) => s,
         Err(e) => {

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+mcp-transport = { path = "../mcp-transport" }
 rmcp = { workspace = true, features = ["server", "client", "transport-async-rw", "transport-io"] }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -26,6 +26,7 @@ pub struct ChildClientHandler {
     pub notifications:
         tokio::sync::broadcast::Sender<rmcp::model::ResourceUpdatedNotificationParam>,
     pub progress: tokio::sync::broadcast::Sender<rmcp::model::ProgressNotificationParam>,
+    pub lifetime: mcp_transport::ConnectionLifetime,
 }
 
 impl ClientHandler for ChildClientHandler {
@@ -244,12 +245,14 @@ pub async fn spawn_child(
 
     let (transport, exit_status) = spawn_managed_transport(command, args, env)
         .map_err(|e| format!("Failed to spawn child process: {e}"))?;
+    let (transport, lifetime) = mcp_transport::client(transport);
 
     let handler = ChildClientHandler {
         upstream_name: upstream_name.to_string(),
         upstream_title: upstream_title.map(|s| s.to_string()),
         notifications: tokio::sync::broadcast::channel(256).0,
         progress: tokio::sync::broadcast::channel(256).0,
+        lifetime,
     };
 
     let client = handler
@@ -294,6 +297,7 @@ mod tests {
             upstream_title: Some("Codex".to_string()),
             notifications: tokio::sync::broadcast::channel(256).0,
             progress: tokio::sync::broadcast::channel(256).0,
+            lifetime: Default::default(),
         };
         let info = handler.get_info();
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
@@ -328,6 +332,7 @@ mod tests {
             upstream_title: None,
             notifications: tokio::sync::broadcast::channel(256).0,
             progress: tokio::sync::broadcast::channel(256).0,
+            lifetime: Default::default(),
         };
         let client = handler
             .serve(client_side)

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -25,9 +25,17 @@ pub struct ChildClientHandler {
     pub upstream_title: Option<String>,
     pub notifications:
         tokio::sync::broadcast::Sender<rmcp::model::ResourceUpdatedNotificationParam>,
+    pub progress: tokio::sync::broadcast::Sender<rmcp::model::ProgressNotificationParam>,
 }
 
 impl ClientHandler for ChildClientHandler {
+    async fn on_progress(
+        &self,
+        params: rmcp::model::ProgressNotificationParam,
+        _: rmcp::service::NotificationContext<RoleChild>,
+    ) {
+        let _ = self.progress.send(params);
+    }
     async fn on_resource_updated(
         &self,
         params: rmcp::model::ResourceUpdatedNotificationParam,
@@ -241,6 +249,7 @@ pub async fn spawn_child(
         upstream_name: upstream_name.to_string(),
         upstream_title: upstream_title.map(|s| s.to_string()),
         notifications: tokio::sync::broadcast::channel(256).0,
+        progress: tokio::sync::broadcast::channel(256).0,
     };
 
     let client = handler
@@ -284,6 +293,7 @@ mod tests {
             upstream_name: "codex-mcp-client".to_string(),
             upstream_title: Some("Codex".to_string()),
             notifications: tokio::sync::broadcast::channel(256).0,
+            progress: tokio::sync::broadcast::channel(256).0,
         };
         let info = handler.get_info();
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
@@ -317,6 +327,7 @@ mod tests {
             upstream_name: "test".to_string(),
             upstream_title: None,
             notifications: tokio::sync::broadcast::channel(256).0,
+            progress: tokio::sync::broadcast::channel(256).0,
         };
         let client = handler
             .serve(client_side)

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -14,6 +14,7 @@ pub mod child;
 pub mod circuit_breaker;
 mod observation_bridge;
 pub mod proxy;
+pub mod request_scope;
 pub mod session;
 pub mod tools;
 pub mod version;

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -17,7 +17,7 @@ use rmcp::model::{
 };
 use rmcp::service::{NotificationContext, Peer, RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
-use tokio::sync::{mpsc, Mutex, Notify, RwLock};
+use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{error, info, warn};
 
 use crate::child::{self, ChildExitStatus, RunningChild};
@@ -169,6 +169,8 @@ pub struct ProxyState {
 }
 
 /// The MCP proxy — manages child process lifecycle and forwards MCP calls.
+type RestartCompletion = tokio::sync::watch::Receiver<Option<Result<(), String>>>;
+
 #[derive(Clone)]
 pub struct McpProxy {
     pub state: Arc<RwLock<ProxyState>>,
@@ -177,8 +179,8 @@ pub struct McpProxy {
     pub child_ready: Arc<Notify>,
     /// Signaled when the proxy should exit (incompatible tool divergence).
     pub exit_signal: Arc<Notify>,
-    /// Flag to prevent concurrent restarts (monitor + tool call racing).
-    restart_in_progress: Arc<Mutex<bool>>,
+    /// Shared completion for one owned restart (monitor and requests may join).
+    restart_in_progress: Arc<std::sync::Mutex<Option<RestartCompletion>>>,
     /// Stable across child generations so automatic rejoin retains the exact
     /// operator used by the explicit connect in the previous child.
     operator_session: String,
@@ -222,7 +224,7 @@ impl McpProxy {
             config: Arc::new(config),
             child_ready: Arc::new(Notify::new()),
             exit_signal: Arc::new(Notify::new()),
-            restart_in_progress: Arc::new(Mutex::new(false)),
+            restart_in_progress: Arc::default(),
             operator_session: uuid::Uuid::new_v4().simple().to_string()[..8].to_string(),
             observation_bridge: Arc::default(),
         }
@@ -399,15 +401,40 @@ impl McpProxy {
     }
 
     async fn restart_child_for_reason(&self) -> Result<(), String> {
-        // Prevent concurrent restarts (monitor task + tool call racing)
-        let mut restart_lock = self.restart_in_progress.lock().await;
-        if *restart_lock {
-            info!("Restart already in progress, skipping duplicate request");
-            return Ok(());
+        let mut completion = {
+            let mut running = self
+                .restart_in_progress
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if running
+                .as_ref()
+                .is_none_or(|receiver| receiver.borrow().is_some())
+            {
+                let (sender, receiver) = tokio::sync::watch::channel(None);
+                let proxy = self.clone();
+                tokio::spawn(async move {
+                    let result = proxy.restart_child_owned().await;
+                    sender.send_replace(Some(result));
+                });
+                *running = Some(receiver);
+            }
+            running
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| "Restart completion channel unavailable".to_string())?
+        };
+        loop {
+            if let Some(result) = completion.borrow_and_update().clone() {
+                return result;
+            }
+            completion
+                .changed()
+                .await
+                .map_err(|_| "Restart task ended without a result".to_string())?;
         }
-        *restart_lock = true;
-        drop(restart_lock);
+    }
 
+    async fn restart_child_owned(&self) -> Result<(), String> {
         let reason = self.current_child_restart_reason().await;
         info!(
             event = "child_restart_classified",
@@ -463,7 +490,6 @@ impl McpProxy {
                 );
                 state.reconnection_message = Some(msg.clone());
                 drop(state);
-                self.clear_restart_in_progress().await;
                 return Err(msg);
             }
 
@@ -497,7 +523,6 @@ impl McpProxy {
                 let mut state = self.state.write().await;
                 state.reconnection_message = Some(msg.clone());
                 drop(state);
-                self.clear_restart_in_progress().await;
                 return Err(msg);
             }
         };
@@ -607,8 +632,6 @@ impl McpProxy {
                     let _ = tx.send(()).await;
                     info!("Notified upstream client of tool list change to keep connection alive");
                 }
-
-                self.clear_restart_in_progress().await;
                 self.child_ready.notify_waiters();
                 info!("Child restarted successfully");
                 Ok(())
@@ -618,7 +641,6 @@ impl McpProxy {
                 state.reconnection_message = Some(format!("Child restart failed: {e}"));
                 error!("Failed to restart child: {e}");
                 drop(state);
-                self.clear_restart_in_progress().await;
                 Err(e)
             }
         }
@@ -1085,7 +1107,7 @@ impl McpProxy {
                 ),
                 generation: Some(generation),
                 transport_closed: false,
-                may_have_run: false,
+                may_have_run: true,
             }),
             Err(error) => Err(ForwardToolFailure {
                 transport_closed: snapshot.peer.is_transport_closed()
@@ -1262,10 +1284,6 @@ impl McpProxy {
             restart_count,
             "Slow child MCP call"
         );
-    }
-
-    async fn clear_restart_in_progress(&self) {
-        *self.restart_in_progress.lock().await = false;
     }
 }
 
@@ -1533,6 +1551,7 @@ impl ServerHandler for McpProxy {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
         require_legacy_handshake(&context)?;
+        crate::request_scope::scope(context.clone(), async {
         // Intercept the built-in reconnect tool before waiting on child
         // readiness — reconnect is the escape hatch when the child is
         // wedged, so it must not block on child readiness itself.
@@ -1550,14 +1569,13 @@ impl ServerHandler for McpProxy {
             );
             tokio::select! {
                 biased;
-                _ = context.ct.cancelled() => return Err(McpError::new(rmcp::model::ErrorCode(-32800), "Request cancelled before the child became ready", None)),
+                _ = mcp_transport::cancelled(&context) => return Err(McpError::new(rmcp::model::ErrorCode(-32800), "Request cancelled before the child became ready", None)),
                 _ = tokio::time::timeout(Duration::from_secs(60), notified) => {},
             }
         }
 
-        crate::request_scope::scope(context, self.forward_tool_call(request))
-            .await
-            .map(Into::into)
+        self.forward_tool_call(request).await.map(Into::into)
+        }).await
     }
 
     // Spawn the child only after the client has sent `notifications/initialized`.
@@ -2562,17 +2580,20 @@ mod tests {
     #[tokio::test]
     async fn restart_in_progress_prevents_duplicate_restarts() {
         let proxy = McpProxy::new(test_config(), None);
-
-        // Simulate restart in progress
-        *proxy.restart_in_progress.lock().await = true;
-
-        // Attempt restart should return early
-        let result = proxy.restart_child().await;
-
-        // Should succeed but do nothing (early return)
-        assert!(result.is_ok());
-
-        // Restart count should still be 0
+        let (sender, receiver) = tokio::sync::watch::channel(None);
+        *proxy.restart_in_progress.lock().unwrap() = Some(receiver);
+        let first = proxy.restart_child();
+        let second = proxy.restart_child();
+        tokio::pin!(first, second);
+        assert!(tokio::time::timeout(Duration::from_millis(20), &mut first)
+            .await
+            .is_err());
+        assert!(tokio::time::timeout(Duration::from_millis(20), &mut second)
+            .await
+            .is_err());
+        sender.send_replace(Some(Err("shared restart failure".to_string())));
+        assert_eq!(first.await.unwrap_err(), "shared restart failure");
+        assert_eq!(second.await.unwrap_err(), "shared restart failure");
         assert_eq!(proxy.restart_count().await, 0);
     }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1648,12 +1648,6 @@ impl McpProxy {
             ));
         }
 
-        // Best-effort wait so the caller's next tool call sees the new
-        // child. Don't fail the reconnect call if the child is slow —
-        // the next forwarded call will retry via the normal restart path.
-        let notified = self.child_ready.notified();
-        let _ = tokio::time::timeout(Duration::from_secs(30), notified).await;
-
         let restart_count = self.restart_count().await;
         let pending = self.state.write().await.reconnection_message.take();
         let detail = pending.unwrap_or_else(|| "Child restarted.".to_string());

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1056,7 +1056,13 @@ impl McpProxy {
         }
         let start = Instant::now();
 
-        let result = match snapshot.peer.call_tool_once(params.clone()).await {
+        let result = match crate::request_scope::call_child(
+            &snapshot.peer,
+            params.clone(),
+            snapshot.progress.subscribe(),
+        )
+        .await
+        {
             Ok(response) => complete_tool_response(response).map_err(|error| ForwardToolFailure {
                 error,
                 generation: Some(generation),
@@ -1065,6 +1071,18 @@ impl McpProxy {
             }),
             Err(rmcp::service::ServiceError::McpError(error)) => Err(ForwardToolFailure {
                 error,
+                generation: Some(generation),
+                transport_closed: false,
+                may_have_run: false,
+            }),
+            Err(rmcp::service::ServiceError::Cancelled { reason }) => Err(ForwardToolFailure {
+                error: McpError::new(
+                    rmcp::model::ErrorCode(-32800),
+                    reason.unwrap_or_else(|| {
+                        "Request observation cancelled; daemon execution may continue".into()
+                    }),
+                    None,
+                ),
                 generation: Some(generation),
                 transport_closed: false,
                 may_have_run: false,
@@ -1209,6 +1227,7 @@ impl McpProxy {
             .ok_or_else(|| McpError::internal_error("nteract MCP server not running", None))?;
         Ok(ChildPeerSnapshot {
             peer: client.peer().clone(),
+            progress: client.service().progress.clone(),
             generation: state.child_generation,
         })
     }
@@ -1252,6 +1271,7 @@ impl McpProxy {
 
 struct ChildPeerSnapshot {
     peer: Peer<child::RoleChild>,
+    progress: tokio::sync::broadcast::Sender<rmcp::model::ProgressNotificationParam>,
     generation: u64,
 }
 
@@ -1528,10 +1548,16 @@ impl ServerHandler for McpProxy {
                 "Tool '{}' called before child ready, waiting...",
                 request.name
             );
-            let _ = tokio::time::timeout(Duration::from_secs(60), notified).await;
+            tokio::select! {
+                biased;
+                _ = context.ct.cancelled() => return Err(McpError::new(rmcp::model::ErrorCode(-32800), "Request cancelled before the child became ready", None)),
+                _ = tokio::time::timeout(Duration::from_secs(60), notified) => {},
+            }
         }
 
-        self.forward_tool_call(request).await.map(Into::into)
+        crate::request_scope::scope(context, self.forward_tool_call(request))
+            .await
+            .map(Into::into)
     }
 
     // Spawn the child only after the client has sent `notifications/initialized`.

--- a/crates/runt-mcp-proxy/src/request_scope.rs
+++ b/crates/runt-mcp-proxy/src/request_scope.rs
@@ -23,7 +23,11 @@ struct ScopedRequest {
 
 /// Preserve the upstream request while supervisor helpers forward to the child.
 /// The scope follows this future only; independent requests have separate state.
-pub async fn scope<T>(context: RequestContext<RoleServer>, future: impl Future<Output = T>) -> T {
+pub async fn scope<T>(
+    context: RequestContext<RoleServer>,
+    future: impl Future<Output = Result<T, rmcp::ErrorData>>,
+) -> Result<T, rmcp::ErrorData> {
+    let cancellation_context = context.clone();
     UPSTREAM_REQUEST
         .scope(
             ScopedRequest {
@@ -31,7 +35,13 @@ pub async fn scope<T>(context: RequestContext<RoleServer>, future: impl Future<O
                 started: tokio::time::Instant::now(),
                 last_progress: Arc::default(),
             },
-            future,
+            async {
+                tokio::select! {
+                    biased;
+                    _ = mcp_transport::cancelled(&cancellation_context) => Err(mcp_transport::cancellation_error()),
+                    result = future => result,
+                }
+            },
         )
         .await
 }
@@ -77,10 +87,14 @@ pub(crate) async fn call_child(
         return peer.call_tool_once(params).await;
     };
     let context = &scope.context;
+    let mut request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
+    if context.meta.get_progress_token().is_none() {
+        mcp_transport::suppress_progress(&mut request);
+    }
     let handle = tokio::select! {
         biased;
         _ = mcp_transport::cancelled(context) => return Err(cancelled()),
-        result = peer.send_cancellable_request(ClientRequest::CallToolRequest(CallToolRequest::new(params)), PeerRequestOptions::no_options()) => result?,
+        result = peer.send_cancellable_request(request, PeerRequestOptions::no_options()) => result?,
     };
     let child_token = handle.progress_token.clone();
     let upstream_token = context.meta.get_progress_token();

--- a/crates/runt-mcp-proxy/src/request_scope.rs
+++ b/crates/runt-mcp-proxy/src/request_scope.rs
@@ -1,0 +1,159 @@
+//! Request-scoped child cancellation and progress-token translation.
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rmcp::model::*;
+use rmcp::service::{
+    Peer, PeerRequestOptions, RequestContext, RoleClient, RoleServer, ServiceError,
+};
+use tokio::sync::broadcast;
+
+tokio::task_local! {
+    static UPSTREAM_REQUEST: ScopedRequest;
+}
+
+#[derive(Clone)]
+struct ScopedRequest {
+    context: RequestContext<RoleServer>,
+    started: tokio::time::Instant,
+    last_progress: Arc<Mutex<Option<tokio::time::Instant>>>,
+}
+
+/// Preserve the upstream request while supervisor helpers forward to the child.
+/// The scope follows this future only; independent requests have separate state.
+pub async fn scope<T>(context: RequestContext<RoleServer>, future: impl Future<Output = T>) -> T {
+    UPSTREAM_REQUEST
+        .scope(
+            ScopedRequest {
+                context,
+                started: tokio::time::Instant::now(),
+                last_progress: Arc::default(),
+            },
+            future,
+        )
+        .await
+}
+
+struct CancelOnDrop {
+    peer: Peer<RoleClient>,
+    id: Option<RequestId>,
+}
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            let peer = self.peer.clone();
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    cancel(&peer, id).await;
+                });
+            }
+        }
+    }
+}
+async fn cancel(peer: &Peer<RoleClient>, id: RequestId) {
+    let _ = tokio::time::timeout(
+        Duration::from_secs(1),
+        peer.notify_cancelled(CancelledNotificationParam::new(
+            Some(id),
+            Some("Upstream request observation ended".into()),
+        )),
+    )
+    .await;
+}
+fn cancelled() -> ServiceError {
+    ServiceError::Cancelled {
+        reason: Some("Request observation cancelled; daemon execution may continue".into()),
+    }
+}
+
+pub(crate) async fn call_child(
+    peer: &Peer<RoleClient>,
+    params: CallToolRequestParams,
+    mut progress: broadcast::Receiver<ProgressNotificationParam>,
+) -> Result<CallToolResponse, ServiceError> {
+    let Ok(scope) = UPSTREAM_REQUEST.try_with(Clone::clone) else {
+        return peer.call_tool_once(params).await;
+    };
+    let context = &scope.context;
+    let handle = tokio::select! {
+        biased;
+        _ = mcp_transport::cancelled(context) => return Err(cancelled()),
+        result = peer.send_cancellable_request(ClientRequest::CallToolRequest(CallToolRequest::new(params)), PeerRequestOptions::no_options()) => result?,
+    };
+    let child_token = handle.progress_token.clone();
+    let upstream_token = context.meta.get_progress_token();
+    let id = handle.id.clone();
+    let mut cleanup = CancelOnDrop {
+        peer: peer.clone(),
+        id: Some(id.clone()),
+    };
+    let response = handle.await_response();
+    tokio::pin!(response);
+    let mut pending: Option<ProgressNotificationParam> = None;
+    let mut progress_open = true;
+    let mut tick = tokio::time::interval(Duration::from_secs(1));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            _ = mcp_transport::cancelled(context) => {
+                cancel(peer, id).await;
+                cleanup.id = None;
+                return Err(cancelled());
+            }
+            result = &mut response => {
+                cleanup.id = None;
+                return match result? {
+                    ServerResult::CallToolResult(result) => Ok(CallToolResponse::Complete(result)),
+                    ServerResult::InputRequiredResult(result) => Ok(CallToolResponse::InputRequired(result)),
+                    ServerResult::CreateTaskResult(result) => Ok(CallToolResponse::Task(result)),
+                    _ => Err(ServiceError::UnexpectedResponse),
+                };
+            }
+            notification = progress.recv(), if upstream_token.is_some() && progress_open => {
+                match notification {
+                    Ok(mut notification) if notification.progress_token == child_token => {
+                        if let Some(token) = &upstream_token {
+                            notification.progress_token = token.clone();
+                            // Child metadata belongs to the private legacy transport.
+                            notification.meta = None;
+                            pending = Some(notification);
+                        }
+                    }
+                    Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {},
+                    Err(broadcast::error::RecvError::Closed) => { pending = None; progress_open = false; },
+                }
+            }
+            _ = tick.tick() => {},
+        }
+        let can_send = {
+            let mut last = scope
+                .last_progress
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if pending.is_some() && last.is_none_or(|last| last.elapsed() >= Duration::from_secs(1))
+            {
+                *last = Some(tokio::time::Instant::now());
+                true
+            } else {
+                false
+            }
+        };
+        if can_send {
+            if let Some(mut notification) = pending.take() {
+                // Keep one monotonic elapsed clock and rate limit across a
+                // safe retry on a replacement child transport.
+                notification.progress = scope.started.elapsed().as_secs_f64();
+                notification.total = None;
+                // A progress delivery failure is not a failed notebook operation.
+                let _ = tokio::time::timeout(
+                    Duration::from_millis(250),
+                    context.peer.notify_progress(notification),
+                )
+                .await;
+            }
+        }
+    }
+}

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -220,6 +220,8 @@ impl ServerHandler for LegacyChild {
                 std::fs::write(background_root.join(format!("completed-{job}")), "done").unwrap();
             });
             if let Some(token) = context.meta.get_progress_token() {
+                std::fs::write(root.join(format!("progress-requested-{job}")), "requested")
+                    .unwrap();
                 context
                     .peer
                     .notify_progress(rmcp_legacy::model::ProgressNotificationParam {
@@ -233,7 +235,7 @@ impl ServerHandler for LegacyChild {
             }
             tokio::select! {
                 _ = context.ct.cancelled() => { std::fs::write(root.join(format!("cancelled-{job}")), context.id.to_string()).unwrap(); },
-                _ = tokio::time::sleep(std::time::Duration::from_millis(400)) => {},
+                _ = tokio::time::sleep(if request.arguments.as_ref().and_then(|args| args.get("expect_cancel")).and_then(serde_json::Value::as_bool).unwrap_or(false) { std::time::Duration::from_secs(60) } else { std::time::Duration::from_millis(400) }) => {},
             }
             return Ok(CallToolResult::success(vec![]));
         }
@@ -249,6 +251,30 @@ impl ServerHandler for LegacyChild {
             );
             let path = root.join("accepted-calls");
             let first = !path.exists();
+            if request
+                .arguments
+                .as_ref()
+                .and_then(|args| args.get("probe_progress"))
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                let attempt = if first { 1 } else { 2 };
+                context
+                    .peer
+                    .notify_progress(rmcp_legacy::model::ProgressNotificationParam {
+                        progress_token: context.meta.get_progress_token().unwrap(),
+                        progress: 0.0,
+                        total: None,
+                        message: Some(format!("attempt-{attempt}")),
+                    })
+                    .await
+                    .unwrap();
+                // The test releases each attempt after observing its progress;
+                // no scheduler-speed assumption controls the crash boundary.
+                while !root.join(format!("release-attempt-{attempt}")).exists() {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
             let mut log = std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)

--- a/crates/runt-mcp-proxy/tests/fixtures/mod.rs
+++ b/crates/runt-mcp-proxy/tests/fixtures/mod.rs
@@ -205,6 +205,38 @@ impl ServerHandler for LegacyChild {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
+        if request.name == "progress_job" {
+            let job = request
+                .arguments
+                .as_ref()
+                .and_then(|args| args.get("job"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            let root =
+                std::path::PathBuf::from(std::env::var("NTERACT_COMPATIBILITY_ROOT").unwrap());
+            let background_root = root.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                std::fs::write(background_root.join(format!("completed-{job}")), "done").unwrap();
+            });
+            if let Some(token) = context.meta.get_progress_token() {
+                context
+                    .peer
+                    .notify_progress(rmcp_legacy::model::ProgressNotificationParam {
+                        progress_token: token,
+                        progress: 0.0,
+                        total: None,
+                        message: Some(format!("job-{job}")),
+                    })
+                    .await
+                    .unwrap();
+            }
+            tokio::select! {
+                _ = context.ct.cancelled() => { std::fs::write(root.join(format!("cancelled-{job}")), context.id.to_string()).unwrap(); },
+                _ = tokio::time::sleep(std::time::Duration::from_millis(400)) => {},
+            }
+            return Ok(CallToolResult::success(vec![]));
+        }
         if self.lose_first_response {
             if request.name == "definitive_error" {
                 return Err(ErrorData::invalid_params(

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -313,6 +313,106 @@ async fn subscriptions_wait_for_startup_and_rebind_after_child_replacement() {
 }
 
 #[tokio::test]
+async fn concurrent_progress_uses_each_upstream_token_and_is_opt_in() {
+    let (_dir, proxy, _) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    for (id, token) in [(90, "alpha"), (91, "beta")] {
+        wire.send(json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":id},"_meta":{"progressToken":token}}})).await;
+    }
+    let mut completed = 0;
+    let mut progress = Vec::new();
+    while completed < 2 {
+        let message = wire.receive().await;
+        if message["id"].is_number() {
+            completed += 1;
+            assert!(message.get("result").is_some());
+        } else if message["method"] == "notifications/progress" {
+            progress.push(message);
+        }
+    }
+    assert_eq!(progress.len(), 2);
+    for message in progress {
+        let token = message["params"]["progressToken"].as_str().unwrap();
+        assert_eq!(
+            message["params"]["message"],
+            if token == "alpha" {
+                "job-90"
+            } else {
+                assert_eq!(token, "beta");
+                "job-91"
+            }
+        );
+    }
+    wire.notifications.clear();
+    wire.request(
+        92,
+        "tools/call",
+        Some(json!({"name":"progress_job","arguments":{"job":92}})),
+    )
+    .await;
+    assert!(!wire
+        .notifications
+        .iter()
+        .any(|notification| notification["method"] == "notifications/progress"));
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn cancellation_targets_child_request_but_background_execution_continues() {
+    let (dir, proxy, resolves) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    wire.send(json!({"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":99},"_meta":{"progressToken":"cancel-this"}}})).await;
+    wire.notification("notifications/progress").await;
+    wire.send(json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":99,"reason":"stop waiting"}})).await;
+    timeout(DEADLINE, async {
+        while !dir.path().join("cancelled-99").exists() || !dir.path().join("completed-99").exists()
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_ne!(
+        std::fs::read_to_string(dir.path().join("cancelled-99")).unwrap(),
+        "99"
+    );
+    assert_eq!(resolves.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        legacy_result(&wire.request(100, "ping", None).await),
+        &json!({})
+    );
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn upstream_disconnect_cancels_the_child_wait() {
+    let (dir, proxy, _) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    wire.send(json!({"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":101},"_meta":{"progressToken":"disconnect"}}})).await;
+    wire.notification("notifications/progress").await;
+    wire.finish().await;
+    timeout(DEADLINE, async {
+        while !dir.path().join("cancelled-101").exists() {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
 async fn resource_subscriptions_relay_early_notifications_and_invalidate_on_child_loss() {
     let (_dir, proxy, _) = isolated_proxy();
     proxy.init_child().await.unwrap();

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -357,6 +357,7 @@ async fn concurrent_progress_uses_each_upstream_token_and_is_opt_in() {
         .notifications
         .iter()
         .any(|notification| notification["method"] == "notifications/progress"));
+    assert!(!_dir.path().join("progress-requested-92").exists());
     stop_child(&proxy).await;
     wire.finish().await;
 }
@@ -368,7 +369,7 @@ async fn cancellation_targets_child_request_but_background_execution_continues()
     let mut wire = Wire::start(proxy.clone());
     wire.initialize("2025-11-25").await;
     wire.initialized().await;
-    wire.send(json!({"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":99},"_meta":{"progressToken":"cancel-this"}}})).await;
+    wire.send(json!({"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":99,"expect_cancel":true},"_meta":{"progressToken":"cancel-this"}}})).await;
     wire.notification("notifications/progress").await;
     wire.send(json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":99,"reason":"stop waiting"}})).await;
     timeout(DEADLINE, async {
@@ -393,13 +394,90 @@ async fn cancellation_targets_child_request_but_background_execution_continues()
 }
 
 #[tokio::test]
+async fn safe_retry_retains_one_progress_clock_and_upstream_token() {
+    let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    wire.send(json!({"jsonrpc":"2.0","id":104,"method":"tools/call","params":{"name":"get_results","arguments":{"probe_progress":true},"_meta":{"progressToken":"retry"}}})).await;
+    let mut updates = Vec::new();
+    for attempt in 1..=2 {
+        wire.notification("notifications/progress").await;
+        let update = wire.notifications.pop().unwrap();
+        assert_eq!(update["params"]["progressToken"], "retry");
+        assert_eq!(update["params"]["message"], format!("attempt-{attempt}"));
+        updates.push(update["params"]["progress"].as_f64().unwrap());
+        std::fs::write(
+            dir.path().join(format!("release-attempt-{attempt}")),
+            "continue",
+        )
+        .unwrap();
+    }
+    assert!(updates[1] - updates[0] >= 1.0, "{updates:?}");
+    let response = wire.receive().await;
+    assert_eq!(response["id"], 104);
+    assert!(response.get("result").is_some());
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn upstream_disconnect_while_waiting_for_startup_ends_promptly() {
+    let (_dir, proxy, resolves) = isolated_proxy();
+    let mut wire = Wire::start(proxy);
+    wire.initialize("2025-11-25").await;
+    // Deliberately omit notifications/initialized so no child starts.
+    wire.send(
+        json!({"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"get_results"}}),
+    )
+    .await;
+    timeout(std::time::Duration::from_secs(1), wire.finish())
+        .await
+        .unwrap();
+    assert_eq!(resolves.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn reconnect_outlives_its_cancelled_observer_and_remains_single_flight() {
+    let (_dir, proxy, resolves) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let generation = proxy.state.read().await.child_generation;
+    let mut wire = Wire::start(proxy.clone());
+    wire.initialize("2025-11-25").await;
+    wire.initialized().await;
+    wire.send(
+        json!({"jsonrpc":"2.0","id":103,"method":"tools/call","params":{"name":"reconnect"}}),
+    )
+    .await;
+    timeout(DEADLINE, async {
+        while proxy.state.read().await.child_generation == generation {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    timeout(std::time::Duration::from_secs(1), wire.finish())
+        .await
+        .unwrap();
+    // A second waiter joins the owned restart instead of reporting early success.
+    timeout(DEADLINE, proxy.restart_child())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(resolves.load(Ordering::SeqCst), 2);
+    assert!(proxy.state.read().await.child_client.is_some());
+    stop_child(&proxy).await;
+}
+
+#[tokio::test]
 async fn upstream_disconnect_cancels_the_child_wait() {
     let (dir, proxy, _) = isolated_proxy();
     proxy.init_child().await.unwrap();
     let mut wire = Wire::start(proxy.clone());
     wire.initialize("2025-11-25").await;
     wire.initialized().await;
-    wire.send(json!({"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":101},"_meta":{"progressToken":"disconnect"}}})).await;
+    wire.send(json!({"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"progress_job","arguments":{"job":101,"expect_cancel":true},"_meta":{"progressToken":"disconnect"}}})).await;
     wire.notification("notifications/progress").await;
     wire.finish().await;
     timeout(DEADLINE, async {

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -1012,3 +1012,30 @@ async fn version_skew_production_spawn_child_pins_legacy_and_reaps_old_sdk_child
     .await
     .expect("production child owner did not reap the old SDK fixture");
 }
+
+#[tokio::test]
+async fn successful_reconnect_returns_when_replacement_is_ready() {
+    let (_dir, proxy, resolves) = isolated_proxy();
+    proxy.init_child().await.unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    assert_initialize(
+        &wire.initialize("2025-11-25").await,
+        "2025-11-25",
+        "compatibility-proxy",
+    );
+    let response = timeout(
+        std::time::Duration::from_secs(5),
+        wire.request(
+            901,
+            "tools/call",
+            Some(json!({"name":"reconnect","arguments":{}})),
+        ),
+    )
+    .await
+    .expect("ready reconnect returns without a lost-notification delay");
+    assert_ne!(response["result"]["isError"], true, "{response}");
+    assert!(response.get("result").is_some(), "{response}");
+    assert_eq!(resolves.load(Ordering::SeqCst), 2);
+    stop_child(&proxy).await;
+    wire.finish().await;
+}

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
+mcp-transport = { path = "../mcp-transport" }
 base64 = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
 reqwest = { workspace = true, features = ["json"] }
@@ -39,6 +40,7 @@ url = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 rmcp = { workspace = true, features = ["client"] }
 futures-util = { workspace = true }
 proptest = { workspace = true }

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -1,7 +1,7 @@
-//! Execution pipeline: submit cell → poll RuntimeStateDoc → collect outputs.
+//! Execution pipeline: submit cell → observe RuntimeStateDoc → collect outputs.
 //!
 //! This module handles the async execution lifecycle for `execute_cell` and
-//! tools that use `and_run`. It polls the RuntimeStateDoc (the daemon-owned
+//! tools that use `and_run`. It observes RuntimeStateDoc (the daemon-owned
 //! Automerge CRDT) for execution lifecycle state, using the CRDT as the
 //! source of truth instead of relying on broadcast hints.
 
@@ -45,7 +45,7 @@ pub struct ExecutionResult {
     /// The cell ID that was executed.
     pub cell_id: String,
     /// The execution ID assigned by the daemon (from `CellQueued`).
-    /// Agents can pass this to `get_cell(execution_id=...)` to read
+    /// Agents can pass this to `get_results(execution_id=...)` to read
     /// outputs for this specific execution, bypassing the cell's
     /// current pointer.
     pub execution_id: String,
@@ -81,12 +81,11 @@ pub fn execution_cell_map(handle: &DocHandle) -> HashMap<String, String> {
 ///
 /// 1. Captures current Automerge heads as a causal precondition.
 /// 2. Sends `ExecuteCell` request.
-/// 3. Polls RuntimeStateDoc until the execution reaches terminal status.
+/// 3. Observes RuntimeStateDoc until the execution reaches terminal status.
 /// 4. Collects and resolves outputs from the CRDT.
 ///
-/// The daemon writes `set_execution_done` AFTER all outputs are written,
-/// so once the synced execution status is `"done"` or `"error"`, outputs
-/// are guaranteed to be present.
+/// The shared wait helper settles trailing stream updates that can arrive in
+/// a later sync frame than the terminal status.
 pub async fn execute_and_wait(
     handle: &DocHandle,
     cell_id: &str,
@@ -129,6 +128,10 @@ pub async fn execute_and_wait(
             )));
         }
     };
+
+    crate::progress::status(format!(
+        "Submitted execution {execution_id}; waiting for its output"
+    ));
 
     // Step 3: Wait for terminal state via the shared helper. This uses
     // the RuntimeStateDoc as the source of truth (no broadcast dependency)
@@ -296,6 +299,7 @@ pub async fn run_all_and_wait(
     timeout: Duration,
 ) -> Result<RunAllResult, ExecutionDispatchError> {
     let mut result = run_all_and_queue(handle).await?;
+    crate::progress::status("Submitted notebook executions; waiting for results");
 
     if result.status == "error" || result.cell_execution_ids.is_empty() {
         return Ok(result);

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -30,6 +30,7 @@ pub mod formatting;
 mod icons;
 pub mod observation;
 pub mod presence;
+mod progress;
 pub mod project_file;
 mod resources;
 mod session;
@@ -600,7 +601,7 @@ impl ServerHandler for NteractMcp {
             }
         }
         let start = std::time::Instant::now();
-        let result = tools::dispatch(self, &request).await;
+        let result = progress::run(&context, &request.name, tools::dispatch(self, &request)).await;
         let elapsed = start.elapsed();
         if elapsed >= SLOW_MCP_TOOL_CALL {
             tracing::warn!(

--- a/crates/runt-mcp/src/progress.rs
+++ b/crates/runt-mcp/src/progress.rs
@@ -1,0 +1,247 @@
+//! Opt-in progress and cancellation confined to one MCP request.
+//!
+//! Numeric progress is elapsed seconds, never a guessed percentage. Daemon
+//! execution outlives this observation future; cancellation sends no kernel RPC.
+
+use std::future::Future;
+use std::time::Duration;
+
+use rmcp::model::{ErrorCode, ProgressNotificationParam};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::ErrorData as McpError;
+use tokio::sync::watch;
+
+tokio::task_local! { static STATUS: watch::Sender<String>; }
+
+/// Record a real lifecycle transition for the current request, if it opted in.
+pub(crate) fn status(message: impl Into<String>) {
+    let message = message.into();
+    let _ = STATUS.try_with(|sender| {
+        sender.send_replace(message);
+    });
+}
+
+pub(crate) async fn run<T>(
+    context: &RequestContext<RoleServer>,
+    tool: &str,
+    operation: impl Future<Output = Result<T, McpError>>,
+) -> Result<T, McpError> {
+    let cancelled = || {
+        McpError::new(
+            ErrorCode(-32800),
+            "Request observation cancelled; daemon execution may continue",
+            None,
+        )
+    };
+    let Some(token) = context.meta.get_progress_token() else {
+        return tokio::select! { biased; _ = mcp_transport::cancelled(context) => Err(cancelled()), result = operation => result };
+    };
+    let initial = format!("Processing {tool}");
+    let (sender, mut receiver) = watch::channel(initial);
+    let operation = STATUS.scope(sender, operation);
+    tokio::pin!(operation);
+    let started = tokio::time::Instant::now();
+    let mut last_sent = None;
+    let mut pending = true;
+    let mut tick = tokio::time::interval(Duration::from_secs(1));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            _ = mcp_transport::cancelled(context) => return Err(cancelled()),
+            result = &mut operation => return result,
+            changed = receiver.changed() => { if changed.is_ok() { pending = true; } },
+            _ = tick.tick() => {},
+        }
+        let elapsed_since_send = last_sent.map(|last: tokio::time::Instant| last.elapsed());
+        if elapsed_since_send.is_none_or(|elapsed| elapsed >= Duration::from_secs(5)) {
+            pending = true;
+        }
+        if pending && elapsed_since_send.is_none_or(|elapsed| elapsed >= Duration::from_secs(1)) {
+            let elapsed = started.elapsed().as_secs_f64();
+            let message = format!(
+                "{} ({elapsed:.0}s elapsed)",
+                receiver.borrow_and_update().as_str()
+            );
+            let notification =
+                ProgressNotificationParam::new(token.clone(), elapsed).with_message(message);
+            // Backpressure on optional status delivery must not stall the tool.
+            tokio::select! {
+                biased;
+                _ = mcp_transport::cancelled(context) => return Err(cancelled()),
+                _ = tokio::time::timeout(Duration::from_millis(250), context.peer.notify_progress(notification)) => {},
+            }
+            last_sent = Some(tokio::time::Instant::now());
+            pending = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::*;
+    use rmcp::service::{NotificationContext, RoleClient};
+    use rmcp::{ClientHandler, ServerHandler, ServiceExt};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    struct Client(tokio::sync::mpsc::UnboundedSender<ProgressNotificationParam>);
+    impl ClientHandler for Client {
+        async fn on_progress(
+            &self,
+            progress: ProgressNotificationParam,
+            _: NotificationContext<RoleClient>,
+        ) {
+            let _ = self.0.send(progress);
+        }
+    }
+    struct Server {
+        finished: Arc<AtomicBool>,
+        observing: Arc<AtomicBool>,
+    }
+    struct ObserveGuard(Arc<AtomicBool>);
+    impl Drop for ObserveGuard {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::SeqCst);
+        }
+    }
+    impl ServerHandler for Server {
+        async fn call_tool(
+            &self,
+            _: CallToolRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> Result<CallToolResponse, McpError> {
+            let done = self.finished.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(6)).await;
+                done.store(true, Ordering::SeqCst);
+            });
+            run(&context, "fixture", async {
+                self.observing.store(true, Ordering::SeqCst);
+                let _guard = ObserveGuard(self.observing.clone());
+                for index in 0..20 {
+                    status(format!("Observed state {index}"));
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                tokio::time::sleep(Duration::from_secs(11)).await;
+                Ok(CallToolResult::success(vec![]).into())
+            })
+            .await
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn real_requests_coalesce_status_and_report_elapsed_heartbeats() {
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let server = Server {
+            finished: Arc::new(AtomicBool::new(false)),
+            observing: Arc::new(AtomicBool::new(false)),
+        };
+        let task = tokio::spawn(async move { server.serve(server_pipe).await.unwrap() });
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut client = Client(sender).serve(client_pipe).await.unwrap();
+        let mut server = task.await.unwrap();
+        client
+            .call_tool_once(CallToolRequestParams::new("fixture"))
+            .await
+            .unwrap();
+        let mut updates = Vec::new();
+        while let Ok(progress) = receiver.try_recv() {
+            updates.push(progress);
+        }
+        assert!((3..=4).contains(&updates.len()), "{updates:?}");
+        assert!(updates.iter().all(|progress| progress.total.is_none()));
+        assert!(updates
+            .windows(2)
+            .all(|pair| pair[1].progress - pair[0].progress >= 1.0));
+        assert!(updates.iter().any(|progress| progress.progress >= 5.0
+            && progress
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("Observed state 19")));
+        client.close().await.unwrap();
+        server.close().await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connection_close_stops_observation_without_stopping_owned_work() {
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let finished = Arc::new(AtomicBool::new(false));
+        let observing = Arc::new(AtomicBool::new(false));
+        let server = Server {
+            finished: finished.clone(),
+            observing: observing.clone(),
+        };
+        let task = tokio::spawn(async move {
+            server
+                .serve(mcp_transport::server(server_pipe))
+                .await
+                .unwrap()
+        });
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut client = Client(sender).serve(client_pipe).await.unwrap();
+        let server = task.await.unwrap();
+        let _request = client
+            .send_cancellable_request(
+                ClientRequest::CallToolRequest(CallToolRequest::new(CallToolRequestParams::new(
+                    "fixture",
+                ))),
+                rmcp::service::PeerRequestOptions::no_options(),
+            )
+            .await
+            .unwrap();
+        receiver.recv().await.unwrap();
+        assert!(observing.load(Ordering::SeqCst));
+        client.close().await.unwrap();
+        server.waiting().await.unwrap();
+        assert!(!observing.load(Ordering::SeqCst));
+        assert!(!finished.load(Ordering::SeqCst));
+        tokio::time::advance(Duration::from_secs(7)).await;
+        tokio::task::yield_now().await;
+        assert!(finished.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn real_cancellation_stops_observation_while_owned_work_finishes() {
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let finished = Arc::new(AtomicBool::new(false));
+        let observing = Arc::new(AtomicBool::new(false));
+        let server = Server {
+            finished: finished.clone(),
+            observing: observing.clone(),
+        };
+        let task = tokio::spawn(async move { server.serve(server_pipe).await.unwrap() });
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut client = Client(sender).serve(client_pipe).await.unwrap();
+        let mut server = task.await.unwrap();
+        let request = client
+            .send_cancellable_request(
+                ClientRequest::CallToolRequest(CallToolRequest::new(CallToolRequestParams::new(
+                    "fixture",
+                ))),
+                rmcp::service::PeerRequestOptions::no_options(),
+            )
+            .await
+            .unwrap();
+        receiver.recv().await.unwrap();
+        assert!(observing.load(Ordering::SeqCst));
+        request.cancel(Some("stop watching".into())).await.unwrap();
+        // A ping ensures the cancellation notification has reached the server.
+        client
+            .send_request(ClientRequest::PingRequest(PingRequest::default()))
+            .await
+            .unwrap();
+        tokio::task::yield_now().await;
+        assert!(!observing.load(Ordering::SeqCst));
+        assert!(!finished.load(Ordering::SeqCst));
+        tokio::time::advance(Duration::from_secs(7)).await;
+        tokio::task::yield_now().await;
+        assert!(finished.load(Ordering::SeqCst));
+        client.close().await.unwrap();
+        server.close().await.unwrap();
+    }
+}

--- a/crates/runt-mcp/src/progress.rs
+++ b/crates/runt-mcp/src/progress.rs
@@ -6,7 +6,7 @@
 use std::future::Future;
 use std::time::Duration;
 
-use rmcp::model::{ErrorCode, ProgressNotificationParam};
+use rmcp::model::ProgressNotificationParam;
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ErrorData as McpError;
 use tokio::sync::watch;
@@ -26,13 +26,7 @@ pub(crate) async fn run<T>(
     tool: &str,
     operation: impl Future<Output = Result<T, McpError>>,
 ) -> Result<T, McpError> {
-    let cancelled = || {
-        McpError::new(
-            ErrorCode(-32800),
-            "Request observation cancelled; daemon execution may continue",
-            None,
-        )
-    };
+    let cancelled = mcp_transport::cancellation_error;
     let Some(token) = context.meta.get_progress_token() else {
         return tokio::select! { biased; _ = mcp_transport::cancelled(context) => Err(cancelled()), result = operation => result };
     };
@@ -57,7 +51,10 @@ pub(crate) async fn run<T>(
         if elapsed_since_send.is_none_or(|elapsed| elapsed >= Duration::from_secs(5)) {
             pending = true;
         }
-        if pending && elapsed_since_send.is_none_or(|elapsed| elapsed >= Duration::from_secs(1)) {
+        if pending
+            && started.elapsed() >= Duration::from_secs(1)
+            && elapsed_since_send.is_none_or(|elapsed| elapsed >= Duration::from_secs(1))
+        {
             let elapsed = started.elapsed().as_secs_f64();
             let message = format!(
                 "{} ({elapsed:.0}s elapsed)",

--- a/crates/runt-mcp/src/tools/observation.rs
+++ b/crates/runt-mcp/src/tools/observation.rs
@@ -81,6 +81,7 @@ async fn run_wait(
         return Ok(change_result(params, notebook_id, initial, None));
     }
     let Some(execution_id) = params.execution_id.as_deref() else {
+        crate::progress::status("Watching notebook edits, outputs, and comments");
         let change = observer
             .wait(params.after.as_deref().unwrap_or(&initial.cursor), timeout)
             .await
@@ -92,6 +93,7 @@ async fn run_wait(
         .map_err(sync_error)?;
     let terminal = async {
         while let Some(progress) = watcher.next().await {
+            crate::progress::status(format!("Execution {execution_id}: {}", progress.status));
             if progress.terminal {
                 return Some(progress);
             }

--- a/crates/runt-mcp/tests/support/mod.rs
+++ b/crates/runt-mcp/tests/support/mod.rs
@@ -24,7 +24,7 @@ impl Wire {
     pub fn start<S: ServerHandler + Send + Sync + 'static>(handler: S) -> Self {
         let (server, client) = tokio::io::duplex(64 * 1024);
         let task = tokio::spawn(async move {
-            match handler.serve(server).await {
+            match handler.serve(mcp_transport::server(server)).await {
                 Ok(service) => service
                     .waiting()
                     .await

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
+mcp-transport = { path = "../mcp-transport" }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -754,7 +754,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let last_session_drop = server.last_session_drop().clone();
     let parked_sessions = server.parked_sessions().clone();
 
-    let transport = rmcp::transport::io::stdio();
+    let transport = mcp_transport::server(rmcp::transport::io::stdio());
     let handle = server.serve(transport).await?;
     if handle.peer().peer_info().is_none() {
         handle.cancel().await?;

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -159,6 +159,11 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "crates/mcp-transport/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/mcp-client-branding/Cargo.toml",
         format: Format::Toml,
         matches: 1,

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -192,9 +192,15 @@ proxy maps cancellation to the private child's request ID and
 maps progress back to the upstream progress token. Independent concurrent
 requests have separate scopes. Dropping a forwarding future also sends a
 bounded cancellation notification to the child; it does not interrupt a kernel.
+Restart work has one owned task with a shared completion result. Concurrent
+callers await that result, and cancelling a caller stops only its wait. This
+also covers reconnect and waiting for child startup.
 
 Progress is opt-in and reports elapsed seconds with real status messages,
-at most once per second, with a heartbeat every five seconds. A request keeps
+at most once per second, with a heartbeat every five seconds. Short calls return
+without status traffic during their first second. The private
+child transport removes the SDK's automatic token when the upstream did not
+request progress. A request keeps
 one elapsed clock and rate limit across a safe child retry. Progress delivery
 has a short timeout so a slow notification consumer cannot indefinitely stall
 the tool. Completion and cancellation discard pending progress updates.
@@ -572,10 +578,8 @@ already implemented separate-child/shared-daemon model.
    a separate compatibility policy. Recovery hints are already caller-specific:
    installed wrapper at `crates/nteract-mcp/src/main.rs:204`, dev supervisor at
    `crates/mcp-supervisor/src/main.rs:3159`.
-5. **Recovery concurrency and protocol compatibility.** Concurrent callers
-   currently skip a restart already in progress rather than await its result.
-   A retry can therefore race replacement startup. Shared restart completion
-   and migration to the newer upstream protocol need explicit lifecycle work;
+5. **Protocol compatibility.** Concurrent callers now await shared restart
+   completion. Migration to the newer upstream protocol needs explicit lifecycle work;
    neither exactly-once execution nor native protocol support follows from
    transparent restart or the SDK version.
 

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -184,6 +184,21 @@ timed_out, resync_required, or unavailable, with compact changes and resource
 links. Neither notification delivery nor a progress callback proves that a host
 has refreshed model context.
 
+Tool requests honor request cancellation and connection teardown throughout
+their observation future. The shared `mcp-transport` adapter attaches a connection
+token to each request and cancels it on EOF, failed writes, close, or drop; the
+SDK's request token alone does not signal EOF during its response drain. The
+proxy maps cancellation to the private child's request ID and
+maps progress back to the upstream progress token. Independent concurrent
+requests have separate scopes. Dropping a forwarding future also sends a
+bounded cancellation notification to the child; it does not interrupt a kernel.
+
+Progress is opt-in and reports elapsed seconds with real status messages,
+at most once per second, with a heartbeat every five seconds. A request keeps
+one elapsed clock and rate limit across a safe child retry. Progress delivery
+has a short timeout so a slow notification consumer cannot indefinitely stall
+the tool. Completion and cancellation discard pending progress updates.
+
 This observation layer does not by itself enable the native `2026-07-28`
 lifecycle or `subscriptions/listen`; those require their own transport and
 discovery support at every entrypoint.


### PR DESCRIPTION
Long notebook operations now report opt-in elapsed progress through the child, proxy, and development supervisor. Cancelling a request stops its observation and addresses the private child request ID; daemon execution continues until it finishes or the user explicitly interrupts the kernel.

Concurrent requests retain separate progress tokens. Updates arrive at most once per second, with five-second elapsed heartbeats and bounded delivery. Short calls produce no initial status notification. A shared transport adapter exposes EOF and write failure because the SDK request token does not cover its EOF response drain. Cancellation also covers startup and reconnect; restart work remains owned and shared, and successful reconnect returns as soon as the replacement is ready.

Validation:
- 245 runt-mcp unit tests, 11 child protocol tests, 122 proxy unit tests, 31 proxy process protocol tests, 29 supervisor tests, and the transport lifetime test passed across the implementation and focused follow-ups.
- Real protocol tests cover concurrent token mapping, private progress opt-in, cancellation by private request ID, startup disconnect, reconnect surviving observer cancellation, successful reconnect latency, and one elapsed clock across a controlled safe retry.
- Affected crates and all three production entry points pass Clippy with warnings denied. Full repository lint passed before each commit.
- The new transport crate is included in the release version inventory; all 47 xtask tests pass.
- Independent Kilo correctness and architecture reviews completed. Verified findings were fixed; focused follow-up review reports no actionable findings.

Builds on #4216. Native lifecycle support follows separately. These protocol tests do not establish desktop model-context refresh; desktop acceptance remains pending.
