### PR TITLE
feat(mcp): support native subscriptions and explicit notebook handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ name = "mcp-transport"
 version = "0.1.0"
 dependencies = [
  "rmcp 3.2.0",
+ "serde_json",
  "tokio",
  "tokio-util",
 ]

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -19,7 +19,6 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
@@ -30,10 +29,10 @@ use std::time::{Duration, Instant, SystemTime};
 
 use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, DiscoverRequestMethod,
-    DiscoverResult, Implementation, ListResourceTemplatesResult, ListResourcesResult,
-    ListToolsResult, ProtocolVersion, ReadResourceRequestParams, ReadResourceResponse,
-    ReadResourceResult, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, ProtocolVersion,
+    ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::schemars;
 use rmcp::service::{RequestContext, RoleServer};
@@ -44,6 +43,7 @@ use serde_json::Value;
 use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{error, info, warn};
 
+#[cfg(test)]
 const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2024_11_05,
     ProtocolVersion::V_2025_03_26,
@@ -51,14 +51,8 @@ const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2025_11_25,
 ];
 
-fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
-    if context.peer.peer_info().is_none() {
-        return Err(McpError::invalid_request(
-            "initialize is required before application requests",
-            None,
-        ));
-    }
-    Ok(())
+fn require_protocol(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    mcp_transport::require_protocol(context)
 }
 
 // ---------------------------------------------------------------------------
@@ -785,6 +779,7 @@ struct SupervisorState {
 
 #[derive(Clone)]
 struct Supervisor {
+    native_identity: Arc<std::sync::OnceLock<Implementation>>,
     state: Arc<RwLock<SupervisorState>>,
     /// Signaled when the child client is first connected by the background
     /// init task. `list_tools` waits on this so the initial tool list
@@ -793,6 +788,28 @@ struct Supervisor {
 }
 
 impl Supervisor {
+    async fn native_proxy_ready(
+        &self,
+        context: &RequestContext<RoleServer>,
+    ) -> Result<McpProxy, McpError> {
+        let ready = self.child_ready.notified();
+        let existing = { self.state.read().await.proxy.clone() };
+        let proxy = match existing {
+            Some(proxy) => proxy,
+            None => {
+                tokio::select! {
+                    _ = mcp_transport::cancelled(context) => return Err(McpError::internal_error("Request cancelled during supervisor startup", None)),
+                    result = tokio::time::timeout(Duration::from_secs(60), ready) => { result.map_err(|_| McpError::internal_error("Supervisor startup timed out", None))?; }
+                }
+                let state = self.state.read().await;
+                Self::get_proxy(&state)?.clone()
+            }
+        };
+        if let Some(info) = context.client_info() {
+            proxy.set_upstream_identity(info.name, info.title).await;
+        }
+        Ok(proxy)
+    }
     /// Create a supervisor with no proxy yet. The stdio MCP server starts
     /// immediately so the client doesn't time out; the proxy and child are
     /// connected later via a background task.
@@ -806,6 +823,7 @@ impl Supervisor {
         let log_dir = project_root.join(".context");
         let _ = std::fs::create_dir_all(&log_dir);
         Self {
+            native_identity: Arc::default(),
             state: Arc::new(RwLock::new(SupervisorState {
                 proxy: None,
                 log_dir,
@@ -1873,6 +1891,17 @@ struct DownParams {
 
 /// MCP ServerHandler that proxies to the nteract child + injects supervisor tools.
 impl ServerHandler for Supervisor {
+    fn accepted_subscription_filter(
+        &self,
+        requested: &rmcp::model::SubscriptionFilter,
+    ) -> Option<rmcp::model::SubscriptionFilter> {
+        Some(mcp_transport::notebook_subscription_filter(requested))
+    }
+    async fn listen(&self, context: rmcp::service::SubscriptionContext) -> Result<(), McpError> {
+        mcp_transport::require_protocol(context.request_context())?;
+        let proxy = self.native_proxy_ready(context.request_context()).await?;
+        proxy.forward_listen(context).await
+    }
     async fn initialize(
         &self,
         request: rmcp::model::InitializeRequestParams,
@@ -1885,24 +1914,25 @@ impl ServerHandler for Supervisor {
             ));
         }
         let mut info = self.get_info();
-        if self
-            .supported_protocol_versions()
-            .contains(&request.protocol_version)
-        {
+        if mcp_transport::LEGACY_VERSIONS.contains(&request.protocol_version) {
             info.protocol_version = request.protocol_version;
         }
         Ok(info)
     }
 
-    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(LEGACY_PROTOCOL_VERSIONS)
+    fn supported_protocol_versions(&self) -> std::borrow::Cow<'static, [ProtocolVersion]> {
+        std::borrow::Cow::Borrowed(mcp_transport::SUPPORTED_VERSIONS)
     }
 
     async fn discover(
         &self,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<DiscoverResult, McpError> {
-        Err(McpError::method_not_found::<DiscoverRequestMethod>())
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::DiscoverResult, McpError> {
+        let result = mcp_transport::discover(&context, self.get_info())?;
+        if let Some(identity) = context.client_info() {
+            let _ = self.native_identity.set(identity);
+        }
+        Ok(result)
     }
 
     fn get_info(&self) -> ServerInfo {
@@ -1936,8 +1966,10 @@ impl ServerHandler for Supervisor {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::ListPromptsResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(rmcp::model::ListPromptsResult::default())
+        require_protocol(&context)?;
+        Ok(rmcp::model::ListPromptsResult::default()
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn complete(
@@ -1945,7 +1977,7 @@ impl ServerHandler for Supervisor {
         _request: rmcp::model::CompleteRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::CompleteResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         Ok(rmcp::model::CompleteResult::default())
     }
 
@@ -1954,7 +1986,7 @@ impl ServerHandler for Supervisor {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         let mut tools = Vec::new();
 
         // Supervisor's own tools. Schema generation is fallible in principle
@@ -2011,20 +2043,23 @@ impl ServerHandler for Supervisor {
             logs_schema,
         ));
 
-        // Get child tools from the proxy (live or cached), falling back
-        // to the built-in tool cache if the proxy isn't ready yet.
-        {
-            let state = self.state.read().await;
-            if let Some(ref proxy) = state.proxy {
-                let child_tools = proxy.child_tools().await;
-                tools.extend(child_tools);
-            } else if let Some(builtin) = runt_mcp_proxy::tools::load_builtin_tools() {
-                info!("Serving {} built-in tools (proxy not ready)", builtin.len());
-                tools.extend(builtin);
-            }
+        // Native discovery waits for the complete catalog. Clone the proxy
+        // before awaiting child I/O so supervisor state remains accessible.
+        let proxy = if mcp_transport::is_native(&context) {
+            Some(self.native_proxy_ready(&context).await?)
+        } else {
+            self.state.read().await.proxy.clone()
+        };
+        if let Some(proxy) = proxy {
+            tools.extend(proxy.child_tools().await);
+        } else if let Some(builtin) = runt_mcp_proxy::tools::load_builtin_tools() {
+            tools.extend(builtin);
         }
 
-        Ok(ListToolsResult::with_all_items(tools))
+        mcp_transport::attachment_tool_schemas(&mut tools, mcp_transport::is_native(&context));
+        Ok(ListToolsResult::with_all_items(tools)
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn list_resources(
@@ -2032,7 +2067,14 @@ impl ServerHandler for Supervisor {
         request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        if mcp_transport::is_native(&context) {
+            return self
+                .native_proxy_ready(&context)
+                .await?
+                .list_resources(request, context)
+                .await;
+        }
         let state = self.state.read().await;
         if let Some(ref proxy) = state.proxy {
             Ok(proxy.child_resources(request).await)
@@ -2046,7 +2088,14 @@ impl ServerHandler for Supervisor {
         request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        if mcp_transport::is_native(&context) {
+            return self
+                .native_proxy_ready(&context)
+                .await?
+                .list_resource_templates(request, context)
+                .await;
+        }
         let state = self.state.read().await;
         if let Some(ref proxy) = state.proxy {
             Ok(proxy.child_resource_templates(request).await)
@@ -2060,7 +2109,14 @@ impl ServerHandler for Supervisor {
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        if mcp_transport::is_native(&context) {
+            return self
+                .native_proxy_ready(&context)
+                .await?
+                .read_resource(request, context)
+                .await;
+        }
         self.forward_read_resource(request)
             .await
             .map(ReadResourceResponse::Complete)
@@ -2071,10 +2127,17 @@ impl ServerHandler for Supervisor {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        mcp_transport::validate_tool_target(&request, &context)?;
+        if mcp_transport::is_native(&context) {
+            self.native_proxy_ready(&context).await?;
+        }
         runt_mcp_proxy::request_scope::scope(context, self.handle_tool_call(request))
             .await
-            .map(CallToolResponse::Complete)
+            .map(|mut result| {
+                result.result_type = Some(rmcp::model::ResultType::COMPLETE);
+                CallToolResponse::Complete(result)
+            })
     }
 
     #[allow(deprecated)]
@@ -2083,7 +2146,7 @@ impl ServerHandler for Supervisor {
         request: rmcp::model::SubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         let ready = self.child_ready.notified();
         let proxy = { self.state.read().await.proxy.clone() };
         let proxy = match proxy {
@@ -2108,7 +2171,7 @@ impl ServerHandler for Supervisor {
         request: rmcp::model::UnsubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         let proxy = {
             let state = self.state.read().await;
             state.proxy.clone()
@@ -3049,10 +3112,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let transport = mcp_transport::server(rmcp::transport::io::stdio());
     let server = supervisor.serve(transport).await?;
-    if server.peer().peer_info().is_none() {
-        server.cancellation_token().cancel();
-        return Err("The initialize handshake is required".into());
-    }
     info!("MCP server initialized on stdio (supervisor tools available)");
 
     // Extract upstream client identity from the MCP initialize handshake.
@@ -3067,7 +3126,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!("Upstream MCP client: name={name:?}, title={title:?}");
             (name, title)
         })
-        .unwrap_or_else(|| ("nteract-dev".to_string(), None));
+        .unwrap_or_else(|| {
+            server
+                .service()
+                .native_identity
+                .get()
+                .map(|info| (info.name.clone(), info.title.clone()))
+                .unwrap_or_else(|| ("nteract-dev".to_string(), None))
+        });
 
     // Clone what we need before waiting() consumes the server
     let state_for_init = server.service().state.clone();
@@ -3346,6 +3412,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             });
 
             let watcher_supervisor = Supervisor {
+                native_identity: Arc::default(),
                 state: state_for_watcher,
                 child_ready: Arc::new(Notify::new()),
             };
@@ -3559,7 +3626,7 @@ mod tests {
             "resources/read",
         ] {
             let responses =
-                supervisor_responses(vec![request_without_handshake(method, "2026-07-28")]).await;
+                supervisor_responses(vec![request_without_handshake(method, "2099-01-01")]).await;
             assert_eq!(responses[0]["error"]["code"], -32022, "{}", responses[0]);
             assert!(responses[0].get("result").is_none());
         }
@@ -3594,7 +3661,7 @@ mod tests {
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
         assert_eq!(
             supervisor.supported_protocol_versions().as_ref(),
-            LEGACY_PROTOCOL_VERSIONS
+            mcp_transport::SUPPORTED_VERSIONS
         );
         assert!(info.capabilities.extensions.as_ref().is_some_and(
             |extensions| extensions.contains_key(runt_mcp_proxy::MCP_APPS_EXTENSION_ID)

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -779,7 +779,6 @@ struct SupervisorState {
 
 #[derive(Clone)]
 struct Supervisor {
-    native_identity: Arc<std::sync::OnceLock<Implementation>>,
     state: Arc<RwLock<SupervisorState>>,
     /// Signaled when the child client is first connected by the background
     /// init task. `list_tools` waits on this so the initial tool list
@@ -823,7 +822,6 @@ impl Supervisor {
         let log_dir = project_root.join(".context");
         let _ = std::fs::create_dir_all(&log_dir);
         Self {
-            native_identity: Arc::default(),
             state: Arc::new(RwLock::new(SupervisorState {
                 proxy: None,
                 log_dir,
@@ -1162,6 +1160,13 @@ impl Supervisor {
         request: &CallToolRequestParams,
         vite_port: u16,
     ) -> Result<CallToolResult, McpError> {
+        if request
+            .arguments
+            .as_ref()
+            .is_some_and(|args| args.contains_key("notebook_handle"))
+        {
+            return self.forward_tool_call(request.clone()).await;
+        }
         let state = self.state.read().await;
 
         let binary = runt_workspace::cargo_binary_path_for_workspace(
@@ -1928,11 +1933,7 @@ impl ServerHandler for Supervisor {
         &self,
         context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::DiscoverResult, McpError> {
-        let result = mcp_transport::discover(&context, self.get_info())?;
-        if let Some(identity) = context.client_info() {
-            let _ = self.native_identity.set(identity);
-        }
-        Ok(result)
+        mcp_transport::discover(&context, self.get_info())
     }
 
     fn get_info(&self) -> ServerInfo {
@@ -3110,8 +3111,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tool_list_changed_tx,
     );
 
-    let transport = mcp_transport::server(rmcp::transport::io::stdio());
+    let (transport, protocol) = mcp_transport::server_with_protocol(rmcp::transport::io::stdio());
     let server = supervisor.serve(transport).await?;
+    if server.peer().peer_info().is_none() && !protocol.wait_for_native().await {
+        server.waiting().await?;
+        return Ok(());
+    }
+
     info!("MCP server initialized on stdio (supervisor tools available)");
 
     // Extract upstream client identity from the MCP initialize handshake.
@@ -3127,11 +3133,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             (name, title)
         })
         .unwrap_or_else(|| {
-            server
-                .service()
-                .native_identity
-                .get()
-                .map(|info| (info.name.clone(), info.title.clone()))
+            protocol
+                .client_info()
+                .map(|info| (info.name, info.title))
                 .unwrap_or_else(|| ("nteract-dev".to_string(), None))
         });
 
@@ -3412,7 +3416,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             });
 
             let watcher_supervisor = Supervisor {
-                native_identity: Arc::default(),
                 state: state_for_watcher,
                 child_ready: Arc::new(Notify::new()),
             };
@@ -3474,6 +3477,30 @@ mod tests {
 
     fn root() -> PathBuf {
         PathBuf::from("/repo")
+    }
+
+    #[tokio::test]
+    async fn handle_qualified_show_uses_child_validation_before_dev_launch() {
+        let (tx, _rx) = mpsc::channel(1);
+        let supervisor = Supervisor::new_empty(root(), DevMode::Attach, root(), None, tx);
+        for arguments in [
+            serde_json::json!({"notebook_handle":"active"}),
+            serde_json::json!({"notebook_handle":"parked","notebook_id":null}),
+            serde_json::json!({"notebook_handle":"expired","notebook_id":"/another.ipynb"}),
+        ] {
+            let request: CallToolRequestParams = serde_json::from_value(
+                serde_json::json!({"name":"show_notebook","arguments":arguments}),
+            )
+            .unwrap();
+            let error = supervisor
+                .show_notebook_dev(&request, 5173)
+                .await
+                .unwrap_err();
+            assert!(
+                error.message.contains("not yet initialized"),
+                "request must reach the child, not bypass it with the dev binary fallback: {error}"
+            );
+        }
     }
 
     async fn supervisor_responses(requests: Vec<Value>) -> Vec<Value> {

--- a/crates/mcp-transport/Cargo.toml
+++ b/crates/mcp-transport/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 rmcp = { workspace = true, features = ["server", "client"] }
 tokio-util = "0.7"
 tokio = { workspace = true, features = ["macros"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mcp-transport/src/lib.rs
+++ b/crates/mcp-transport/src/lib.rs
@@ -347,6 +347,12 @@ pub fn require_protocol(context: &RequestContext<RoleServer>) -> Result<(), rmcp
         return Ok(());
     }
     if is_native(context) {
+        if let Some(protocol) = context.extensions.get::<ProtocolSession>() {
+            if let Some(identity) = context.client_info() {
+                let _ = protocol.identity.set(identity);
+            }
+            protocol.accepted.cancel();
+        }
         return Ok(());
     }
     Err(rmcp::ErrorData::invalid_request(
@@ -385,20 +391,61 @@ pub async fn cancelled(context: &RequestContext<RoleServer>) {
     }
 }
 
+/// A valid native request opens the protocol lifecycle. Rejected metadata must
+/// not start notebook recovery or development-daemon setup.
+#[derive(Clone)]
+pub struct ProtocolSession {
+    accepted: CancellationToken,
+    closed: CancellationToken,
+    identity: Arc<std::sync::OnceLock<rmcp::model::Implementation>>,
+}
+impl ProtocolSession {
+    pub async fn wait_for_native(&self) -> bool {
+        tokio::select! {
+            biased;
+            _ = self.accepted.cancelled() => true,
+            _ = self.closed.cancelled() => false,
+        }
+    }
+    pub fn client_info(&self) -> Option<rmcp::model::Implementation> {
+        self.identity.get().cloned()
+    }
+}
+
 /// Apply once at each server entry point, including in-memory wire tests.
 pub fn server<T, E, A>(transport: T) -> impl Transport<RoleServer, Error = E>
 where
     T: IntoTransport<RoleServer, E, A>,
     E: std::error::Error + Send + Sync + 'static,
 {
-    ServerTransport {
-        inner: transport.into_transport(),
+    server_with_protocol(transport).0
+}
+
+pub fn server_with_protocol<T, E, A>(
+    transport: T,
+) -> (impl Transport<RoleServer, Error = E>, ProtocolSession)
+where
+    T: IntoTransport<RoleServer, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let protocol = ProtocolSession {
+        accepted: CancellationToken::new(),
         closed: CancellationToken::new(),
-        opening: Arc::new(Mutex::new(Opening::default())),
-    }
+        identity: Arc::default(),
+    };
+    (
+        ServerTransport {
+            inner: transport.into_transport(),
+            closed: protocol.closed.clone(),
+            protocol: protocol.clone(),
+            opening: Arc::new(Mutex::new(Opening::default())),
+        },
+        protocol,
+    )
 }
 
 struct ServerTransport<T> {
+    protocol: ProtocolSession,
     inner: T,
     closed: CancellationToken,
     opening: Arc<Mutex<Opening>>,
@@ -503,6 +550,10 @@ impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
                     .request
                     .extensions_mut()
                     .insert(ConnectionClosed(self.closed.clone()));
+                request
+                    .request
+                    .extensions_mut()
+                    .insert(self.protocol.clone());
                 let mut opening = self.opening.lock().unwrap_or_else(|e| e.into_inner());
                 if matches!(
                     request.request,
@@ -545,6 +596,7 @@ impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
                         discovery
                             .extensions_mut()
                             .insert(ConnectionClosed(self.closed.clone()));
+                        discovery.extensions_mut().insert(self.protocol.clone());
                         let prime = JsonRpcMessage::request(discovery, request.id.clone());
                         opening.priming_id = Some(request.id.clone());
                         opening.pending = message.take();

--- a/crates/mcp-transport/src/lib.rs
+++ b/crates/mcp-transport/src/lib.rs
@@ -4,10 +4,14 @@
 //! Attach a separate connection token before dispatch so observation can end
 //! immediately, while daemon-owned execution continues independently.
 
-use rmcp::model::{GetExtensions, GetMeta, JsonRpcMessage};
+use rmcp::model::{
+    ClientRequest, DiscoverRequest, GetExtensions, GetMeta, JsonRpcMessage, ProtocolVersion,
+    RequestId,
+};
 use rmcp::service::{RequestContext, RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::{IntoTransport, Transport};
 use std::future::Future;
+use std::sync::{Arc, Mutex};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
@@ -21,75 +25,28 @@ pub fn cancellation_error() -> rmcp::ErrorData {
     )
 }
 
-/// Wait for either explicit request cancellation or transport teardown.
-pub async fn cancelled(context: &RequestContext<RoleServer>) {
-    let connection = context.extensions.get::<ConnectionClosed>();
-    match connection {
-        Some(connection) => {
-            tokio::select! {
-                _ = context.ct.cancelled() => {},
-                _ = connection.0.cancelled() => {},
-            }
-        }
-        None => context.ct.cancelled().await,
-    }
-}
+#[derive(Default)]
+struct Acknowledgment(Mutex<Option<rmcp::model::ServerNotification>>);
+#[derive(Clone)]
+struct ReleaseAcknowledgment;
 
-/// Apply once at each server entry point, including in-memory wire tests.
-pub fn server<T, E, A>(transport: T) -> impl Transport<RoleServer, Error = E>
-where
-    T: IntoTransport<RoleServer, E, A>,
-    E: std::error::Error + Send + Sync + 'static,
-{
-    ServerTransport {
-        inner: transport.into_transport(),
-        closed: CancellationToken::new(),
-    }
-}
-
-struct ServerTransport<T> {
-    inner: T,
-    closed: CancellationToken,
-}
-impl<T> Drop for ServerTransport<T> {
-    fn drop(&mut self) {
-        self.closed.cancel();
-    }
-}
-impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
-    type Error = T::Error;
-    fn send(
-        &mut self,
-        item: TxJsonRpcMessage<RoleServer>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
-        let sent = self.inner.send(item);
-        let closed = self.closed.clone();
-        async move {
-            let result = sent.await;
-            if result.is_err() {
-                closed.cancel();
+/// Publish the SDK acknowledgment only after installing the watch/baseline.
+/// Until then the adapter retains it in this request's extension slot.
+pub async fn acknowledge(context: &RequestContext<RoleServer>) -> Result<(), rmcp::ErrorData> {
+    let pending = context
+        .extensions
+        .get::<Arc<Acknowledgment>>()
+        .and_then(|slot| slot.0.lock().unwrap_or_else(|e| e.into_inner()).take());
+    if let Some(mut notification) = pending {
+        notification.extensions_mut().insert(ReleaseAcknowledgment);
+        tokio::select! {
+            _ = cancelled(context) => return Err(rmcp::ErrorData::internal_error("Subscription cancelled before acknowledgment", None)),
+            result = tokio::time::timeout(std::time::Duration::from_secs(1), context.peer.send_notification(notification)) => {
+                result.map_err(|_| rmcp::ErrorData::internal_error("Subscription acknowledgment timed out", None))?.map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
             }
-            result
         }
     }
-    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
-        let mut message = self.inner.receive().await;
-        match &mut message {
-            Some(JsonRpcMessage::Request(request)) => {
-                request
-                    .request
-                    .extensions_mut()
-                    .insert(ConnectionClosed(self.closed.clone()));
-            }
-            None => self.closed.cancel(),
-            _ => {}
-        }
-        message
-    }
-    async fn close(&mut self) -> Result<(), Self::Error> {
-        self.closed.cancel();
-        self.inner.close().await
-    }
+    Ok(())
 }
 
 #[derive(Clone, Default)]
@@ -241,5 +198,367 @@ mod tests {
             }
             assert!(closed.0.is_cancelled(), "{ending}");
         }
+    }
+}
+
+pub const LEGACY_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+];
+pub const SUPPORTED_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+    ProtocolVersion::V_2026_07_28,
+];
+pub fn notebook_scoped_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "save_notebook"
+            | "show_notebook"
+            | "launch_app"
+            | "disconnect_notebook"
+            | "get_cell"
+            | "get_all_cells"
+            | "create_cell"
+            | "set_cell"
+            | "delete_cell"
+            | "move_cell"
+            | "clear_outputs"
+            | "add_cell_tags"
+            | "remove_cell_tags"
+            | "set_cells_source_hidden"
+            | "set_cells_outputs_hidden"
+            | "sync_environment"
+            | "execute_cell"
+            | "run_all_cells"
+            | "get_results"
+            | "interrupt_kernel"
+            | "restart_kernel"
+            | "manage_dependencies"
+            | "add_dependency"
+            | "remove_dependency"
+            | "get_dependencies"
+            | "approve_trust"
+            | "replace_match"
+            | "replace_regex"
+            | "create_comment"
+            | "reply_comment"
+            | "resolve_comment"
+            | "reopen_comment"
+    )
+}
+pub fn attachment_tool_schemas(tools: &mut [rmcp::model::Tool], required: bool) {
+    for tool in tools {
+        if !notebook_scoped_tool(&tool.name) {
+            continue;
+        }
+        let schema = Arc::make_mut(&mut tool.input_schema);
+        if let Some(properties) = schema
+            .entry("properties")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+        {
+            properties.insert("notebook_handle".into(), serde_json::json!({"type":"string","description":"Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks."}));
+        }
+        if required {
+            if let Some(fields) = schema
+                .entry("required")
+                .or_insert_with(|| serde_json::json!([]))
+                .as_array_mut()
+            {
+                if !fields.iter().any(|field| field == "notebook_handle") {
+                    fields.push(serde_json::json!("notebook_handle"));
+                }
+            }
+        }
+    }
+}
+pub fn validate_tool_target(
+    request: &rmcp::model::CallToolRequestParams,
+    context: &RequestContext<RoleServer>,
+) -> Result<(), rmcp::ErrorData> {
+    if is_native(context)
+        && notebook_scoped_tool(&request.name)
+        && request
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("notebook_handle"))
+            .and_then(serde_json::Value::as_str)
+            .is_none_or(|handle| handle.is_empty())
+    {
+        return Err(rmcp::ErrorData::invalid_params(
+            "notebook_handle is required; use connect_notebook or create_notebook to obtain one",
+            None,
+        ));
+    }
+    Ok(())
+}
+pub fn is_native(context: &RequestContext<RoleServer>) -> bool {
+    context.peer.peer_info().is_none()
+        && context.meta.protocol_version() == Some(ProtocolVersion::V_2026_07_28)
+}
+pub fn validate_resource_uri(
+    uri: &str,
+    context: &RequestContext<RoleServer>,
+) -> Result<(), rmcp::ErrorData> {
+    if is_native(context) && uri.starts_with("nteract://notebooks/") {
+        return Err(rmcp::ErrorData::invalid_params(
+            "Use the nteract://sessions/ resource URI returned with your notebook_handle",
+            None,
+        ));
+    }
+    Ok(())
+}
+pub fn resource_error(
+    mut error: rmcp::ErrorData,
+    context: &RequestContext<RoleServer>,
+) -> rmcp::ErrorData {
+    if is_native(context) && error.code.0 == -32002 {
+        error.code = rmcp::model::ErrorCode::INVALID_PARAMS;
+    }
+    error
+}
+/// Only explicit notebook resources are supported by native listen today.
+pub fn notebook_subscription_filter(
+    requested: &rmcp::model::SubscriptionFilter,
+) -> rmcp::model::SubscriptionFilter {
+    let mut accepted = rmcp::model::SubscriptionFilter::builder();
+    let mut seen = std::collections::BTreeSet::new();
+    for uri in requested.resource_subscriptions.iter().flatten() {
+        if uri.starts_with("nteract://sessions/") && seen.insert(uri) && seen.len() <= 128 {
+            accepted = accepted.resource_subscription(uri);
+        }
+    }
+    accepted.build()
+}
+/// Keep legacy handshakes and native per-request negotiation distinct.
+pub fn require_protocol(context: &RequestContext<RoleServer>) -> Result<(), rmcp::ErrorData> {
+    if context.peer.peer_info().is_some() {
+        if context.meta.protocol_version() == Some(ProtocolVersion::V_2026_07_28) {
+            return Err(rmcp::ErrorData::unsupported_protocol_version(
+                ProtocolVersion::V_2026_07_28,
+                LEGACY_VERSIONS,
+            ));
+        }
+        return Ok(());
+    }
+    if is_native(context) {
+        return Ok(());
+    }
+    Err(rmcp::ErrorData::invalid_request(
+        "initialize is required for legacy application requests",
+        None,
+    ))
+}
+/// Discovery must remain pure: the SDK may invoke it before its peer pump starts.
+pub fn discover(
+    context: &RequestContext<RoleServer>,
+    info: rmcp::model::ServerInfo,
+) -> Result<rmcp::model::DiscoverResult, rmcp::ErrorData> {
+    require_protocol(context)?;
+    if !is_native(context) {
+        return Err(rmcp::ErrorData::method_not_found::<
+            rmcp::model::DiscoverRequestMethod,
+        >());
+    }
+    Ok(rmcp::model::DiscoverResult::from_server_info(
+        SUPPORTED_VERSIONS.to_vec(),
+        info,
+    ))
+}
+
+/// Wait for either explicit request cancellation or transport teardown.
+pub async fn cancelled(context: &RequestContext<RoleServer>) {
+    let connection = context.extensions.get::<ConnectionClosed>();
+    match connection {
+        Some(connection) => {
+            tokio::select! {
+                _ = context.ct.cancelled() => {},
+                _ = connection.0.cancelled() => {},
+            }
+        }
+        None => context.ct.cancelled().await,
+    }
+}
+
+/// Apply once at each server entry point, including in-memory wire tests.
+pub fn server<T, E, A>(transport: T) -> impl Transport<RoleServer, Error = E>
+where
+    T: IntoTransport<RoleServer, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    ServerTransport {
+        inner: transport.into_transport(),
+        closed: CancellationToken::new(),
+        opening: Arc::new(Mutex::new(Opening::default())),
+    }
+}
+
+struct ServerTransport<T> {
+    inner: T,
+    closed: CancellationToken,
+    opening: Arc<Mutex<Opening>>,
+}
+#[derive(Default)]
+struct Opening {
+    started: bool,
+    priming_id: Option<RequestId>,
+    pending: Option<RxJsonRpcMessage<RoleServer>>,
+    acknowledgments: std::collections::HashMap<RequestId, std::sync::Weak<Acknowledgment>>,
+}
+impl<T> Drop for ServerTransport<T> {
+    fn drop(&mut self) {
+        self.closed.cancel();
+    }
+}
+impl<T: Transport<RoleServer>> Transport<RoleServer> for ServerTransport<T> {
+    type Error = T::Error;
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleServer>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        // rmcp dispatches the first native request before starting its peer
+        // pump. Prime with a pure discovery request so a first listen/progress
+        // callback can use that pump. This response is private to the adapter.
+        let defer_ack = {
+            let mut opening = self.opening.lock().unwrap_or_else(|e| e.into_inner());
+            opening
+                .acknowledgments
+                .retain(|_, slot| slot.strong_count() > 0);
+            if let JsonRpcMessage::Notification(message) = &item {
+                let notification = &message.notification;
+                if matches!(
+                    notification,
+                    rmcp::model::ServerNotification::SubscriptionsAcknowledgedNotification(_)
+                ) && notification
+                    .extensions()
+                    .get::<ReleaseAcknowledgment>()
+                    .is_none()
+                {
+                    notification
+                        .get_meta()
+                        .subscription_id()
+                        .and_then(|id| opening.acknowledgments.get(&id))
+                        .and_then(std::sync::Weak::upgrade)
+                        .map(|slot| {
+                            *slot.0.lock().unwrap_or_else(|e| e.into_inner()) =
+                                Some(notification.clone());
+                        })
+                        .is_some()
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+        let suppress = defer_ack || {
+            let mut opening = self.opening.lock().unwrap_or_else(|e| e.into_inner());
+            match (&item, opening.priming_id.as_ref()) {
+                (JsonRpcMessage::Response(response), Some(id)) if response.id == *id => {
+                    opening.priming_id = None;
+                    true
+                }
+                (JsonRpcMessage::Error(error), Some(id)) if error.id.as_ref() == Some(id) => {
+                    opening.priming_id = None;
+                    opening.pending = None;
+                    false // Preserve validation errors under the real request ID.
+                }
+                _ => false,
+            }
+        };
+        let sent = (!suppress).then(|| self.inner.send(item));
+        let closed = self.closed.clone();
+        async move {
+            let result = match sent {
+                Some(sent) => sent.await,
+                None => Ok(()),
+            };
+            if result.is_err() {
+                closed.cancel();
+            }
+            result
+        }
+    }
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        let pending = {
+            let mut opening = self.opening.lock().unwrap_or_else(|e| e.into_inner());
+            if opening.priming_id.is_none() {
+                opening.pending.take()
+            } else {
+                None
+            }
+        };
+        if pending.is_some() {
+            return pending;
+        }
+        let mut message = self.inner.receive().await;
+        match &mut message {
+            Some(JsonRpcMessage::Request(request)) => {
+                request
+                    .request
+                    .extensions_mut()
+                    .insert(ConnectionClosed(self.closed.clone()));
+                let mut opening = self.opening.lock().unwrap_or_else(|e| e.into_inner());
+                if matches!(
+                    request.request,
+                    ClientRequest::SubscriptionsListenRequest(_)
+                ) {
+                    opening
+                        .acknowledgments
+                        .retain(|_, slot| slot.strong_count() > 0);
+                    let slot = opening
+                        .acknowledgments
+                        .get(&request.id)
+                        .and_then(std::sync::Weak::upgrade)
+                        .unwrap_or_else(|| Arc::new(Acknowledgment::default()));
+                    opening
+                        .acknowledgments
+                        .insert(request.id.clone(), Arc::downgrade(&slot));
+                    request.request.extensions_mut().insert(slot);
+                }
+                if !opening.started {
+                    let native = request.request.get_meta().protocol_version()
+                        == Some(ProtocolVersion::V_2026_07_28);
+                    let preinit_ping =
+                        matches!(request.request, ClientRequest::PingRequest(_)) && !native;
+                    if !preinit_ping {
+                        opening.started = true;
+                    }
+                    if request
+                        .request
+                        .get_meta()
+                        .missing_required_keys(&ProtocolVersion::V_2026_07_28)
+                        .is_empty()
+                        && !matches!(
+                            request.request,
+                            ClientRequest::InitializeRequest(_) | ClientRequest::DiscoverRequest(_)
+                        )
+                    {
+                        let mut discovery =
+                            ClientRequest::DiscoverRequest(DiscoverRequest::default());
+                        *discovery.get_meta_mut() = request.request.get_meta().clone();
+                        discovery
+                            .extensions_mut()
+                            .insert(ConnectionClosed(self.closed.clone()));
+                        let prime = JsonRpcMessage::request(discovery, request.id.clone());
+                        opening.priming_id = Some(request.id.clone());
+                        opening.pending = message.take();
+                        return Some(prime);
+                    }
+                }
+            }
+            None => self.closed.cancel(),
+            _ => {}
+        }
+        message
+    }
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        self.closed.cancel();
+        self.inner.close().await
     }
 }

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -262,7 +262,7 @@ async fn main() -> ExitCode {
     let proxy = McpProxy::new(config, None);
 
     // Start the MCP server on stdio immediately
-    let transport = mcp_transport::server(rmcp::transport::io::stdio());
+    let (transport, protocol) = mcp_transport::server_with_protocol(rmcp::transport::io::stdio());
     let server = match proxy.serve(transport).await {
         Ok(s) => s,
         Err(e) => {
@@ -271,6 +271,10 @@ async fn main() -> ExitCode {
         }
     };
 
+    if server.peer().peer_info().is_none() && !protocol.wait_for_native().await {
+        let _ = server.waiting().await;
+        return ExitCode::SUCCESS;
+    }
     let proxy_ref = server.service().clone();
     if let Some(info) = server.peer().peer_info() {
         proxy_ref

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -270,28 +270,16 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    if server.peer().peer_info().is_none() {
-        error!("The initialize handshake is required");
-        server.cancellation_token().cancel();
-        return ExitCode::FAILURE;
-    }
-
-    // Extract upstream client identity
-    let (upstream_name, upstream_title) = server
-        .peer()
-        .peer_info()
-        .map(|info| {
-            let name = info.client_info.name.clone();
-            let title = info.client_info.title.clone();
-            info!("Upstream MCP client: name={name:?}, title={title:?}");
-            (name, title)
-        })
-        .unwrap_or_else(|| ("unknown".to_string(), None));
 
     let proxy_ref = server.service().clone();
-    proxy_ref
-        .set_upstream_identity(upstream_name, upstream_title)
-        .await;
+    if let Some(info) = server.peer().peer_info() {
+        proxy_ref
+            .set_upstream_identity(
+                info.client_info.name.clone(),
+                info.client_info.title.clone(),
+            )
+            .await;
+    }
 
     // Child spawn and `tools/list_changed` / `resources/list_changed` notifications
     // happen in `McpProxy::on_initialized`, after the client sends
@@ -404,12 +392,7 @@ mod tests {
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_11_25);
         assert_eq!(
             proxy.supported_protocol_versions().as_ref(),
-            &[
-                ProtocolVersion::V_2024_11_05,
-                ProtocolVersion::V_2025_03_26,
-                ProtocolVersion::V_2025_06_18,
-                ProtocolVersion::V_2025_11_25,
-            ]
+            mcp_transport::SUPPORTED_VERSIONS
         );
     }
 

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod child;
 pub mod circuit_breaker;
+mod native_subscriptions;
 mod observation_bridge;
 pub mod proxy;
 pub mod request_scope;

--- a/crates/runt-mcp-proxy/src/native_subscriptions.rs
+++ b/crates/runt-mcp-proxy/src/native_subscriptions.rs
@@ -1,0 +1,290 @@
+//! Reference-counted private-child watches for request-scoped native listeners.
+//! An actor owns acknowledgments and cleanup so cancellation cannot strand a
+//! half-installed watch or unsubscribe a watch still used by another listener.
+
+use rmcp::model::{SubscribeRequestParams, UnsubscribeRequestParams};
+use rmcp::service::{Peer, RoleClient};
+use rmcp::ErrorData;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+
+type Key = (u64, String);
+enum Operation {
+    Acquire {
+        generation: u64,
+        uris: Vec<String>,
+        child: Peer<RoleClient>,
+        reply: oneshot::Sender<Result<(Vec<Key>, OwnedSemaphorePermit), ErrorData>>,
+        permit: OwnedSemaphorePermit,
+    },
+    Release(Vec<Key>, OwnedSemaphorePermit),
+}
+struct Worker {
+    sender: mpsc::UnboundedSender<Operation>,
+    task: tokio::task::JoinHandle<()>,
+}
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+pub(crate) struct Registry {
+    worker: Mutex<Option<Worker>>,
+    slots: Arc<Semaphore>,
+}
+impl Default for Registry {
+    fn default() -> Self {
+        Self {
+            worker: Mutex::new(None),
+            slots: Arc::new(Semaphore::new(128)),
+        }
+    }
+}
+pub(crate) struct Lease {
+    keys: Vec<Key>,
+    sender: mpsc::UnboundedSender<Operation>,
+    permit: Option<OwnedSemaphorePermit>,
+}
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if let Some(permit) = self.permit.take() {
+            let _ = self
+                .sender
+                .send(Operation::Release(std::mem::take(&mut self.keys), permit));
+        }
+    }
+}
+impl Registry {
+    pub(crate) async fn acquire(
+        &self,
+        generation: u64,
+        uris: Vec<String>,
+        child: Peer<RoleClient>,
+    ) -> Result<Lease, ErrorData> {
+        let count = u32::try_from(uris.len())
+            .map_err(|_| ErrorData::invalid_params("Too many resource watches", None))?;
+        let permit = self
+            .slots
+            .clone()
+            .try_acquire_many_owned(count)
+            .map_err(|_| {
+                ErrorData::invalid_request(
+                    "At most 128 native resource watches may be active",
+                    None,
+                )
+            })?;
+        let sender = {
+            let mut worker = self.worker.lock().unwrap_or_else(|e| e.into_inner());
+            if worker
+                .as_ref()
+                .is_some_and(|worker| worker.task.is_finished())
+            {
+                worker.take();
+            }
+            worker
+                .get_or_insert_with(|| {
+                    let (sender, receiver) = mpsc::unbounded_channel();
+                    Worker {
+                        sender,
+                        task: tokio::spawn(run(receiver)),
+                    }
+                })
+                .sender
+                .clone()
+        };
+        let (reply, response) = oneshot::channel();
+        sender
+            .send(Operation::Acquire {
+                generation,
+                uris,
+                child,
+                reply,
+                permit,
+            })
+            .map_err(|_| unavailable())?;
+        // The actor owns cancellation cleanup. The permit returns only after
+        // pending child acknowledgments and any resulting unsubscriptions.
+        let (keys, permit) = tokio::time::timeout(Duration::from_secs(30), response)
+            .await
+            .map_err(|_| unavailable())?
+            .map_err(|_| unavailable())??;
+        Ok(Lease {
+            keys,
+            sender,
+            permit: Some(permit),
+        })
+    }
+}
+fn unavailable() -> ErrorData {
+    ErrorData::internal_error("Native subscription relay is unavailable", None)
+}
+struct Watch {
+    peer: Peer<RoleClient>,
+    users: usize,
+}
+
+#[allow(deprecated)]
+async fn release(watches: &mut HashMap<Key, Watch>, keys: Vec<Key>) {
+    let mut cleanup = tokio::task::JoinSet::new();
+    for key in keys {
+        let last = watches.get_mut(&key).is_some_and(|watch| {
+            watch.users -= 1;
+            watch.users == 0
+        });
+        if last {
+            if let Some(watch) = watches.remove(&key) {
+                cleanup.spawn(async move {
+                    let _ = tokio::time::timeout(
+                        Duration::from_secs(5),
+                        watch.peer.unsubscribe(UnsubscribeRequestParams::new(key.1)),
+                    )
+                    .await;
+                });
+            }
+        }
+    }
+    while cleanup.join_next().await.is_some() {}
+}
+
+#[allow(deprecated)]
+async fn run(mut operations: mpsc::UnboundedReceiver<Operation>) {
+    let mut watches: HashMap<Key, Watch> = HashMap::new();
+    while let Some(operation) = operations.recv().await {
+        match operation {
+            Operation::Release(keys, _permit) => release(&mut watches, keys).await,
+            Operation::Acquire {
+                generation,
+                uris,
+                child,
+                reply,
+                permit,
+            } => {
+                if reply.is_closed() {
+                    continue;
+                }
+                let mut keys = Vec::new();
+                let mut error = None;
+                for uri in uris {
+                    if reply.is_closed() {
+                        error = Some(unavailable());
+                        break;
+                    }
+                    let key = (generation, uri.clone());
+                    if let Some(watch) = watches.get_mut(&key) {
+                        watch.users += 1;
+                        keys.push(key);
+                        continue;
+                    }
+                    let result = tokio::time::timeout(
+                        Duration::from_secs(5),
+                        child.subscribe(SubscribeRequestParams::new(&uri)),
+                    )
+                    .await;
+                    match result {
+                        Ok(Ok(_)) => {
+                            watches.insert(
+                                key.clone(),
+                                Watch {
+                                    peer: child.clone(),
+                                    users: 1,
+                                },
+                            );
+                            keys.push(key);
+                        }
+                        Ok(Err(rmcp::service::ServiceError::McpError(mut child_error))) => {
+                            if child_error.code.0 == -32002 {
+                                child_error.code = rmcp::model::ErrorCode::INVALID_PARAMS;
+                            }
+                            error = Some(child_error);
+                            break;
+                        }
+                        _ => {
+                            error = Some(unavailable());
+                            break;
+                        }
+                    }
+                }
+                if let Some(error) = error {
+                    release(&mut watches, keys).await;
+                    let _ = reply.send(Err(error));
+                } else if let Err(Ok((keys, _permit))) = reply.send(Ok((keys, permit))) {
+                    release(&mut watches, keys).await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, deprecated)]
+mod tests {
+    use super::*;
+    use rmcp::service::{RequestContext, RoleServer};
+    use rmcp::{ServerHandler, ServiceExt};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    struct Child {
+        subscribed: Arc<AtomicUsize>,
+        unsubscribed: Arc<AtomicUsize>,
+    }
+    impl ServerHandler for Child {
+        async fn subscribe(
+            &self,
+            _: SubscribeRequestParams,
+            _: RequestContext<RoleServer>,
+        ) -> Result<(), ErrorData> {
+            self.subscribed.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn unsubscribe(
+            &self,
+            _: UnsubscribeRequestParams,
+            _: RequestContext<RoleServer>,
+        ) -> Result<(), ErrorData> {
+            self.unsubscribed.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+    #[tokio::test]
+    async fn cancelling_one_listener_keeps_the_shared_child_watch_until_the_last_lease() {
+        let registry = Registry::default();
+        let subscribed = Arc::new(AtomicUsize::new(0));
+        let unsubscribed = Arc::new(AtomicUsize::new(0));
+        let child = Child {
+            subscribed: subscribed.clone(),
+            unsubscribed: unsubscribed.clone(),
+        };
+        let (server_pipe, client_pipe) = tokio::io::duplex(65536);
+        let task = tokio::spawn(async move { child.serve(server_pipe).await.unwrap() });
+        let mut client = ().serve(client_pipe).await.unwrap();
+        let mut server = task.await.unwrap();
+        let first = registry
+            .acquire(1, vec!["fixture://one".into()], client.peer().clone())
+            .await
+            .unwrap();
+        let second = registry
+            .acquire(1, vec!["fixture://one".into()], client.peer().clone())
+            .await
+            .unwrap();
+        assert_eq!(subscribed.load(Ordering::SeqCst), 1);
+        drop(first);
+        let third = registry
+            .acquire(1, vec!["fixture://one".into()], client.peer().clone())
+            .await
+            .unwrap();
+        assert_eq!(unsubscribed.load(Ordering::SeqCst), 0);
+        drop(second);
+        drop(third);
+        let barrier = registry
+            .acquire(1, vec!["fixture://other".into()], client.peer().clone())
+            .await
+            .unwrap();
+        assert_eq!(unsubscribed.load(Ordering::SeqCst), 1);
+        assert_eq!(subscribed.load(Ordering::SeqCst), 2);
+        drop(barrier);
+        drop(registry);
+        client.close().await.unwrap();
+        server.close().await.unwrap();
+    }
+}

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -150,6 +150,7 @@ pub struct ProxyState {
     /// durable handoff target may instead be a path or hosted URL, so retain
     /// both forms to recognize an explicit disconnect by notebook id.
     last_notebook_session_id: Option<String>,
+    last_notebook_handle: Option<String>,
     /// Upstream MCP client name (forwarded to child).
     pub upstream_name: String,
     /// Upstream MCP client title (forwarded to child).
@@ -185,6 +186,8 @@ pub struct McpProxy {
     /// operator used by the explicit connect in the previous child.
     operator_session: String,
     observation_bridge: Arc<crate::observation_bridge::ObservationBridge>,
+    native_subscriptions: Arc<crate::native_subscriptions::Registry>,
+    native_startup: Arc<std::sync::OnceLock<RestartCompletion>>,
 }
 
 impl McpProxy {
@@ -212,6 +215,7 @@ impl McpProxy {
                 cached_tools,
                 last_notebook_id: None,
                 last_notebook_session_id: None,
+                last_notebook_handle: None,
                 upstream_name: "unknown".to_string(),
                 upstream_title: None,
                 last_daemon_version: None,
@@ -227,6 +231,8 @@ impl McpProxy {
             restart_in_progress: Arc::default(),
             operator_session: uuid::Uuid::new_v4().simple().to_string()[..8].to_string(),
             observation_bridge: Arc::default(),
+            native_subscriptions: Arc::default(),
+            native_startup: Arc::default(),
         }
     }
 
@@ -241,6 +247,60 @@ impl McpProxy {
             self.operator_session.clone(),
         );
         child_env
+    }
+
+    pub async fn forward_listen(
+        &self,
+        context: rmcp::service::SubscriptionContext,
+    ) -> Result<(), McpError> {
+        let uris = context
+            .accepted()
+            .resource_subscriptions
+            .clone()
+            .unwrap_or_default();
+        if uris.is_empty() {
+            mcp_transport::acknowledge(context.request_context()).await?;
+            return Ok(());
+        }
+        let (peer, generation, mut notifications, lifetime) = {
+            let state = self.state.read().await;
+            let child = state.child_client.as_ref().ok_or_else(|| {
+                McpError::internal_error("Child not ready; reconnect and subscribe again", None)
+            })?;
+            (
+                child.peer().clone(),
+                state.child_generation,
+                child.service().notifications.subscribe(),
+                child.service().lifetime.clone(),
+            )
+        };
+        let _lease = tokio::select! {
+            _ = mcp_transport::cancelled(context.request_context()) => return Ok(()),
+            _ = lifetime.closed() => return Ok(()),
+            lease = self.native_subscriptions.acquire(generation, uris.clone(), peer) => lease?,
+        };
+        mcp_transport::acknowledge(context.request_context()).await?;
+        loop {
+            let changed = tokio::select! {
+                _ = mcp_transport::cancelled(context.request_context()) => return Ok(()),
+                _ = lifetime.closed() => return Ok(()),
+                update = notifications.recv() => match update {
+                    Ok(update) => vec![update.uri],
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => uris.clone(),
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return Ok(()),
+                },
+            };
+            for uri in changed {
+                if uris.contains(&uri) {
+                    tokio::select! {
+                        _ = mcp_transport::cancelled(context.request_context()) => return Ok(()),
+                        result = tokio::time::timeout(Duration::from_secs(1), context.sink().notify_resource_updated(uri)) => {
+                            result.map_err(|_| McpError::internal_error("Subscription delivery timed out; read a fresh baseline", None))?.map_err(|error| McpError::internal_error(error.to_string(), None))?;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Subscribe only after child startup, with one recovery for a closed child.
@@ -435,6 +495,9 @@ impl McpProxy {
     }
 
     async fn restart_child_owned(&self) -> Result<(), String> {
+        if self.state.read().await.child_generation == 0 {
+            return self.init_child().await;
+        }
         let reason = self.current_child_restart_reason().await;
         info!(
             event = "child_restart_classified",
@@ -447,6 +510,7 @@ impl McpProxy {
             let mut state = self.state.write().await;
             let was_dead = state.child_client.is_none();
             let old_child = state.child_client.take();
+            state.last_notebook_handle = None;
             state.child_exit_status = None;
             if old_child.is_some() {
                 state.child_generation = state.child_generation.wrapping_add(1);
@@ -1143,7 +1207,10 @@ impl McpProxy {
             .peer
             .read_resource_once(params.clone())
             .await
-            .map_err(|e| McpError::internal_error(format!("Child resource read failed: {e}"), None))
+            .map_err(|e| match e {
+                rmcp::service::ServiceError::McpError(error) => error,
+                e => McpError::internal_error(format!("Child resource read failed: {e}"), None),
+            })
             .and_then(complete_resource_response);
         self.log_child_call_if_slow(
             "read_resource",
@@ -1162,13 +1229,24 @@ impl McpProxy {
             .and_then(|args| args.get("notebook_id"))
             .and_then(serde_json::Value::as_str);
         let mut state = self.state.write().await;
-        let disconnected_active = requested_id.is_none()
-            || requested_id == state.last_notebook_id.as_deref()
-            || requested_id == state.last_notebook_session_id.as_deref();
+        let requested_handle = params
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("notebook_handle"));
+        let disconnected_active = if let Some(handle) = requested_handle {
+            handle
+                .as_str()
+                .is_some_and(|handle| state.last_notebook_handle.as_deref() == Some(handle))
+        } else {
+            requested_id.is_none()
+                || requested_id == state.last_notebook_id.as_deref()
+                || requested_id == state.last_notebook_session_id.as_deref()
+        };
         if disconnected_active {
             info!("Clearing notebook handoff target for explicit disconnect intent");
             state.last_notebook_id = None;
             state.last_notebook_session_id = None;
+            state.last_notebook_handle = None;
         }
     }
 
@@ -1180,6 +1258,28 @@ impl McpProxy {
 
         if let Some(id) = session::extract_session_id(params, result) {
             let mut state = self.state.write().await;
+            if params.name == "save_notebook" {
+                if let Some(handle) = params
+                    .arguments
+                    .as_ref()
+                    .and_then(|args| args.get("notebook_handle"))
+                    .and_then(serde_json::Value::as_str)
+                {
+                    if state.last_notebook_handle.as_deref() != Some(handle) {
+                        return;
+                    }
+                }
+            } else {
+                state.last_notebook_handle = result.content.iter().find_map(|content| {
+                    if let ContentBlock::Text(text) = content {
+                        serde_json::from_str::<serde_json::Value>(&text.text)
+                            .ok()
+                            .and_then(|value| value["notebook_handle"].as_str().map(str::to_owned))
+                    } else {
+                        None
+                    }
+                });
+            }
             let saving_hosted_session = params.name.as_ref() == "save_notebook"
                 && state
                     .last_notebook_id
@@ -1345,14 +1445,8 @@ fn unknown_tool_outcome(
     result
 }
 
-fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
-    if context.peer.peer_info().is_none() {
-        return Err(McpError::invalid_request(
-            "initialize is required before application requests",
-            None,
-        ));
-    }
-    Ok(())
+fn require_protocol(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    mcp_transport::require_protocol(context)
 }
 
 fn complete_tool_response(response: CallToolResponse) -> Result<CallToolResult, McpError> {
@@ -1385,6 +1479,17 @@ fn complete_resource_response(
 /// IS the MCP server. The supervisor wraps this with its own ServerHandler that
 /// adds supervisor_* tools.
 impl ServerHandler for McpProxy {
+    fn accepted_subscription_filter(
+        &self,
+        requested: &rmcp::model::SubscriptionFilter,
+    ) -> Option<rmcp::model::SubscriptionFilter> {
+        Some(mcp_transport::notebook_subscription_filter(requested))
+    }
+    async fn listen(&self, context: rmcp::service::SubscriptionContext) -> Result<(), McpError> {
+        mcp_transport::require_protocol(context.request_context())?;
+        self.native_ready(context.request_context()).await?;
+        self.forward_listen(context).await
+    }
     async fn initialize(
         &self,
         request: rmcp::model::InitializeRequestParams,
@@ -1397,23 +1502,14 @@ impl ServerHandler for McpProxy {
             ));
         }
         let mut info = self.get_info();
-        if self
-            .supported_protocol_versions()
-            .contains(&request.protocol_version)
-        {
+        if mcp_transport::LEGACY_VERSIONS.contains(&request.protocol_version) {
             info.protocol_version = request.protocol_version;
         }
         Ok(info)
     }
 
     fn supported_protocol_versions(&self) -> std::borrow::Cow<'static, [ProtocolVersion]> {
-        const VERSIONS: &[ProtocolVersion] = &[
-            ProtocolVersion::V_2024_11_05,
-            ProtocolVersion::V_2025_03_26,
-            ProtocolVersion::V_2025_06_18,
-            ProtocolVersion::V_2025_11_25,
-        ];
-        std::borrow::Cow::Borrowed(VERSIONS)
+        std::borrow::Cow::Borrowed(mcp_transport::SUPPORTED_VERSIONS)
     }
 
     fn get_info(&self) -> ServerInfo {
@@ -1449,11 +1545,9 @@ impl ServerHandler for McpProxy {
 
     async fn discover(
         &self,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::DiscoverResult, McpError> {
-        Err(McpError::method_not_found::<
-            rmcp::model::DiscoverRequestMethod,
-        >())
+        mcp_transport::discover(&context, self.get_info())
     }
 
     async fn list_prompts(
@@ -1461,8 +1555,11 @@ impl ServerHandler for McpProxy {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::ListPromptsResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(rmcp::model::ListPromptsResult::default())
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
+        Ok(rmcp::model::ListPromptsResult::default()
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn complete(
@@ -1470,7 +1567,8 @@ impl ServerHandler for McpProxy {
         _request: rmcp::model::CompleteRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<rmcp::model::CompleteResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
         Ok(rmcp::model::CompleteResult::default())
     }
 
@@ -1479,7 +1577,8 @@ impl ServerHandler for McpProxy {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
         // Serve tools optimistically: if the child is connected, query it live;
         // otherwise return the cached/built-in tool definitions immediately.
         // This avoids blocking the MCP client during async child initialization.
@@ -1495,7 +1594,10 @@ impl ServerHandler for McpProxy {
             cached
         };
         tools.push(reconnect_tool());
-        Ok(ListToolsResult::with_all_items(tools))
+        mcp_transport::attachment_tool_schemas(&mut tools, mcp_transport::is_native(&context));
+        Ok(ListToolsResult::with_all_items(tools)
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn list_resources(
@@ -1503,8 +1605,24 @@ impl ServerHandler for McpProxy {
         request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(self.child_resources(request).await)
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
+        let mut result = self.child_resources(request).await;
+        if mcp_transport::is_native(&context) {
+            result.resources.retain(|resource| {
+                resource.uri == "ui://nteract/output.html" || resource.uri == "nteract://notebooks"
+            });
+            if result.resources.is_empty() {
+                return Err(McpError::internal_error(
+                    "Notebook resource catalog is unavailable",
+                    None,
+                ));
+            }
+        }
+        result.result_type = Some(rmcp::model::ResultType::COMPLETE);
+        Ok(result
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn list_resource_templates(
@@ -1512,8 +1630,18 @@ impl ServerHandler for McpProxy {
         request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(self.child_resource_templates(request).await)
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
+        let mut result = self.child_resource_templates(request).await;
+        if mcp_transport::is_native(&context) {
+            result
+                .resource_templates
+                .retain(|template| template.uri_template.starts_with("nteract://sessions/"));
+        }
+        result.result_type = Some(rmcp::model::ResultType::COMPLETE);
+        Ok(result
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn read_resource(
@@ -1521,8 +1649,19 @@ impl ServerHandler for McpProxy {
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
-        require_legacy_handshake(&context)?;
-        self.forward_read_resource(request).await.map(Into::into)
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
+        mcp_transport::validate_resource_uri(&request.uri, &context)?;
+        self.forward_read_resource(request)
+            .await
+            .map(|mut result| {
+                result.result_type = Some(rmcp::model::ResultType::COMPLETE);
+                result
+                    .with_ttl_ms(0)
+                    .with_cache_scope(rmcp::model::CacheScope::Private)
+            })
+            .map_err(|error| mcp_transport::resource_error(error, &context))
+            .map(Into::into)
     }
 
     #[allow(deprecated)]
@@ -1531,7 +1670,8 @@ impl ServerHandler for McpProxy {
         request: rmcp::model::SubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
         self.forward_subscribe(request.uri, context.peer).await
     }
 
@@ -1541,7 +1681,8 @@ impl ServerHandler for McpProxy {
         request: rmcp::model::UnsubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        self.native_ready(&context).await?;
         self.forward_unsubscribe(request.uri).await
     }
 
@@ -1550,14 +1691,17 @@ impl ServerHandler for McpProxy {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        mcp_transport::validate_tool_target(&request, &context)?;
         crate::request_scope::scope(context.clone(), async {
         // Intercept the built-in reconnect tool before waiting on child
         // readiness — reconnect is the escape hatch when the child is
         // wedged, so it must not block on child readiness itself.
         if request.name == RECONNECT_TOOL_NAME {
+            if let Some(identity) = context.client_info() { self.set_upstream_identity(identity.name, identity.title).await; }
             return self.handle_reconnect().await.map(Into::into);
         }
+        self.native_ready(&context).await?;
 
         // Wait for child if not ready
         let notified = self.child_ready.notified();
@@ -1574,7 +1718,7 @@ impl ServerHandler for McpProxy {
             }
         }
 
-        self.forward_tool_call(request).await.map(Into::into)
+        self.forward_tool_call(request).await.map(|mut result| { result.result_type = Some(rmcp::model::ResultType::COMPLETE); result.into() })
         }).await
     }
 
@@ -1631,6 +1775,52 @@ fn reconnect_tool() -> Tool {
 }
 
 impl McpProxy {
+    async fn native_ready(&self, context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+        if !mcp_transport::is_native(context) {
+            return Ok(());
+        }
+        if self.state.read().await.child_client.is_some() {
+            return Ok(());
+        }
+        let mut ready = self
+            .native_startup
+            .get_or_init(|| {
+                let (sender, receiver) = tokio::sync::watch::channel(None);
+                let proxy = self.clone();
+                let identity = context.client_info();
+                tokio::spawn(async move {
+                    if let Some(identity) = identity {
+                        proxy
+                            .set_upstream_identity(identity.name, identity.title)
+                            .await;
+                    }
+                    let already_started = { proxy.state.read().await.child_client.is_some() };
+                    let result = if already_started {
+                        Ok(())
+                    } else {
+                        proxy.restart_child().await
+                    };
+                    sender.send_replace(Some(result));
+                });
+                receiver
+            })
+            .clone();
+        let wait = async {
+            loop {
+                if let Some(result) = ready.borrow_and_update().clone() {
+                    return result.map_err(|error| McpError::internal_error(error, None));
+                }
+                ready.changed().await.map_err(|_| {
+                    McpError::internal_error("Child startup ended without a result", None)
+                })?;
+            }
+        };
+        tokio::select! {
+            _ = mcp_transport::cancelled(context) => Err(McpError::internal_error("Request cancelled during child startup", None)),
+            result = tokio::time::timeout(Duration::from_secs(60), wait) => result.map_err(|_| McpError::internal_error("Child startup timed out", None))?,
+        }
+    }
+
     /// Handle the built-in `reconnect` tool call.
     ///
     /// Kicks the child via `restart_child()` and waits briefly for the new
@@ -1707,8 +1897,8 @@ mod tests {
     async fn legacy_initialize_negotiates_each_supported_version() {
         let proxy = McpProxy::new(test_config(), None);
         let versions = proxy.supported_protocol_versions();
-        assert_eq!(versions.len(), 4);
-        for version in versions.iter() {
+        assert_eq!(versions.len(), 5);
+        for version in mcp_transport::LEGACY_VERSIONS {
             let response = first_request_response(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -1726,7 +1916,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn modern_first_requests_are_rejected_before_dispatch() {
+    async fn future_first_requests_are_rejected_before_dispatch() {
         for method in ["server/discover", "tools/list"] {
             let response = first_request_response(serde_json::json!({
                 "jsonrpc": "2.0",
@@ -1734,7 +1924,7 @@ mod tests {
                 "method": method,
                 "params": {
                     "_meta": {
-                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/protocolVersion": "2099-01-01",
                         "io.modelcontextprotocol/clientCapabilities": {}
                     }
                 }

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -187,7 +187,7 @@ pub struct McpProxy {
     operator_session: String,
     observation_bridge: Arc<crate::observation_bridge::ObservationBridge>,
     native_subscriptions: Arc<crate::native_subscriptions::Registry>,
-    native_startup: Arc<std::sync::OnceLock<RestartCompletion>>,
+    native_startup: Arc<std::sync::Mutex<Option<RestartCompletion>>>,
 }
 
 impl McpProxy {
@@ -495,8 +495,19 @@ impl McpProxy {
     }
 
     async fn restart_child_owned(&self) -> Result<(), String> {
-        if self.state.read().await.child_generation == 0 {
-            return self.init_child().await;
+        let cold_start = { self.state.read().await.child_generation == 0 };
+        if cold_start {
+            let allowed = { self.state.write().await.circuit_breaker.record_crash() };
+            if !allowed {
+                return Err(
+                    "Child startup failed repeatedly; retry after the recovery cooldown".into(),
+                );
+            }
+            let result = self.init_child().await;
+            if result.is_ok() {
+                self.state.write().await.circuit_breaker.reset();
+            }
+            return result;
         }
         let reason = self.current_child_restart_reason().await;
         info!(
@@ -1782,9 +1793,15 @@ impl McpProxy {
         if self.state.read().await.child_client.is_some() {
             return Ok(());
         }
-        let mut ready = self
-            .native_startup
-            .get_or_init(|| {
+        let mut ready = {
+            let mut startup = self
+                .native_startup
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if startup
+                .as_ref()
+                .is_none_or(|receiver| receiver.borrow().is_some())
+            {
                 let (sender, receiver) = tokio::sync::watch::channel(None);
                 let proxy = self.clone();
                 let identity = context.client_info();
@@ -1802,9 +1819,13 @@ impl McpProxy {
                     };
                     sender.send_replace(Some(result));
                 });
-                receiver
-            })
-            .clone();
+                *startup = Some(receiver);
+            }
+            startup
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| McpError::internal_error("Startup completion unavailable", None))?
+        };
         let wait = async {
             loop {
                 if let Some(result) = ready.borrow_and_update().clone() {

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -1094,3 +1094,36 @@ async fn successful_reconnect_returns_when_replacement_is_ready() {
     stop_child(&proxy).await;
     wire.finish().await;
 }
+
+#[tokio::test]
+async fn native_recovers_after_a_transient_first_start_failure() {
+    let (dir, proxy, resolves) = isolated_proxy();
+    std::fs::write(dir.path().join("fail-resolution"), "fail").unwrap();
+    let mut wire = Wire::start(proxy.clone());
+    let params =
+        json!({"name":"compatibility_echo","arguments":{},"_meta":modern_meta("2026-07-28",false)});
+    assert!(wire
+        .request(1, "tools/call", Some(params.clone()))
+        .await
+        .get("error")
+        .is_some());
+    std::fs::remove_file(dir.path().join("fail-resolution")).unwrap();
+    let response = wire.request(2, "tools/call", Some(params)).await;
+    assert_eq!(response["result"]["resultType"], "complete", "{response}");
+    assert_eq!(resolves.load(Ordering::SeqCst), 2);
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn repeated_native_start_failures_are_bounded_by_the_circuit_breaker() {
+    let (dir, proxy, resolves) = isolated_proxy();
+    std::fs::write(dir.path().join("fail-resolution"), "fail").unwrap();
+    let mut wire = Wire::start(proxy);
+    for id in 1..=8 {
+        let response=wire.request(id,"tools/call",Some(json!({"name":"compatibility_echo","arguments":{},"_meta":modern_meta("2026-07-28",false)}))).await;
+        assert!(response.get("error").is_some(), "{response}");
+    }
+    assert_eq!(resolves.load(Ordering::SeqCst), 5);
+    wire.finish().await;
+}

--- a/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp-proxy/tests/protocol_compatibility.rs
@@ -62,6 +62,61 @@ fn isolated_proxy_with_mode(mode: &str) -> (tempfile::TempDir, McpProxy, Arc<Ato
 }
 
 #[tokio::test]
+async fn native_first_listen_installs_child_watch_before_ack_and_closes_on_child_loss() {
+    let (dir, proxy, resolves) = isolated_proxy();
+    let mut wire = Wire::start(proxy.clone());
+    let uri = "nteract://sessions/fixture/cells";
+    wire.send(json!({"jsonrpc":"2.0","id":7,"method":"subscriptions/listen","params":{"_meta":modern_meta("2026-07-28",false),"notifications":{"resourceSubscriptions":[uri,"compatibility://unsupported"],"toolsListChanged":true}}})).await;
+    let ack = wire.receive().await;
+    assert_eq!(
+        ack["method"], "notifications/subscriptions/acknowledged",
+        "{ack}"
+    );
+    assert_eq!(
+        ack["params"]["notifications"]["resourceSubscriptions"],
+        json!([uri])
+    );
+    assert_eq!(
+        ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        7
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("subscription-calls"))
+            .unwrap()
+            .trim(),
+        uri
+    );
+    let update = wire.receive().await;
+    assert_eq!(update["method"], "notifications/resources/updated");
+    assert_eq!(update["params"]["uri"], uri);
+    assert_eq!(
+        update["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        7
+    );
+    assert_eq!(resolves.load(Ordering::SeqCst), 1);
+    stop_child(&proxy).await;
+    let completed = wire.receive().await;
+    assert_eq!(completed["id"], 7);
+    assert_eq!(completed["result"]["resultType"], "complete");
+    wire.finish().await;
+}
+
+#[tokio::test]
+async fn native_tool_uses_a_private_legacy_child_with_empty_capabilities() {
+    let (_dir, proxy, _) = isolated_proxy();
+    let mut wire = Wire::start(proxy.clone());
+    let result = wire.request(8, "tools/call", Some(json!({"name":"compatibility_echo","arguments":{"probe":"native"},"_meta":modern_meta("2026-07-28",false)}))).await;
+    assert_eq!(result["result"]["resultType"], "complete", "{result}");
+    let payload: Value =
+        serde_json::from_str(result["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(payload["protocolVersion"], "2025-11-25");
+    assert_eq!(payload["capabilities"], json!({}));
+    assert_eq!(payload["arguments"], json!({"probe":"native"}));
+    stop_child(&proxy).await;
+    wire.finish().await;
+}
+
+#[tokio::test]
 async fn lost_mutation_response_is_not_replayed_even_with_read_only_hints() {
     for name in ["execute_cell", "future_mutation"] {
         let (dir, proxy, _) = isolated_proxy_with_mode("response-loss");
@@ -651,7 +706,7 @@ async fn legacy_proxy_wire(version: &str) {
             Some(json!({"uri": "compatibility://missing"})),
         )
         .await;
-    assert_eq!(response["error"]["code"], -32603);
+    assert_eq!(response["error"]["code"], -32002);
     assert!(response["error"]["message"]
         .as_str()
         .expect("forwarded resource error")
@@ -717,8 +772,8 @@ legacy_test!(version_skew_new_proxy_to_old_child_2025_03_26, "2025-03-26");
 legacy_test!(version_skew_new_proxy_to_old_child_2025_06_18, "2025-06-18");
 legacy_test!(version_skew_new_proxy_to_old_child_2025_11_25, "2025-11-25");
 
-async fn reject_modern_without_handshake(anonymous: bool) {
-    for version in ["2026-07-28", "2099-01-01"] {
+async fn reject_future_without_handshake(anonymous: bool) {
+    for version in ["2099-01-01"] {
         for (method, mut params) in modern_requests() {
             let (dir, proxy, resolves) = isolated_proxy();
             let cached = std::fs::read(dir.path().join("tool-cache.json")).expect("cached tools");
@@ -738,13 +793,13 @@ async fn reject_modern_without_handshake(anonymous: bool) {
 }
 
 #[tokio::test]
-async fn modern_named_requests_rejected_without_handshake_or_child_side_effects() {
-    reject_modern_without_handshake(false).await;
+async fn future_named_requests_rejected_without_handshake_or_child_side_effects() {
+    reject_future_without_handshake(false).await;
 }
 
 #[tokio::test]
-async fn modern_anonymous_requests_rejected_without_handshake_or_child_side_effects() {
-    reject_modern_without_handshake(true).await;
+async fn future_anonymous_requests_rejected_without_handshake_or_child_side_effects() {
+    reject_future_without_handshake(true).await;
 }
 
 #[tokio::test]
@@ -821,7 +876,7 @@ async fn repeated_initialize_cannot_change_proxy_protocol_or_identity() {
 #[tokio::test]
 async fn legacy_inline_metadata_and_initialized_notification_cannot_start_a_child() {
     for anonymous in [false, true] {
-        for version in ["2025-11-25", "2026-07-28"] {
+        for version in ["2025-11-25", "2099-01-01"] {
             let (dir, proxy, resolves) = isolated_proxy();
             let mut wire = Wire::start(proxy.clone());
             let response = wire

--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -151,6 +151,10 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "path": {
           "default": null,
           "description": "Path to save the notebook to (e.g., \"~/analysis.ipynb\").\nRequired for ephemeral notebooks created with create_notebook().\nOmit to save to the notebook's existing file path.",
@@ -174,6 +178,10 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "notebook_id": {
           "default": null,
           "description": "Notebook ID to show. Defaults to current session's notebook.",
@@ -197,6 +205,10 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "notebook_id": {
           "default": null,
           "description": "Notebook ID to disconnect and release. If omitted, disconnects the\nactive session. Pass a notebook_id to release a specific parked session\nwithout switching away from the current one.",
@@ -294,6 +306,10 @@
             "null"
           ]
         },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "source": {
           "default": null,
           "description": "Cell source code or markdown content.",
@@ -352,6 +368,10 @@
             "null"
           ]
         },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "source": {
           "default": null,
           "description": "New source code (None to leave unchanged).",
@@ -391,6 +411,10 @@
         "cell_id": {
           "description": "The cell ID to delete.",
           "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
         }
       },
       "required": [
@@ -423,6 +447,10 @@
         "cell_id": {
           "description": "The cell ID to move.",
           "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
         }
       },
       "required": [
@@ -449,6 +477,10 @@
       "properties": {
         "cell_id": {
           "description": "The cell ID to execute.",
+          "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
           "type": "string"
         },
         "timeout_secs": {
@@ -483,6 +515,10 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "timeout_secs": {
           "default": null,
           "description": "Max seconds to wait for all cells to finish. Default: 300.",
@@ -531,6 +567,10 @@
             "boolean",
             "null"
           ]
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
         }
       },
       "required": [
@@ -551,6 +591,12 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Empty params for tools that take no arguments.",
+      "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        }
+      },
       "title": "EmptyParams",
       "type": "object"
     },
@@ -565,6 +611,12 @@
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Empty params for tools that take no arguments.",
+      "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        }
+      },
       "title": "EmptyParams",
       "type": "object"
     },
@@ -608,6 +660,10 @@
             "string",
             "null"
           ]
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
         },
         "remove": {
           "default": [],
@@ -678,6 +734,10 @@
           "description": "Literal text to find (must match exactly once).",
           "type": "string"
         },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "timeout_secs": {
           "default": null,
           "description": "Max seconds to wait for execution.",
@@ -726,6 +786,10 @@
         },
         "content": {
           "description": "Literal replacement text — not interpreted as a regex or escape sequence. To insert a newline, use an actual newline character in the JSON string.",
+          "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
           "type": "string"
         },
         "pattern": {
@@ -797,6 +861,10 @@
         "body": {
           "description": "Comment text (markdown supported).",
           "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
         }
       },
       "required": [
@@ -820,6 +888,10 @@
       "properties": {
         "body": {
           "description": "Reply text (markdown supported).",
+          "type": "string"
+        },
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
           "type": "string"
         },
         "thread_id": {
@@ -847,6 +919,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "thread_id": {
           "description": "Thread ID to resolve.",
           "type": "string"
@@ -871,6 +947,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
       "properties": {
+        "notebook_handle": {
+          "description": "Attachment handle from connect_notebook or create_notebook; also addresses parked notebooks.",
+          "type": "string"
+        },
         "thread_id": {
           "description": "Thread ID to reopen.",
           "type": "string"

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -6,7 +6,6 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -14,9 +13,9 @@ use std::time::Duration;
 
 use rmcp::model::{
     CallToolRequestParams, CallToolResponse, CallToolResult, CompleteRequestParams, CompleteResult,
-    DiscoverRequestMethod, DiscoverResult, Implementation, ListPromptsResult,
-    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, ProtocolVersion,
-    ReadResourceRequestParams, ReadResourceResponse, ServerCapabilities, ServerInfo,
+    Implementation, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
+    ListToolsResult, ProtocolVersion, ReadResourceRequestParams, ReadResourceResponse,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
@@ -37,6 +36,7 @@ mod session;
 mod session_activation;
 mod structured;
 mod subscriptions;
+mod targets;
 pub mod tools;
 
 use session::{
@@ -45,12 +45,6 @@ use session::{
 use session_activation::SessionActivation;
 
 const SLOW_MCP_TOOL_CALL: Duration = Duration::from_secs(30);
-const LEGACY_PROTOCOL_VERSIONS: [ProtocolVersion; 4] = [
-    ProtocolVersion::V_2024_11_05,
-    ProtocolVersion::V_2025_03_26,
-    ProtocolVersion::V_2025_06_18,
-    ProtocolVersion::V_2025_11_25,
-];
 /// Client names are untrusted handshake input. Keep the derived operator slug
 /// compact enough for actor labels, logs, and UI while retaining useful brand
 /// names in full.
@@ -144,6 +138,7 @@ pub struct NteractMcp {
     parked_sessions: Arc<RwLock<std::collections::HashMap<String, NotebookSession>>>,
     observation_waits: tokio::sync::Semaphore,
     resource_subscriptions: Arc<subscriptions::ResourceSubscriptions>,
+    native_subscription_slots: tokio::sync::Semaphore,
     /// Context from the most recently dropped session — allows error messages
     /// to tell agents *why* the session was lost and *which notebook_id* to
     /// reconnect to, instead of the generic "No active notebook session".
@@ -171,6 +166,26 @@ pub struct NteractMcp {
 }
 
 impl NteractMcp {
+    pub(crate) async fn attachment_identity(
+        &self,
+        handle: &str,
+    ) -> Option<(String, Option<String>)> {
+        {
+            let active = self.session.read().await;
+            if let Some(session) = active
+                .as_ref()
+                .filter(|session| session.notebook_handle == handle)
+            {
+                return Some((session.notebook_id.clone(), session.notebook_path.clone()));
+            }
+        }
+        self.parked_sessions
+            .read()
+            .await
+            .values()
+            .find(|session| session.notebook_handle == handle)
+            .map(|session| (session.notebook_id.clone(), session.notebook_path.clone()))
+    }
     pub(crate) async fn observer_for_handle(
         &self,
         notebook_handle: &str,
@@ -222,6 +237,7 @@ impl NteractMcp {
             parked_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             observation_waits: tokio::sync::Semaphore::new(8),
             resource_subscriptions: Arc::default(),
+            native_subscription_slots: tokio::sync::Semaphore::new(128),
             last_session_drop: Arc::new(RwLock::new(None)),
             peer_label: Arc::new(RwLock::new("Inkwell".to_string())),
             operator: Arc::new(RwLock::new(agent_operator(
@@ -324,6 +340,23 @@ impl NteractMcp {
         &self,
         requirement: SessionRequirement,
     ) -> Result<Option<SessionAccess>, SessionAccessError> {
+        if let Some(handle) = targets::current() {
+            {
+                let active = self.session.read().await;
+                if let Some(session) = active
+                    .as_ref()
+                    .filter(|session| session.notebook_handle == handle)
+                {
+                    return session.access(requirement).map(Some);
+                }
+            }
+            let parked = self.parked_sessions.read().await;
+            return parked
+                .values()
+                .find(|session| session.notebook_handle == handle)
+                .map(|session| session.access(requirement))
+                .transpose();
+        }
         let guard = self.session.read().await;
         let Some(session) = guard.as_ref() else {
             return Ok(None);
@@ -350,6 +383,15 @@ impl NteractMcp {
         &self,
         access: &SessionAccess,
     ) -> Result<(), SessionAccessError> {
+        if let Some(handle) = targets::current() {
+            return if access.notebook_handle == handle
+                && self.attachment_identity(&handle).await.is_some()
+            {
+                Ok(())
+            } else {
+                Err(Self::superseded_access_error(access))
+            };
+        }
         let generation = access.readiness.session_generation;
         let target = &access.readiness.target;
         let activation_current = generation == 0
@@ -376,6 +418,30 @@ impl NteractMcp {
         access: &SessionAccess,
         path: String,
     ) -> Result<(), SessionAccessError> {
+        if let Some(handle) = targets::current() {
+            if access.notebook_handle != handle {
+                return Err(Self::superseded_access_error(access));
+            }
+            {
+                let mut active = self.session.write().await;
+                if let Some(session) = active
+                    .as_mut()
+                    .filter(|session| session.notebook_handle == handle)
+                {
+                    session.notebook_path = Some(path);
+                    return Ok(());
+                }
+            }
+            let mut parked = self.parked_sessions.write().await;
+            if let Some(session) = parked
+                .values_mut()
+                .find(|session| session.notebook_handle == handle)
+            {
+                session.notebook_path = Some(path);
+                return Ok(());
+            }
+            return Err(Self::superseded_access_error(access));
+        }
         let generation = access.readiness.session_generation;
         let target = &access.readiness.target;
         let mut guard = self.session.write().await;
@@ -438,17 +504,21 @@ impl NteractMcp {
     }
 }
 
-fn require_legacy_handshake(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
-    if context.peer.peer_info().is_none() {
-        return Err(McpError::invalid_request(
-            "initialize is required before application requests",
-            None,
-        ));
-    }
-    Ok(())
+fn require_protocol(context: &RequestContext<RoleServer>) -> Result<(), McpError> {
+    mcp_transport::require_protocol(context)
 }
 
 impl ServerHandler for NteractMcp {
+    fn accepted_subscription_filter(
+        &self,
+        requested: &rmcp::model::SubscriptionFilter,
+    ) -> Option<rmcp::model::SubscriptionFilter> {
+        Some(mcp_transport::notebook_subscription_filter(requested))
+    }
+    async fn listen(&self, context: rmcp::service::SubscriptionContext) -> Result<(), McpError> {
+        mcp_transport::require_protocol(context.request_context())?;
+        subscriptions::listen(self, context).await
+    }
     async fn initialize(
         &self,
         request: rmcp::model::InitializeRequestParams,
@@ -461,24 +531,21 @@ impl ServerHandler for NteractMcp {
             ));
         }
         let mut info = self.get_info();
-        if self
-            .supported_protocol_versions()
-            .contains(&request.protocol_version)
-        {
+        if mcp_transport::LEGACY_VERSIONS.contains(&request.protocol_version) {
             info.protocol_version = request.protocol_version;
         }
         Ok(info)
     }
 
-    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(&LEGACY_PROTOCOL_VERSIONS)
+    fn supported_protocol_versions(&self) -> std::borrow::Cow<'static, [ProtocolVersion]> {
+        std::borrow::Cow::Borrowed(mcp_transport::SUPPORTED_VERSIONS)
     }
 
     async fn discover(
         &self,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<DiscoverResult, McpError> {
-        Err(McpError::method_not_found::<DiscoverRequestMethod>())
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::DiscoverResult, McpError> {
+        mcp_transport::discover(&context, self.get_info())
     }
 
     async fn list_prompts(
@@ -486,8 +553,10 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(ListPromptsResult::default())
+        require_protocol(&context)?;
+        Ok(ListPromptsResult::default()
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn complete(
@@ -495,7 +564,7 @@ impl ServerHandler for NteractMcp {
         _request: CompleteRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CompleteResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         Ok(CompleteResult::default())
     }
 
@@ -554,7 +623,7 @@ impl ServerHandler for NteractMcp {
         _request: rmcp::model::SetLevelRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         Ok(())
     }
 
@@ -563,12 +632,15 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         let mut tools = tools::all_tools();
         if self.no_show {
             tools.retain(|t| t.name.as_ref() != "show_notebook");
         }
-        Ok(ListToolsResult::with_all_items(tools))
+        mcp_transport::attachment_tool_schemas(&mut tools, mcp_transport::is_native(&context));
+        Ok(ListToolsResult::with_all_items(tools)
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     async fn call_tool(
@@ -576,7 +648,7 @@ impl ServerHandler for NteractMcp {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         // Sniff client name on first call for use as the notebook peer label.
         // The title (e.g., "Claude Desktop") is preferred over the raw
         // implementation name ("claude-ai"), then known names are canonicalized.
@@ -584,11 +656,10 @@ impl ServerHandler for NteractMcp {
             let current = self.peer_label.read().await;
             if *current == "Inkwell" {
                 drop(current);
-                if let Some(info) = context.peer.peer_info() {
-                    if let Some(label) = mcp_client_branding::display_name(
-                        &info.client_info.name,
-                        info.client_info.title.as_deref(),
-                    ) {
+                if let Some(info) = context.client_info() {
+                    if let Some(label) =
+                        mcp_client_branding::display_name(&info.name, info.title.as_deref())
+                    {
                         *self.peer_label.write().await = label.into_owned();
                     }
                     // The operator slug comes from the raw implementation name,
@@ -596,12 +667,17 @@ impl ServerHandler for NteractMcp {
                     // against the client roster in `mcp-client-branding`, which is
                     // keyed by that raw name ("claude-code", "codex-mcp-client").
                     *self.operator.write().await =
-                        agent_operator(&info.client_info.name, &self.operator_session);
+                        agent_operator(&info.name, &self.operator_session);
                 }
             }
         }
         let start = std::time::Instant::now();
-        let result = progress::run(&context, &request.name, tools::dispatch(self, &request)).await;
+        let result = progress::run(
+            &context,
+            &request.name,
+            targets::dispatch(self, &request, mcp_transport::is_native(&context)),
+        )
+        .await;
         let elapsed = start.elapsed();
         if elapsed >= SLOW_MCP_TOOL_CALL {
             tracing::warn!(
@@ -622,8 +698,14 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
-        require_legacy_handshake(&context)?;
-        resources::list_resources(self).await
+        require_protocol(&context)?;
+        resources::list_resources_for_mode(self, mcp_transport::is_native(&context))
+            .await
+            .map(|result| {
+                result
+                    .with_ttl_ms(0)
+                    .with_cache_scope(rmcp::model::CacheScope::Private)
+            })
     }
 
     async fn read_resource(
@@ -631,9 +713,16 @@ impl ServerHandler for NteractMcp {
         request: ReadResourceRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
+        mcp_transport::validate_resource_uri(&request.uri, &context)?;
         resources::read_resource(self, &request)
             .await
+            .map_err(|error| mcp_transport::resource_error(error, &context))
+            .map(|result| {
+                result
+                    .with_ttl_ms(0)
+                    .with_cache_scope(rmcp::model::CacheScope::Private)
+            })
             .map(Into::into)
     }
 
@@ -642,8 +731,17 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
-        require_legacy_handshake(&context)?;
-        Ok(resources::list_resource_templates())
+        require_protocol(&context)?;
+        let mut result = resources::list_resource_templates();
+        if mcp_transport::is_native(&context) {
+            result
+                .resource_templates
+                .retain(|template| template.uri_template.starts_with("nteract://sessions/"));
+        }
+        result.result_type = Some(rmcp::model::ResultType::COMPLETE);
+        Ok(result
+            .with_ttl_ms(0)
+            .with_cache_scope(rmcp::model::CacheScope::Private))
     }
 
     #[allow(deprecated)]
@@ -652,7 +750,7 @@ impl ServerHandler for NteractMcp {
         request: rmcp::model::SubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         let target = resources::parse_notebook_resource_uri(&request.uri)
             .map_err(|message| McpError::resource_not_found(message, None))?;
         let notebook_id = match &target {
@@ -683,7 +781,7 @@ impl ServerHandler for NteractMcp {
         request: rmcp::model::UnsubscribeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        require_legacy_handshake(&context)?;
+        require_protocol(&context)?;
         self.resource_subscriptions.unsubscribe(&request.uri)
     }
 }
@@ -787,7 +885,7 @@ mod tests {
     use rmcp::model::{CallToolResult, ContentBlock};
 
     #[test]
-    fn server_advertises_only_legacy_protocol_versions() {
+    fn server_advertises_legacy_and_native_protocol_versions() {
         let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None);
         assert_eq!(
             server.get_info().protocol_version,
@@ -799,7 +897,13 @@ mod tests {
                 .iter()
                 .map(ProtocolVersion::as_str)
                 .collect::<Vec<_>>(),
-            ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+            [
+                "2024-11-05",
+                "2025-03-26",
+                "2025-06-18",
+                "2025-11-25",
+                "2026-07-28"
+            ]
         );
     }
 
@@ -877,7 +981,7 @@ mod tests {
                     assert_eq!(error.code, ErrorCode::INVALID_REQUEST);
                     assert_eq!(
                         error.message,
-                        "initialize is required before application requests"
+                        "initialize is required for legacy application requests"
                     );
                 }
             }
@@ -885,7 +989,14 @@ mod tests {
                 .discover(context())
                 .await
                 .expect_err("discovery is unsupported");
-            assert_eq!(error.code, ErrorCode::METHOD_NOT_FOUND);
+            assert_eq!(
+                error.code,
+                if initialized {
+                    ErrorCode::METHOD_NOT_FOUND
+                } else {
+                    ErrorCode::INVALID_REQUEST
+                }
+            );
             running.close().await.expect("close test service");
         }
     }

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -69,7 +69,15 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> MetaObject {
 }
 
 /// List available MCP resources.
+#[cfg(test)]
 pub async fn list_resources(server: &NteractMcp) -> Result<ListResourcesResult, McpError> {
+    list_resources_for_mode(server, false).await
+}
+
+pub(crate) async fn list_resources_for_mode(
+    server: &NteractMcp,
+    native: bool,
+) -> Result<ListResourcesResult, McpError> {
     let mut resources = Vec::new();
     resources.push(resource(
         OUTPUT_RESOURCE_URI,
@@ -88,7 +96,12 @@ pub async fn list_resources(server: &NteractMcp) -> Result<ListResourcesResult, 
         NOTEBOOK_CONTEXT_PRIORITY,
     ));
 
-    for notebook_id in known_session_notebook_ids(server).await {
+    let notebook_ids = if native {
+        Vec::new()
+    } else {
+        known_session_notebook_ids(server).await
+    };
+    for notebook_id in notebook_ids {
         resources.push(assistant_resource(
             notebook_cells_uri(&notebook_id),
             format!("nteract cells {notebook_id}"),
@@ -617,6 +630,12 @@ pub(crate) fn attachment_cells_uri(notebook_handle: &str) -> String {
 pub(crate) fn attachment_cells_resource_link(notebook_handle: &str) -> Resource {
     let mut resource = notebook_cells_resource_link(notebook_handle);
     resource.uri = attachment_cells_uri(notebook_handle);
+    resource
+}
+
+pub(crate) fn attachment_cell_resource_link(notebook_handle: &str, cell_id: &str) -> Resource {
+    let mut resource = notebook_cell_resource_link(notebook_handle, cell_id);
+    resource.uri = attachment_cell_uri(notebook_handle, cell_id);
     resource
 }
 

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -173,6 +173,7 @@ pub struct SessionReadiness {
 
 #[derive(Debug, Clone)]
 pub struct SessionAccess {
+    pub notebook_handle: String,
     pub handle: DocHandle,
     pub notebook_id: String,
     pub notebook_path: Option<String>,
@@ -587,6 +588,7 @@ impl NotebookSession {
         }
 
         Ok(SessionAccess {
+            notebook_handle: self.notebook_handle.clone(),
             handle: self.handle.clone(),
             notebook_id: self.notebook_id.clone(),
             notebook_path: self.notebook_path.clone(),

--- a/crates/runt-mcp/src/subscriptions.rs
+++ b/crates/runt-mcp/src/subscriptions.rs
@@ -12,6 +12,99 @@ use crate::observation::{ChangeKind, ChangeOutcome, NotebookChanges, Observation
 use crate::resources::NotebookResourceUri;
 
 const MAX_WATCHES: usize = 128;
+
+pub(crate) async fn listen(
+    server: &crate::NteractMcp,
+    context: rmcp::service::SubscriptionContext,
+) -> Result<(), McpError> {
+    let uris = context
+        .accepted()
+        .resource_subscriptions
+        .clone()
+        .unwrap_or_default();
+    let _permit = server
+        .native_subscription_slots
+        .try_acquire_many(uris.len() as u32)
+        .map_err(|_| {
+            McpError::invalid_request("At most 128 native resource watches may be active", None)
+        })?;
+    let mut prepared = Vec::new();
+    for uri in uris {
+        let target = crate::resources::parse_notebook_resource_uri(&uri)
+            .map_err(|e| McpError::invalid_params(e, None))?;
+        let handle = match &target {
+            NotebookResourceUri::Cells { notebook_id }
+            | NotebookResourceUri::Cell { notebook_id, .. }
+            | NotebookResourceUri::Comments { notebook_id } => notebook_id,
+            NotebookResourceUri::Notebooks => {
+                return Err(McpError::invalid_params(
+                    "Use a notebook attachment URI",
+                    None,
+                ))
+            }
+        };
+        let (_, observer) = server.observer_for_handle(handle).await?.ok_or_else(|| {
+            McpError::invalid_params(
+                "Notebook attachment expired; connect again and obtain a new handle",
+                None,
+            )
+        })?;
+        let baseline = observer
+            .read(None)
+            .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+        if baseline.outcome == ChangeOutcome::Unavailable {
+            return Err(McpError::invalid_params(
+                "Notebook attachment is unavailable",
+                None,
+            ));
+        }
+        prepared.push((uri, target, observer, baseline.cursor));
+    }
+    // Receivers and cursors exist before the client sees its acknowledgment.
+    mcp_transport::acknowledge(context.request_context()).await?;
+    let mut watches = tokio::task::JoinSet::new();
+    for (uri, target, observer, mut cursor) in prepared {
+        let sink = context.sink().clone();
+        watches.spawn(async move {
+            loop {
+                let change = observer
+                    .wait(&cursor, Duration::from_secs(50))
+                    .await
+                    .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+                cursor = change.cursor;
+                let invalidated = matches!(
+                    change.outcome,
+                    ChangeOutcome::Unavailable | ChangeOutcome::ResyncRequired
+                );
+                if invalidated || affects(&target, &change.changes) {
+                    tokio::time::timeout(
+                        Duration::from_secs(1),
+                        sink.notify_resource_updated(&uri),
+                    )
+                    .await
+                    .map_err(|_| {
+                        McpError::internal_error(
+                            "Subscription delivery timed out; read a fresh baseline",
+                            None,
+                        )
+                    })?
+                    .map_err(|error| McpError::internal_error(error.to_string(), None))?;
+                }
+                if change.outcome == ChangeOutcome::Unavailable {
+                    return Ok::<(), McpError>(());
+                }
+            }
+        });
+    }
+    if watches.is_empty() {
+        return Ok(());
+    }
+    tokio::select! {
+        _ = mcp_transport::cancelled(context.request_context()) => Ok(()),
+        ended = watches.join_next() => ended.ok_or_else(|| McpError::internal_error("Subscription worker ended", None))?.map_err(|error| McpError::internal_error(error.to_string(), None))?,
+    }
+}
+
 type ResourceWatch = (uuid::Uuid, ObservationReader, tokio::task::JoinHandle<()>);
 
 #[derive(Default)]

--- a/crates/runt-mcp/src/subscriptions.rs
+++ b/crates/runt-mcp/src/subscriptions.rs
@@ -96,13 +96,19 @@ pub(crate) async fn listen(
             }
         });
     }
-    if watches.is_empty() {
-        return Ok(());
-    }
     tokio::select! {
         _ = mcp_transport::cancelled(context.request_context()) => Ok(()),
-        ended = watches.join_next() => ended.ok_or_else(|| McpError::internal_error("Subscription worker ended", None))?.map_err(|error| McpError::internal_error(error.to_string(), None))?,
+        result = drain_watches(&mut watches) => result,
     }
+}
+
+async fn drain_watches(
+    watches: &mut tokio::task::JoinSet<Result<(), McpError>>,
+) -> Result<(), McpError> {
+    while let Some(ended) = watches.join_next().await {
+        ended.map_err(|error| McpError::internal_error(error.to_string(), None))??;
+    }
+    Ok(())
 }
 
 type ResourceWatch = (uuid::Uuid, ObservationReader, tokio::task::JoinHandle<()>);
@@ -243,6 +249,31 @@ mod tests {
     use rmcp::model::*;
     use rmcp::service::{NotificationContext, RequestContext, RoleClient};
     use rmcp::{ClientHandler, ServerHandler, ServiceExt};
+
+    #[tokio::test]
+    async fn releasing_one_attachment_keeps_other_listener_watches_running() {
+        let mut watches = tokio::task::JoinSet::new();
+        let (released, observed) = tokio::sync::oneshot::channel();
+        watches.spawn(async move {
+            let _ = released.send(());
+            Ok(())
+        });
+        let (release_second, second) = tokio::sync::oneshot::channel();
+        watches.spawn(async move {
+            let _ = second.await;
+            Ok(())
+        });
+        observed.await.expect("first attachment released");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(30), drain_watches(&mut watches))
+                .await
+                .is_err()
+        );
+        release_second.send(()).expect("second watch still alive");
+        drain_watches(&mut watches)
+            .await
+            .expect("all attachments released");
+    }
 
     struct Notifications(tokio::sync::mpsc::UnboundedSender<String>);
     impl ClientHandler for Notifications {

--- a/crates/runt-mcp/src/targets.rs
+++ b/crates/runt-mcp/src/targets.rs
@@ -1,0 +1,57 @@
+//! Explicit attachment selection follows this request; it never changes active selection.
+use crate::NteractMcp;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::ErrorData;
+tokio::task_local! { static TARGET: Option<String>; }
+pub(crate) fn current() -> Option<String> {
+    TARGET.try_with(Clone::clone).ok().flatten()
+}
+
+pub(crate) async fn dispatch(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+    native: bool,
+) -> Result<CallToolResult, ErrorData> {
+    if !mcp_transport::notebook_scoped_tool(&request.name) {
+        return crate::tools::dispatch(server, request).await;
+    }
+    let mut request = request.clone();
+    let value = request
+        .arguments
+        .as_mut()
+        .and_then(|arguments| arguments.remove("notebook_handle"));
+    let target = match value {
+        Some(serde_json::Value::String(handle)) if !handle.is_empty() => Some(handle),
+        Some(_) => return Err(ErrorData::invalid_params("notebook_handle must be a nonempty attachment handle", None)),
+        None if native => return Err(ErrorData::invalid_params("notebook_handle is required; use the handle returned by connect_notebook or create_notebook", None)),
+        None => None,
+    };
+    if let Some(handle) = target.as_ref() {
+        if server.attachment_identity(handle).await.is_none() {
+            return Err(ErrorData::invalid_params(
+                "Notebook attachment expired; connect again and obtain a new handle",
+                None,
+            ));
+        }
+        if request
+            .arguments
+            .as_ref()
+            .is_some_and(|args| args.contains_key("notebook_id"))
+        {
+            return Err(ErrorData::invalid_params(
+                "Use notebook_handle without notebook_id",
+                None,
+            ));
+        }
+    }
+    TARGET
+        .scope(target, crate::tools::dispatch(server, &request))
+        .await
+}
+
+pub(crate) async fn with_handle<T>(
+    handle: String,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    TARGET.scope(Some(handle), future).await
+}

--- a/crates/runt-mcp/src/targets.rs
+++ b/crates/runt-mcp/src/targets.rs
@@ -33,11 +33,10 @@ pub(crate) async fn dispatch(
                 None,
             ));
         }
-        if request
-            .arguments
-            .as_ref()
-            .is_some_and(|args| args.contains_key("notebook_id"))
-        {
+        if request.arguments.as_ref().is_some_and(|args| {
+            args.get("notebook_id")
+                .is_some_and(|value| !value.is_null())
+        }) {
             return Err(ErrorData::invalid_params(
                 "Use notebook_handle without notebook_id",
                 None,

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -340,7 +340,7 @@ pub async fn move_cell(
         "cell_id": cell_id,
         "after_cell_id": after_cell_id,
         "moved": true,
-        "uri": crate::resources::notebook_cell_uri(handle.notebook_id(), cell_id),
+        "uri": super::cell_resource_uri(handle.notebook_id(), cell_id),
     });
     cell_resource_json_success(result, handle.notebook_id(), cell_id)
 }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -304,7 +304,7 @@ pub async fn delete_cell(
     let result = serde_json::json!({
         "cell_id": cell_id,
         "deleted": true,
-        "resources": crate::resources::notebook_resources_json(handle.notebook_id()),
+        "resources": super::notebook_resources_json(handle.notebook_id()),
     });
     cells_resource_json_success(result, handle.notebook_id())
 }
@@ -404,10 +404,7 @@ fn cell_resource_success(
 ) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![
         crate::formatting::assistant_text(message),
-        ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
-            notebook_id,
-            cell_id,
-        )),
+        super::cell_resource_content(notebook_id, cell_id),
     ]))
 }
 
@@ -420,10 +417,7 @@ fn cell_resource_json_success(
         crate::formatting::assistant_text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         ),
-        ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
-            notebook_id,
-            cell_id,
-        )),
+        super::cell_resource_content(notebook_id, cell_id),
     ]))
 }
 
@@ -435,7 +429,7 @@ fn cells_resource_json_success(
         crate::formatting::assistant_text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         ),
-        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        super::cells_resource_content(notebook_id),
     ]))
 }
 
@@ -473,6 +467,22 @@ fn explicit_after_cell_id_arg(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn handle_routed_mutation_results_only_link_to_that_attachment() {
+        crate::targets::with_handle("attachment".into(), async {
+            for result in [
+                cell_resource_success("created".into(), "notebook", "cell/1"),
+                cell_resource_json_success(serde_json::json!({"uri": super::super::cell_resource_uri("notebook", "cell/1")}), "notebook", "cell/1"),
+                cells_resource_json_success(serde_json::json!({"resources": super::super::notebook_resources_json("notebook")}), "notebook"),
+            ] {
+                let result = result.expect("mutation result");
+                let value = serde_json::to_string(&result).expect("wire result");
+                assert!(!value.contains("nteract://notebooks/"), "{value}");
+                assert!(result.content[1].as_resource_link().expect("link").uri.starts_with("nteract://sessions/attachment/cells"));
+            }
+        }).await;
+    }
 
     #[test]
     fn cell_resource_success_returns_mcp_resource_link() {

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock};
+use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
 use runtimed_outputs::output_resolver;
 use schemars::JsonSchema;
@@ -17,7 +17,7 @@ use super::{arg_bool, arg_str, assert_cell_exists, tool_error};
 fn cells_resource_result(message: String, notebook_id: &str) -> CallToolResult {
     CallToolResult::success(vec![
         formatting::assistant_text(message),
-        ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(notebook_id)),
+        super::cells_resource_content(notebook_id),
     ])
 }
 
@@ -241,9 +241,7 @@ pub async fn run_all_cells(
     let comms = runtime_state.as_ref().map(|rs| &rs.comms);
     let mut content_items = vec![
         formatting::assistant_text(header.clone()),
-        rmcp::model::ContentBlock::resource_link(crate::resources::notebook_cells_resource_link(
-            handle.notebook_id(),
-        )),
+        super::cells_resource_content(handle.notebook_id()),
     ];
     let mut structured_cells: Vec<serde_json::Value> = Vec::new();
 
@@ -329,7 +327,7 @@ pub async fn run_all_cells(
                     if let Some(obj) = cell_data.as_object_mut() {
                         obj.insert(
                             "uri".to_string(),
-                            serde_json::Value::String(crate::resources::notebook_cell_uri(
+                            serde_json::Value::String(super::cell_resource_uri(
                                 handle.notebook_id(),
                                 &cell.id,
                             )),

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -60,7 +60,27 @@ fn always_load_meta() -> MetaObject {
     MetaObject(meta)
 }
 
+fn cell_resource_uri(notebook_id: &str, cell_id: &str) -> String {
+    match crate::targets::current() {
+        Some(handle) => crate::resources::attachment_cell_resource_link(&handle, cell_id).uri,
+        None => crate::resources::notebook_cell_uri(notebook_id, cell_id),
+    }
+}
+
+fn cells_resource_content(notebook_id: &str) -> ContentBlock {
+    let resource = match crate::targets::current() {
+        Some(handle) => crate::resources::attachment_cells_resource_link(&handle),
+        None => crate::resources::notebook_cells_resource_link(notebook_id),
+    };
+    ContentBlock::resource_link(resource)
+}
+
 fn cell_resource_content(notebook_id: &str, cell_id: &str) -> ContentBlock {
+    if let Some(handle) = crate::targets::current() {
+        return ContentBlock::resource_link(crate::resources::attachment_cell_resource_link(
+            &handle, cell_id,
+        ));
+    }
     ContentBlock::resource_link(crate::resources::notebook_cell_resource_link(
         notebook_id,
         cell_id,
@@ -334,6 +354,7 @@ pub fn cli_discoverable_tools() -> Vec<Tool> {
 }
 
 fn attach_icons(tools: &mut [Tool]) {
+    mcp_transport::attachment_tool_schemas(tools, false);
     for tool in tools {
         if let Some(icon) = crate::icons::tool_icon(tool.name.as_ref()) {
             tool.icons = Some(crate::icons::icons(icon));
@@ -730,10 +751,7 @@ pub async fn build_execution_result(
         if let Some(cell_obj) = sc.get_mut("cell").and_then(|c| c.as_object_mut()) {
             cell_obj.insert(
                 "uri".to_string(),
-                serde_json::Value::String(crate::resources::notebook_cell_uri(
-                    handle.notebook_id(),
-                    &result.cell_id,
-                )),
+                serde_json::Value::String(cell_resource_uri(handle.notebook_id(), &result.cell_id)),
             );
             // Inject execution_id into structured content so MCP App renderers
             // can associate outputs with a specific execution.

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -60,6 +60,14 @@ fn always_load_meta() -> MetaObject {
     MetaObject(meta)
 }
 
+fn notebook_resources_json(notebook_id: &str) -> serde_json::Value {
+    if let Some(handle) = crate::targets::current() {
+        let cells = crate::resources::attachment_cells_uri(&handle);
+        return serde_json::json!({"cells":cells,"cell_template":format!("{cells}/{{cell_id}}")});
+    }
+    crate::resources::notebook_resources_json(notebook_id)
+}
+
 fn cell_resource_uri(notebook_id: &str, cell_id: &str) -> String {
     match crate::targets::current() {
         Some(handle) => crate::resources::attachment_cell_resource_link(&handle, cell_id).uri,

--- a/crates/runt-mcp/src/tools/observation.rs
+++ b/crates/runt-mcp/src/tools/observation.rs
@@ -54,12 +54,15 @@ pub async fn wait_for_notebook_change(
             "message":"This notebook attachment is no longer available. Connect again and obtain a new handle."
         })));
     };
-    run_wait(
-        server,
-        &params,
-        &notebook_id,
-        &observer,
-        Duration::from_secs_f64(seconds),
+    crate::targets::with_handle(
+        params.notebook_handle.clone(),
+        run_wait(
+            server,
+            &params,
+            &notebook_id,
+            &observer,
+            Duration::from_secs_f64(seconds),
+        ),
     )
     .await
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -961,6 +961,48 @@ pub async fn disconnect_notebook(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
+    if let Some(handle) = crate::targets::current() {
+        let removed = {
+            let mut active = server.session.write().await;
+            if active
+                .as_ref()
+                .is_some_and(|session| session.notebook_handle == handle)
+            {
+                server.advance_session_intent_epoch();
+                active.take()
+            } else {
+                None
+            }
+        };
+        if let Some(session) = removed {
+            *server.last_session_drop.write().await = Some(SessionDropInfo {
+                reason: SessionDropReason::Disconnected,
+                notebook_id: session.notebook_id.clone(),
+                notebook_path: session.notebook_path.clone(),
+                rejoin_target: Some(session.rejoin_target()),
+            });
+            drop(session);
+            return tool_success(
+                "Released the notebook attachment. Connect again to obtain a new handle.",
+            );
+        }
+        let removed = {
+            let mut parked = server.parked_sessions.write().await;
+            let key = parked
+                .iter()
+                .find(|(_, session)| session.notebook_handle == handle)
+                .map(|(key, _)| key.clone());
+            key.and_then(|key| parked.remove(&key))
+        };
+        if removed.is_some() {
+            drop(removed);
+            return tool_success("Released the parked notebook attachment.");
+        }
+        return Err(McpError::invalid_params(
+            "Notebook attachment expired",
+            None,
+        ));
+    }
     let target_id = arg_str(request, "notebook_id");
 
     match target_id {
@@ -1885,15 +1927,22 @@ pub async fn show_notebook(
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     // Resolve notebook_id (and optional path) from param or current session
-    let (target, session_path) = match arg_str(request, "notebook_id") {
-        Some(id) => (id.to_string(), None),
-        None => {
-            let session = server.session.read().await;
-            match session.as_ref() {
-                Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
-                None => {
-                    drop(session);
-                    return super::no_session_error(server).await;
+    let (target, session_path) = if let Some(handle) = crate::targets::current() {
+        server
+            .attachment_identity(&handle)
+            .await
+            .ok_or_else(|| McpError::invalid_params("Notebook attachment expired", None))?
+    } else {
+        match arg_str(request, "notebook_id") {
+            Some(id) => (id.to_string(), None),
+            None => {
+                let session = server.session.read().await;
+                match session.as_ref() {
+                    Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
+                    None => {
+                        drop(session);
+                        return super::no_session_error(server).await;
+                    }
                 }
             }
         }

--- a/crates/runt-mcp/tests/native_protocol.rs
+++ b/crates/runt-mcp/tests/native_protocol.rs
@@ -1,0 +1,168 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+mod support;
+use rmcp::model::*;
+use rmcp::service::{RequestContext, RoleServer, SubscriptionContext};
+use rmcp::{ErrorData, ServerHandler};
+use serde_json::json;
+use support::{modern_meta, Wire};
+
+struct FirstRequest;
+impl ServerHandler for FirstRequest {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .enable_resources_subscribe()
+                .build(),
+        )
+    }
+    async fn discover(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<DiscoverResult, ErrorData> {
+        mcp_transport::discover(&context, self.get_info())
+    }
+    fn accepted_subscription_filter(
+        &self,
+        requested: &SubscriptionFilter,
+    ) -> Option<SubscriptionFilter> {
+        Some(requested.clone())
+    }
+    async fn listen(&self, context: SubscriptionContext) -> Result<(), ErrorData> {
+        mcp_transport::acknowledge(context.request_context()).await?;
+        context
+            .sink()
+            .notify_resource_updated("fixture://resource")
+            .await
+            .unwrap();
+        mcp_transport::cancelled(context.request_context()).await;
+        Ok(())
+    }
+    async fn call_tool(
+        &self,
+        _: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        let token = context.meta.get_progress_token().unwrap();
+        context
+            .peer
+            .notify_progress(ProgressNotificationParam::new(token, 0.0))
+            .await
+            .unwrap();
+        Ok(CallToolResult::success(vec![ContentBlock::text("completed")]).into())
+    }
+}
+
+#[tokio::test]
+async fn first_native_listen_acknowledges_without_discovery_and_closes_on_cancel() {
+    let mut wire = Wire::start(FirstRequest);
+    wire.send(json!({"jsonrpc":"2.0","id":7,"method":"subscriptions/listen","params":{"_meta":modern_meta("2026-07-28",false),"notifications":{"resourceSubscriptions":["fixture://resource"]}}})).await;
+    wire.notification("notifications/subscriptions/acknowledged")
+        .await;
+    wire.notification("notifications/resources/updated").await;
+    for notification in &wire.notifications {
+        assert_eq!(
+            notification["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+            7
+        );
+    }
+    wire.send(json!({"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}))
+        .await;
+    assert!(wire.finish().await);
+}
+
+#[tokio::test]
+async fn first_native_tool_can_send_progress_before_its_result() {
+    let mut wire = Wire::start(FirstRequest);
+    let mut meta = modern_meta("2026-07-28", false);
+    meta["progressToken"] = json!("first-tool");
+    let response = wire
+        .request(
+            8,
+            "tools/call",
+            Some(json!({"name":"fixture","_meta":meta})),
+        )
+        .await;
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(
+        wire.notifications[0]["params"]["progressToken"],
+        "first-tool"
+    );
+    assert!(wire.finish().await);
+}
+
+#[tokio::test]
+async fn actual_notebook_server_supports_native_first_reads_and_expired_waits() {
+    for (method, mut params) in [
+        ("server/discover", json!({})),
+        ("tools/list", json!({})),
+        ("resources/list", json!({})),
+        ("resources/templates/list", json!({})),
+        (
+            "tools/call",
+            json!({"name":"wait_for_notebook_change","arguments":{"notebook_handle":"expired"}}),
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let server = runt_mcp::NteractMcp::new_no_show(
+            dir.path().join("daemon.sock"),
+            None,
+            Some(dir.path().join("blobs")),
+        );
+        let mut wire = Wire::start(server);
+        params["_meta"] = modern_meta("2026-07-28", false);
+        let response = wire.request(1, method, Some(params)).await;
+        assert!(response.get("error").is_none(), "{method}: {response}");
+        assert_eq!(response["result"]["resultType"], "complete", "{response}");
+        if [
+            "server/discover",
+            "tools/list",
+            "resources/list",
+            "resources/templates/list",
+        ]
+        .contains(&method)
+        {
+            assert_eq!(response["result"]["ttlMs"], 0, "{response}");
+            assert_eq!(response["result"]["cacheScope"], "private", "{response}");
+        }
+        assert!(wire.finish().await);
+    }
+}
+#[tokio::test]
+async fn native_requires_handles_and_rejects_expired_subscriptions_before_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let server = runt_mcp::NteractMcp::new_no_show(dir.path().join("daemon.sock"), None, None);
+    let mut wire = Wire::start(server);
+    for (id, method, mut params) in [
+        (
+            1,
+            "tools/call",
+            json!({"name":"create_cell","arguments":{"source":"must not run"}}),
+        ),
+        (
+            2,
+            "tools/call",
+            json!({"name":"get_all_cells","arguments":{"notebook_handle":"expired"}}),
+        ),
+        (
+            3,
+            "resources/read",
+            json!({"uri":"nteract://notebooks/old/cells"}),
+        ),
+        (
+            4,
+            "subscriptions/listen",
+            json!({"notifications":{"resourceSubscriptions":["nteract://sessions/expired/cells"]}}),
+        ),
+    ] {
+        params["_meta"] = modern_meta("2026-07-28", false);
+        let response = wire.request(id, method, Some(params)).await;
+        assert!(response.get("error").is_some(), "{response}");
+    }
+    assert!(!wire
+        .notifications
+        .iter()
+        .any(|n| n["method"] == "notifications/subscriptions/acknowledged"));
+    assert!(wire.finish().await);
+}

--- a/crates/runt-mcp/tests/protocol_compatibility.rs
+++ b/crates/runt-mcp/tests/protocol_compatibility.rs
@@ -142,8 +142,8 @@ legacy_test!(legacy_2025_03_26_newline_wire, "2025-03-26");
 legacy_test!(legacy_2025_06_18_newline_wire, "2025-06-18");
 legacy_test!(legacy_2025_11_25_newline_wire, "2025-11-25");
 
-async fn reject_modern_without_handshake(anonymous: bool) {
-    for version in ["2026-07-28", "2099-01-01"] {
+async fn reject_future_without_handshake(anonymous: bool) {
+    for version in ["2099-01-01"] {
         for (method, mut params) in modern_requests() {
             let (dir, server) = isolated_server();
             let label = server.peer_label_shared().read().await.clone();
@@ -177,13 +177,13 @@ async fn reject_modern_without_handshake(anonymous: bool) {
 }
 
 #[tokio::test]
-async fn modern_named_requests_rejected_without_handshake_or_notebook_side_effects() {
-    reject_modern_without_handshake(false).await;
+async fn future_named_requests_rejected_without_handshake_or_notebook_side_effects() {
+    reject_future_without_handshake(false).await;
 }
 
 #[tokio::test]
-async fn modern_anonymous_requests_rejected_without_handshake_or_notebook_side_effects() {
-    reject_modern_without_handshake(true).await;
+async fn future_anonymous_requests_rejected_without_handshake_or_notebook_side_effects() {
+    reject_future_without_handshake(true).await;
 }
 
 #[tokio::test]

--- a/crates/runt-mcp/tests/support/mod.rs
+++ b/crates/runt-mcp/tests/support/mod.rs
@@ -270,5 +270,9 @@ pub fn assert_unsupported(response: &Value, version: &str) {
         .map(|value| value.as_str().expect("protocol version string"))
         .collect();
     supported.sort_unstable();
-    assert_eq!(supported, LEGACY_VERSIONS);
+    let mut expected = LEGACY_VERSIONS.to_vec();
+    if version != "2026-07-28" {
+        expected.push("2026-07-28");
+    }
+    assert_eq!(supported, expected);
 }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -754,8 +754,12 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let last_session_drop = server.last_session_drop().clone();
     let parked_sessions = server.parked_sessions().clone();
 
-    let transport = mcp_transport::server(rmcp::transport::io::stdio());
+    let (transport, protocol) = mcp_transport::server_with_protocol(rmcp::transport::io::stdio());
     let handle = server.serve(transport).await?;
+    if handle.peer().peer_info().is_none() && !protocol.wait_for_native().await {
+        handle.waiting().await?;
+        return Ok(());
+    }
 
     // Grab a cancellation token before `waiting()` moves ownership of `handle`.
     // Used to gracefully close the MCP transport on daemon upgrade so the

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -756,10 +756,6 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
 
     let transport = mcp_transport::server(rmcp::transport::io::stdio());
     let handle = server.serve(transport).await?;
-    if handle.peer().peer_info().is_none() {
-        handle.cancel().await?;
-        return Ok(());
-    }
 
     // Grab a cancellation token before `waiting()` moves ownership of `handle`.
     // Used to gracefully close the MCP transport on daemon upgrade so the

--- a/crates/runt/tests/mcp_startup.rs
+++ b/crates/runt/tests/mcp_startup.rs
@@ -11,9 +11,9 @@ use tokio::time::timeout;
 #[tokio::test]
 async fn rejected_first_request_does_not_start_notebook_recovery() {
     for (method, version, expected_code) in [
-        ("tools/list", "2026-07-28", -32022),
+        ("tools/list", "2099-01-01", -32022),
         ("tools/list", "2025-11-25", -32600),
-        ("server/discover", "2025-11-25", -32601),
+        ("server/discover", "2025-11-25", -32600),
     ] {
         let dir = tempfile::tempdir().expect("isolated runt MCP directory");
         let notebook = dir.path().join("rejoin.ipynb");

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -230,6 +230,19 @@ so cancelling one listener cannot unsubscribe another. Child loss ends native
 streams rather than silently moving them to replacement attachments. Clients
 must reconnect, obtain new handles, and establish new baselines.
 
+Legacy responses also carry the zero-TTL private cache hints as optional fields;
+legacy clients may ignore them. Only native responses require the result-type
+discriminator. A rejected first request does not open the native lifecycle:
+entrypoints wait for valid protocol metadata before starting recovery or dev
+setup. Transient native child startup failures can retry, within the existing
+circuit breaker's attempt budget.
+
+Handle-qualified `show_notebook` requests always reach the child's attachment
+validation and launch policy. The supervisor's direct Vite launch path applies
+to legacy explicit-path requests; it must not bypass a supplied handle. Releasing
+one attachment ends only its per-URI watches; other watches in the native listen
+request continue until cancelled, unavailable, or the child connection ends.
+
 The shared transport adapter covers two SDK 3.2 lifecycle ordering constraints.
 It primes a native first application request with a private, pure discovery
 request so the SDK's peer pump is running before a tool emits progress or a

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -205,9 +205,39 @@ one elapsed clock and rate limit across a safe child retry. Progress delivery
 has a short timeout so a slow notification consumer cannot indefinitely stall
 the tool. Completion and cancellation discard pending progress updates.
 
-This observation layer does not by itself enable the native `2026-07-28`
-lifecycle or `subscriptions/listen`; those require their own transport and
-discovery support at every entrypoint.
+The native `2026-07-28` lifecycle is available at the child, installed wrapper,
+and development supervisor. Clients may send `server/discover` or an application
+request first, with the revision's required inline metadata. Initialize-based
+connections remain on their negotiated legacy revision. Inline metadata cannot
+upgrade an existing legacy connection.
+
+Native notebook-scoped tools require the attachment's `notebook_handle`.
+Legacy tools may also supply it. Selecting a handle routes just that request to
+an active or parked attachment; it does not switch the connection's active
+notebook. Native resource catalogs contain the static output UI and notebook
+listing, plus handle-qualified resource templates. Catalog entries do not depend
+on which notebooks this connection has opened. Reads and catalogs use private
+caching with zero TTL. The private child remains on `2025-11-25`, advertises empty
+client capabilities, and disables SDK caching. The proxy restores native result
+discriminators when forwarding deserialized legacy responses.
+
+`subscriptions/listen` accepts handle-qualified resource subscriptions, with a
+128-watch connection limit. Unsupported filter categories are declined. Watch
+installation and baseline capture happen before acknowledgment. Each accepted
+stream correlates invalidations with its subscription ID; cancellation releases
+only that listener's watches. The proxy reference-counts shared child watches,
+so cancelling one listener cannot unsubscribe another. Child loss ends native
+streams rather than silently moving them to replacement attachments. Clients
+must reconnect, obtain new handles, and establish new baselines.
+
+The shared transport adapter covers two SDK 3.2 lifecycle ordering constraints.
+It primes a native first application request with a private, pure discovery
+request so the SDK's peer pump is running before a tool emits progress or a
+listener acknowledges. It also holds the SDK's early subscription acknowledgment
+in a request-owned slot until the handler has installed its watch. Validation
+errors retain the original request ID; this does not dispatch or replay an
+application operation. Tests exercise first-request progress, filtered
+acknowledgments, cancellation, and child transport loss over the actual SDK wire.
 
 ## Decision 4: Tool intent and guarded publication are the convergence point
 
@@ -536,23 +566,17 @@ application lifecycle checks, not an upstream MCP conformance suite.
 
 ## MCP protocol checkpoint
 
-`Cargo.toml:90` requests `rmcp = "1.4"`; `Cargo.lock:7357` resolves it to 1.5.0.
-That SDK defaults `ServerInfo::new` to MCP `2025-11-25`, which the child and
-proxy use (`crates/runt-mcp/src/lib.rs:413`,
-`crates/runt-mcp-proxy/src/proxy.rs:1113`). Older requested revisions can be
-negotiated by the SDK, but negotiation is not proof of a complete old-client
-compatibility matrix. The child emits resource links without a version-specific
-fallback, and the proxy initializes its child with a separate default-capability
-handshake (`crates/runt-mcp/src/tools/session.rs:808`,
-`crates/runt-mcp-proxy/src/child.rs:28`).
+The workspace uses `rmcp` 3.2.0. The public stdio entrypoints support the four
+legacy revisions from `2024-11-05` through `2025-11-25`, and native `2026-07-28`
+metadata, discovery, and resource subscriptions. The private child handshake is
+pinned to `2025-11-25`. Protocol tests cover negotiation, metadata validation,
+first requests, and old/new SDK interoperability.
 
-The upstream `2026-07-28` revision removes the initialize/protocol-session model
-and introduces per-request metadata, `server/discover`, and MRTR. The shipped
-entrypoints still use initialize-based stdio and do not implement that newer
-contract. Tools, resources, and the MCP Apps UI extension are advertised; the
-SDK dependency alone does not imply every protocol feature is exposed. Detailed
-compatibility and migration followups belong in the
-[MCP, cloud, and Automerge audit](../audits/mcp-cloud-automerge-audit.md).
+This is one upstream client per process. HTTP transport, Tasks, multi-round-trip
+requests, and multiplexing independent clients into one child are outside this
+change. Protocol support does not establish how a particular host exposes
+notifications to its model; host probes and desktop acceptance remain separate
+checks. See the [MCP, cloud, and Automerge audit](../audits/mcp-cloud-automerge-audit.md).
 
 ## Open Follow-ups
 
@@ -579,8 +603,8 @@ already implemented separate-child/shared-daemon model.
    installed wrapper at `crates/nteract-mcp/src/main.rs:204`, dev supervisor at
    `crates/mcp-supervisor/src/main.rs:3159`.
 5. **Protocol compatibility.** Concurrent callers now await shared restart
-   completion. Migration to the newer upstream protocol needs explicit lifecycle work;
-   neither exactly-once execution nor native protocol support follows from
+   completion. Further protocol features need explicit lifecycle work;
+   exactly-once execution does not follow from
    transparent restart or the SDK version.
 
 Already-absent UUID refusal and file-backed UUID registry recovery are


### PR DESCRIPTION
Native MCP clients can discover and call the notebook server without initialize, and listen for changes to a specific notebook attachment. Notebook-scoped tools require the handle returned by connect/create; requests can address parked notebooks without changing the active selection. Released or replaced handles expire instead of silently rebinding.

All three stdio entrypoints support the 2026-07-28 lifecycle alongside the four legacy revisions. Native catalogs are independent of attachment history, with private zero-TTL caching and handle-qualified resource links. The private child remains on 2025-11-25 with empty client capabilities and SDK caching disabled.

Native subscriptions install watches before acknowledgment, correlate updates with the listener ID, and reference-count shared child watches. Cancelling one listener preserves the others; child loss ends the streams. The transport adapter accommodates SDK first-request and early-acknowledgment ordering without replaying application requests.

Validation:
- 247 notebook MCP unit tests, 11 legacy child protocol tests, four native protocol tests, 123 proxy unit tests, 35 proxy protocol tests, 30 supervisor tests, seven installed-wrapper tests, the transport lifetime test, and all 33 runt CLI/unit/startup tests passed.
- Live source-build verification passed through the child, installed wrapper, and development supervisor: parked edits, stable catalogs, collaborator notifications, exact execution completion, comments, handle expiry, and continued use of the active notebook. Cancelling observation preserves daemon execution; historical results retain original source after reruns. Wrapper restart closes streams and returns fresh handles on reconnect. Follow-up live runs also verify that one attachment release preserves another watch, nullable defaults work, CRUD links are usable, and valid native requests work after an initially rejected request. All test processes were cleaned up.
- Full repository lint and affected-crate Clippy passed. Generated tool cache contains 24 tools within the 1,500-byte description budget.
- Kilo correctness and architecture reviews completed; verified link, routing, multi-notebook watch, and startup retry findings were fixed. Focused follow-up review reports no actionable findings. All CI checks passed or were appropriately skipped. Desktop model-context refresh is a separate acceptance check and remains unverified.

Builds on #4217. HTTP, Tasks, multi-round-trip requests, and independent-client multiplexing are outside this change.
