### PR TITLE
fix(notebook-cloud): fixture blob hashes and edit-mode smoke URLs

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 
 import { chromium } from "@playwright/test";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { viewerUrlWithMode } from "./hosted-render-smoke-routes.mjs";
 import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
 
 const viewerUrl =
@@ -53,7 +54,9 @@ async function main() {
   }
   assertScope(requestedScope);
 
-  const url = new URL(viewerUrl);
+  // Execute buttons only accept clicks in edit mode; the runtime-peer smoke
+  // hands over the canonical (view-mode) room URL.
+  const url = new URL(viewerUrlWithMode(viewerUrl, "edit"));
   const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
   const token = JSON.parse(tokenStorageJson);
   const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -13,7 +13,7 @@ import {
 } from "./hosted-collab-smoke-env.mjs";
 import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-performance.mjs";
 import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
-import { isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
+import { isRenderCacheApiUrl, viewerUrlWithMode } from "./hosted-render-smoke-routes.mjs";
 import { firstPositionalArg } from "./cli-args.mjs";
 import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
 
@@ -57,6 +57,10 @@ async function main() {
     ? roomFromViewerUrl(providedViewerUrl)
     : await timed("protocol_seed", seedThrowawayRoom);
   const viewerUrl = room.viewerUrl;
+  // Editing identities must request edit mode; the canonical room URL opens in
+  // view mode. Charlie requests it too so the smoke proves the viewer downgrades
+  // an ungranted editor rather than trivially observing view mode.
+  const editorViewerUrl = viewerUrlWithMode(viewerUrl, "edit");
   const origin = new URL(viewerUrl).origin;
   const checks = [providedViewerUrl ? "reused_existing_room" : "protocol_seeded_throwaway_room"];
   const browser = await chromium.launch({
@@ -73,7 +77,7 @@ async function main() {
       openNotebookContext({
         browser,
         name: "alice",
-        viewerUrl,
+        viewerUrl: editorViewerUrl,
         storageState: storageStateForDevIdentity({
           origin,
           token,
@@ -89,7 +93,7 @@ async function main() {
       openNotebookContext({
         browser,
         name: "bob",
-        viewerUrl,
+        viewerUrl: editorViewerUrl,
         storageState: storageStateForDevIdentity({
           origin,
           token,
@@ -211,7 +215,7 @@ ${bobMarker}
       openNotebookContext({
         browser,
         name: "charlie",
-        viewerUrl,
+        viewerUrl: editorViewerUrl,
         storageState: storageStateForDevIdentity({
           origin,
           token,
@@ -256,6 +260,7 @@ ${bobMarker}
         {
           ok: true,
           viewerUrl,
+          editorViewerUrl,
           roomId: room.roomId,
           checks,
           timings_ms: timingSummary,

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -43,3 +43,18 @@ export function pinnedNotebookViewerUrl(viewerUrl) {
 export function defaultPresenceTitleForViewerUrl(viewerUrl) {
   return pinnedNotebookViewerUrl(viewerUrl) === null ? "participant" : "";
 }
+
+/**
+ * Canonical viewer URLs carry no `mode` and the hosted viewer opens them in
+ * view mode. Smokes that type into cells or click execute must ask for edit
+ * mode explicitly; the viewer still downgrades identities without editor or
+ * owner access back to view.
+ */
+export function viewerUrlWithMode(viewerUrl, mode) {
+  if (mode !== "edit" && mode !== "view") {
+    throw new Error(`viewer mode must be "edit" or "view", got ${JSON.stringify(mode)}`);
+  }
+  const parsed = new URL(viewerUrl);
+  parsed.searchParams.set("mode", mode);
+  return parsed.href;
+}

--- a/apps/notebook-cloud/scripts/publish-fixture-blobs.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture-blobs.mjs
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto";
+
+const SHA256_PREFIX = "sha256:";
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+/**
+ * Resolve the hash a fixture blob must be uploaded under.
+ *
+ * The hosted blob route is content-addressed by bare lowercase sha256 hex and
+ * rejects any path hash that does not equal the digest of the body. Fixture
+ * manifests are expected to carry the same bare hex; an explicit `sha256:`
+ * prefix is tolerated on the way in so older manifests still publish, but the
+ * bytes must match the declared digest either way.
+ */
+export function fixtureBlobUploadHash(blob, bytes) {
+  const declared = typeof blob?.hash === "string" ? blob.hash.trim() : "";
+  if (declared.length === 0) {
+    throw new Error("Fixture blob is missing hash");
+  }
+  const hash = declared.startsWith(SHA256_PREFIX) ? declared.slice(SHA256_PREFIX.length) : declared;
+  if (!SHA256_HEX.test(hash)) {
+    throw new Error(
+      `Fixture blob ${blob.path ?? declared} hash must be sha256 hex, got ${JSON.stringify(declared)}`,
+    );
+  }
+
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (digest !== hash) {
+    throw new Error(
+      `Fixture blob ${blob.path ?? declared} hash mismatch: manifest declares ${hash}, bytes digest to ${digest}`,
+    );
+  }
+  return hash;
+}

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -10,6 +10,7 @@ import {
 } from "./publish-notebook-id.mjs";
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
+import { fixtureBlobUploadHash } from "./publish-fixture-blobs.mjs";
 import { initializeRuntimedWasmSyncForNode } from "./runtimed-wasm-artifact.mjs";
 
 const baseUrl = notebookCloudBaseUrl();
@@ -117,16 +118,10 @@ async function uploadFixtureBlob(blob) {
   const blobUrl = new URL(blob.path, fixtureRoot);
   await assertExists(blobUrl);
   const bytes = await readFile(blobUrl);
-  if (blob.hash.startsWith("sha256:")) {
-    const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
-    assert(
-      digest === blob.hash,
-      `Fixture blob ${blob.path} hash mismatch: ${digest} !== ${blob.hash}`,
-    );
-  }
+  const uploadHash = fixtureBlobUploadHash(blob, bytes);
 
   await putBytes(
-    `/api/n/${encodeURIComponent(notebookId)}/blobs/${encodeURIComponent(blob.hash)}`,
+    `/api/n/${encodeURIComponent(notebookId)}/blobs/${encodeURIComponent(uploadHash)}`,
     bytes,
     typeof blob.content_type === "string" ? blob.content_type : "application/octet-stream",
   );

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -5,7 +5,7 @@ import type { NteractEmbedHostContextPatch } from "../../../../src/components/is
 import { resolveCell, type RenderCell, type ResolvedCell } from "../../viewer/render-resolution.ts";
 import type { SnapshotWidgetComm } from "runtimed";
 
-const ARROW_BLOB_HASH = "sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f";
+const ARROW_BLOB_HASH = "10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f";
 
 const ONE_BY_ONE_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -7,6 +7,7 @@ import {
   isRenderCacheApiUrl,
   notebookViewerUrl,
   pinnedNotebookViewerUrl,
+  viewerUrlWithMode,
 } from "../scripts/hosted-render-smoke-routes.mjs";
 
 describe("hosted render smoke routes", () => {
@@ -73,5 +74,21 @@ describe("hosted render smoke routes", () => {
     assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/blobs/sha256"), false);
     assert.equal(isRenderCacheApiUrl("https://example.com/n/foo/r/heads"), false);
     assert.equal(isRenderCacheApiUrl("not a url"), false);
+  });
+
+  it("adds an explicit mode to canonical viewer URLs", () => {
+    assert.equal(
+      viewerUrlWithMode("http://127.0.0.1:8787/n/room%2Fid/collab", "edit"),
+      "http://127.0.0.1:8787/n/room%2Fid/collab?mode=edit",
+    );
+    assert.equal(
+      viewerUrlWithMode("https://example.com/n/foo/notebook?mode=view&profile=1#cell", "edit"),
+      "https://example.com/n/foo/notebook?mode=edit&profile=1#cell",
+    );
+    assert.equal(
+      viewerUrlWithMode("https://example.com/n/foo/notebook?mode=edit", "view"),
+      "https://example.com/n/foo/notebook?mode=view",
+    );
+    assert.throws(() => viewerUrlWithMode("https://example.com/n/foo/notebook", "owner"), /mode/);
   });
 });

--- a/apps/notebook-cloud/test/publish-fixture-blobs.test.mjs
+++ b/apps/notebook-cloud/test/publish-fixture-blobs.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+import { fixtureBlobUploadHash } from "../scripts/publish-fixture-blobs.mjs";
+
+const bytes = new TextEncoder().encode("fixture blob body");
+const digest = createHash("sha256").update(bytes).digest("hex");
+
+describe("publish fixture blob hashes", () => {
+  it("uploads bare sha256 hex manifests under the declared hash", () => {
+    assert.equal(fixtureBlobUploadHash({ hash: digest, path: "blobs/a.bin" }, bytes), digest);
+  });
+
+  it("strips a sha256: prefix so the Worker path hash matches the body digest", () => {
+    assert.equal(
+      fixtureBlobUploadHash({ hash: `sha256:${digest}`, path: "blobs/a.bin" }, bytes),
+      digest,
+    );
+  });
+
+  it("rejects bytes that do not digest to the declared hash", () => {
+    assert.throws(
+      () => fixtureBlobUploadHash({ hash: digest, path: "blobs/a.bin" }, new Uint8Array([1])),
+      /hash mismatch: manifest declares/,
+    );
+  });
+
+  it("rejects hashes that are not sha256 hex", () => {
+    assert.throws(() => fixtureBlobUploadHash({ hash: "" }, bytes), /missing hash/);
+    assert.throws(
+      () => fixtureBlobUploadHash({ hash: "md5:abc", path: "blobs/a.bin" }, bytes),
+      /must be sha256 hex/,
+    );
+    assert.throws(
+      () => fixtureBlobUploadHash({ hash: "sha256:not-hex" }, bytes),
+      /must be sha256 hex/,
+    );
+  });
+
+  it("matches the checked-in sift_arrow_output fixture", async () => {
+    const fixtureRoot = new URL(
+      "../../../packages/runtimed/tests/fixtures/sift_arrow_output/",
+      import.meta.url,
+    );
+    const manifest = JSON.parse(await readFile(new URL("manifest.json", fixtureRoot), "utf8"));
+    const [blob] = manifest.blobs;
+    const blobBytes = await readFile(new URL(blob.path, fixtureRoot));
+
+    assert.equal(fixtureBlobUploadHash(blob, blobBytes), blob.hash);
+    assert.match(blob.hash, /^[0-9a-f]{64}$/);
+  });
+});

--- a/crates/notebook-doc/tests/generate_fixtures.rs
+++ b/crates/notebook-doc/tests/generate_fixtures.rs
@@ -136,9 +136,11 @@ fn inline(s: &str) -> ContentRef {
     }
 }
 
+/// Bare lowercase hex, matching the daemon `BlobStore` and the hosted blob
+/// route: blob refs carry no `sha256:` algorithm prefix anywhere in the
+/// production output path, so fixtures must not introduce one.
 fn sha256_hex(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    format!("sha256:{}", hex::encode(digest))
+    hex::encode(Sha256::digest(bytes))
 }
 
 // ── Fixture writing ─────────────────────────────────────────────────
@@ -514,7 +516,8 @@ fn scenario_sift_arrow_output() {
     let arrow_bytes = fs::read(&arrow_path).expect("read polars arrow fixture");
     let arrow_hash = sha256_hex(&arrow_bytes);
     let arrow_size = arrow_bytes.len() as u64;
-    let blob_path = format!("blobs/{}.arrow", arrow_hash.replace(':', "-"));
+    // The sidecar file name spells out the algorithm; the hash itself stays bare.
+    let blob_path = format!("blobs/sha256-{arrow_hash}.arrow");
     let blob = FixtureBlob {
         hash: arrow_hash.clone(),
         path: blob_path.clone(),

--- a/packages/runtimed/tests/fixtures/sift_arrow_output/manifest.json
+++ b/packages/runtimed/tests/fixtures/sift_arrow_output/manifest.json
@@ -2,7 +2,7 @@
   "blobs": [
     {
       "content_type": "application/vnd.apache.arrow.stream",
-      "hash": "sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f",
+      "hash": "10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f",
       "path": "blobs/sha256-10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f.arrow",
       "size": 9352
     }
@@ -10,7 +10,7 @@
   "description": "Cell produces a Sift-compatible Arrow stream manifest with a real blob sidecar",
   "expected": {
     "blob_content_type": "application/vnd.apache.arrow.stream",
-    "blob_hash": "sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f",
+    "blob_hash": "10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f",
     "blob_path": "blobs/sha256-10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f.arrow",
     "blob_size": 9352,
     "cell_id": "cell-1",

--- a/packages/runtimed/tests/fixtures/sift_arrow_output/state_doc.bin
+++ b/packages/runtimed/tests/fixtures/sift_arrow_output/state_doc.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f373c5b4aecee76eb217c36c01a394ba593b987ac53a9865c9007e8217ee2fe2
-size 1191
+oid sha256:07973fdd1e023abfb3d4a7648e575f0cbe9473623958b5b5ee5c88960cd3dd01
+size 1175


### PR DESCRIPTION
Two pre-existing bugs in the `apps/notebook-cloud` scripts, both found while running the hosted smokes against a loopback Worker in #4219. Neither is host-specific.

## Fixture blob hashes carried a `sha256:` prefix the Worker never accepts

`publish:fixture` with `NOTEBOOK_CLOUD_FIXTURE=sift_arrow_output` failed with `blob hash mismatch` because the fixture manifest declared `"hash": "sha256:<hex>"` and the script put that value in the blob path. The Worker's blob route is content-addressed by bare hex and compares the path hash to the body digest.

Stripping the prefix in the upload path alone would not have been enough. The same prefixed hash sits inside the inline Arrow manifest in `state_doc.bin`, and the snapshot publish checks R2 for every blob the materialized render references, so the failure would have moved to a 424. The prefix was also fixture-only: dx emits `hexdigest()`, the daemon `BlobStore` keys by bare hex, and the runtime peer uploads by bare hex. The fixture generator (`crates/notebook-doc/tests/generate_fixtures.rs`) was the single source of the prefixed form.

The fix makes the generator emit bare hex and regenerates the sift fixture. `doc.bin` and the `.arrow` sidecar are byte-identical; only `manifest.json` and `state_doc.bin` change. `publish-fixture.mjs` now always verifies the sidecar bytes against the declared digest and tolerates a leading `sha256:` on the way in, uploading under the bare hex the Worker validates. The Worker's hash validation is untouched.

## Editing smokes opened the canonical (view-mode) URL

Canonical viewer URLs carry no `mode` query and the viewer opens them in view mode. `smoke:hosted:collab` with no URL argument seeds a room via `wasm-roundtrip.mjs` and opened that URL for every identity, so `ensureEditableMarkdown` timed out waiting for a contenteditable editor that view mode never renders. `hosted-browser-execute-smoke.mjs` has the same gap: the runtime-peer smoke hands it the canonical URL and execute buttons only accept clicks when the cell is not read-only.

`viewerUrlWithMode` in `hosted-render-smoke-routes.mjs` sets the mode on a viewer URL. The collab smoke opens alice, bob, and charlie with `?mode=edit`; charlie requesting edit is what makes the ungranted-editor downgrade assertion meaningful. The anonymous viewer keeps the plain URL. Canonical URL producers (`canonicalViewerUrl`, `viewerUrlForRoom`, the Worker's `viewer_url`) are unchanged so links in smoke output still open in view mode. The widget cross-window and workstation toolbar smokes do not depend on edit surfaces (the toolbar smoke switches mode through the UI on purpose) and are left alone.

## Verification

`pnpm --dir apps/notebook-cloud typecheck` and `test` pass (1458 tests). `packages/runtimed/tests/fixture-integration.test.ts` passes against the regenerated fixture. Against a local Wrangler Worker: `publish:fixture` for `sift_arrow_output` succeeds and the blob GETs back with a matching digest; `smoke:hosted:collab` with no URL argument passes all 18 checks including `ungranted_editor_downgraded_to_viewer`. The browser-execute change was not exercised live because that smoke needs an OIDC token and a running runtime peer.
