### PR TITLE
fix(runtimed): stop duplicating stream outputs when stdout and stderr interleave

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1618,6 +1618,14 @@ impl KernelConnection for JupyterKernel {
 
                 let comm_coalesce_tx = comm_coalesce_tx_for_iopub;
                 let mut stream_flushes = StreamFlushBuffer::default();
+                // Ordinary outputs (display_data, execute_result, error) and
+                // stream flushes commit on separate queues. A stream chunk that
+                // follows an ordinary output must not reach the document first,
+                // or it lands before that output and the end-of-execution
+                // stream flush then appends it a second time. Set after each
+                // ordinary output is enqueued; the next stream chunk drains the
+                // output committer before it is fed.
+                let mut stream_awaits_ordinary_outputs = false;
 
                 loop {
                     match iopub.read().await {
@@ -1872,19 +1880,21 @@ impl KernelConnection for JupyterKernel {
                                         };
                                         let eid = execution_id.clone().unwrap_or_default();
 
-                                        {
-                                            let mut terminals = iopub_stream_terminals.lock().await;
-                                            terminals.feed_chunk(&eid, stream_name, &stream.text);
+                                        if stream_awaits_ordinary_outputs {
+                                            output_committer.flush_for_ordering().await;
+                                            stream_awaits_ordinary_outputs = false;
                                         }
 
-                                        if let Some(flush) = stream_flushes.record_chunk(
+                                        crate::stream_committer::ingest_stream_chunk(
+                                            &iopub_stream_terminals,
+                                            &mut stream_flushes,
+                                            &stream_committer,
                                             &eid,
                                             stream_name,
-                                            stream.text.len(),
+                                            &stream.text,
                                             std::time::Instant::now(),
-                                        ) {
-                                            stream_committer.request_flush(flush);
-                                        }
+                                        )
+                                        .await;
                                     }
                                 }
 
@@ -2046,6 +2056,7 @@ impl KernelConnection for JupyterKernel {
                                                     },
                                                 })
                                                 .await;
+                                            stream_awaits_ordinary_outputs = true;
 
                                             // Rich-traceback detection. A display_data or
                                             // execute_result carrying TRACEBACK_MIME IS an error
@@ -2211,6 +2222,7 @@ impl KernelConnection for JupyterKernel {
                                                     kind: OrdinaryOutputKind::Error,
                                                 })
                                                 .await;
+                                            stream_awaits_ordinary_outputs = true;
                                         }
 
                                         output_committer.flush_then_signal(

--- a/crates/runtimed/src/output_committer.rs
+++ b/crates/runtimed/src/output_committer.rs
@@ -787,6 +787,7 @@ mod tests {
             vec![crate::stream_flush::PendingStreamFlush {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
+                segment: 0,
             }],
             LifecycleSignal::ExecutionDone {
                 execution_id: "exec-1".to_string(),

--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -17,7 +17,7 @@ use crate::output_blob_publisher::publish_or_warn;
 use crate::output_commit_context::OutputCommitContext;
 use crate::output_prep::LifecycleSignal;
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
-use crate::stream_flush::PendingStreamFlush;
+use crate::stream_flush::{PendingStreamFlush, StreamFlushBuffer};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
 use crate::task_supervisor::spawn_supervised;
 
@@ -75,6 +75,21 @@ impl StreamCommitterHandle {
         for flush in flushes {
             self.request_flush(flush);
         }
+    }
+
+    /// Queue a flush that must commit before any later periodic flush.
+    ///
+    /// Used for a stream segment sealed by the other stream interleaving: the
+    /// sealed text has to reach the document before the next stream's output is
+    /// appended, or the upsert would append it again after that output. The
+    /// priority queue is unbounded and FIFO, so this is never dropped and does
+    /// not block the caller.
+    pub(crate) fn request_ordered_flush(&self, flush: PendingStreamFlush) {
+        let _ = self.priority_tx.send(PriorityStreamCommit {
+            flushes: timed_stream_flushes(vec![flush]),
+            signal: None,
+            ack: None,
+        });
     }
 
     /// Flush streams through the committer before the caller performs an
@@ -272,19 +287,19 @@ pub(crate) async fn commit_stream_flush(
 ) {
     let (known_state, rendered_text) = {
         let terminals = stream_terminals.lock().await;
-        if !terminals.has_stream(&flush.execution_id, &flush.stream_name) {
+        if !terminals.has_segment(&flush.execution_id, &flush.stream_name, flush.segment) {
             debug!(
-                "[stream-committer] Skipping stale stream flush for execution={} stream={}",
-                flush.execution_id, flush.stream_name
+                "[stream-committer] Skipping stale stream flush for execution={} stream={} segment={}",
+                flush.execution_id, flush.stream_name, flush.segment
             );
             return;
         }
         (
             terminals
-                .get_output_state(&flush.execution_id, &flush.stream_name)
+                .get_segment_output_state(&flush.execution_id, &flush.stream_name, flush.segment)
                 .cloned(),
             terminals
-                .render(&flush.execution_id, &flush.stream_name)
+                .render_segment(&flush.execution_id, &flush.stream_name, flush.segment)
                 .unwrap_or_default(),
         )
     };
@@ -356,14 +371,57 @@ pub(crate) async fn commit_stream_flush(
 
     let (_updated, output_id) = upsert_result;
     let mut terminals = stream_terminals.lock().await;
-    terminals.set_output_state(
+    terminals.set_segment_output_state(
         &flush.execution_id,
         &flush.stream_name,
+        flush.segment,
         StreamOutputState {
             output_id,
             blob_hash,
         },
     );
+    // A sealed segment receives no more chunks; this commit rendered its final
+    // text, so its terminal can go. No-op for the current segment.
+    terminals.retire_segment(&flush.execution_id, &flush.stream_name, flush.segment);
+}
+
+/// Route one IOPub stream chunk through the terminals and the committer.
+///
+/// Feeds the chunk into the stream's current terminal segment. If the chunk
+/// switched streams, the other stream's segment is sealed and its flush is
+/// queued ahead of everything periodic so the document keeps nbformat order:
+/// `stdout, stderr, stdout` becomes three outputs, each holding only its own
+/// text. Then the usual coalescing policy decides whether this chunk's segment
+/// flushes now.
+pub(crate) async fn ingest_stream_chunk(
+    stream_terminals: &Arc<Mutex<StreamTerminals>>,
+    stream_flushes: &mut StreamFlushBuffer,
+    committer: &StreamCommitterHandle,
+    execution_id: &str,
+    stream_name: &str,
+    text: &str,
+    now: std::time::Instant,
+) {
+    let placement = {
+        let mut terminals = stream_terminals.lock().await;
+        terminals.feed_chunk(execution_id, stream_name, text)
+    };
+    if let Some(sealed) = placement.sealed {
+        if let Some(flush) =
+            stream_flushes.take_segment(execution_id, &sealed.stream_name, sealed.segment, now)
+        {
+            committer.request_ordered_flush(flush);
+        }
+    }
+    if let Some(flush) = stream_flushes.record_chunk(
+        execution_id,
+        stream_name,
+        placement.segment,
+        text.len(),
+        now,
+    ) {
+        committer.request_flush(flush);
+    }
 }
 
 #[cfg(test)]
@@ -434,6 +492,7 @@ mod tests {
             vec![PendingStreamFlush {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
+                segment: 0,
             }],
             LifecycleSignal::ExecutionDone {
                 execution_id: "exec-1".to_string(),
@@ -466,6 +525,182 @@ mod tests {
         assert_eq!(outputs[0]["name"], "stdout");
     }
 
+    fn stream_text(output: &serde_json::Value) -> String {
+        output["text"]["inline"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    /// `print("out-1"); print("err-1", file=sys.stderr); print("out-2")` must
+    /// produce three outputs holding only their own text. Before segments, the
+    /// stdout terminal kept accumulating across the stderr interleave and the
+    /// final flush re-committed clean streams, so the document ended up with
+    /// `out-1`, `err-1`, `out-1\nout-2`, `err-1`.
+    #[tokio::test]
+    async fn interleaved_streams_commit_one_output_per_segment() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(dir.path().to_path_buf()));
+        let state = runtime_state();
+        create_execution(&state);
+
+        let terminals = Arc::new(Mutex::new(StreamTerminals::new()));
+        let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
+        let handle = start_stream_committer(
+            commit_context(state.clone(), blob_store, lifecycle_tx),
+            terminals.clone(),
+        );
+        // Zero delay so every chunk flushes on arrival, like chunks spaced
+        // further apart than STREAM_FLUSH_MAX_DELAY.
+        let mut flushes = StreamFlushBuffer::new(std::time::Duration::ZERO, 1024);
+        let now = std::time::Instant::now();
+
+        for (stream, text) in [
+            ("stdout", "out-1\n"),
+            ("stderr", "err-1\n"),
+            ("stdout", "out-2\n"),
+        ] {
+            ingest_stream_chunk(
+                &terminals,
+                &mut flushes,
+                &handle,
+                "exec-1",
+                stream,
+                text,
+                now,
+            )
+            .await;
+        }
+
+        let done = flushes.flush_execution("exec-1", now);
+        flushes.clear_execution("exec-1");
+        handle.flush_then_signal(
+            done,
+            LifecycleSignal::ExecutionDone {
+                execution_id: "exec-1".to_string(),
+            },
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(2), lifecycle_rx.recv())
+            .await
+            .expect("signal timeout")
+            .expect("signal");
+
+        let outputs = state
+            .read(|sd| sd.get_outputs("exec-1"))
+            .expect("read outputs");
+        let summary: Vec<(String, String)> = outputs
+            .iter()
+            .map(|output| {
+                (
+                    output["name"].as_str().unwrap_or_default().to_string(),
+                    stream_text(output),
+                )
+            })
+            .collect();
+        assert_eq!(
+            summary,
+            vec![
+                ("stdout".to_string(), "out-1\n".to_string()),
+                ("stderr".to_string(), "err-1\n".to_string()),
+                ("stdout".to_string(), "out-2\n".to_string()),
+            ]
+        );
+
+        // Sealed segments are retired once committed; the live one stays.
+        let terminals = terminals.lock().await;
+        assert!(!terminals.has_segment("exec-1", "stdout", 0));
+        assert!(!terminals.has_segment("exec-1", "stderr", 0));
+        assert!(terminals.has_segment("exec-1", "stdout", 1));
+    }
+
+    /// Chunks that arrive faster than the coalescing delay stay in the same
+    /// segment and update in place; the interleave still splits correctly.
+    #[tokio::test]
+    async fn coalesced_chunks_before_an_interleave_stay_in_one_output() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(dir.path().to_path_buf()));
+        let state = runtime_state();
+        create_execution(&state);
+
+        let terminals = Arc::new(Mutex::new(StreamTerminals::new()));
+        let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
+        let handle = start_stream_committer(
+            commit_context(state.clone(), blob_store, lifecycle_tx),
+            terminals.clone(),
+        );
+        let mut flushes = StreamFlushBuffer::new(std::time::Duration::from_secs(60), 1 << 20);
+        let now = std::time::Instant::now();
+
+        // "a" flushes immediately (first chunk); "b" and "c" coalesce and are
+        // still pending when stderr interleaves.
+        for text in ["a\n", "b\n", "c\n"] {
+            ingest_stream_chunk(
+                &terminals,
+                &mut flushes,
+                &handle,
+                "exec-1",
+                "stdout",
+                text,
+                now,
+            )
+            .await;
+        }
+        ingest_stream_chunk(
+            &terminals,
+            &mut flushes,
+            &handle,
+            "exec-1",
+            "stderr",
+            "e\n",
+            now,
+        )
+        .await;
+        ingest_stream_chunk(
+            &terminals,
+            &mut flushes,
+            &handle,
+            "exec-1",
+            "stdout",
+            "d\n",
+            now,
+        )
+        .await;
+
+        let done = flushes.flush_execution("exec-1", now);
+        flushes.clear_execution("exec-1");
+        handle.flush_then_signal(
+            done,
+            LifecycleSignal::ExecutionDone {
+                execution_id: "exec-1".to_string(),
+            },
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(2), lifecycle_rx.recv())
+            .await
+            .expect("signal timeout")
+            .expect("signal");
+
+        let outputs = state
+            .read(|sd| sd.get_outputs("exec-1"))
+            .expect("read outputs");
+        let summary: Vec<(String, String)> = outputs
+            .iter()
+            .map(|output| {
+                (
+                    output["name"].as_str().unwrap_or_default().to_string(),
+                    stream_text(output),
+                )
+            })
+            .collect();
+        assert_eq!(
+            summary,
+            vec![
+                ("stdout".to_string(), "a\nb\nc\n".to_string()),
+                ("stderr".to_string(), "e\n".to_string()),
+                ("stdout".to_string(), "d\n".to_string()),
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn flush_for_ordering_commits_without_lifecycle_signal() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -489,6 +724,7 @@ mod tests {
             .flush_for_ordering(vec![PendingStreamFlush {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
+                segment: 0,
             }])
             .await;
 
@@ -515,6 +751,7 @@ mod tests {
             PendingStreamFlush {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
+                segment: 0,
             },
         )
         .await;
@@ -574,10 +811,12 @@ mod tests {
         handle.request_flush(PendingStreamFlush {
             execution_id: "exec-1".to_string(),
             stream_name: "stdout".to_string(),
+            segment: 0,
         });
         handle.request_flush(PendingStreamFlush {
             execution_id: "exec-2".to_string(),
             stream_name: "stdout".to_string(),
+            segment: 0,
         });
 
         let received = periodic_rx.try_recv().expect("first flush stays queued");

--- a/crates/runtimed/src/stream_flush.rs
+++ b/crates/runtimed/src/stream_flush.rs
@@ -9,7 +9,8 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-type StreamKey = (String, String);
+/// One coalescing entry per terminal segment: (execution_id, stream_name, segment).
+type StreamKey = (String, String, u64);
 
 pub(crate) const STREAM_FLUSH_MAX_DELAY: Duration = Duration::from_millis(75);
 pub(crate) const STREAM_FLUSH_MAX_BYTES: usize = 64 * 1024;
@@ -18,6 +19,9 @@ pub(crate) const STREAM_FLUSH_MAX_BYTES: usize = 64 * 1024;
 pub(crate) struct PendingStreamFlush {
     pub execution_id: String,
     pub stream_name: String,
+    /// Terminal segment this flush renders. Segments split a stream where the
+    /// other stream interleaved; each maps to one output in the document.
+    pub segment: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -53,10 +57,11 @@ impl StreamFlushBuffer {
         &mut self,
         execution_id: &str,
         stream_name: &str,
+        segment: u64,
         chunk_bytes: usize,
         now: Instant,
     ) -> Option<PendingStreamFlush> {
-        let key = (execution_id.to_string(), stream_name.to_string());
+        let key = (execution_id.to_string(), stream_name.to_string(), segment);
         let entry = self.entries.entry(key.clone()).or_insert(StreamFlushEntry {
             pending_bytes: 0,
             has_flushed: false,
@@ -74,24 +79,49 @@ impl StreamFlushBuffer {
         None
     }
 
+    /// Take every segment of an execution for a boundary flush.
+    ///
+    /// Clean segments are included on purpose: a periodic flush may still be
+    /// queued behind this boundary, and re-rendering the live segment here is
+    /// what makes its latest text durable before the boundary's signal. Sealed
+    /// segments have been retired by their own ordered flush by the time this
+    /// runs, so the committer skips them instead of appending a second copy.
+    /// Segments are returned in creation order so earlier text commits first.
     pub(crate) fn flush_execution(
         &mut self,
         execution_id: &str,
         now: Instant,
     ) -> Vec<PendingStreamFlush> {
-        let keys: Vec<_> = self
+        let mut keys: Vec<_> = self
             .entries
             .keys()
-            .filter(|(eid, _)| eid == execution_id)
+            .filter(|(eid, _, _)| eid == execution_id)
             .cloned()
             .collect();
+        keys.sort_by_key(|(_, _, segment)| *segment);
         keys.into_iter()
             .filter_map(|key| self.take_key(&key, now))
             .collect()
     }
 
+    /// Take one segment's flush.
+    ///
+    /// Used when the other stream interleaves: the sealed segment must reach
+    /// the document before the next stream's output is appended, and its
+    /// terminal is retired after that commit, so it is flushed even when clean.
+    pub(crate) fn take_segment(
+        &mut self,
+        execution_id: &str,
+        stream_name: &str,
+        segment: u64,
+        now: Instant,
+    ) -> Option<PendingStreamFlush> {
+        let key = (execution_id.to_string(), stream_name.to_string(), segment);
+        self.take_key(&key, now)
+    }
+
     pub(crate) fn clear_execution(&mut self, execution_id: &str) {
-        self.entries.retain(|(eid, _), _| eid != execution_id);
+        self.entries.retain(|(eid, _, _), _| eid != execution_id);
     }
 
     fn take_key(&mut self, key: &StreamKey, now: Instant) -> Option<PendingStreamFlush> {
@@ -102,6 +132,7 @@ impl StreamFlushBuffer {
         Some(PendingStreamFlush {
             execution_id: key.0.clone(),
             stream_name: key.1.clone(),
+            segment: key.2,
         })
     }
 }
@@ -120,7 +151,7 @@ mod tests {
         let mut buffer = buffer();
 
         let flush = buffer
-            .record_chunk("e1", "stdout", 5, now)
+            .record_chunk("e1", "stdout", 0, 5, now)
             .expect("first chunk should flush");
 
         assert_eq!(flush.execution_id, "e1");
@@ -131,13 +162,13 @@ mod tests {
     fn subsequent_small_chunks_are_coalesced_until_delay() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer.record_chunk("e1", "stdout", 1, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 1, now).is_some());
         assert!(buffer
-            .record_chunk("e1", "stdout", 1, now + Duration::from_millis(10))
+            .record_chunk("e1", "stdout", 0, 1, now + Duration::from_millis(10))
             .is_none());
 
         buffer
-            .record_chunk("e1", "stdout", 1, now + Duration::from_millis(100))
+            .record_chunk("e1", "stdout", 0, 1, now + Duration::from_millis(100))
             .expect("delay should flush");
     }
 
@@ -145,11 +176,11 @@ mod tests {
     fn byte_threshold_flushes() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer.record_chunk("e1", "stdout", 1, now).is_some());
-        assert!(buffer.record_chunk("e1", "stdout", 6, now).is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 1, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 6, now).is_none());
 
         buffer
-            .record_chunk("e1", "stdout", 4, now)
+            .record_chunk("e1", "stdout", 0, 4, now)
             .expect("byte threshold should flush");
     }
 
@@ -157,12 +188,12 @@ mod tests {
     fn flush_execution_returns_all_dirty_streams_for_execution() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer.record_chunk("e1", "stdout", 3, now).is_some());
-        assert!(buffer.record_chunk("e1", "stdout", 4, now).is_none());
-        assert!(buffer.record_chunk("e1", "stderr", 3, now).is_some());
-        assert!(buffer.record_chunk("e1", "stderr", 4, now).is_none());
-        assert!(buffer.record_chunk("e2", "stdout", 5, now).is_some());
-        assert!(buffer.record_chunk("e2", "stdout", 6, now).is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 4, now).is_none());
+        assert!(buffer.record_chunk("e1", "stderr", 0, 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stderr", 0, 4, now).is_none());
+        assert!(buffer.record_chunk("e2", "stdout", 0, 5, now).is_some());
+        assert!(buffer.record_chunk("e2", "stdout", 0, 6, now).is_none());
 
         let mut flushes = buffer.flush_execution("e1", now);
         flushes.sort_by(|a, b| a.stream_name.cmp(&b.stream_name));
@@ -178,11 +209,42 @@ mod tests {
     }
 
     #[test]
+    fn flush_execution_orders_segments_by_creation() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        for segment in [2_u64, 0, 1] {
+            assert!(buffer
+                .record_chunk("e1", "stdout", segment, 3, now)
+                .is_some());
+            assert!(buffer
+                .record_chunk("e1", "stdout", segment, 2, now)
+                .is_none());
+        }
+
+        let flushes = buffer.flush_execution("e1", now);
+        let segments: Vec<u64> = flushes.iter().map(|flush| flush.segment).collect();
+        assert_eq!(segments, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn take_segment_flushes_a_clean_segment() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        assert!(buffer.record_chunk("e1", "stdout", 0, 3, now).is_some());
+
+        let flush = buffer
+            .take_segment("e1", "stdout", 0, now)
+            .expect("sealed segment flushes even when clean");
+        assert_eq!(flush.segment, 0);
+        assert!(buffer.take_segment("e1", "stdout", 7, now).is_none());
+    }
+
+    #[test]
     fn clear_execution_discards_dirty_streams() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer.record_chunk("e1", "stdout", 3, now).is_some());
-        assert!(buffer.record_chunk("e1", "stdout", 4, now).is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 0, 4, now).is_none());
 
         buffer.clear_execution("e1");
 

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -6,7 +6,7 @@
 //! emulator, and the rendered content is serialized back to ANSI text for the
 //! frontend to display.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use alacritty_terminal::event::VoidListener;
 use alacritty_terminal::grid::Dimensions;
@@ -22,12 +22,37 @@ use crate::terminal_size::{TERMINAL_COLUMNS, TERMINAL_LINES};
 /// Keep minimal since notebook outputs don't need scrollback.
 const SCROLLBACK_HISTORY: usize = 10000;
 
-/// Key for terminal buffers: (execution_id, stream_name).
+/// Key for a stream within an execution: (execution_id, stream_name).
 type StreamKey = (String, String);
+
+/// Key for one terminal segment: (execution_id, stream_name, segment).
+///
+/// A stream is split into segments at every point where the other stream
+/// interleaves. Each segment maps to exactly one `stream` output in the
+/// RuntimeStateDoc, so `stdout, stderr, stdout` renders as three outputs with
+/// only the text that belongs to each, matching nbformat's coalescing rule.
+type SegmentKey = (String, String, u64);
 
 // Re-export from the shared notebook-doc crate so existing callers
 // (output_prep, notebook_sync_server) continue to compile.
 pub use runtime_doc::StreamOutputState;
+
+/// A sealed segment: the other stream interleaved after it, so no further
+/// chunks will land in it. Its pending text still has to be committed, and its
+/// terminal can be retired once that commit has rendered it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedStreamSegment {
+    pub stream_name: String,
+    pub segment: u64,
+}
+
+/// Where a fed chunk landed, plus the segment it sealed on the other stream
+/// (if this chunk switched streams).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamChunkPlacement {
+    pub segment: u64,
+    pub sealed: Option<SealedStreamSegment>,
+}
 
 /// Simple dimensions struct for creating terminals.
 struct TermDimensions {
@@ -60,17 +85,28 @@ impl Dimensions for TermDimensions {
 
 /// Manages terminal emulators for stream outputs.
 ///
-/// Each (execution_id, stream_name) pair gets its own terminal emulator to properly
-/// handle escape sequences. When text is fed to a stream, it's processed through
-/// the terminal and the rendered content is returned as ANSI text.
+/// Each (execution_id, stream_name, segment) gets its own terminal emulator to
+/// properly handle escape sequences. A new segment starts whenever the other
+/// stream interleaves, because the previous segment's output is no longer the
+/// last output of the execution and must not absorb later text. A sealed
+/// segment's terminal stays alive until its final commit has rendered it, then
+/// `retire_segment` drops it.
 ///
-/// Also tracks the output state (index + manifest hash) for each stream to enable
-/// efficient in-place updates with validation against external modifications.
+/// Also tracks the output state (output_id + manifest hash) for each segment to
+/// enable efficient in-place updates with validation against external
+/// modifications.
 pub struct StreamTerminals {
-    terminals: HashMap<StreamKey, Term<VoidListener>>,
-    processors: HashMap<StreamKey, Processor>,
-    /// Output state for each (execution_id, stream_name) - tracks output_id and last hash for validation.
-    output_states: HashMap<StreamKey, StreamOutputState>,
+    terminals: HashMap<SegmentKey, Term<VoidListener>>,
+    processors: HashMap<SegmentKey, Processor>,
+    /// Output state per segment - tracks output_id and last hash for validation.
+    output_states: HashMap<SegmentKey, StreamOutputState>,
+    /// Segment currently receiving chunks for each stream.
+    current_segments: HashMap<StreamKey, u64>,
+    /// Stream that received the most recent chunk for each execution.
+    last_stream: HashMap<String, String>,
+    /// Segments the other stream has interleaved after. They take no more
+    /// chunks and are dropped once their final commit has rendered them.
+    sealed_segments: HashSet<SegmentKey>,
 }
 
 impl Default for StreamTerminals {
@@ -86,14 +122,52 @@ impl StreamTerminals {
             terminals: HashMap::new(),
             processors: HashMap::new(),
             output_states: HashMap::new(),
+            current_segments: HashMap::new(),
+            last_stream: HashMap::new(),
+            sealed_segments: HashSet::new(),
         }
     }
 
-    /// Feed text to the terminal for (execution_id, stream_name).
-    pub fn feed_chunk(&mut self, execution_id: &str, stream_name: &str, text: &str) {
-        let key = (execution_id.to_string(), stream_name.to_string());
+    /// Feed text to the current segment of (execution_id, stream_name).
+    ///
+    /// If this chunk switches streams, the other stream's current segment is
+    /// sealed and returned so the caller can commit it ahead of this stream's
+    /// next output. If this stream already had a segment, it moves to a fresh
+    /// one so its next output carries only text from after the switch.
+    pub fn feed_chunk(
+        &mut self,
+        execution_id: &str,
+        stream_name: &str,
+        text: &str,
+    ) -> StreamChunkPlacement {
+        let stream_key = (execution_id.to_string(), stream_name.to_string());
+        let mut sealed = None;
+        match self.last_stream.get(execution_id) {
+            Some(previous) if previous != stream_name => {
+                let previous_key = (execution_id.to_string(), previous.clone());
+                if let Some(segment) = self.current_segments.get(&previous_key) {
+                    self.sealed_segments.insert((
+                        execution_id.to_string(),
+                        previous.clone(),
+                        *segment,
+                    ));
+                    sealed = Some(SealedStreamSegment {
+                        stream_name: previous.clone(),
+                        segment: *segment,
+                    });
+                }
+                if let Some(segment) = self.current_segments.get_mut(&stream_key) {
+                    *segment += 1;
+                }
+            }
+            _ => {}
+        }
+        self.last_stream
+            .insert(execution_id.to_string(), stream_name.to_string());
+        let segment = *self.current_segments.entry(stream_key).or_insert(0);
+        let key = (execution_id.to_string(), stream_name.to_string(), segment);
 
-        // Get or create terminal and processor for this stream
+        // Get or create terminal and processor for this segment
         let term = self.terminals.entry(key.clone()).or_insert_with(|| {
             let config = Config {
                 scrolling_history: SCROLLBACK_HISTORY,
@@ -115,22 +189,43 @@ impl StreamTerminals {
                 processor.advance(term, std::slice::from_ref(byte));
             }
         }
+        StreamChunkPlacement { segment, sealed }
     }
 
-    /// Render the terminal content for (execution_id, stream_name).
+    /// Segment currently receiving chunks for (execution_id, stream_name).
+    pub fn current_segment(&self, execution_id: &str, stream_name: &str) -> Option<u64> {
+        self.current_segments
+            .get(&(execution_id.to_string(), stream_name.to_string()))
+            .copied()
+    }
+
+    /// Render the current segment of (execution_id, stream_name).
     pub fn render(&self, execution_id: &str, stream_name: &str) -> Option<String> {
-        let key = (execution_id.to_string(), stream_name.to_string());
-        self.terminals.get(&key).map(serialize_to_ansi)
+        let segment = self.current_segment(execution_id, stream_name)?;
+        self.render_segment(execution_id, stream_name, segment)
+    }
+
+    /// Render one segment's terminal content.
+    pub fn render_segment(
+        &self,
+        execution_id: &str,
+        stream_name: &str,
+        segment: u64,
+    ) -> Option<String> {
+        self.terminals
+            .get(&(execution_id.to_string(), stream_name.to_string(), segment))
+            .map(serialize_to_ansi)
     }
 
     /// Feed text to the terminal for (execution_id, stream_name).
     ///
-    /// Returns the rendered ANSI text representation of the terminal content.
+    /// Returns the rendered ANSI text representation of the current segment.
     /// This handles escape sequences like `\r` (carriage return) and cursor
     /// movement, so progress bars will show only their final state.
     pub fn feed(&mut self, execution_id: &str, stream_name: &str, text: &str) -> String {
-        self.feed_chunk(execution_id, stream_name, text);
-        self.render(execution_id, stream_name).unwrap_or_default()
+        let placement = self.feed_chunk(execution_id, stream_name, text);
+        self.render_segment(execution_id, stream_name, placement.segment)
+            .unwrap_or_default()
     }
 
     /// Clear terminal(s) for an execution.
@@ -138,43 +233,100 @@ impl StreamTerminals {
     /// Called when a non-stream output arrives to break the stream chain,
     /// or when clearing outputs for an execution.
     pub fn clear(&mut self, execution_id: &str) {
-        // Remove all terminals for this execution (both stdout and stderr)
-        self.terminals.retain(|(eid, _), _| eid != execution_id);
-        self.processors.retain(|(eid, _), _| eid != execution_id);
-        self.output_states.retain(|(eid, _), _| eid != execution_id);
+        // Remove all segments for this execution (both stdout and stderr)
+        self.terminals.retain(|(eid, _, _), _| eid != execution_id);
+        self.processors.retain(|(eid, _, _), _| eid != execution_id);
+        self.output_states
+            .retain(|(eid, _, _), _| eid != execution_id);
+        self.current_segments
+            .retain(|(eid, _), _| eid != execution_id);
+        self.sealed_segments
+            .retain(|(eid, _, _)| eid != execution_id);
+        self.last_stream.remove(execution_id);
     }
 
-    /// Check if a stream exists for an execution.
-    pub fn has_stream(&self, execution_id: &str, stream_name: &str) -> bool {
-        let key = (execution_id.to_string(), stream_name.to_string());
-        self.terminals.contains_key(&key)
-    }
-
-    /// Get the output state for a stream (if known).
+    /// Drop a sealed segment's terminal after its final commit.
     ///
-    /// Returns the state (output_id + manifest hash) we last wrote for this stream.
-    /// Used to validate before updating in place.
+    /// No-op for an unsealed segment: it is still receiving chunks and must
+    /// keep rendering until the stream switches or the execution ends.
+    pub fn retire_segment(&mut self, execution_id: &str, stream_name: &str, segment: u64) {
+        let key = (execution_id.to_string(), stream_name.to_string(), segment);
+        if !self.sealed_segments.remove(&key) {
+            return;
+        }
+        self.terminals.remove(&key);
+        self.processors.remove(&key);
+        self.output_states.remove(&key);
+    }
+
+    /// Whether the other stream has interleaved after this segment.
+    pub fn is_sealed(&self, execution_id: &str, stream_name: &str, segment: u64) -> bool {
+        self.sealed_segments
+            .contains(&(execution_id.to_string(), stream_name.to_string(), segment))
+    }
+
+    /// Check if a stream currently has a segment for an execution.
+    pub fn has_stream(&self, execution_id: &str, stream_name: &str) -> bool {
+        self.current_segment(execution_id, stream_name)
+            .is_some_and(|segment| self.has_segment(execution_id, stream_name, segment))
+    }
+
+    /// Check if a specific segment still has a terminal.
+    pub fn has_segment(&self, execution_id: &str, stream_name: &str, segment: u64) -> bool {
+        self.terminals
+            .contains_key(&(execution_id.to_string(), stream_name.to_string(), segment))
+    }
+
+    /// Get the output state for the current segment of a stream (if known).
     pub fn get_output_state(
         &self,
         execution_id: &str,
         stream_name: &str,
     ) -> Option<&StreamOutputState> {
-        let key = (execution_id.to_string(), stream_name.to_string());
-        self.output_states.get(&key)
+        let segment = self.current_segment(execution_id, stream_name).unwrap_or(0);
+        self.get_segment_output_state(execution_id, stream_name, segment)
     }
 
-    /// Set the output state for a stream.
+    /// Get the output state for one segment (if known).
     ///
-    /// Called after upserting a stream output to track its identity and hash
-    /// for future validation.
+    /// Returns the state (output_id + manifest hash) we last wrote for this
+    /// segment. Used to validate before updating in place.
+    pub fn get_segment_output_state(
+        &self,
+        execution_id: &str,
+        stream_name: &str,
+        segment: u64,
+    ) -> Option<&StreamOutputState> {
+        self.output_states
+            .get(&(execution_id.to_string(), stream_name.to_string(), segment))
+    }
+
+    /// Set the output state for the current segment of a stream.
     pub fn set_output_state(
         &mut self,
         execution_id: &str,
         stream_name: &str,
         state: StreamOutputState,
     ) {
-        let key = (execution_id.to_string(), stream_name.to_string());
-        self.output_states.insert(key, state);
+        let segment = self.current_segment(execution_id, stream_name).unwrap_or(0);
+        self.set_segment_output_state(execution_id, stream_name, segment, state);
+    }
+
+    /// Set the output state for one segment.
+    ///
+    /// Called after upserting a stream output to track its identity and hash
+    /// for future validation.
+    pub fn set_segment_output_state(
+        &mut self,
+        execution_id: &str,
+        stream_name: &str,
+        segment: u64,
+        state: StreamOutputState,
+    ) {
+        self.output_states.insert(
+            (execution_id.to_string(), stream_name.to_string(), segment),
+            state,
+        );
     }
 }
 


### PR DESCRIPTION
A cell that writes to both stdout and stderr rendered its outputs twice. For `print("out-1"); print("err-1", file=sys.stderr); print("out-2")` the RuntimeStateDoc held four outputs: `out-1`, `err-1`, `out-1\nout-2`, `err-1`. Found while running the hosted viewer on celld in #4219; reproduced identically on Wrangler and then through the local daemon with no cloud involved, so this is `runtimed`'s output pipeline.

## Diagnosis

Two mechanisms combined:

- The stream terminal for `(execution, stream)` kept accumulating across the interleave. `upsert_stream_output` correctly refuses to update an output that is no longer last (`doc.rs`: "if something was appended after, append instead of updating"), so the second stdout flush appended the whole buffer as a new output.
- The end-of-execution flush re-committed every stream, dirty or not. stderr was now also not last, so it was appended again.

A third, pre-existing ordering gap showed up under a stress cell: ordinary outputs (`display_data`, `execute_result`, `error`) and stream flushes commit on separate queues, and a stream chunk that follows a display could reach the document first. The boundary flush then duplicated it.

## Fix

Terminals are per segment, `(execution, stream, segment)`. A chunk that switches streams seals the other stream's current segment and moves its own stream to a fresh segment, so each segment maps to exactly one document output holding only its own text (nbformat's coalescing rule). Chunks arriving faster than the coalescing delay still update their segment in place.

Design choices worth calling out:

- The sealed segment's flush rides the committer's unbounded priority queue, ahead of periodic flushes. That keeps document order without blocking the IOPub reader on every stdout/stderr alternation (tqdm on stderr with prints on stdout is a normal pattern). The display boundary keeps its existing awaited flush.
- Sealed terminals are retired once their commit has rendered them. alacritty `Term`s are 128x100 with scrollback, so a few hundred switches per cell would otherwise be a real memory cost.
- Boundary flushes still re-render live segments. That is the guarantee that the last periodic flush is durable before `ExecutionDone`; it is safe again because sealed segments are gone by then. Filtering to dirty segments would have removed the guarantee.
- The IOPub reader drains the output committer before feeding the first stream chunk after an ordinary output, mirroring the barrier already used for `update_display_data`. One await per display-to-stream transition.

`ingest_stream_chunk` in `stream_committer.rs` is the new seam that owns feed, seal, and flush scheduling; `jupyter_kernel.rs` calls it instead of doing the three steps inline.

## Verification

- Two regression tests at the committer seam (`interleaved_streams_commit_one_output_per_segment`, `coalesced_chunks_before_an_interleave_stay_in_one_output`) reproduce the exact production shape without the fix and pass with it. Flush-buffer tests cover segment ordering and sealed-segment flushes.
- With a kernel through the local daemon: the three-line repro yields three outputs with only their own text. A stress cell with 200 alternating flushed stdout/stderr prints plus two `display_data` boundaries yields 405 outputs in order with no duplicates.
- `cargo test -p runtimed --lib`: 1342 pass. `shell_env_overlay::tests::capture_returns_at_least_path` fails on this machine under the full parallel run on unmodified `main` too and passes alone; unrelated. `cargo test -p runtimed --test tokio_mutex_lint` passes. `cargo xtask lint --fix` clean.
