### PR TITLE
feat(notebook-cloud): run workstation agent and runtime smokes with loopback dev auth

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -828,6 +828,45 @@ old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
 private; anonymous hosted render smokes may return a catalog 404 unless the
 browser context has a credential for the owning principal.
 
+Runtime smokes against a loopback Worker (dev auth):
+
+The runtime-peer, runtime-browser-execute, browser-execute, workstation-agent,
+and workstation-toolbar smokes all accept
+`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev`. That kind uses the Worker's
+loopback dev credentials instead of a bearer: REST calls send
+`X-Notebook-Cloud-Dev-Token` + `X-User` + `X-Scope`, the browser seeds the
+`nteract:notebook-cloud:dev-token` / `:user` / `:scope` localStorage keys, and
+the spawned `runtimed cloud-runtime-agent` / `cloud-peer` run with
+`--auth-kind dev`, `RUNT_CLOUD_TOKEN`, and `RUNT_CLOUD_DEV_USER`. The Worker
+maps the identity to `user:dev:<user>`. Any non-empty token works on loopback.
+
+```bash
+pnpm --dir apps/notebook-cloud dev            # note the printed loopback URL
+cargo build -p runtimed
+NOTEBOOK_CLOUD_URL=http://127.0.0.1:<port> \
+NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev \
+NOTEBOOK_CLOUD_DEV_TOKEN=local-loopback-dev-token \
+NOTEBOOK_CLOUD_DEV_USER=smoke \
+NOTEBOOK_CLOUD_RUNTIMED_BIN=target/debug/runtimed \
+NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON=/path/to/python-with-ipykernel \
+pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer
+```
+
+The same environment drives `smoke:hosted:runtime-browser-execute` (the
+orchestrator forwards the room owner's dev user to the browser step) and
+`smoke:hosted:workstation-agent`. `NOTEBOOK_CLOUD_DEV_USER` is required for the
+agent and browser smokes; the runtime-peer smoke defaults it to
+`runtime-peer-smoke`. The dev kind is refused unless the target URL is loopback
+(`127.0.0.1`, `localhost`, or `[::1]`), so a stray `dev` setting can never send
+placeholder credentials to preview. Per-script overrides:
+`NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_AUTH_KIND`,
+`NOTEBOOK_CLOUD_BROWSER_EXECUTE_AUTH_KIND` (`oidc` or `dev`; the browser smoke
+also falls back to `dev` on its own when the OIDC token cache file is missing and
+`NOTEBOOK_CLOUD_DEV_TOKEN` is set), and
+`NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND`. Defaults are unchanged:
+`anaconda-key` for the peer/agent smokes and the OIDC token cache for the
+browser smokes.
+
 Hosted workstation agent smoke:
 
 ```bash
@@ -855,8 +894,11 @@ attach jobs are durable D1 rows, so reconnect recovery polls the queue rather
 than replaying transient wakeup events. API-key auth is the default
 (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
 `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc` when `NTERACT_API_KEY` carries a
-short-lived OIDC bearer token. Prefer API-key auth for long-lived tmux/systemd
-workstations; browser OIDC token refresh depends on an active browser session.
+short-lived OIDC bearer token, or `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev`
+with `NOTEBOOK_CLOUD_DEV_TOKEN` and `NOTEBOOK_CLOUD_DEV_USER` against a
+loopback Worker (see the dev-auth section above). Prefer API-key auth for
+long-lived tmux/systemd workstations; browser OIDC token refresh depends on an
+active browser session.
 The credential is passed to the runtime peer through `RUNT_CLOUD_TOKEN`, not
 through argv; `runtimed` removes cloud environment variables again before
 launching the Python kernel. When the hosted service returns a rate-limit or

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -3,8 +3,15 @@ import os from "node:os";
 
 import { chromium } from "@playwright/test";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { storageStateForDevIdentity } from "./hosted-collab-smoke-env.mjs";
 import { viewerUrlWithMode } from "./hosted-render-smoke-routes.mjs";
+import {
+  DEV_WORKSTATION_AUTH_KIND,
+  WORKSTATION_DEV_TOKEN_ENV,
+  WORKSTATION_DEV_USER_ENV,
+} from "./hosted-workstation-agent-core.mjs";
 import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
+import { isLoopbackBaseUrl } from "./wasm-roundtrip-env.mjs";
 
 const viewerUrl =
   firstPositionalArg() ??
@@ -14,6 +21,18 @@ const tokenPath =
   process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
   process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
   `${os.homedir()}/token.preview.json`;
+// Explicit `dev` selects the loopback dev identity even when an OIDC token
+// cache exists on this machine (a preview token is useless against a local
+// Worker). Without it, the dev identity is only a fallback for a missing cache.
+const requestedAuthKind = (
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_AUTH_KIND ??
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
+  ""
+)
+  .trim()
+  .toLowerCase();
+const devToken = process.env[WORKSTATION_DEV_TOKEN_ENV]?.trim() || null;
+const devUser = process.env[WORKSTATION_DEV_USER_ENV]?.trim() || null;
 const requestedScope = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE ?? "owner";
 const executeButtonIndex = parseNonNegativeInteger(
   process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_BUTTON_INDEX,
@@ -57,31 +76,38 @@ async function main() {
   // Execute buttons only accept clicks in edit mode; the runtime-peer smoke
   // hands over the canonical (view-mode) room URL.
   const url = new URL(viewerUrlWithMode(viewerUrl, "edit"));
-  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
-  const token = JSON.parse(tokenStorageJson);
-  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
-  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
-    throw new Error(
-      `${tokenPath} is expired or near expiry; refresh it before running the browser execute smoke`,
-    );
-  }
+  const identity = await resolveBrowserIdentity(url);
 
   const browser = await chromium.launch({ headless: true });
   try {
-    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
-    await context.addInitScript(
-      ({ origin, scope, tokenJson }) => {
-        try {
-          if (globalThis.location?.origin !== origin) return;
-          globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
-          globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
-        } catch {
-          // Sandboxed output frames do not always have localStorage. Ignore them:
-          // only the first-party notebook shell needs the token cache.
-        }
-      },
-      { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
-    );
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 1000 },
+      ...(identity.kind === "dev"
+        ? {
+            storageState: storageStateForDevIdentity({
+              origin: url.origin,
+              token: identity.token,
+              user: identity.user,
+              scope: requestedScope,
+            }),
+          }
+        : {}),
+    });
+    if (identity.kind === "oidc") {
+      await context.addInitScript(
+        ({ origin, scope, tokenJson }) => {
+          try {
+            if (globalThis.location?.origin !== origin) return;
+            globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+            globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
+          } catch {
+            // Sandboxed output frames do not always have localStorage. Ignore them:
+            // only the first-party notebook shell needs the token cache.
+          }
+        },
+        { origin: url.origin, scope: requestedScope, tokenJson: identity.tokenStorageJson },
+      );
+    }
 
     const page = await context.newPage();
     const events = {
@@ -227,10 +253,15 @@ async function main() {
         {
           ok: true,
           viewerUrl: url.href,
-          token: {
-            path: tokenPath,
-            secondsRemaining: tokenSecondsRemaining,
-          },
+          auth: identity.kind,
+          ...(identity.kind === "oidc"
+            ? {
+                token: {
+                  path: tokenPath,
+                  secondsRemaining: identity.secondsRemaining,
+                },
+              }
+            : { devUser: identity.user }),
           click: {
             executeButtonIndex,
             clickedAria,
@@ -240,7 +271,9 @@ async function main() {
             preClickSettleMs,
           },
           checks: [
-            "oidc_token_seeded_in_browser_storage",
+            identity.kind === "oidc"
+              ? "oidc_token_seeded_in_browser_storage"
+              : "dev_identity_seeded_in_browser_storage",
             "execute_button_rendered",
             "execute_button_clicked",
             "execution_count_advanced_after_click",
@@ -259,6 +292,51 @@ async function main() {
   } finally {
     await browser.close().catch(() => {});
   }
+}
+
+async function resolveBrowserIdentity(url) {
+  if (requestedAuthKind === DEV_WORKSTATION_AUTH_KIND) {
+    return devIdentity(url);
+  }
+  if (requestedAuthKind && requestedAuthKind !== "oidc") {
+    // Bearer kinds (anaconda-key) have no browser storage equivalent; the
+    // viewer only knows OIDC and dev identities.
+    throw new Error(
+      "NOTEBOOK_CLOUD_BROWSER_EXECUTE_AUTH_KIND must be oidc or dev for the browser execute smoke",
+    );
+  }
+
+  let tokenStorageJson;
+  try {
+    tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  } catch (error) {
+    if (error?.code === "ENOENT" && devToken) {
+      return devIdentity(url);
+    }
+    throw error;
+  }
+  const token = JSON.parse(tokenStorageJson);
+  const secondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(secondsRemaining) || secondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the browser execute smoke`,
+    );
+  }
+  return { kind: "oidc", tokenStorageJson, secondsRemaining };
+}
+
+function devIdentity(url) {
+  if (!devToken || !devUser) {
+    throw new Error(
+      `${WORKSTATION_DEV_TOKEN_ENV} and ${WORKSTATION_DEV_USER_ENV} are required for the dev browser identity`,
+    );
+  }
+  if (!isLoopbackBaseUrl(url.origin)) {
+    throw new Error(
+      `dev browser identity is only allowed against a loopback Worker (127.0.0.1, localhost, or [::1]); refusing ${url.origin}`,
+    );
+  }
+  return { kind: "dev", token: devToken, user: devUser };
 }
 
 async function readOidcTokenStorageJson(path) {

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
@@ -1,9 +1,13 @@
 import { isLoopbackBaseUrl } from "./wasm-roundtrip-env.mjs";
+// Import the storage keys from their defining module rather than the viewer
+// re-export: `src/dev-auth-storage.ts` carries only type imports, so plain
+// `node` (no tsx loader) can strip and load it. That keeps this helper usable
+// from smokes that run without `--import tsx`.
 import {
   NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
   NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
   NOTEBOOK_CLOUD_USER_STORAGE_KEY,
-} from "../viewer/collaborator-auth.ts";
+} from "../src/dev-auth-storage.ts";
 
 export function assertHostedCollabSmokeEnv({ baseUrl, devAuthToken }) {
   if (devAuthToken || isLoopbackBaseUrl(baseUrl)) {

--- a/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
@@ -33,6 +33,7 @@ async function main() {
     ok: true,
     source,
     scopes,
+    authKind: runs[0]?.runtimePeer?.authKind ?? null,
     checks: [
       "runtime_peer_browser_execute_passed_for_requested_scopes",
       "runtime_peers_stopped_after_browser_smokes",
@@ -71,6 +72,14 @@ async function runScope(scope) {
         ...process.env,
         NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT: source,
         NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE: scope,
+        // With dev auth the runtime-peer smoke owns the room as `user:dev:<devUser>`;
+        // the browser must present the same dev user to get owner scope there.
+        ...(typeof runtime.devUser === "string" && runtime.devUser
+          ? {
+              NOTEBOOK_CLOUD_BROWSER_EXECUTE_AUTH_KIND: "dev",
+              NOTEBOOK_CLOUD_DEV_USER: runtime.devUser,
+            }
+          : {}),
       },
     );
     const browserSummary = browserRunSummary(browser, scope);
@@ -90,6 +99,8 @@ async function runScope(scope) {
         ...(runtimePeerStopped ? ["runtime_peer_stopped_after_browser_smoke"] : []),
       ],
       runtimePeer: {
+        authKind: runtime.authKind ?? null,
+        devUser: runtime.devUser ?? null,
         notebookId: runtime.notebookId,
         vanityName: runtime.vanityName,
         pid: runtime.runtimePeer?.pid ?? null,

--- a/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
@@ -5,7 +5,16 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseHttpResponseBody } from "./hosted-workstation-agent-core.mjs";
+import {
+  assertWorkstationAuthKindAllowedForBaseUrl,
+  buildWorkstationAuthHeaders,
+  DEFAULT_WORKSTATION_AUTH_KIND,
+  DEV_WORKSTATION_AUTH_KIND,
+  devPrincipalForUser,
+  normalizeWorkstationAuthKind,
+  parseHttpResponseBody,
+  resolveWorkstationCredential,
+} from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -14,7 +23,18 @@ const workspaceRoot = notebookCloudWorkspaceRoot({ cwd: appDir });
 await loadOptionalEnvFile();
 
 const baseUrl = notebookCloudBaseUrl();
-const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+// Default stays the preview API-key path; `dev` is the loopback Worker path
+// (Wrangler dev or a local celld launcher) and shares the workstation agent's
+// env contract: NOTEBOOK_CLOUD_DEV_TOKEN + NOTEBOOK_CLOUD_DEV_USER.
+const authKind = normalizeWorkstationAuthKind(
+  process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_AUTH_KIND ??
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
+    process.env.NTERACT_CLOUD_AUTH_KIND ??
+    DEFAULT_WORKSTATION_AUTH_KIND,
+);
+const DEFAULT_DEV_USER = "runtime-peer-smoke";
+let cloudCredential = null;
+let cloudDevUser = null;
 const vanityName = process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_VANITY ?? "lab2-dualpeer";
 const source =
   process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_CODE ?? "print('preview runtime peer smoke')";
@@ -44,11 +64,13 @@ const runtimedBin = path.resolve(
   workspaceRoot,
   process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ?? "target/release/runtimed",
 );
-// The diagnostic cloud peer is the hidden `runtimed cloud-peer` subcommand
-// (the standalone runt-cloud-peer binary was absorbed into runtimed).
+// The diagnostic cloud peer is the hidden `runtimed cloud-peer` subcommand, so
+// it defaults to the same binary as the runtime peer unless overridden.
 const cloudPeerBin = path.resolve(
   workspaceRoot,
-  process.env.NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN ?? "target/release/runtimed",
+  process.env.NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN ??
+    process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ??
+    "target/release/runtimed",
 );
 
 const timingsMs = {};
@@ -64,7 +86,7 @@ main().catch((error) => {
 
 async function main() {
   try {
-    requireApiKey();
+    requireCloudCredential();
     await assertBinaryExists(runtimedBin, "runtimed");
     await assertBinaryExists(cloudPeerBin, "runtimed cloud-peer");
     const pythonPath = await resolvePythonPath();
@@ -110,12 +132,16 @@ async function main() {
         {
           ok: true,
           baseUrl,
+          authKind,
+          ...(cloudDevUser ? { devUser: cloudDevUser } : {}),
           notebookId: room.notebookId,
           vanityName,
           viewerUrl: viewerUrl(room.notebookId, vanityName),
           source,
           checks: [
-            "preview_api_key_room_created",
+            authKind === DEV_WORKSTATION_AUTH_KIND
+              ? "loopback_dev_room_created"
+              : "preview_api_key_room_created",
             "runtime_peer_acl_granted",
             "runtime_peer_current_python_ready",
             "owner_execute_cell_request_sent",
@@ -171,12 +197,13 @@ async function loadOptionalEnvFile() {
   }
 }
 
-function requireApiKey() {
-  if (!apiKey) {
-    throw new Error(
-      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted runtime-peer smoke",
-    );
-  }
+function requireCloudCredential() {
+  assertWorkstationAuthKindAllowedForBaseUrl(authKind, baseUrl);
+  const resolved = resolveWorkstationCredential(process.env, authKind, {
+    defaultDevUser: DEFAULT_DEV_USER,
+  });
+  cloudCredential = resolved.credential;
+  cloudDevUser = resolved.devUser;
 }
 
 async function assertBinaryExists(binaryPath, name) {
@@ -270,7 +297,7 @@ async function createNotebookRoom() {
   const response = await fetch(new URL("/api/n", baseUrl), {
     method: "POST",
     headers: {
-      ...apiKeyHeaders("owner"),
+      ...cloudAuthHeaders("owner"),
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ vanity_name: vanityName }),
@@ -291,11 +318,20 @@ async function grantRuntimePeer(notebookId) {
     (entry) => entry.scope === "owner" && entry.subject_kind === "principal",
   );
   assert(owner?.subject, "room ACL did not include owner principal to grant runtime_peer");
+  if (cloudDevUser) {
+    // The runtime peer connects with the same dev user, so the room's owner row
+    // must be that user's dev principal or the grant lands on the wrong subject.
+    const expected = devPrincipalForUser(cloudDevUser);
+    assert(
+      owner.subject === expected,
+      `room owner principal ${owner.subject} does not match dev identity ${expected}`,
+    );
+  }
 
   const response = await fetch(new URL(`/api/n/${encodeURIComponent(notebookId)}/acl`, baseUrl), {
     method: "POST",
     headers: {
-      ...apiKeyHeaders("owner"),
+      ...cloudAuthHeaders("owner"),
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -310,18 +346,29 @@ async function grantRuntimePeer(notebookId) {
 
 async function fetchJson(pathname) {
   const response = await fetch(new URL(pathname, baseUrl), {
-    headers: apiKeyHeaders("owner"),
+    headers: cloudAuthHeaders("owner"),
   });
   const body = await parseHttpResponseBody(response);
   assertResponse(response, body, `GET ${pathname}`, 200);
   return body;
 }
 
-function apiKeyHeaders(scope) {
+function cloudAuthHeaders(scope) {
   return {
-    Authorization: `Bearer ${apiKey}`,
-    "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+    ...buildWorkstationAuthHeaders(authKind, cloudCredential, { devUser: cloudDevUser, scope }),
     "X-Scope": scope,
+  };
+}
+
+function cloudPeerEnv() {
+  return {
+    ...process.env,
+    // `runtimed cloud-runtime-agent` and `runtimed cloud-peer` read the
+    // credential from the environment, never argv, so it cannot leak into the
+    // process command line. `--auth-kind dev` also needs the user label.
+    RUNT_CLOUD_TOKEN: cloudCredential,
+    ...(cloudDevUser ? { RUNT_CLOUD_DEV_USER: cloudDevUser } : {}),
+    RUST_LOG: process.env.RUST_LOG ?? "info",
   };
 }
 
@@ -346,7 +393,7 @@ function startRuntimePeer({ notebookId, pythonPath }) {
         [
           "cloud-runtime-agent",
           "--auth-kind",
-          "anaconda-key",
+          authKind,
           "--cloud-url",
           baseUrl,
           "--notebook-id",
@@ -361,11 +408,7 @@ function startRuntimePeer({ notebookId, pythonPath }) {
         {
           cwd: workspaceRoot,
           detached: keepRuntimePeer,
-          env: {
-            ...process.env,
-            RUNT_CLOUD_TOKEN: apiKey,
-            RUST_LOG: process.env.RUST_LOG ?? "info",
-          },
+          env: cloudPeerEnv(),
           stdio: ["ignore", logFd, logFd],
         },
       );
@@ -465,7 +508,7 @@ async function runOwnerPeer({ notebookId }) {
     [
       "cloud-peer",
       "--auth-kind",
-      "anaconda-key",
+      authKind,
       "--cloud-url",
       baseUrl,
       "--notebook-id",
@@ -483,13 +526,7 @@ async function runOwnerPeer({ notebookId }) {
       logPath: ownerLogPath,
       completeWhen: /status=done\b/,
       timeoutMs: seconds * 1000 + 20_000,
-      env: {
-        ...process.env,
-        // `runtimed cloud-peer` reads the credential from the environment,
-        // never argv, so it cannot leak into the process command line.
-        RUNT_CLOUD_TOKEN: apiKey,
-        RUST_LOG: process.env.RUST_LOG ?? "info",
-      },
+      env: cloudPeerEnv(),
     },
   );
 }

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -1,12 +1,21 @@
 import os from "node:os";
 import path from "node:path";
 
+import { isLoopbackBaseUrl } from "./wasm-roundtrip-env.mjs";
+
 export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
+export const DEV_WORKSTATION_AUTH_KIND = "dev";
 export const DEFAULT_WORKSTATION_RETRY_AFTER_MS = 60_000;
 export const MAX_WORKSTATION_RETRY_AFTER_MS = 15 * 60_000;
 export const WORKSTATION_RETRYABLE_STATUS_CODES = new Set([429, 503]);
 export const STALE_WORKSTATION_RETRYABLE_STATUS_CODES = new Set([404, 410, 429, 503]);
-export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
+export const WORKSTATION_AUTH_KINDS = new Set([
+  DEFAULT_WORKSTATION_AUTH_KIND,
+  "oidc",
+  DEV_WORKSTATION_AUTH_KIND,
+]);
+export const WORKSTATION_DEV_TOKEN_ENV = "NOTEBOOK_CLOUD_DEV_TOKEN";
+export const WORKSTATION_DEV_USER_ENV = "NOTEBOOK_CLOUD_DEV_USER";
 
 export function buildWorkstationRegistrationPayload({
   workstationId,
@@ -65,6 +74,7 @@ export function buildAttachJobSpawnPlan({
   const logPath = path.join(runRoot, "runtime-peer.log");
   const launchDirectory = job.working_directory ?? workingDirectory;
   const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
+  assertWorkstationAuthKindAllowedForBaseUrl(normalizedAuthKind, baseUrl);
   const args = [
     "cloud-runtime-agent",
     "--auth-kind",
@@ -106,7 +116,8 @@ export function buildAttachJobSpawnPlan({
   };
 }
 
-export function buildRuntimeAgentEnv(env, credential) {
+export function buildRuntimeAgentEnv(env, credential, { authKind, devUser } = {}) {
+  const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
   return compactEnv({
     HOME: env.HOME,
     PATH: env.PATH,
@@ -117,13 +128,31 @@ export function buildRuntimeAgentEnv(env, credential) {
     RUST_BACKTRACE: env.RUST_BACKTRACE,
     RUST_LOG: env.RUST_LOG ?? "info",
     RUNT_CLOUD_TOKEN: credential,
+    // `runtimed cloud-runtime-agent --auth-kind dev` needs the user label next
+    // to the token; it becomes the `X-User` header on the WebSocket upgrade.
+    RUNT_CLOUD_DEV_USER: normalizedAuthKind === DEV_WORKSTATION_AUTH_KIND ? devUser : undefined,
   });
 }
 
-export function buildWorkstationAuthHeaders(authKind, credential) {
+export function buildWorkstationAuthHeaders(
+  authKind,
+  credential,
+  { devUser, scope = "owner" } = {},
+) {
   const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
   const token = credential?.trim();
   assert(token, "hosted workstation credential is required");
+  if (normalizedAuthKind === DEV_WORKSTATION_AUTH_KIND) {
+    const user = devUser?.trim();
+    assert(user, `${WORKSTATION_DEV_USER_ENV} is required for dev workstation auth`);
+    // Loopback dev credentials: the Worker maps this trio to `user:dev:<user>`.
+    // Dev auth defaults to viewer scope, so the scope is always explicit here.
+    return {
+      "X-Notebook-Cloud-Dev-Token": token,
+      "X-User": user,
+      "X-Scope": scope,
+    };
+  }
   const headers = {
     Authorization: `Bearer ${token}`,
   };
@@ -131,6 +160,49 @@ export function buildWorkstationAuthHeaders(authKind, credential) {
     headers["X-Notebook-Cloud-Auth-Provider"] = "anaconda-api-key";
   }
   return headers;
+}
+
+export function resolveWorkstationCredential(env, authKind, { defaultDevUser } = {}) {
+  const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
+  if (normalizedAuthKind === DEV_WORKSTATION_AUTH_KIND) {
+    const credential = env[WORKSTATION_DEV_TOKEN_ENV]?.trim();
+    const devUser = (env[WORKSTATION_DEV_USER_ENV] ?? defaultDevUser)?.trim();
+    assert(
+      credential,
+      `${WORKSTATION_DEV_TOKEN_ENV} is required when NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev (any non-empty value is accepted by a loopback Worker)`,
+    );
+    assert(
+      devUser,
+      `${WORKSTATION_DEV_USER_ENV} is required when NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev`,
+    );
+    return { authKind: normalizedAuthKind, credential, devUser };
+  }
+  const credential = (env.NTERACT_API_KEY ?? env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN)?.trim();
+  assert(
+    credential,
+    "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation auth",
+  );
+  return { authKind: normalizedAuthKind, credential, devUser: null };
+}
+
+export function devPrincipalForUser(user) {
+  const normalized = String(user ?? "").trim();
+  assert(normalized, "dev user cannot be empty");
+  // Mirrors `principalForDevUser` in src/identity.ts.
+  return `user:dev:${encodeURIComponent(normalized)}`;
+}
+
+export function assertWorkstationAuthKindAllowedForBaseUrl(authKind, baseUrl) {
+  const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
+  if (normalizedAuthKind !== DEV_WORKSTATION_AUTH_KIND) {
+    return normalizedAuthKind;
+  }
+  if (!isLoopbackBaseUrl(baseUrl)) {
+    throw new Error(
+      `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev is only allowed against a loopback Worker (127.0.0.1, localhost, or [::1]); refusing ${baseUrl}`,
+    );
+  }
+  return normalizedAuthKind;
 }
 
 export function normalizeWorkstationAuthKind(value) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertWorkstationAuthKindAllowedForBaseUrl,
   buildAttachJobSpawnPlan,
   buildRuntimeAgentEnv,
   buildWorkstationAuthHeaders,
@@ -14,6 +15,7 @@ import {
   normalizeWorkstationAuthKind,
   parseHttpResponseBody,
   parsePositiveInteger,
+  resolveWorkstationCredential,
   retryCooldownMs,
   retryAfterMs,
   runtimePeerExitMessage,
@@ -28,13 +30,15 @@ const workspaceRoot = notebookCloudWorkspaceRoot({ cwd: appDir });
 await loadOptionalEnvFile();
 
 const baseUrl = notebookCloudBaseUrl();
-const cloudCredential =
-  process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
 const authKind = normalizeWorkstationAuthKind(
   process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
     process.env.NTERACT_CLOUD_AUTH_KIND ??
     DEFAULT_WORKSTATION_AUTH_KIND,
 );
+// Resolved lazily in main() so a missing credential reports one clear error
+// instead of failing at module load.
+let cloudCredential = null;
+let cloudDevUser = null;
 const workstationId =
   process.env.NOTEBOOK_CLOUD_WORKSTATION_ID ?? stableWorkstationId(os.hostname());
 const displayName =
@@ -85,6 +89,7 @@ async function main() {
       workingDirectory,
       pythonPath,
       authKind,
+      ...(cloudDevUser ? { devUser: cloudDevUser } : {}),
       pollIntervalMs,
     }),
   );
@@ -485,19 +490,26 @@ async function loadOptionalEnvFile() {
 }
 
 function requireCloudCredential() {
-  if (!cloudCredential) {
-    throw new Error(
-      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation agent",
-    );
-  }
+  // Dev credentials only make sense against a loopback Worker; refuse before
+  // any request so a misconfigured agent never sends them to a deployed host.
+  assertWorkstationAuthKindAllowedForBaseUrl(authKind, baseUrl);
+  const resolved = resolveWorkstationCredential(process.env, authKind);
+  cloudCredential = resolved.credential;
+  cloudDevUser = resolved.devUser;
 }
 
 function cloudAuthHeaders() {
-  return buildWorkstationAuthHeaders(authKind, cloudCredential);
+  return buildWorkstationAuthHeaders(authKind, cloudCredential, {
+    devUser: cloudDevUser,
+    scope: "owner",
+  });
 }
 
 function runtimeAgentEnv() {
-  return buildRuntimeAgentEnv(process.env, cloudCredential);
+  return buildRuntimeAgentEnv(process.env, cloudCredential, {
+    authKind,
+    devUser: cloudDevUser,
+  });
 }
 
 async function resolvePythonPath() {

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -5,11 +5,15 @@ import { pathToFileURL } from "node:url";
 
 import { chromium } from "@playwright/test";
 
+import { storageStateForDevIdentity } from "./hosted-collab-smoke-env.mjs";
 import {
+  assertWorkstationAuthKindAllowedForBaseUrl,
   buildWorkstationAuthHeaders,
   DEFAULT_WORKSTATION_AUTH_KIND,
+  DEV_WORKSTATION_AUTH_KIND,
   normalizeWorkstationAuthKind,
   parseHttpResponseBody,
+  resolveWorkstationCredential,
 } from "./hosted-workstation-agent-core.mjs";
 import {
   saveSmokeScreenshot,
@@ -30,7 +34,8 @@ if (isMainModule()) {
 async function main() {
   await loadOptionalEnvFile();
 
-  const baseUrl = process.env.NTERACT_CLOUD_URL ?? "https://preview.runt.run";
+  const baseUrl =
+    process.env.NTERACT_CLOUD_URL ?? process.env.NOTEBOOK_CLOUD_URL ?? "https://preview.runt.run";
   const authKind = normalizeWorkstationAuthKind(
     process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND ??
       process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
@@ -73,30 +78,21 @@ async function main() {
   );
   const reportPath = smokeJsonReportPath("hosted-workstation-toolbar-smoke");
 
-  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
-  const token = JSON.parse(tokenStorageJson);
-  const cloudCredential =
-    authKind === "oidc"
-      ? token.accessToken
-      : (process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN);
-  if (!cloudCredential) {
-    throw new Error(
-      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation toolbar smoke",
-    );
-  }
-  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
-  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
-    throw new Error(
-      `${tokenPath} is expired or near expiry; refresh it before running the workstation toolbar smoke`,
-    );
-  }
+  // The browser identity is either the OIDC token cache (preview) or the
+  // loopback dev trio (local Worker). The REST credential follows the same
+  // split: OIDC reuses the cached access token, dev reuses the dev token.
+  const { browserIdentity, cloudCredential, cloudDevUser } = await resolveToolbarSmokeIdentity({
+    authKind,
+    baseUrl,
+    tokenPath,
+  });
+  const restAuth = { authKind, credential: cloudCredential, devUser: cloudDevUser };
 
   const workstationList = await fetchJson({
     baseUrl,
     label: "list workstations",
     pathname: "/api/workstations",
-    authKind,
-    credential: cloudCredential,
+    ...restAuth,
   });
   const workstation = Array.isArray(workstationList.workstations)
     ? workstationList.workstations.find((item) => item?.workstation_id === workstationId)
@@ -118,8 +114,7 @@ async function main() {
       label: "set default workstation",
       method: "PATCH",
       pathname: "/api/workstations/default",
-      authKind,
-      credential: cloudCredential,
+      ...restAuth,
     });
   }
   const created = await fetchJson({
@@ -129,20 +124,23 @@ async function main() {
     label: "create notebook",
     method: "POST",
     pathname: "/api/n",
-    authKind,
-    credential: cloudCredential,
+    ...restAuth,
   });
-  const viewerUrl = scalarString(created.viewer_url);
-  if (!viewerUrl) {
+  const createdViewerUrl = scalarString(created.viewer_url);
+  if (!createdViewerUrl) {
     throw new Error("create notebook response did not include viewer_url");
   }
+  // The Worker reports viewer_url on its configured public host. A loopback
+  // Worker still advertises the deployed hostname, so keep the path and drive
+  // the browser at the origin this smoke was pointed at.
+  const viewerUrl = rebaseUrl(createdViewerUrl, baseUrl);
 
   const browserResult = await runBrowserSmoke({
+    browserIdentity,
     runMarker,
     screenshotPath,
     source,
     timeoutMs,
-    tokenStorageJson,
     viewerUrl,
     workstationDisplayName: scalarString(workstation.display_name) ?? workstationId,
     workstationId,
@@ -155,10 +153,14 @@ async function main() {
     notebookId: created.notebook_id,
     source,
     title,
-    token: {
-      path: tokenPath,
-      secondsRemaining: tokenSecondsRemaining,
-    },
+    ...(browserIdentity.kind === "oidc"
+      ? {
+          token: {
+            path: tokenPath,
+            secondsRemaining: browserIdentity.secondsRemaining,
+          },
+        }
+      : { devUser: browserIdentity.user }),
     viewerUrl,
     workstation: {
       id: workstationId,
@@ -182,11 +184,11 @@ async function main() {
 }
 
 async function runBrowserSmoke({
+  browserIdentity,
   runMarker,
   screenshotPath,
   source,
   timeoutMs,
-  tokenStorageJson,
   viewerUrl,
   workstationDisplayName,
   workstationId,
@@ -197,16 +199,16 @@ async function runBrowserSmoke({
   try {
     const blockedRuns = await assertOwnerBlockedWorkstationStates({
       browser,
+      browserIdentity,
       timeoutMs,
-      tokenStorageJson,
       url,
       workstationId,
     });
 
     const ownerContext = await authenticatedContext(browser, {
+      browserIdentity,
       origin: url.origin,
       scope: "owner",
-      tokenStorageJson,
     });
     let ownerRun;
     try {
@@ -226,16 +228,18 @@ async function runBrowserSmoke({
 
     const viewModeControlCheck = await assertViewModeDoesNotExposeExecutionControls({
       browser,
+      browserIdentity,
       runMarker,
       timeoutMs,
-      tokenStorageJson,
       url,
     });
 
     return {
       ...ownerRun,
       checks: [
-        "oidc_token_seeded_in_browser_storage",
+        browserIdentity.kind === "oidc"
+          ? "oidc_token_seeded_in_browser_storage"
+          : "dev_identity_seeded_in_browser_storage",
         "toolbar_start_compute_rendered",
         "toolbar_start_compute_clicked",
         "execute_button_rendered_after_compute_start",
@@ -434,13 +438,14 @@ function assertKernelStatusNotInitializing(status, context) {
 
 async function assertOwnerBlockedWorkstationStates({
   browser,
+  browserIdentity,
   timeoutMs,
-  tokenStorageJson,
   url,
   workstationId,
 }) {
   const noWorkstations = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
+    browserIdentity,
     expectedLabel: "Set up compute",
     expectedPanelText: "No workstation registered",
     expectedTitleIncludes: ["Open workstations panel"],
@@ -450,11 +455,11 @@ async function assertOwnerBlockedWorkstationStates({
     },
     scenario: "no_registered_workstations",
     timeoutMs,
-    tokenStorageJson,
     url,
   });
   const offlineDefault = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
+    browserIdentity,
     expectedLabel: "Review compute",
     expectedPanelText: "Offline workstation",
     expectedTitleIncludes: ["Open workstations panel"],
@@ -475,11 +480,11 @@ async function assertOwnerBlockedWorkstationStates({
     },
     scenario: "offline_default_workstation",
     timeoutMs,
-    tokenStorageJson,
     url,
   });
   const missingWorkingDirectory = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
+    browserIdentity,
     expectedLabel: "Review compute",
     expectedPanelText:
       "This workstation does not have a working directory configured for notebook execution.",
@@ -499,11 +504,11 @@ async function assertOwnerBlockedWorkstationStates({
     },
     scenario: "missing_working_directory",
     timeoutMs,
-    tokenStorageJson,
     url,
   });
   const missingEnvironment = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
+    browserIdentity,
     expectedLabel: "Review compute",
     expectedPanelText: "This workstation does not have a runnable default environment configured.",
     expectedTitleIncludes: ["Open workstations panel"],
@@ -521,7 +526,6 @@ async function assertOwnerBlockedWorkstationStates({
     },
     scenario: "missing_environment",
     timeoutMs,
-    tokenStorageJson,
     url,
   });
   return [noWorkstations, offlineDefault, missingWorkingDirectory, missingEnvironment];
@@ -529,19 +533,19 @@ async function assertOwnerBlockedWorkstationStates({
 
 async function assertOwnerToolbarActionWithMockedWorkstations({
   browser,
+  browserIdentity,
   expectedLabel,
   expectedPanelText = null,
   expectedTitleIncludes,
   registry,
   scenario,
   timeoutMs,
-  tokenStorageJson,
   url,
 }) {
   const context = await authenticatedContext(browser, {
+    browserIdentity,
     origin: url.origin,
     scope: "owner",
-    tokenStorageJson,
   });
   await context.route("**/api/workstations", (route) =>
     route.fulfill({
@@ -586,15 +590,15 @@ async function assertOwnerToolbarActionWithMockedWorkstations({
 
 async function assertViewModeDoesNotExposeExecutionControls({
   browser,
+  browserIdentity,
   runMarker,
   timeoutMs,
-  tokenStorageJson,
   url,
 }) {
   const context = await authenticatedContext(browser, {
+    browserIdentity,
     origin: url.origin,
     scope: "owner",
-    tokenStorageJson,
   });
   try {
     const page = await context.newPage();
@@ -617,7 +621,22 @@ async function assertViewModeDoesNotExposeExecutionControls({
   }
 }
 
-async function authenticatedContext(browser, { origin, scope, tokenStorageJson }) {
+async function authenticatedContext(browser, { browserIdentity, origin, scope }) {
+  if (browserIdentity.kind === "dev") {
+    // Dev identities authenticate every viewer request from localStorage; no
+    // app session cookie is involved.
+    return browser.newContext({
+      viewport: { width: 1440, height: 1000 },
+      storageState: storageStateForDevIdentity({
+        origin,
+        token: browserIdentity.token,
+        user: browserIdentity.user,
+        scope,
+      }),
+    });
+  }
+
+  const { tokenStorageJson } = browserIdentity;
   const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
   const token = JSON.parse(tokenStorageJson);
   const accessToken = typeof token.accessToken === "string" ? token.accessToken : null;
@@ -805,7 +824,13 @@ function assertCleanBrowserDiagnostics(events) {
 
 async function openNotebookShell(page, href, timeout) {
   await smokePhase("open notebook shell", async () => {
-    await page.goto(href, { waitUntil: "domcontentloaded", timeout });
+    // The command toolbar only renders with edit/execute capabilities, and the
+    // shell lands in view mode unless the URL asks for edit mode.
+    const target = new URL(href);
+    if (!target.searchParams.has("mode")) {
+      target.searchParams.set("mode", "edit");
+    }
+    await page.goto(target.href, { waitUntil: "domcontentloaded", timeout });
   });
   await waitForNotebookReady(page, timeout);
 }
@@ -1111,6 +1136,7 @@ async function fetchJson({
   pathname,
   authKind,
   credential,
+  devUser = null,
 }) {
   return smokePhase(`api ${label}`, async () => {
     const controller = new AbortController();
@@ -1121,7 +1147,7 @@ async function fetchJson({
     try {
       const requestInit = {
         headers: {
-          ...buildWorkstationAuthHeaders(authKind, credential),
+          ...buildWorkstationAuthHeaders(authKind, credential, { devUser, scope: "owner" }),
           "Content-Type": "application/json",
           "X-Scope": "owner",
         },
@@ -1167,6 +1193,41 @@ async function loadOptionalEnvFile() {
   }
 }
 
+async function resolveToolbarSmokeIdentity({ authKind, baseUrl, tokenPath }) {
+  assertWorkstationAuthKindAllowedForBaseUrl(authKind, baseUrl);
+  if (authKind === DEV_WORKSTATION_AUTH_KIND) {
+    const { credential, devUser } = resolveWorkstationCredential(process.env, authKind);
+    return {
+      browserIdentity: { kind: "dev", token: credential, user: devUser },
+      cloudCredential: credential,
+      cloudDevUser: devUser,
+    };
+  }
+
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const cloudCredential =
+    authKind === "oidc"
+      ? token.accessToken
+      : (process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN);
+  if (!cloudCredential) {
+    throw new Error(
+      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation toolbar smoke",
+    );
+  }
+  const secondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(secondsRemaining) || secondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the workstation toolbar smoke`,
+    );
+  }
+  return {
+    browserIdentity: { kind: "oidc", tokenStorageJson, secondsRemaining },
+    cloudCredential,
+    cloudDevUser: null,
+  };
+}
+
 async function readOidcTokenStorageJson(tokenPath) {
   const raw = await readFile(tokenPath, "utf8");
   const token = JSON.parse(raw);
@@ -1195,6 +1256,15 @@ export function redactDiagnosticUrl(url) {
 
 function scalarString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function rebaseUrl(href, baseUrl) {
+  const source = new URL(href);
+  const target = new URL(baseUrl);
+  if (source.origin === target.origin) {
+    return source.href;
+  }
+  return new URL(`${source.pathname}${source.search}${source.hash}`, target.origin).href;
 }
 
 function parsePositiveInteger(value, label, fallback) {

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -2,13 +2,16 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  assertWorkstationAuthKindAllowedForBaseUrl,
   buildWorkstationAuthHeaders,
   buildAttachJobSpawnPlan,
   buildRuntimeAgentEnv,
   buildWorkstationRegistrationPayload,
+  devPrincipalForUser,
   normalizeWorkstationAuthKind,
   parseHttpResponseBody,
   parsePositiveInteger,
+  resolveWorkstationCredential,
   retryAfterMs,
   retryCooldownMs,
   runtimePeerExitMessage,
@@ -153,7 +156,117 @@ describe("hosted workstation agent launch contract", () => {
     });
     assert.equal(normalizeWorkstationAuthKind("anaconda-api-key"), "anaconda-key");
     assert.equal(normalizeWorkstationAuthKind("oidc-bearer"), "oidc");
+    assert.equal(normalizeWorkstationAuthKind("dev"), "dev");
     assert.throws(() => normalizeWorkstationAuthKind("cookie"), /WORKSTATION_AUTH_KIND/);
+  });
+
+  it("sends the loopback dev credential trio instead of a bearer for dev auth", () => {
+    assert.deepEqual(
+      buildWorkstationAuthHeaders("dev", "local-loopback-dev-token", { devUser: "smoke" }),
+      {
+        "X-Notebook-Cloud-Dev-Token": "local-loopback-dev-token",
+        "X-User": "smoke",
+        "X-Scope": "owner",
+      },
+    );
+    assert.deepEqual(
+      buildWorkstationAuthHeaders("dev", "tok", { devUser: "smoke", scope: "runtime_peer" })[
+        "X-Scope"
+      ],
+      "runtime_peer",
+    );
+    assert.throws(
+      () => buildWorkstationAuthHeaders("dev", "local-loopback-dev-token"),
+      /NOTEBOOK_CLOUD_DEV_USER/,
+    );
+    assert.equal(devPrincipalForUser("smoke"), "user:dev:smoke");
+    assert.equal(devPrincipalForUser("smoke user"), "user:dev:smoke%20user");
+  });
+
+  it("passes the dev user label to the runtime peer only for dev auth", () => {
+    const devEnv = buildRuntimeAgentEnv({ HOME: "/home/dev", PATH: "/usr/bin" }, "dev-token", {
+      authKind: "dev",
+      devUser: "smoke",
+    });
+    assert.equal(devEnv.RUNT_CLOUD_TOKEN, "dev-token");
+    assert.equal(devEnv.RUNT_CLOUD_DEV_USER, "smoke");
+
+    const bearerEnv = buildRuntimeAgentEnv({ HOME: "/home/dev", PATH: "/usr/bin" }, "key", {
+      authKind: "anaconda-key",
+      devUser: "smoke",
+    });
+    assert.equal(bearerEnv.RUNT_CLOUD_TOKEN, "key");
+    assert.equal(bearerEnv.RUNT_CLOUD_DEV_USER, undefined);
+  });
+
+  it("spawns dev-auth runtime peers only against loopback Workers", () => {
+    const spawn = (baseUrl) =>
+      buildAttachJobSpawnPlan({
+        job: { job_id: "job-dev", notebook_id: "nb-dev" },
+        pythonPath: "/opt/k/bin/python",
+        agentRoot: "/tmp/agent",
+        baseUrl,
+        workingDirectory: "/home/dev/project",
+        workstationId: "ws-dev",
+        displayName: "dev workstation",
+        authKind: "dev",
+      });
+
+    for (const baseUrl of [
+      "http://127.0.0.1:45123",
+      "http://localhost:8787",
+      "http://[::1]:8787",
+    ]) {
+      const plan = spawn(baseUrl);
+      assert.deepEqual(plan.args.slice(0, 3), ["cloud-runtime-agent", "--auth-kind", "dev"]);
+      assert.equal(plan.args.includes("local-loopback-dev-token"), false);
+    }
+
+    assert.throws(() => spawn("https://preview.runt.run"), /only allowed against a loopback/);
+    assert.throws(
+      () => assertWorkstationAuthKindAllowedForBaseUrl("dev", "https://preview.runt.run"),
+      /refusing https:\/\/preview\.runt\.run/,
+    );
+    assert.equal(
+      assertWorkstationAuthKindAllowedForBaseUrl("anaconda-key", "https://preview.runt.run"),
+      "anaconda-key",
+    );
+  });
+
+  it("resolves the dev credential from NOTEBOOK_CLOUD_DEV_TOKEN and NOTEBOOK_CLOUD_DEV_USER", () => {
+    assert.deepEqual(
+      resolveWorkstationCredential(
+        {
+          NOTEBOOK_CLOUD_DEV_TOKEN: "local-loopback-dev-token",
+          NOTEBOOK_CLOUD_DEV_USER: "smoke",
+          NTERACT_API_KEY: "ignored-for-dev",
+        },
+        "dev",
+      ),
+      { authKind: "dev", credential: "local-loopback-dev-token", devUser: "smoke" },
+    );
+    assert.deepEqual(
+      resolveWorkstationCredential({ NOTEBOOK_CLOUD_DEV_TOKEN: "tok" }, "dev", {
+        defaultDevUser: "runtime-peer-smoke",
+      }),
+      { authKind: "dev", credential: "tok", devUser: "runtime-peer-smoke" },
+    );
+    assert.throws(
+      () => resolveWorkstationCredential({ NOTEBOOK_CLOUD_DEV_USER: "smoke" }, "dev"),
+      /NOTEBOOK_CLOUD_DEV_TOKEN/,
+    );
+    assert.throws(
+      () => resolveWorkstationCredential({ NOTEBOOK_CLOUD_DEV_TOKEN: "tok" }, "dev"),
+      /NOTEBOOK_CLOUD_DEV_USER/,
+    );
+    assert.deepEqual(
+      resolveWorkstationCredential(
+        { NTERACT_API_KEY: "key-secret", NOTEBOOK_CLOUD_DEV_TOKEN: "unused" },
+        "anaconda-key",
+      ),
+      { authKind: "anaconda-key", credential: "key-secret", devUser: null },
+    );
+    assert.throws(() => resolveWorkstationCredential({}, "oidc"), /NTERACT_API_KEY/);
   });
 
   it("projects stable registration metadata for the current Python launcher", () => {

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -199,17 +199,28 @@ RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
 
 The credential is always passed through the environment, never argv. Defaults: scope
 `runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda
-API keys, `--auth-kind workstation` for a pairing-flow credential). Blob root
+API keys, `--auth-kind workstation` for a pairing-flow credential,
+`--auth-kind dev` for a loopback Worker's dev credentials). Blob root
 defaults under the daemon's standard cache. `--python-path` launches a kernel
 in that interpreter immediately on attach (launch-on-attach); omit it to
 attach idle and wait for the room to dispatch work. `--workstation-id` /
 `--workstation-display-name` set the non-secret identity shown in the
 notebook's workstation panel.
 
+`--auth-kind dev` reads `RUNT_CLOUD_TOKEN` plus `RUNT_CLOUD_DEV_USER` and sends
+`X-Notebook-Cloud-Dev-Token` / `X-User` / `X-Scope` on the upgrade; the Worker
+maps that to `user:dev:<user>`. The Worker only honors dev credentials on
+loopback requests, so this kind is for Wrangler dev or a local celld launcher,
+never a deployed host.
+
 The Node connector (`apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`)
 is the dev-loop equivalent of `runtimed workstation-agent` and keeps working
 against the same attach-job surface with `NTERACT_API_KEY` or
-`NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN`.
+`NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN`. Against a loopback Worker, set
+`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev` with `NOTEBOOK_CLOUD_DEV_TOKEN` and
+`NOTEBOOK_CLOUD_DEV_USER`; the connector refuses `dev` for any non-loopback
+`NOTEBOOK_CLOUD_URL`. The `apps/notebook-cloud` README covers the matching
+runtime smoke commands.
 
 For browser-coupled OIDC peers whose token expires, mint fresh tokens via a
 refresher (the transport supports per-connect refresh; see


### PR DESCRIPTION
The runtime smokes and the Node workstation agent could not run against a loopback Worker. Every script hardcoded bearer auth (`Authorization: Bearer` with an Anaconda API key or an OIDC token cache), so the regression net for hosted compute only existed against preview. #4219 made that gap concrete: the local celld launcher gives you a Worker on 127.0.0.1, and nothing in `apps/notebook-cloud/scripts` could drive compute through it.

This adds a `dev` auth kind that uses the Worker's existing loopback dev credentials. The Rust side already supported it (`runtimed cloud-runtime-agent --auth-kind dev` reads `RUNT_CLOUD_TOKEN` + `RUNT_CLOUD_DEV_USER` and sends `x-notebook-cloud-dev-token` / `x-user` / `x-scope` on the upgrade); this PR teaches the Node scripts the same contract. Nothing in Rust or the Worker changes.

## What each script gained

| Script | Selector | Credential env | Effect |
|---|---|---|---|
| `hosted-workstation-agent.mjs` (+ core) | `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev` | `NOTEBOOK_CLOUD_DEV_TOKEN`, `NOTEBOOK_CLOUD_DEV_USER` | REST uses the dev trio at owner scope; spawned peers get `--auth-kind dev` + `RUNT_CLOUD_DEV_USER` |
| `hosted-runtime-peer-smoke.mjs` | `NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_AUTH_KIND` or the shared `..._WORKSTATION_AUTH_KIND` | same; user defaults to `runtime-peer-smoke` | REST, runtime peer, and owner `cloud-peer` all switch; asserts the room owner row is `user:dev:<user>` before granting `runtime_peer` |
| `hosted-browser-execute-smoke.mjs` | `NOTEBOOK_CLOUD_BROWSER_EXECUTE_AUTH_KIND=dev`, or automatic when the OIDC cache file is missing and `NOTEBOOK_CLOUD_DEV_TOKEN` is set | same | seeds the dev-auth localStorage keys via `storageStateForDevIdentity` instead of the OIDC cache; opens the room with `?mode=edit` |
| `hosted-runtime-browser-execute-smoke.mjs` | inherits from the runtime-peer step | forwards `devUser` from the peer smoke result | browser presents the same dev user that owns the room |
| `hosted-workstation-toolbar-smoke.mjs` | shared `..._WORKSTATION_AUTH_KIND=dev` or `..._TOOLBAR_SMOKE_AUTH_KIND` | same | dev storage state instead of OIDC + app session; rebases the Worker's `viewer_url` onto the target origin; honors `NOTEBOOK_CLOUD_URL` |

Defaults are unchanged: `anaconda-key` for the peer and agent paths, the OIDC token cache for the browser paths. Existing preview invocations behave as before.

## Design callout: loopback-only guard

`dev` is refused unless the target URL's host is `127.0.0.1`, `localhost`, or `[::1]`. The check runs in `assertWorkstationAuthKindAllowedForBaseUrl` before any request, and again inside `buildAttachJobSpawnPlan` so a spawned peer can't be pointed elsewhere by a job payload. The Worker itself only honors dev credentials on loopback requests, so this is not a security boundary, it is a fast, local failure: a stray `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev` against preview produces one clear error instead of a stream of 401s with placeholder credentials in flight.

## Smaller fixes that fell out

- `hosted-collab-smoke-env.mjs` now imports the storage-key constants from `src/dev-auth-storage.ts` (their defining module, type-only imports) instead of the viewer re-export. Plain `node` can strip and load it, so the browser-execute smoke can reuse `storageStateForDevIdentity` without adding `--import tsx`.
- `hosted-runtime-peer-smoke.mjs` resolves `cloud-peer` from `NOTEBOOK_CLOUD_RUNTIMED_BIN` when `NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN` is unset; it is the same binary.
- The browser-execute and toolbar smokes open rooms in edit mode. The hosted shell lands in view mode by default and hides every execution control there, so the execute button these smokes wait for never existed. #4220 makes the same change to the browser-execute smoke through `viewerUrlWithMode`; whichever lands second keeps that helper.

## Verified locally

Against a Wrangler dev Worker on 127.0.0.1 with `target/debug/runtimed`: `smoke:hosted:runtime-peer` and `smoke:hosted:runtime-browser-execute` pass with `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=dev`. The Node agent registers as `user:dev:smoke`, a `POST /api/n/<id>/workstation-attachments` produces `attach_job_spawned`, the peer connects with the dev principal, and the job reaches `running`. The toolbar smoke gets through identity, workstation listing, default selection, notebook creation, and the `Start compute` toolbar action with the dev identity, then fails a workstation-panel copy assertion (`No workstation registered`) that predates this change and is unrelated to auth.

The Worker's `viewer_url` and attach-job `runtime_peer.cloud_url` still report the configured public host (`http://preview.runt.run`) from a loopback Worker. The smokes now work around it by rebasing on the target origin; a follow-up could have the Worker derive them from the request origin on loopback.

Docs: `apps/notebook-cloud/README.md` gains a dev-auth section next to the smoke docs, and `docs/runbooks/remote-workstation.md` lists `dev` alongside the other auth kinds with the loopback caveat.
