### PR TITLE
feat(notebook-cloud): NOTEBOOK_CLOUD_PUBLIC_ORIGIN for TLS-terminating proxies

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -74,6 +74,13 @@ node apps/notebook-cloud/scripts/celld-local.mjs start     # also: status | stop
 node apps/notebook-cloud/scripts/celld-local.mjs workstation-start   # pairing-flow kernel host
 ```
 
+Behind a TLS-terminating proxy that speaks plain HTTP to the Worker (celld
+behind cloudflared, an ALB), set `NOTEBOOK_CLOUD_PUBLIC_ORIGIN` to the browser-
+facing origin. Viewer links, the runtime peer's `cloud_url`, OG image URLs, and
+the root redirect are built from it instead of `request.url`; the origin
+allow-list includes it. `celld-local.mjs export` sets it from
+`NOTEBOOK_CLOUD_CELLD_PUBLIC_ORIGINS`. Unset on Cloudflare.
+
 The script header documents the celld constraints it works around (JSON config,
 project-relative `main`/assets, one deployment per store, static WASM import).
 Smoke and publish scripts target it with `NOTEBOOK_CLOUD_URL=http://127.0.0.1:9876`.

--- a/apps/notebook-cloud/scripts/celld-local.mjs
+++ b/apps/notebook-cloud/scripts/celld-local.mjs
@@ -456,6 +456,10 @@ function mainVars(sessionSecret) {
     return {
       DEPLOYMENT_ENV: "celld",
       NOTEBOOK_CLOUD_BUILD_SHA: gitCommit(),
+      // The TLS terminator in front of celld delivers plain HTTP, so
+      // request.url carries the hop's scheme and host. Absolute URLs the
+      // Worker hands out (viewer links, runtime peer cloud_url) come from here.
+      NOTEBOOK_CLOUD_PUBLIC_ORIGIN: main,
       NOTEBOOK_CLOUD_ALLOWED_ORIGINS: main,
       NOTEBOOK_CLOUD_OIDC_ISSUER: publicOidc.issuer,
       NOTEBOOK_CLOUD_OIDC_CLIENT_ID: publicOidc.clientId,

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -8,6 +8,15 @@ export interface Env {
   DEPLOYMENT_ENV?: string;
   NOTEBOOK_CLOUD_BUILD_SHA?: string;
   NOTEBOOK_CLOUD_ALLOWED_ORIGINS?: string;
+  /**
+   * Origin browsers and runtime peers use to reach this deployment, for
+   * example `https://app.example.com`. Set it when a TLS-terminating proxy
+   * delivers plain HTTP to the Worker (celld behind cloudflared or an ALB),
+   * so absolute URLs the Worker hands out (viewer links, the runtime peer's
+   * `cloud_url`, OG images) carry the public scheme and host instead of the
+   * proxy hop's. Unset on Cloudflare, where `request.url` is already public.
+   */
+  NOTEBOOK_CLOUD_PUBLIC_ORIGIN?: string;
   NOTEBOOK_CLOUD_ANACONDA_API_KEY_PRINCIPAL_NAMESPACE?: string;
   NOTEBOOK_CLOUD_ANACONDA_API_KEY_USERINFO_URL?: string;
   NOTEBOOK_CLOUD_APP_SESSION_SECRET?: string;

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -294,7 +294,7 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   {
     match: exactPath("/", "/index.html"),
     methods: ["GET", "HEAD"],
-    handler: (_match, request) => rootNotebookListRedirect(request),
+    handler: (_match, request, env) => rootNotebookListRedirect(request, env),
   },
   {
     match: exactPath("/n", "/n/"),
@@ -908,8 +908,20 @@ function rejectUntrustedMutationOrigin(request: Request, env: Env): Response | n
   return null;
 }
 
+/**
+ * The origin clients use to reach this deployment. `NOTEBOOK_CLOUD_PUBLIC_ORIGIN`
+ * wins when set; otherwise the request's own origin, which is correct on
+ * Cloudflare and on any host that sees the public scheme and host directly.
+ */
+function publicOrigin(request: Request, env: Env): string {
+  return (
+    normalizedOrigin(env.NOTEBOOK_CLOUD_PUBLIC_ORIGIN?.trim() ?? null) ??
+    new URL(request.url).origin
+  );
+}
+
 function allowedTrustedOrigins(request: Request, env: Env): Set<string> {
-  const origins = new Set<string>([new URL(request.url).origin]);
+  const origins = new Set<string>([new URL(request.url).origin, publicOrigin(request, env)]);
   const loopbackOrigin = trustedLoopbackBrowserOrigin(request, env);
   if (loopbackOrigin) {
     origins.add(loopbackOrigin);
@@ -2356,7 +2368,7 @@ async function routeNotebookWorkstationAttachment(
   return json(
     {
       ok: true,
-      job: workstationAttachJobResponseRow(request, job),
+      job: workstationAttachJobResponseRow(request, env, job),
       workstation: workstationResponseRow(workstation, {
         defaultWorkstationId,
         now: Date.now(),
@@ -2527,7 +2539,7 @@ async function routeWorkstationAttachJobs(
       now: Date.now(),
       lease,
     }),
-    jobs: jobs.map((job) => workstationAttachJobResponseRow(request, job)),
+    jobs: jobs.map((job) => workstationAttachJobResponseRow(request, env, job)),
   });
 }
 
@@ -2833,7 +2845,7 @@ async function routeWorkstationAttachJob(
     return json(
       {
         error: "workstation attach job is no longer active",
-        job: workstationAttachJobResponseRow(request, job),
+        job: workstationAttachJobResponseRow(request, env, job),
       },
       409,
     );
@@ -2852,7 +2864,7 @@ async function routeWorkstationAttachJob(
   }
   return json({
     ok: true,
-    job: workstationAttachJobResponseRow(request, job),
+    job: workstationAttachJobResponseRow(request, env, job),
   });
 }
 
@@ -3309,6 +3321,7 @@ function parseStoredWorkstationEnvironments(value: string | null): unknown[] {
 
 function workstationAttachJobResponseRow(
   request: Request,
+  env: Env,
   job: WorkstationAttachJobRow,
 ): Record<string, unknown> {
   return {
@@ -3323,7 +3336,7 @@ function workstationAttachJobResponseRow(
     finished_at: job.finished_at,
     error_message: job.error_message,
     runtime_peer: {
-      cloud_url: new URL(request.url).origin,
+      cloud_url: publicOrigin(request, env),
       notebook_id: job.notebook_id,
       scope: "runtime_peer",
     },
@@ -3529,12 +3542,14 @@ function viewerUrlForRequest(
   vanityName: string | null,
   env?: Env,
 ): string {
-  const url = new URL(trustedLoopbackBrowserOrigin(request, env) ?? request.url);
+  const origin =
+    trustedLoopbackBrowserOrigin(request, env) ??
+    (env ? publicOrigin(request, env) : new URL(request.url).origin);
   const vanitySegment = vanityName?.trim() || "notebook";
-  url.pathname = `/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanitySegment)}`;
-  url.search = "";
-  url.hash = "";
-  return url.href;
+  return new URL(
+    `/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanitySegment)}`,
+    origin,
+  ).href;
 }
 
 function latestNotebookOgImageUrlForRequest(
@@ -3542,11 +3557,8 @@ function latestNotebookOgImageUrlForRequest(
   env: Env,
   notebookId: string,
 ): string {
-  const url = new URL(trustedLoopbackBrowserOrigin(request, env) ?? request.url);
-  url.pathname = `/n/${encodeURIComponent(notebookId)}/r/latest/ogImage.png`;
-  url.search = "";
-  url.hash = "";
-  return url.href;
+  const origin = trustedLoopbackBrowserOrigin(request, env) ?? publicOrigin(request, env);
+  return new URL(`/n/${encodeURIComponent(notebookId)}/r/latest/ogImage.png`, origin).href;
 }
 
 function oidcHealth(env: Env): {
@@ -4921,7 +4933,7 @@ async function validateSnapshotPair(options: {
       runtimeStateBytes: options.runtimeStateBytes,
       commsDocBytes: options.commsDocBytes,
       blobResolver: createNotebookCloudBlobResolver({
-        baseUrl: options.request.url,
+        baseUrl: publicOrigin(options.request, options.env),
         blobBasePath: notebookCloudBlobBasePath(options.notebookId),
       }),
     });
@@ -6088,10 +6100,11 @@ interface ViewerShellResourceHints {
   runtimedWasmPath?: string | null;
 }
 
-function rootNotebookListRedirect(request: Request): Response {
+function rootNotebookListRedirect(request: Request, env: Env): Response {
   const url = new URL(request.url);
-  url.pathname = "/n";
-  return Response.redirect(url.toString(), 302);
+  const target = new URL("/n", publicOrigin(request, env));
+  target.search = url.search;
+  return Response.redirect(target.href, 302);
 }
 
 async function notebookListViewer(request: Request, env: Env): Promise<Response> {
@@ -6489,7 +6502,9 @@ function oidcAuthConfigForRequest(request: Request, env: Env): Record<string, st
   return {
     issuer,
     clientId,
-    redirectUri: env.NOTEBOOK_CLOUD_OIDC_REDIRECT_URI?.trim() || new URL("/oidc", request.url).href,
+    redirectUri:
+      env.NOTEBOOK_CLOUD_OIDC_REDIRECT_URI?.trim() ||
+      new URL("/oidc", publicOrigin(request, env)).href,
     ...(providerLabel ? { providerLabel } : {}),
     // Server-derived: only the dev issuer mount sets this, and the viewer keys
     // its login_hint forwarding on it. Deriving it here (not from the issuer

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -4579,6 +4579,96 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  // A TLS-terminating proxy that delivers plain HTTP (celld behind cloudflared,
+  // an ALB) makes request.url carry the hop's scheme and host. Absolute URLs
+  // the Worker hands out must come from the configured public origin instead:
+  // a runtime peer dialing ws://<public host> would get a redirect, not a
+  // socket.
+  it("hands runtime peers the configured public origin as cloud_url", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_CLOUD_PUBLIC_ORIGIN: "https://app.example.test",
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () =>
+            new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-1",
+      notebookId: "nb-1",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://127.0.0.1:9876/api/workstations/ws-lab2/attach-jobs/job-1", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "running" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { job: { runtime_peer: { cloud_url: string } } };
+    assert.equal(body.job.runtime_peer.cloud_url, "https://app.example.test");
+  });
+
+  it("builds viewer links from the configured public origin", async () => {
+    const env = fakeEnv({ NOTEBOOK_CLOUD_PUBLIC_ORIGIN: "https://app.example.test/" });
+
+    const response = await worker.fetch(
+      new Request("http://127.0.0.1:9876/api/n", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Public Origin" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 201);
+    const body = (await response.json()) as { notebook_id: string; viewer_url: string };
+    assert.equal(body.viewer_url, `https://app.example.test/n/${body.notebook_id}/Public%20Origin`);
+
+    // Unset, the request's own origin is the public origin.
+    const plain = fakeEnv();
+    const plainResponse = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Own Origin" }),
+      }),
+      plain,
+      fakeContext(),
+    );
+    assert.equal(plainResponse.status, 201);
+    const plainBody = (await plainResponse.json()) as { notebook_id: string; viewer_url: string };
+    assert.equal(plainBody.viewer_url, `http://localhost/n/${plainBody.notebook_id}/Own%20Origin`);
+  });
+
   it("publishes workstation claim progress into RuntimeStateDoc", async () => {
     let attachmentStatus: string | undefined;
     let attachmentMessage: string | undefined | null;


### PR DESCRIPTION
Adds `NOTEBOOK_CLOUD_PUBLIC_ORIGIN`, the browser-facing origin of a deployment, for hosts where a TLS-terminating proxy delivers plain HTTP to the Worker. Follows #4225; this is what app.runt.run runs now.

## Diagnosis

The Worker builds several absolute URLs from `request.url`: the viewer link, the runtime peer's `cloud_url` in attach-job responses, the OG image URL, the root redirect, the server-side blob resolver base, and the OIDC redirect fallback. On Cloudflare `request.url` is the public origin. On celld behind cloudflared (or behind an ALB) it is the hop's `http://` origin, so an attaching workstation was handed `cloud_url: "http://app.runt.run"`, dialed `ws://`, and got a redirect instead of a socket.

celld's `--trust-forwarded-headers` would fix the scheme but also trusts `X-Forwarded-Host`, which Cloudflare passes through from clients unchanged, and the request origin feeds the trusted-origin set. The lab deployment worked around it with a loopback proxy that overwrote both headers. That hop is gone with this change.

## Change

`publicOrigin(request, env)` returns the configured origin when set and `request.url`'s origin otherwise, so Cloudflare deployments are byte-for-byte unchanged. Used at the six sites above; the trusted-origin set includes it. `workstationAttachJobResponseRow` and `rootNotebookListRedirect` now take `env`. The root redirect keeps its query string.

`celld-local.mjs export` sets the var from `NOTEBOOK_CLOUD_CELLD_PUBLIC_ORIGINS` in public-origin mode. README documents when to set it.

## Verification

Two new route tests: an attach-job PATCH arriving over `http://127.0.0.1:9876` returns `cloud_url: "https://app.example.test"`, and notebook creation over the same hop returns an `https://app.example.test/n/...` viewer link, with the unset case still deriving from the request. 211/211 route tests pass; typecheck and `cargo xtask lint` clean.

Live: deployed to lab1 with cloudflared forwarding directly to celld (no proxy hop, no forwarded-header trust). A plain `http://127.0.0.1:9876/?x=1` on the box with `Host: app.runt.run` redirects to `https://app.runt.run/n?x=1`; the public notebook page emits `https://app-assets.runt.run`, `https://app-outputs.runt.run`, and `https://app.runt.run/oidc`.
