### PR TITLE
fix(notebook-cloud): tell users to start the agent when a paired workstation is not listening

### DIFF
--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -23,8 +23,9 @@ export const WORKSTATION_LEASE_GC_MS = 24 * 60 * 60_000;
 // Hard ceiling on a single went_offline delivery so a slow or dead events DO
 // cannot keep the background notify (and thus the registry DO) alive.
 const WORKSTATION_WENT_OFFLINE_NOTIFY_TIMEOUT_MS = 5_000;
+// Shown to the user on the attachment and in the panel: say what to do.
 const WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_MESSAGE =
-  "workstation lease expired: no heartbeat within the lease window";
+  "the workstation stopped sending heartbeats before it picked up this request. Run `runt workstation run` on that machine, then attach again.";
 const WORKSTATION_LEASE_EXPIRED_ATTACH_JOB_TIMEOUT_MS = 5_000;
 const WORKSTATION_LEASE_RUNTIME_REPAIR_TIMEOUT_MS = 5_000;
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1809,6 +1809,18 @@ const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 // offline agree. The DO's alarm makes the transition proactive instead of
 // only-on-read.
 const WORKSTATION_LEASE_TTL_MS = WORKSTATION_HEARTBEAT_STALE_MS;
+
+// What a user can do about a workstation that is not taking compute requests.
+// The command is the same on every platform and is what `runt workstation
+// connect` prints; repeating it here is what turns a grey button into a fix.
+const WORKSTATION_START_AGENT_HINT =
+  "Run `runt workstation run` on that machine, then attach again.";
+function workstationNotListeningMessage(displayName: string): string {
+  return `${displayName} is paired but no workstation agent is listening. ${WORKSTATION_START_AGENT_HINT}`;
+}
+function workstationNoHeartbeatMessage(displayName: string): string {
+  return `${displayName} stopped sending heartbeats. ${WORKSTATION_START_AGENT_HINT}`;
+}
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
 const MISSING_WORKSTATION_RETRY_AFTER_SECONDS = 15 * 60;
 const MAX_WORKSTATION_ACCELERATORS = 16;
@@ -2310,15 +2322,19 @@ async function routeNotebookWorkstationAttachment(
       reason: `workstation ${workstationId} is not online while attaching compute`,
       operation: "offline_workstation_attach",
     });
+    const row = workstationResponseRow(workstation, {
+      defaultWorkstationId,
+      now: Date.now(),
+      eventPresence,
+      lease,
+    });
+    // The viewer surfaces this string as the panel status line, so it has to
+    // say what to do, not only that the request was refused.
     return json(
       {
-        error: "workstation is not online",
-        workstation: workstationResponseRow(workstation, {
-          defaultWorkstationId,
-          now: Date.now(),
-          eventPresence,
-          lease,
-        }),
+        error: row.status_message ?? "workstation is not online",
+        error_code: "workstation_not_online",
+        workstation: row,
       },
       409,
     );
@@ -3039,6 +3055,11 @@ function parseWorkstationRegistrationPayload(
     return environmentsJson;
   }
 
+  const listening = payload.listening;
+  if (listening !== undefined && typeof listening !== "boolean") {
+    return json({ error: "listening must be a boolean" }, 400);
+  }
+
   return {
     workstationId,
     displayName,
@@ -3054,6 +3075,7 @@ function parseWorkstationRegistrationPayload(
     memoryBytes,
     acceleratorsJson,
     environmentsJson,
+    ...(listening === undefined ? {} : { listening }),
   };
 }
 
@@ -3204,13 +3226,15 @@ function workstationResponseRow(
     provider_label: workstation.provider_label,
     status,
     status_message:
-      status === "offline" && options.eventPresence?.connected === false
-        ? "Workstation event socket is not connected."
-        : status === "online" && options.eventPresence?.connected === true
-          ? workstation.status_message
-          : status === "offline" && workstation.status === "online"
-            ? "No heartbeat from this workstation recently."
-            : workstation.status_message,
+      status === "connecting" && workstation.status === "connecting"
+        ? (workstation.status_message ?? workstationNotListeningMessage(workstation.display_name))
+        : status === "offline" && options.eventPresence?.connected === false
+          ? workstationNoHeartbeatMessage(workstation.display_name)
+          : status === "online" && options.eventPresence?.connected === true
+            ? workstation.status_message
+            : status === "offline" && workstation.status === "online"
+              ? workstationNoHeartbeatMessage(workstation.display_name)
+              : workstation.status_message,
     default_environment_label: workstation.default_environment_label,
     environment_policy: workstation.environment_policy,
     installed_build: workstation.installed_build,

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -185,6 +185,15 @@ export interface WorkstationRegistrationInput {
   memoryBytes?: number | null;
   acceleratorsJson?: string | null;
   environmentsJson?: string | null;
+  /**
+   * False when the registrant is not serving attach requests. `runt workstation
+   * connect` sends this: pairing registers the machine so it appears in the
+   * catalog, but nothing is listening until `runt workstation run` starts. The
+   * row is stored as `connecting`, which the viewer already treats as not
+   * attachable, and the first agent heartbeat (which omits the field) flips it
+   * to `online`. Default true.
+   */
+  listening?: boolean;
 }
 
 export interface WorkstationAttachJobRow {
@@ -1066,7 +1075,7 @@ export async function registerWorkstation(
        created_at,
        updated_at,
        last_seen_at
-     ) VALUES (?, ?, ?, ?, ?, 'online', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(owner_principal, workstation_id) DO UPDATE SET
        display_name = excluded.display_name,
        provider = excluded.provider,
@@ -1091,6 +1100,7 @@ export async function registerWorkstation(
       input.displayName,
       input.provider ?? "runtime_peer",
       input.providerLabel ?? null,
+      input.listening === false ? "connecting" : "online",
       input.statusMessage ?? null,
       input.defaultEnvironmentLabel ?? null,
       input.environmentPolicy ?? null,

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -211,7 +211,8 @@ describe("OwnerComputeIndex lease notifications and GC", () => {
     await object.alarm();
     await settle();
 
-    const expectedError = "workstation lease expired: no heartbeat within the lease window";
+    const expectedError =
+      "the workstation stopped sending heartbeats before it picked up this request. Run `runt workstation run` on that machine, then attach again.";
     for (const jobId of ["pending-job", "accepted-job", "running-job"]) {
       assert.equal(jobs.get(jobId)?.status, "failed");
       assert.equal(jobs.get(jobId)?.error_message, expectedError);

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3700,9 +3700,14 @@ describe("Worker artifact routes", () => {
     assert.equal(attach.status, 409);
     const body = (await attach.json()) as {
       error?: string;
+      error_code?: string;
       workstation?: { workstation_id?: string; status?: string };
     };
-    assert.equal(body.error, "workstation is not online");
+    assert.equal(
+      body.error,
+      "Lab2 stopped sending heartbeats. Run `runt workstation run` on that machine, then attach again.",
+    );
+    assert.equal(body.error_code, "workstation_not_online");
     assert.equal(body.workstation?.workstation_id, "ws-lab1");
     assert.equal(body.workstation?.status, "offline");
     assert.equal(env.DB.workstationAttachJobs.size, 0);
@@ -3817,6 +3822,122 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  // `runt workstation connect` registers the machine so it shows up, but nothing
+  // serves compute until `runt workstation run` starts. Three users hit this on
+  // the first public deployment: the row read "Online", attach was accepted,
+  // and the job died three minutes later with no visible explanation.
+  it("registers a paired-but-not-listening workstation as connecting with a hint", async () => {
+    const env = fakeEnv();
+    const register = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "cli:runt",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({
+          workstation_id: "ws-paired",
+          display_name: "Anils MacBook",
+          listening: false,
+        }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(register.status, 201);
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: { "X-Operator": "browser:tab", "X-Scope": "owner", "X-User": "alice" },
+      }),
+      env,
+      fakeContext(),
+    );
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+        status_message: string | null;
+      }>;
+    };
+    const row = body.workstations.find((entry) => entry.workstation_id === "ws-paired");
+    assert.equal(row?.status, "connecting");
+    assert.equal(
+      row?.status_message,
+      "Anils MacBook is paired but no workstation agent is listening. Run `runt workstation run` on that machine, then attach again.",
+    );
+
+    // Attaching now is refused with the same instruction instead of a job that
+    // will fail later.
+    seedNotebook(env, "nb-paired");
+    seedAcl(env, { notebookId: "nb-paired", subject: "user:dev:alice", scope: "owner" });
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/nb-paired/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-paired" }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(attach.status, 409);
+    const attachBody = (await attach.json()) as { error: string; error_code: string };
+    assert.equal(attachBody.error_code, "workstation_not_online");
+    assert.match(attachBody.error, /runt workstation run/);
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+
+    // The agent's first heartbeat omits `listening` and brings the row online.
+    const heartbeat = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:anil",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({
+          workstation_id: "ws-paired",
+          display_name: "Anils MacBook",
+          installed_build: "0.1.0+abc123",
+        }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.ok(heartbeat.status === 200 || heartbeat.status === 201);
+    assert.equal(
+      env.DB.workstations.get(workstationKey("user:dev:alice", "ws-paired"))?.status,
+      "online",
+    );
+  });
+
+  it("rejects a non-boolean listening flag on registration", async () => {
+    const env = fakeEnv();
+    const register = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "cli:runt",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-x", display_name: "X", listening: "no" }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(register.status, 400);
+  });
+
   it("allows attach requests for stale workstations with a connected event socket", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
@@ -3912,9 +4033,14 @@ describe("Worker artifact routes", () => {
     assert.equal(attach.status, 409);
     const body = (await attach.json()) as {
       error?: string;
+      error_code?: string;
       workstation?: { workstation_id?: string; status?: string };
     };
-    assert.equal(body.error, "workstation is not online");
+    assert.equal(
+      body.error,
+      "Lab2 stopped sending heartbeats. Run `runt workstation run` on that machine, then attach again.",
+    );
+    assert.equal(body.error_code, "workstation_not_online");
     assert.equal(body.workstation?.workstation_id, "ws-lab2");
     assert.equal(body.workstation?.status, "offline");
     assert.deepEqual(roomRequests, ["/internal/n/attach-lease-demo/runtime-state-repair"]);
@@ -10351,6 +10477,7 @@ class FakeD1Statement implements D1PreparedStatement {
         displayName,
         provider,
         providerLabel,
+        status,
         statusMessage,
         defaultEnvironmentLabel,
         environmentPolicy,
@@ -10370,6 +10497,7 @@ class FakeD1Statement implements D1PreparedStatement {
         string,
         string,
         string | null,
+        WorkstationRow["status"],
         string | null,
         string | null,
         string | null,
@@ -10392,7 +10520,7 @@ class FakeD1Statement implements D1PreparedStatement {
         display_name: displayName,
         provider,
         provider_label: providerLabel,
-        status: "online",
+        status,
         status_message: statusMessage,
         default_environment_label: defaultEnvironmentLabel,
         environment_policy: environmentPolicy,

--- a/apps/notebook-cloud/viewer/cloud-workstations-store.ts
+++ b/apps/notebook-cloud/viewer/cloud-workstations-store.ts
@@ -87,6 +87,12 @@ export interface CloudWorkstationPairing {
   status: CloudWorkstationPairingStatus;
   workstationId: string | null;
   workstationName: string | null;
+  /**
+   * Whether the registered workstation is serving compute. `runt workstation
+   * connect` registers the machine before the agent runs, so "registered" is
+   * not "connected"; the dialog says which one it is.
+   */
+  workstationOnline: boolean | null;
   error: string | null;
 }
 
@@ -307,6 +313,7 @@ export function cloudWorkstationPairingEquals(
     a.status === b.status &&
     a.workstationId === b.workstationId &&
     a.workstationName === b.workstationName &&
+    a.workstationOnline === b.workstationOnline &&
     a.error === b.error
   );
 }
@@ -321,6 +328,7 @@ const _CLOUD_WORKSTATION_PAIRING_FIELDS = {
   status: true,
   workstationId: true,
   workstationName: true,
+  workstationOnline: true,
   error: true,
 } satisfies Record<keyof CloudWorkstationPairing, true>;
 void _CLOUD_WORKSTATION_PAIRING_FIELDS;
@@ -357,7 +365,13 @@ function resolvePairingName(
     return pairing;
   }
   const registered = workstations.find((workstation) => workstation.id === pairing.workstationId);
-  return registered ? { ...pairing, workstationName: registered.displayName } : pairing;
+  return registered
+    ? {
+        ...pairing,
+        workstationName: registered.displayName,
+        workstationOnline: registered.status === "online",
+      }
+    : pairing;
 }
 
 function errorMessage(error: unknown): string {
@@ -631,6 +645,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
           status: "pending",
           workstationId: null,
           workstationName: null,
+          workstationOnline: null,
           error: null,
         },
       }));
@@ -649,6 +664,7 @@ export class CloudWorkstationsStore extends ObservableStore<CloudWorkstationsSta
           status: "expired",
           workstationId: null,
           workstationName: null,
+          workstationOnline: null,
           error: errorMessage(error),
         },
       }));

--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -215,6 +215,7 @@ async fn connect(
             println!(
                 "Registered workstation \"{display_name}\" ({workstation_id}) with {cloud_url}."
             );
+            println!("It is not serving compute yet.");
         }
         Ok(response) => {
             eprintln!(
@@ -232,18 +233,18 @@ async fn connect(
     }
 
     let cli = runt_workspace::cli_command_name();
-    println!("To serve attach requests in this terminal:");
+    println!();
+    println!("Next, start the agent and leave it running while you use the notebook:");
     println!("  {cli} workstation run");
+    println!("Pass --python-path <python with ipykernel> if the default interpreter lacks it.");
     #[cfg(target_os = "linux")]
     {
-        println!("To keep this workstation available with user systemd:");
+        println!("Or keep it running as a user service:");
         println!("  {cli} workstation service install --start");
     }
     #[cfg(not(target_os = "linux"))]
     {
-        println!(
-            "Persistent workstation service management starts with Linux user systemd; use the foreground command in tmux for now."
-        );
+        println!("Keep that terminal (or a tmux session) open; the workstation goes offline about a minute after it exits.");
     }
     Ok(())
 }
@@ -310,6 +311,12 @@ pub(crate) fn parse_redeem_response(
 /// Minimal registration payload for the one-shot `connect` registration.
 /// (`runtimed workstation-agent` sends the full payload — python path,
 /// capabilities, memory — on every heartbeat.)
+///
+/// `listening: false` tells the cloud that nothing is serving attach requests
+/// yet: the row lists as `connecting` with a "run `runt workstation run`" hint
+/// instead of `online`, and attach is refused with that hint rather than
+/// queued into a job that fails when the pairing lease lapses. The agent's
+/// first heartbeat omits the field and flips the row to `online`.
 pub(crate) fn minimal_registration_payload(
     workstation_id: &str,
     display_name: &str,
@@ -322,6 +329,7 @@ pub(crate) fn minimal_registration_payload(
         "provider": "runtime_peer",
         "environment_policy": "current_python",
         "default_environment_label": "Current Python",
+        "listening": false,
     });
     if let Some(dir) = working_directory {
         payload["working_directory"] = dir.into();
@@ -1407,6 +1415,7 @@ mod tests {
                 "provider": "runtime_peer",
                 "environment_policy": "current_python",
                 "default_environment_label": "Current Python",
+                "listening": false,
                 "working_directory": "/home/ubuntu/project",
                 "cpu_count": 8,
             })
@@ -1415,6 +1424,9 @@ mod tests {
         let sparse = minimal_registration_payload("ws", "ws", None, None);
         assert!(sparse.get("working_directory").is_none());
         assert!(sparse.get("cpu_count").is_none());
+        // connect never claims to be serving compute; only the agent heartbeat
+        // (which omits the field) brings the row online.
+        assert_eq!(sparse.get("listening"), Some(&serde_json::json!(false)));
     }
 
     #[test]

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -52,6 +52,12 @@ export interface NotebookWorkstationPairingView {
   expiresAt: string;
   status: "pending" | "redeemed" | "registered" | "expired";
   workstationName: string | null;
+  /**
+   * Whether the registered machine is serving compute. Pairing registers it
+   * before the agent runs; `registered` alone means it is listed, not ready.
+   * Omitted (or null) reads as not yet serving.
+   */
+  workstationOnline?: boolean | null;
   error: string | null;
 }
 
@@ -327,7 +333,9 @@ export function WorkstationPairingDialog({
             <div className="flex min-w-0 items-center gap-2 text-sm text-foreground">
               <CircleCheck className="size-4 shrink-0 text-emerald-500" aria-hidden="true" />
               <span data-testid="workstation-pairing-status" aria-live="polite">
-                {pairing.workstationName ?? "Workstation"} is connected.
+                {pairing.workstationOnline
+                  ? `${pairing.workstationName ?? "Workstation"} is connected.`
+                  : `${pairing.workstationName ?? "Workstation"} is registered. Run \`runt workstation run\` on it to start serving compute.`}
               </span>
             </div>
           ) : pairing.status === "expired" ? (
@@ -762,7 +770,8 @@ type WorkstationDetailFact = Omit<NotebookRegisteredWorkstationFactProjection, "
     | "provider"
     | "build"
     | "channel"
-    | "last_seen";
+    | "last_seen"
+    | "status";
 };
 
 function registeredWorkstationDetailFacts(
@@ -792,6 +801,12 @@ function registeredWorkstationDetailFacts(
   );
   push("channel", "Channel", workstation.channel);
   push("last_seen", "Last seen", workstationLastSeenLabel(workstation));
+  // Why a workstation cannot take compute right now, in the server's words.
+  // Online rows carry no such message; for the rest it is the one line that
+  // tells the user what to do (start the agent, usually).
+  if (workstation.status !== "online") {
+    push("status", "Status", workstation.statusMessage, null, "attention");
+  }
 
   return [...workstation.facts, ...extras];
 }

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -354,6 +354,11 @@ describe("NotebookWorkstationsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /Offline workstation/ }));
     expect(rows().map((row) => row.dataset.selected)).toEqual(["false", "true"]);
     expect(within(details()).getByText("id ws-offline")).toBeVisible();
+    // A workstation that cannot take compute says why, in the details only.
+    expect(within(details()).getByText("Status")).toBeVisible();
+    expect(
+      within(details()).getByText("No heartbeat from this workstation recently."),
+    ).toBeVisible();
     fireEvent.click(within(details()).getByRole("button", { name: "Set default" }));
     expect(defaults).toEqual(["ws-offline"]);
   });
@@ -638,10 +643,11 @@ describe("NotebookWorkstationsPanel", () => {
     const details = within(screen.getByRole("region", { name: "Workstation details" }));
     expect(details.getByText("Current Python")).toBeVisible();
     expect(details.getByText("id ws-lab2")).toBeVisible();
-    // The raw per-workstation message never renders; status is conveyed by the label.
-    expect(
-      screen.queryByText("No heartbeat from this workstation recently."),
-    ).not.toBeInTheDocument();
+    // The per-workstation message renders once, as a detail fact of the
+    // selected row: the label says "Offline", the fact says what to do.
+    expect(details.getByText("Status")).toBeVisible();
+    expect(details.getByText("No heartbeat from this workstation recently.")).toBeVisible();
+    expect(screen.getAllByText("No heartbeat from this workstation recently.")).toHaveLength(1);
   });
 
   it("lists the attached workstation alongside the other registered ones", () => {
@@ -1075,9 +1081,26 @@ describe("NotebookWorkstationsPanel", () => {
     );
     expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(/Machine connected/);
 
+    // `connect` registers the machine before the agent runs; the dialog must
+    // not call that "connected".
     rerender(
       <WorkstationPairingDialog
         pairing={{ ...pairingBase, status: "registered", workstationName: "Hub devbox" }}
+        onCancel={() => dismissed.push(1)}
+      />,
+    );
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
+      "Hub devbox is registered. Run `runt workstation run` on it to start serving compute.",
+    );
+
+    rerender(
+      <WorkstationPairingDialog
+        pairing={{
+          ...pairingBase,
+          status: "registered",
+          workstationName: "Hub devbox",
+          workstationOnline: true,
+        }}
         onCancel={() => dismissed.push(1)}
       />,
     );


### PR DESCRIPTION
Makes the "paired but nothing is listening" state visible and actionable. Three users hit it on the first public celld deployment today; one retried three times.

## Diagnosis

`runt workstation connect` registers the machine with `status = 'online'` and a 3-minute lease so it shows up in the panel immediately. Nothing serves attach requests until `runt workstation run` starts and heartbeats. In that window the row reads "Online", attach is accepted and queues a job, the lease lapses, `fleet_registry.attach_jobs_failed_for_expired_lease` fails the job, and the room repair publishes `disconnected`. The failure message never reaches the panel (the row's `status_message` was not rendered, and the label alone is "Offline"), so the user sees a button turn grey.

Neither `installed_build` nor event-socket presence works as the signal: the Node agent registers without `installed_build` and polls instead of opening the socket, so either rule would have blocked real agents.

## Change

| Layer | Before | After |
| --- | --- | --- |
| `runt workstation connect` | registers as if serving | registers with `listening: false`; output leads with the `run` command and mentions `--python-path` |
| `POST /api/workstations` | always `online` | `listening: false` stores `connecting`; agent heartbeats (which omit the field) flip it to `online` |
| `GET /api/workstations` | `status_message` null for the paired row | "`<name>` is paired but no workstation agent is listening. Run `runt workstation run` on that machine, then attach again." |
| `POST .../workstation-attachments` | accepted, job fails 3 min later | `409 { error: <that message>, error_code: "workstation_not_online" }`, no job |
| offline `status_message` | "No heartbeat from this workstation recently." | "`<name>` stopped sending heartbeats. Run `runt workstation run` on that machine, then attach again." |
| lease-expiry job failure | "workstation lease expired: no heartbeat within the lease window" | says the agent stopped before picking up the request and what to run |
| panel details | `status_message` never rendered | non-online rows show it as a "Status" fact (attention tone); still never above the list |
| pairing dialog | "`<name>` is connected." after `connect` alone | "is registered. Run `runt workstation run` on it to start serving compute." until the row is online |

`connecting` is an existing `WorkstationStatus`; the viewer already labels it and disables Start for it. No schema change.

## Verification

New route tests: paired registration lists as `connecting` with the hint, attach is refused with the hint and creates no job, a heartbeat flips the row online, a non-boolean `listening` is a 400. The two existing 409 tests assert the actionable copy and `error_code`. Panel tests cover the "Status" fact in details (and its absence above the list) and both pairing dialog states. `runt` payload tests assert `listening: false`. notebook-cloud: 1466/1466; panel and hook suites: 32/32; `cargo test -p runt` green; `cargo xtask lint` clean.

Not yet verified against a real user's attach on app.runt.run; the server side deploys with the next celld push, the CLI side ships with the next nightly.
