### PR TITLE
ci(release): use NumFOCUS Apple signing credentials

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -283,33 +283,44 @@ jobs:
       - name: Install Tauri CLI
         uses: ./.github/actions/install-tauri-cli
 
-      - name: Import Apple signing certificate
+      # Keep the NumFOCUS certificate and notarization credentials together.
+      - name: Prepare NumFOCUS Apple signing and notarization
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.NUMFOCUS_APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.NUMFOCUS_APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.NUMFOCUS_APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.NUMFOCUS_APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.NUMFOCUS_APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.NUMFOCUS_APPLE_API_PRIVATE_KEY }}
         run: |
-          if [ -z "$APPLE_CERTIFICATE" ]; then
-            echo "No signing certificate configured, skipping"
-            exit 0
-          fi
+          set -euo pipefail
+          umask 077
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing NumFOCUS credential: $name"
+              exit 1
+            fi
+          done
 
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
           security import "$RUNNER_TEMP/certificate.p12" \
             -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+            -T /usr/bin/codesign -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
 
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq -- "$APPLE_SIGNING_IDENTITY"
           rm "$RUNNER_TEMP/certificate.p12"
 
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$RUNNER_TEMP/notarization-key.p8"
 
       - name: Set version in tauri.conf.json
         run: |
@@ -354,20 +365,22 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.NUMFOCUS_APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.NUMFOCUS_APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.NUMFOCUS_APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notarization-key.p8
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: crates/notebook
           args: --bundles app,dmg --config '{"build":{"beforeBuildCommand":""}}'
           includeUpdaterJson: false
 
-      - name: Cleanup keychain
+      - name: Cleanup Apple signing credentials
         if: always()
         run: |
-          if [ -n "$KEYCHAIN_PATH" ] && [ -f "$KEYCHAIN_PATH" ]; then
+          rm -f "$RUNNER_TEMP/certificate.p12" "$RUNNER_TEMP/notarization-key.p8"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
 
@@ -454,33 +467,44 @@ jobs:
       - name: Install Tauri CLI
         uses: ./.github/actions/install-tauri-cli
 
-      - name: Import Apple signing certificate
+      # Keep the NumFOCUS certificate and notarization credentials together.
+      - name: Prepare NumFOCUS Apple signing and notarization
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.NUMFOCUS_APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.NUMFOCUS_APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.NUMFOCUS_APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.NUMFOCUS_APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.NUMFOCUS_APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.NUMFOCUS_APPLE_API_PRIVATE_KEY }}
         run: |
-          if [ -z "$APPLE_CERTIFICATE" ]; then
-            echo "No signing certificate configured, skipping"
-            exit 0
-          fi
+          set -euo pipefail
+          umask 077
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing NumFOCUS credential: $name"
+              exit 1
+            fi
+          done
 
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
           security import "$RUNNER_TEMP/certificate.p12" \
             -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+            -T /usr/bin/codesign -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
 
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -Fq -- "$APPLE_SIGNING_IDENTITY"
           rm "$RUNNER_TEMP/certificate.p12"
 
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$RUNNER_TEMP/notarization-key.p8"
 
       - name: Set version in tauri.conf.json
         run: |
@@ -525,20 +549,22 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.NUMFOCUS_APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.NUMFOCUS_APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.NUMFOCUS_APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/notarization-key.p8
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: crates/notebook
           args: --target x86_64-apple-darwin --bundles app,dmg --config '{"build":{"beforeBuildCommand":""}}'
           includeUpdaterJson: false
 
-      - name: Cleanup keychain
+      - name: Cleanup Apple signing credentials
         if: always()
         run: |
-          if [ -n "$KEYCHAIN_PATH" ] && [ -f "$KEYCHAIN_PATH" ]; then
+          rm -f "$RUNNER_TEMP/certificate.p12" "$RUNNER_TEMP/notarization-key.p8"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
 


### PR DESCRIPTION
Switch the shared Stable/Nightly macOS ARM64 and Intel notebook builds to NumFOCUS's Developer ID Application certificate and App Store Connect API-key notarization. Both jobs use the six separately staged `NUMFOCUS_APPLE_*` repository secrets, so merging this change switches signing and notarization together without replacing the credentials used by the current workflow.

The preparation step fails when any credential is missing, verifies the imported signing identity, restricts key-file permissions, and limits imported-key access to codesign. Cleanup removes the P12, notarization key, and temporary keychain on success or failure. Tauri updater signing keys and app bundle identifiers are unchanged.

Validation:

- Certificate/private-key match, current validity, and macOS code-signing trust verified. Identity: `Developer ID Application: NumFOCUS, Inc. (2YJ64GUAVW)`; expires February 1, 2027 at 22:12:15 UTC.
- Apple's read-only notarization submission-history endpoint accepted the API credentials (HTTP 200). No software submission or release was made.
- Confirmed API-key environment handling in the pinned Tauri CLI 2.11.0 source and [Tauri's signing documentation](https://tauri.app/distribute/sign/macos/).
- `actionlint .github/workflows/release-common.yml`, `cargo xtask lint --fix`, and `git diff --check` passed.
- Executed both preparation/cleanup scripts with a mock keychain: all six missing credentials fail; success writes the expected key with mode 0600; import failure and success both clean up credential files and keychain.
- All six new GitHub secrets were created successfully and their metadata verified. Existing Apple and Tauri updater secret timestamps are unchanged. Local credential staging was removed.

Independent Kilo correctness, security, and operability reviews completed with source integrity preserved. No actionable findings survived verification: security suggestions were pre-existing or contradicted by shell/masking behavior, and the claimed missing cleanup is explicitly implemented and covered by the failure-path checks. PR CI passed at commit `6c83edfa3`: lint, browser E2E, JavaScript tests/benchmarks, WASM/Deno, shared UI artifacts, Linux Rust tests/Clippy, Node package, Python unit tests, Windows Clippy, and the final CI health summary. This validates credentials and workflow configuration; an actual signed/notarized nteract artifact and cross-team upgrade behavior remain to be verified during the authorized Nightly run after merge. Merging activates the credentials for subsequent Stable/Nightly runs, including the scheduled Nightly run. Reverting this workflow change restores the old secret references while those secrets remain available.
