### PR TITLE
fix(runtimed): distinguish lock failures from contention

### DIFF
--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -225,7 +225,7 @@ Each open notebook has a room (`NotebookRoom`), keyed by UUID. A `PathIndex` map
 
 ## Troubleshooting
 
-**Daemon lock held:** `runt daemon status` → check with `lsof`. Remove stale `daemon.lock` + `daemon.json` if crashed.
+**Daemon lock held:** Inspect the selected endpoint with `runt daemon status` and check its `daemon.lock` with `lsof`. The OS releases the advisory lock when its owner exits; an existing file is not proof of a live owner. Do not delete the lock file to bypass contention, since replacing its inode can allow two owners. Filesystem failures are separate errors, and live socket metadata is the discovery source.
 
 **Pool not replenishing:** Verify `uv --version` and check `~/.cache/runt/envs/`.
 

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -249,7 +249,7 @@ Manage with `runt daemon start/stop/status/logs`. Cross-platform install/uninsta
 
 ## Troubleshooting
 
-**Daemon won't start (lock held):** Check `lsof ~/.cache/<namespace>/daemon.lock`. If stale, remove the lock file.
+**Daemon won't start (lock held):** Check the selected endpoint and `lsof ~/.cache/<namespace>/daemon.lock`. A lock file can outlive its owner; the OS releases the advisory lock when the process exits. Do not delete the file to bypass contention: replacing its inode can allow two owners of the same runtime state. Filesystem failures are reported separately from contention.
 
 **Pool not replenishing:** Verify `uv --version` works and check `~/.cache/<namespace>/envs/`.
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -32,12 +32,11 @@ use crate::notebook_sync_server::{NotebookRooms, RoomRegistry};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{Request, Response};
 use crate::settings_doc::{SettingsDoc, SyncedSettings};
-use crate::singleton::DaemonLock;
+use crate::singleton::{DaemonLock, DaemonLockError};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::trusted_packages::{log_store_unavailable, TrustedPackageStore};
 use crate::{default_blob_store_dir, is_pool_env_dir, is_within_cache_dir, EnvType, PooledEnv};
 use notebook_protocol::connection::{self, Handshake};
-use runtimed_client::singleton::DaemonInfo;
 
 fn existing_file_allows_write(path: &Path) -> bool {
     match std::fs::metadata(path) {
@@ -1324,13 +1323,6 @@ pub struct Daemon {
     pub(crate) shell_env_overlay: Arc<crate::shell_env_overlay::ShellEnvOverlay>,
 }
 
-/// Error returned when another daemon is already running.
-#[derive(Debug, thiserror::Error)]
-#[error("Another daemon is already running: {info:?}")]
-pub struct DaemonAlreadyRunning {
-    pub info: Box<DaemonInfo>,
-}
-
 #[doc(hidden)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestRecoveryManifestFacts {
@@ -1558,7 +1550,7 @@ impl Daemon {
     /// Test-only convenience that constructs a `Daemon` with an empty shell-env
     /// overlay. Integration tests reach this through the crate's public surface.
     #[doc(hidden)]
-    pub fn new_for_test(mut config: DaemonConfig) -> Result<Arc<Self>, DaemonAlreadyRunning> {
+    pub fn new_for_test(mut config: DaemonConfig) -> Result<Arc<Self>, DaemonLockError> {
         // Test daemons must never write into the real shared file-claim
         // registry; force a config-scoped (tempdir-scoped) one when the
         // test did not pick its own.
@@ -1572,21 +1564,20 @@ impl Daemon {
 
     /// Create a new daemon with the given configuration.
     ///
-    /// Returns an error if another daemon is already running.
-    pub fn new(config: DaemonConfig) -> Result<Arc<Self>, DaemonAlreadyRunning> {
+    /// Returns an error on lock contention or a failure to access the lock.
+    pub fn new(config: DaemonConfig) -> Result<Arc<Self>, DaemonLockError> {
         Self::new_with_overlay(config, crate::shell_env_overlay::ShellEnvOverlay::capture)
     }
 
     fn new_with_overlay(
         config: DaemonConfig,
         overlay_provider: impl FnOnce() -> crate::shell_env_overlay::ShellEnvOverlay,
-    ) -> Result<Arc<Self>, DaemonAlreadyRunning> {
+    ) -> Result<Arc<Self>, DaemonLockError> {
         // Acquire the singleton lock BEFORE capturing the shell env. Duplicate
         // launchd/double-click starts hit this path, and we don't want them to
         // pay the up-to-3s shell-capture cost or run rc files for side effects
         // before discovering the existing daemon and exiting cleanly.
-        let lock = DaemonLock::try_acquire(config.lock_dir.as_ref())
-            .map_err(|info| DaemonAlreadyRunning { info })?;
+        let lock = DaemonLock::try_acquire(config.lock_dir.as_ref())?;
 
         let shell_env_overlay = Arc::new(overlay_provider());
         tracing::info!(
@@ -7778,6 +7769,34 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    #[test]
+    fn lock_failures_do_not_capture_shell_environment() -> anyhow::Result<()> {
+        let tmp = TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        let config = DaemonConfig {
+            lock_dir: Some(dir.clone()),
+            ..Default::default()
+        };
+        let owner = DaemonLock::try_acquire(Some(&dir))?;
+        assert!(matches!(
+            Daemon::new_with_overlay(config.clone(), || panic!(
+                "duplicate must not run shell rc files"
+            )),
+            Err(DaemonLockError::Contended { .. })
+        ));
+        drop(owner);
+        // Replace the unlocked file with a directory to force a real open error.
+        std::fs::remove_file(dir.join("daemon.lock"))?;
+        std::fs::create_dir(dir.join("daemon.lock"))?;
+        assert!(matches!(
+            Daemon::new_with_overlay(config, || panic!(
+                "lock failure must not run shell rc files"
+            )),
+            Err(DaemonLockError::Io { .. })
+        ));
+        Ok(())
+    }
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -767,17 +767,21 @@ async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     info!("  Pixi pool size: {}", config.pixi_pool_size);
     let daemon = match Daemon::new(config) {
         Ok(d) => d,
-        Err(e) => {
+        Err(runtimed::singleton::DaemonLockError::Contended { path }) => {
             // Another daemon is already running — this is expected during
             // launchd double-start races, NOT a crash. Exit 0 so launchd's
             // KeepAlive.Crashed does not restart us.
             let msg = format!(
-                "Another daemon already running (pid={}, endpoint={}), exiting cleanly",
-                e.info.pid, e.info.endpoint
+                "Another process holds the daemon lock at {}; exiting cleanly (socket readiness is not yet known)",
+                path.display()
             );
-            early_log(&msg);
+            warn!("{msg}");
             eprintln!("{msg}");
-            std::process::exit(0);
+            return Ok(());
+        }
+        Err(error) => {
+            tracing::error!("{error}");
+            return Err(error.into());
         }
     };
 
@@ -990,4 +994,47 @@ async fn flush_pool() -> anyhow::Result<()> {
     println!("Pool flushed. Environments will be rebuilt with current settings.");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn duplicate_start_succeeds_without_claiming_socket_readiness() -> anyhow::Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        let _owner = runtimed::singleton::DaemonLock::try_acquire(Some(&dir))?;
+        let socket_path = dir.join("never-bound.sock");
+        let config = DaemonConfig {
+            lock_dir: Some(dir),
+            socket_path: socket_path.clone(),
+            ..Default::default()
+        };
+        run_daemon(config).await?;
+        assert!(!socket_path.exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn lock_io_failure_is_a_startup_error() -> anyhow::Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        std::fs::create_dir(dir.join("daemon.lock"))?;
+        let config = DaemonConfig {
+            lock_dir: Some(dir),
+            ..Default::default()
+        };
+        let error = run_daemon(config)
+            .await
+            .expect_err("lock I/O must fail startup");
+        assert!(matches!(
+            error.downcast_ref::<runtimed::singleton::DaemonLockError>(),
+            Some(runtimed::singleton::DaemonLockError::Io {
+                operation: "open",
+                ..
+            })
+        ));
+        Ok(())
+    }
 }

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -259,11 +259,14 @@ mod tests {
         let dir = tmp.path().to_path_buf();
         let path = dir.join("daemon.lock");
         std::fs::write(&path, "existing contents")?;
-        let _first = DaemonLock::try_acquire(Some(&dir))?;
-        assert!(matches!(
-            DaemonLock::try_acquire(Some(&dir)),
-            Err(DaemonLockError::Contended { .. })
-        ));
+        {
+            let _first = DaemonLock::try_acquire(Some(&dir))?;
+            assert!(matches!(
+                DaemonLock::try_acquire(Some(&dir)),
+                Err(DaemonLockError::Contended { .. })
+            ));
+        }
+        // Windows denies reads through a second handle while the lock is held.
         assert_eq!(std::fs::read_to_string(path)?, "existing contents");
         Ok(())
     }

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -9,7 +9,7 @@ use std::fs::{File, OpenOptions};
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
-use tracing::{info, warn};
+use tracing::info;
 
 // Re-export all client-side singleton items so `runtimed::singleton::*` still works.
 use runtimed_client::singleton as client_singleton;
@@ -21,17 +21,31 @@ pub struct DaemonLock {
     _lock_path: PathBuf,
 }
 
+/// Failure to claim the runtime's state directory. Contention says nothing
+/// about the holder's identity or whether its socket is ready.
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonLockError {
+    #[error("Another process holds the daemon lock at {path}")]
+    Contended { path: PathBuf },
+    #[error("Failed to {operation} daemon lock at {path}: {source}")]
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
 impl DaemonLock {
     /// Attempt to acquire the daemon lock.
     ///
     /// Returns `Ok(lock)` if we acquired the lock (we are the singleton).
-    /// Returns `Err(info)` if another daemon is running (with its info).
+    /// Returns `Contended` if another process holds the lock, or `Io` for a
+    /// filesystem/locking failure. Neither outcome fabricates daemon metadata.
     ///
     /// If `custom_lock_dir` is provided, uses that directory for lock files
     /// instead of the default. This is primarily for testing.
-    pub fn try_acquire(
-        custom_lock_dir: Option<&PathBuf>,
-    ) -> Result<Self, Box<client_singleton::DaemonInfo>> {
+    pub fn try_acquire(custom_lock_dir: Option<&PathBuf>) -> Result<Self, DaemonLockError> {
         let lock_path = if let Some(dir) = custom_lock_dir {
             dir.join("daemon.lock")
         } else {
@@ -40,22 +54,24 @@ impl DaemonLock {
 
         // Ensure parent directory exists
         if let Some(parent) = lock_path.parent() {
-            std::fs::create_dir_all(parent).ok();
+            std::fs::create_dir_all(parent).map_err(|source| DaemonLockError::Io {
+                operation: "create directory for",
+                path: lock_path.clone(),
+                source,
+            })?;
         }
 
         // Try to open/create the lock file
-        let lock_file = match OpenOptions::new()
+        let lock_file = OpenOptions::new()
             .create(true)
-            .truncate(true)
+            .truncate(false)
             .write(true)
             .open(&lock_path)
-        {
-            Ok(f) => f,
-            Err(e) => {
-                warn!("[singleton] Failed to open lock file: {}", e);
-                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
-            }
-        };
+            .map_err(|source| DaemonLockError::Io {
+                operation: "open",
+                path: lock_path.clone(),
+                source,
+            })?;
 
         // Try to acquire exclusive lock (non-blocking)
         #[cfg(unix)]
@@ -64,9 +80,16 @@ impl DaemonLock {
             let fd = lock_file.as_raw_fd();
             let result = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
             if result != 0 {
-                // Another process holds the lock
-                info!("[singleton] Another daemon is already running");
-                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
+                let source = std::io::Error::last_os_error();
+                return Err(if source.kind() == std::io::ErrorKind::WouldBlock {
+                    DaemonLockError::Contended { path: lock_path }
+                } else {
+                    DaemonLockError::Io {
+                        operation: "acquire",
+                        path: lock_path,
+                        source,
+                    }
+                });
             }
         }
 
@@ -92,8 +115,20 @@ impl DaemonLock {
                 )
             };
             if result == 0 {
-                info!("[singleton] Another daemon is already running");
-                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
+                let source = std::io::Error::last_os_error();
+                return Err(
+                    if source.raw_os_error()
+                        == Some(windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION as i32)
+                    {
+                        DaemonLockError::Contended { path: lock_path }
+                    } else {
+                        DaemonLockError::Io {
+                            operation: "acquire",
+                            path: lock_path,
+                            source,
+                        }
+                    },
+                );
             }
         }
 
@@ -116,24 +151,6 @@ impl Drop for DaemonLock {
             libc::flock(self._lock_file.as_raw_fd(), libc::LOCK_UN);
         }
         info!("[singleton] Released daemon lock");
-    }
-}
-
-fn placeholder_daemon_info(custom_lock_dir: Option<&PathBuf>) -> client_singleton::DaemonInfo {
-    let endpoint = custom_lock_dir
-        .map(|dir| dir.join("runtimed.sock"))
-        .unwrap_or_else(runt_workspace::default_socket_path);
-    client_singleton::DaemonInfo {
-        endpoint: endpoint.to_string_lossy().to_string(),
-        protocol_version: notebook_protocol::connection::PROTOCOL_VERSION.into(),
-        daemon_api_version: runtimed_client::protocol::DAEMON_API_VERSION,
-        pid: 0,
-        version: "unknown".to_string(),
-        started_at: chrono::Utc::now(),
-        blob_port: None,
-        execution_store_dir: None,
-        worktree_path: None,
-        workspace_description: None,
     }
 }
 
@@ -163,15 +180,10 @@ mod tests {
         let dir = tmp.path().to_path_buf();
         let first = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "first acquire")?;
 
-        let Err(info) = DaemonLock::try_acquire(Some(&dir)) else {
+        let Err(DaemonLockError::Contended { path }) = DaemonLock::try_acquire(Some(&dir)) else {
             return Err("second acquire should have failed".into());
         };
-        assert_eq!(
-            info.endpoint,
-            dir.join("runtimed.sock").to_string_lossy().as_ref()
-        );
-        assert_eq!(info.pid, 0);
-        assert_eq!(info.version, "unknown");
+        assert_eq!(path, dir.join("daemon.lock"));
         drop(first);
         Ok(())
     }
@@ -199,6 +211,104 @@ mod tests {
             DaemonLock::try_acquire(Some(&nested)).map_err(|_| "acquire in nonexistent dir")?;
         assert!(nested.exists());
         assert!(nested.join("daemon.lock").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn directory_failure_preserves_io_error() -> TestResult {
+        let tmp = TempDir::new()?;
+        let file = tmp.path().join("not-a-directory");
+        std::fs::write(&file, "occupied")?;
+        let dir = file.join("runtime");
+        let Err(DaemonLockError::Io {
+            operation,
+            path,
+            source,
+        }) = DaemonLock::try_acquire(Some(&dir))
+        else {
+            return Err("directory failure must not be reported as contention".into());
+        };
+        assert_eq!(operation, "create directory for");
+        assert_eq!(path, dir.join("daemon.lock"));
+        assert!(source.raw_os_error().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn open_failure_preserves_io_error() -> TestResult {
+        let tmp = TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        std::fs::create_dir(dir.join("daemon.lock"))?;
+        let Err(DaemonLockError::Io {
+            operation,
+            path,
+            source,
+        }) = DaemonLock::try_acquire(Some(&dir))
+        else {
+            return Err("open failure must not be reported as contention".into());
+        };
+        assert_eq!(operation, "open");
+        assert_eq!(path, dir.join("daemon.lock"));
+        assert!(source.raw_os_error().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn acquire_preserves_existing_lock_file() -> TestResult {
+        let tmp = TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        let path = dir.join("daemon.lock");
+        std::fs::write(&path, "existing contents")?;
+        let _first = DaemonLock::try_acquire(Some(&dir))?;
+        assert!(matches!(
+            DaemonLock::try_acquire(Some(&dir)),
+            Err(DaemonLockError::Contended { .. })
+        ));
+        assert_eq!(std::fs::read_to_string(path)?, "existing contents");
+        Ok(())
+    }
+
+    #[test]
+    fn independent_directories_can_hold_locks_concurrently() -> TestResult {
+        let tmp = TempDir::new()?;
+        let first_dir = tmp.path().join("first");
+        let second_dir = tmp.path().join("second");
+        let _first = DaemonLock::try_acquire(Some(&first_dir))?;
+        let _second = DaemonLock::try_acquire(Some(&second_dir))?;
+        assert!(matches!(
+            DaemonLock::try_acquire(Some(&first_dir)),
+            Err(DaemonLockError::Contended { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn simultaneous_starts_elect_one_owner() -> TestResult {
+        let tmp = TempDir::new()?;
+        let dir = tmp.path().to_path_buf();
+        let barrier = std::sync::Barrier::new(8);
+        let results = std::thread::scope(|scope| {
+            let attempts: Vec<_> = (0..8)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        let result = DaemonLock::try_acquire(Some(&dir));
+                        // Hold the winner until every other contender has tried.
+                        barrier.wait();
+                        result.map(|_lock| true).or_else(|error| match error {
+                            DaemonLockError::Contended { .. } => Ok(false),
+                            error => Err(error),
+                        })
+                    })
+                })
+                .collect();
+            attempts
+                .into_iter()
+                .map(|attempt| attempt.join().expect("contender panicked"))
+                .collect::<Result<Vec<_>, _>>()
+        })?;
+        assert_eq!(results.into_iter().filter(|won| *won).count(), 1);
+        let _after_race = DaemonLock::try_acquire(Some(&dir))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Daemon startup treats filesystem and locking failures as an already-running daemon and exits successfully, hiding errors such as an inaccessible lock file. This change returns distinct contention and I/O errors, preserves the path and underlying OS error, and reserves the clean duplicate-start exit for actual lock contention. It stops fabricating daemon identity from a failed lock attempt and leaves existing lock-file contents intact.

Tests cover simultaneous contenders, independent directories, lock release, directory/open errors, and startup success versus failure before shell environment capture. Troubleshooting guidance explains why an existing lock file must not be deleted to bypass contention. Runtime discovery, readiness negotiation, and shared-service lifetime remain separate work.

Validation on `e5f5188650c690625c66a0a4aa0d43e8cc24ea2c`:

- Nine singleton tests, the lock-before-shell-capture regression, two startup tests, Tokio mutex lint, strict Clippy, and repository lint passed. Two independent Kilo reviews completed; confirmed findings about test placement and Stable-channel logging were fixed and checked again.
- [Standard PR checks passed](https://github.com/nteract/nteract/actions/runs/34506619902). The broader [manual Build](https://github.com/nteract/nteract/actions/runs/34506624166) passed its native Windows and macOS jobs, including the Windows lock tests after correcting a test that read through a second handle while the exclusive lock was held.
- The broader Build remains failed in Python integration: `TestKernelLifecycle.test_async_shutdown_kernel` failed its initial client-readiness assertion before shutdown (126 passed, one failed, one skipped). Server logs show successful kernel launch; they do not establish that the client had received and applied runtime state.

The bounded readiness investigation found no reproduced regression from this lock patch. Ten normal and ten forced-fallback cases passed on each revision. With the same diagnostic harness deliberately delaying runtime-state messages, both the base and PR versions returned from the existing Python helper after a successful fallback launch while the client still reported `Resolving`. Both reached `Running/Idle` after those messages were released. This demonstrates a pre-existing missing readiness check after fallback, not a natural reproduction or a conclusive explanation of the CI failure. The local comparison used macOS/Python 3.13; CI used Linux/Python 3.12.

Merge disposition: accept the narrow lock fix with this validation limitation recorded. Follow up the helper's post-fallback readiness wait and timeout diagnostics separately. No desktop launch, packaged-app validation, or release qualification is claimed.
