### PR TITLE
feat(cli): open notebook paths and fresh directory notebooks

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -564,6 +564,87 @@ struct PreparedHostedRelay {
     raw_frame_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
 }
 
+struct StartupWindow {
+    label: String,
+    title: String,
+    mode: OpenMode,
+    saved_scale_factor: Option<f64>,
+}
+
+/// Directory opens always create a fresh room. The resolved directory travels
+/// with the request instead of depending on the Desktop process's working directory.
+fn directory_open_window(path: &Path, runtime: &Runtime) -> Result<Option<StartupWindow>, String> {
+    if !path.is_dir() {
+        return Ok(None);
+    }
+    let working_dir = path
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve directory '{}': {e}", path.display()))?;
+    Ok(Some(StartupWindow {
+        label: format!("notebook-{}", uuid::Uuid::new_v4()),
+        title: "Untitled.ipynb".to_string(),
+        mode: OpenMode::Create {
+            runtime: runtime.to_string(),
+            working_dir: Some(working_dir),
+            notebook_id: None,
+        },
+        saved_scale_factor: None,
+    }))
+}
+
+/// macOS delivers the CLI's directory as both a cold-launch argument and a
+/// document event. Consume that event once; later opens of the same directory
+/// must still create fresh notebooks. A running app receives only the event.
+#[cfg(any(test, target_os = "macos"))]
+struct InitialDirectoryEvent {
+    path: PathBuf,
+    expires_at: std::time::Instant,
+}
+
+#[cfg(any(test, target_os = "macos"))]
+impl InitialDirectoryEvent {
+    fn new(path: PathBuf, now: std::time::Instant) -> Self {
+        Self {
+            path,
+            // Defensive fallback if LaunchServices omits the initial event.
+            // This is not a delivery guarantee: a very late event opens fresh.
+            expires_at: now + std::time::Duration::from_secs(5),
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn consume_initial_directory_event(
+    pending: &mut Option<InitialDirectoryEvent>,
+    url: &tauri::Url,
+    now: std::time::Instant,
+) -> bool {
+    let Some(expected) = pending.as_ref() else {
+        return false;
+    };
+    if now >= expected.expires_at {
+        *pending = None;
+        return false;
+    }
+    let Ok(path) = url.to_file_path() else {
+        return false;
+    };
+    if path.canonicalize().is_ok_and(|path| path == expected.path) {
+        *pending = None;
+        true
+    } else {
+        false
+    }
+}
+
+/// Explicit document opens can name an extensionless notebook (for example
+/// `nteract ./open`). The daemon validates the notebook bytes; a filename suffix
+/// is not a content check. Preserve the existing missing `.ipynb` open path too.
+#[cfg(any(test, target_os = "macos"))]
+fn is_notebook_file_open_candidate(path: &Path) -> bool {
+    path.is_file() || path.extension().and_then(|extension| extension.to_str()) == Some("ipynb")
+}
+
 fn normalize_hosted_notebook_locator(value: &str) -> Result<String, String> {
     let (domain, notebook_id) = notebook_cloud_transport::registry::parse_hosted_url(value.trim())?;
     Ok(notebook_cloud_transport::registry::hosted_notebook_url(
@@ -1309,6 +1390,147 @@ async fn setup_sync_receivers(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn directory_opens_create_distinct_untitled_windows_in_resolved_directory() {
+        let project = tempfile::tempdir().unwrap();
+        let requested = project.path().join(".");
+        let first = super::directory_open_window(&requested, &super::Runtime::Python)
+            .unwrap()
+            .unwrap();
+        let second = super::directory_open_window(&requested, &super::Runtime::Python)
+            .unwrap()
+            .unwrap();
+        assert_ne!(first.label, second.label);
+        for window in [first, second] {
+            assert_eq!(window.title, "Untitled.ipynb");
+            assert!(window.saved_scale_factor.is_none());
+            let super::OpenMode::Create {
+                runtime,
+                working_dir,
+                notebook_id,
+            } = window.mode
+            else {
+                panic!("a directory must create a fresh room, not open or restore a notebook");
+            };
+            assert_eq!(runtime, "python");
+            assert_eq!(working_dir, Some(project.path().canonicalize().unwrap()));
+            assert!(
+                notebook_id.is_none(),
+                "the daemon must allocate a fresh notebook ID"
+            );
+        }
+    }
+
+    #[test]
+    fn directory_opens_leave_file_and_missing_path_handling_unchanged() {
+        let project = tempfile::tempdir().unwrap();
+        let file = project.path().join("saved.ipynb");
+        std::fs::write(&file, "{}").unwrap();
+        for path in [file, project.path().join("missing.ipynb")] {
+            assert!(super::directory_open_window(&path, &super::Runtime::Python)
+                .unwrap()
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn directory_handoff_consumes_only_one_matching_initial_event() {
+        let project = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let requested = tauri::Url::from_directory_path(project.path().join(".")).unwrap();
+        let unrelated = tauri::Url::from_directory_path(other.path()).unwrap();
+        let now = std::time::Instant::now();
+        let mut pending = Some(super::InitialDirectoryEvent::new(
+            project.path().canonicalize().unwrap(),
+            now,
+        ));
+        // Other document events do not consume the launch request.
+        assert!(!super::consume_initial_directory_event(
+            &mut pending,
+            &unrelated,
+            now
+        ));
+        assert!(super::consume_initial_directory_event(
+            &mut pending,
+            &requested,
+            now
+        ));
+        // Repeated CLI invocations must pass through to fresh notebook creation.
+        assert!(!super::consume_initial_directory_event(
+            &mut pending,
+            &requested,
+            now
+        ));
+        assert!(!super::consume_initial_directory_event(
+            &mut pending,
+            &requested,
+            now
+        ));
+    }
+
+    #[test]
+    fn running_desktop_never_consumes_directory_requests_as_startup_duplicates() {
+        let project = tempfile::tempdir().unwrap();
+        let requested = tauri::Url::from_directory_path(project.path()).unwrap();
+        assert!(!super::consume_initial_directory_event(
+            &mut None,
+            &requested,
+            std::time::Instant::now()
+        ));
+    }
+
+    #[test]
+    fn missing_initial_directory_event_cannot_suppress_later_requests_indefinitely() {
+        let project = tempfile::tempdir().unwrap();
+        let requested = tauri::Url::from_directory_path(project.path()).unwrap();
+        let now = std::time::Instant::now();
+        let token =
+            || super::InitialDirectoryEvent::new(project.path().canonicalize().unwrap(), now);
+        assert!(super::consume_initial_directory_event(
+            &mut Some(token()),
+            &requested,
+            now + std::time::Duration::from_secs(4)
+        ));
+        let mut pending = Some(token());
+        assert!(!super::consume_initial_directory_event(
+            &mut pending,
+            &requested,
+            now + std::time::Duration::from_secs(5)
+        ));
+        assert!(pending.is_none());
+        assert!(!super::consume_initial_directory_event(
+            &mut pending,
+            &requested,
+            now + std::time::Duration::from_secs(6)
+        ));
+    }
+
+    #[test]
+    fn explicit_document_opens_accept_existing_files_without_an_ipynb_suffix() {
+        let project = tempfile::tempdir().unwrap();
+        for name in ["open", "nb", "renamed.data", "notebook.ipynb"] {
+            let path = project.path().join(name);
+            std::fs::write(
+                &path,
+                r#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#,
+            )
+            .unwrap();
+            assert!(super::is_notebook_file_open_candidate(&path), "{name}");
+        }
+        // Content validation remains the daemon's responsibility, including
+        // invalid files that happen to carry the conventional suffix.
+        let invalid = project.path().join("invalid-content");
+        std::fs::write(&invalid, "not notebook JSON").unwrap();
+        assert!(super::is_notebook_file_open_candidate(&invalid));
+        assert!(super::is_notebook_file_open_candidate(
+            &project.path().join("new.ipynb")
+        ));
+        assert!(!super::is_notebook_file_open_candidate(
+            &project.path().join("missing")
+        ));
+        assert!(!super::is_notebook_file_open_candidate(project.path()));
+    }
+
     #[tokio::test]
     async fn desktop_runtime_admission_absence_allows_startup_without_ready() {
         #[cfg(unix)]
@@ -3305,7 +3527,30 @@ fn handle_open_url(
         _ => None,
     };
     let Some(path) = path else { return };
-    if path.extension().and_then(|e| e.to_str()) != Some("ipynb") {
+    match directory_open_window(&path, &settings::load_settings().default_runtime) {
+        Ok(Some(request)) => {
+            // A directory is an instruction to create, never a saved document
+            // to focus or a startup placeholder to retarget.
+            if let Err(error) = create_notebook_window_for_daemon(
+                app_handle,
+                registry,
+                request.mode,
+                Some(request.label),
+            ) {
+                log::error!(
+                    "[directory-open] Failed to open '{}': {error}",
+                    path.display()
+                );
+            }
+            return;
+        }
+        Ok(None) => {}
+        Err(error) => {
+            log::error!("[directory-open] {error}");
+            return;
+        }
+    }
+    if !is_notebook_file_open_candidate(&path) {
         return;
     }
 
@@ -4620,7 +4865,15 @@ pub fn run(
     notebook_path: Option<PathBuf>,
     runtime: Option<Runtime>,
     notebook_id: Option<String>,
+    open_directory: Option<PathBuf>,
 ) -> anyhow::Result<()> {
+    let initial_directory = open_directory
+        .map(|path| {
+            anyhow::ensure!(path.is_dir(), "Not a directory: '{}'", path.display());
+            path.canonicalize().map_err(anyhow::Error::from)
+        })
+        .transpose()?;
+    let notebook_path = initial_directory.clone().or(notebook_path);
     // Initialize logging via tauri-plugin-log — unified backend for both Rust
     // log::* macros and frontend JS log calls. Writes to notebook.log, stderr,
     // and forwards to webview console.
@@ -4704,11 +4957,25 @@ pub fn run(
     let app_settings = settings::load_settings();
     let needs_onboarding = !app_settings.onboarding_completed && notebook_path.is_none();
 
+    let runtime = runtime.unwrap_or(app_settings.default_runtime);
+    let directory_window = notebook_path
+        .as_deref()
+        .map(|path| directory_open_window(path, &runtime))
+        .transpose()
+        .map_err(anyhow::Error::msg)?
+        .flatten();
+
     // Capture working directory early for untitled notebook project detection.
     // This must happen before Tauri startup, which may change the CWD.
     // Filter out "/" — macOS sets CWD to root when launched from Finder/Dock.
     // Fall back to ~/notebooks (creating it if needed), same as onboarding.
-    let working_dir = if notebook_path.is_none() {
+    let working_dir = if let Some(StartupWindow {
+        mode: OpenMode::Create { working_dir, .. },
+        ..
+    }) = &directory_window
+    {
+        working_dir.clone()
+    } else if notebook_path.is_none() {
         std::env::current_dir()
             .ok()
             .filter(|p| p.parent().is_some())
@@ -4716,9 +4983,6 @@ pub fn run(
     } else {
         None
     };
-
-    // Use provided runtime or fall back to user's default from settings
-    let runtime = runtime.unwrap_or(app_settings.default_runtime);
 
     // Try to restore session if no notebook path/id provided and not onboarding
     let restored_session = if notebook_path.is_none() && notebook_id.is_none() && !needs_onboarding
@@ -4734,16 +4998,11 @@ pub fn run(
     // Build the list of ALL notebook windows to create at startup.
     // All windows are created immediately (showing loading UI) and synced
     // with the daemon once it's available — no primary/secondary distinction.
-    struct StartupWindow {
-        label: String,
-        title: String,
-        mode: OpenMode,
-        saved_scale_factor: Option<f64>,
-    }
-
     let startup_windows: Vec<StartupWindow> = if needs_onboarding {
         info!("[startup] Onboarding needed, skipping notebook state setup");
         Vec::new()
+    } else if let Some(window) = directory_window {
+        vec![window]
     } else if let Some(ref path) = notebook_path {
         // CLI arg: open a specific notebook
         let title = path
@@ -5663,15 +5922,15 @@ pub fn run(
                                 );
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
                                     .message(success_message)
-                                    .title("CLI Installed")
+                                    .title("nteract CLI Installed")
                                     .kind(tauri_plugin_dialog::MessageDialogKind::Info)
                                     .blocking_show();
                             }
                             Ok(Err(e)) => {
                                 log::error!("[cli_install] CLI installation failed: {}", e);
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                    .message(format!("Failed to install CLI: {}", e))
-                                    .title("Installation Failed")
+                                    .message(format!("Failed to install nteract CLI: {}", e))
+                                    .title("Install nteract CLI")
                                     .kind(tauri_plugin_dialog::MessageDialogKind::Error)
                                     .blocking_show();
                             }
@@ -5744,6 +6003,9 @@ pub fn run(
     let registry_for_exit_session = window_registry.clone();
     let registry_for_window_close = window_registry.clone();
     let app_quitting = Arc::new(AtomicBool::new(false));
+    #[cfg(target_os = "macos")]
+    let mut pending_directory_event =
+        initial_directory.map(|path| InitialDirectoryEvent::new(path, std::time::Instant::now()));
     app.run(move |app_handle, event| {
         // Drain deferred file-open URLs once startup sync is complete.
         // These were queued by RunEvent::Opened events that arrived before
@@ -5850,6 +6112,17 @@ pub fn run(
         // whose Tauri webviews haven't been created yet.
         #[cfg(target_os = "macos")]
         if let RunEvent::Opened { urls } = &event {
+            let urls: Vec<_> = urls
+                .iter()
+                .filter(|url| {
+                    !consume_initial_directory_event(
+                        &mut pending_directory_event,
+                        url,
+                        std::time::Instant::now(),
+                    )
+                })
+                .cloned()
+                .collect();
             log::info!(
                 "[file-open] RunEvent::Opened with {} URL(s): {:?}",
                 urls.len(),
@@ -5867,7 +6140,7 @@ pub fn run(
                 }
             } else {
                 registry_for_open.prune_stale_entries(app_handle);
-                for url in urls {
+                for url in &urls {
                     handle_open_url(app_handle, &registry_for_open, url, false);
                 }
             }

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "notebook", about = "Open notebooks")]
 struct Args {
-    /// Path to notebook file to open or create
+    /// Notebook file to open, or directory for a fresh untitled notebook
     path: Option<PathBuf>,
 
     /// Runtime for new notebooks (python, deno). Falls back to user settings if not specified.
@@ -19,15 +19,24 @@ struct Args {
     /// Join an existing untitled notebook by its daemon ID (UUID)
     #[arg(long)]
     notebook_id: Option<String>,
+
+    /// Seed a directory launch and consume its matching macOS document event once.
+    #[arg(long, hide = true, conflicts_with_all = ["path", "notebook_id"])]
+    open_directory: Option<PathBuf>,
 }
 
 fn main() {
     let args = Args::parse();
 
-    if let Err(e) = notebook::run(args.path.clone(), args.runtime, args.notebook_id.clone()) {
+    if let Err(e) = notebook::run(
+        args.path.clone(),
+        args.runtime,
+        args.notebook_id.clone(),
+        args.open_directory.clone(),
+    ) {
         // Show native error dialog before exiting
         let title = "Cannot Open Notebook";
-        let message = match &args.path {
+        let message = match args.path.as_ref().or(args.open_directory.as_ref()) {
             Some(path) => format!("Failed to open '{}':\n\n{}", path.display(), e),
             None => format!("Failed to start notebook:\n\n{}", e),
         };
@@ -39,5 +48,38 @@ fn main() {
             .show();
 
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directory_document_handoff_carries_explicit_path() {
+        let args =
+            Args::try_parse_from(["notebook", "--open-directory", "/project with spaces"]).unwrap();
+        assert_eq!(
+            args.open_directory,
+            Some(PathBuf::from("/project with spaces"))
+        );
+        assert!(args.path.is_none());
+        assert!(args.notebook_id.is_none());
+    }
+
+    #[test]
+    fn directory_document_handoff_cannot_also_open_a_file_or_existing_notebook() {
+        assert!(
+            Args::try_parse_from(["notebook", "--open-directory", "/project", "saved.ipynb"])
+                .is_err()
+        );
+        assert!(Args::try_parse_from([
+            "notebook",
+            "--open-directory",
+            "/project",
+            "--notebook-id",
+            "existing-room"
+        ])
+        .is_err());
     }
 }

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -68,7 +68,7 @@ pub fn about_menu_label() -> String {
 }
 
 pub fn install_cli_menu_label() -> String {
-    "Install 'nteract' Command in PATH".to_string()
+    "Install nteract CLI".to_string()
 }
 
 pub fn window_menu_item_id(window_label: &str) -> String {

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -603,6 +603,14 @@ fn macos_open_args(
 ) -> Vec<OsString> {
     let mut args = Vec::new();
 
+    // A running app ignores everything after --args. ID joins already require
+    // a new instance; directory opens with an explicit runtime do too, so the
+    // requested runtime reaches the seeded window. Default directory opens
+    // still reuse the running app via its document event.
+    if !extra_args.is_empty() && (path.is_none() || open_directory) {
+        args.push(OsString::from("-n"));
+    }
+
     // Pass the notebook path as a document argument (before --args) so macOS
     // delivers it via Apple Events (kAEOpenDocuments) whether the app is
     // freshly launched or already running.
@@ -682,12 +690,6 @@ fn open_notebook_installed_for(
         #[cfg(target_os = "macos")]
         let spawn_result = {
             let mut cmd = Command::new("open");
-            // When there's no file path but we have CLI args (e.g. --notebook-id),
-            // force a new instance with -n. Without this, macOS `open` activates
-            // the running app and silently drops everything after --args.
-            if path.is_none() && !extra_args.is_empty() {
-                cmd.arg("-n");
-            }
             cmd.arg("-a").arg(app_name);
             cmd.args(macos_open_args(
                 path,
@@ -2018,16 +2020,30 @@ mod tests {
     }
 
     #[test]
-    fn test_macos_directory_handoff_supports_cold_and_running_desktop() {
+    fn test_macos_directory_handoff_forces_new_instance_for_explicit_runtime() {
         let path = Path::new("/tmp/my project");
         let args = macos_open_args(Some(path), &["--runtime", "deno"], true);
         assert_eq!(
             args,
             vec![
+                OsString::from("-n"),
                 OsString::from("/tmp/my project"),
                 OsString::from("--args"),
                 OsString::from("--runtime"),
                 OsString::from("deno"),
+                OsString::from("--open-directory"),
+                OsString::from("/tmp/my project"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_macos_default_directory_handoff_reuses_running_desktop() {
+        assert_eq!(
+            macos_open_args(Some(Path::new("/tmp/my project")), &[], true),
+            vec![
+                OsString::from("/tmp/my project"),
+                OsString::from("--args"),
                 OsString::from("--open-directory"),
                 OsString::from("/tmp/my project"),
             ]
@@ -2041,6 +2057,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                OsString::from("-n"),
                 OsString::from("--args"),
                 OsString::from("--runtime"),
                 OsString::from("deno"),

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -596,7 +596,11 @@ fn open_notebook_dev(path: Option<&Path>, extra_args: &[&str]) -> Result<(), Str
 }
 
 #[cfg(any(target_os = "macos", test))]
-fn macos_open_args(path: Option<&Path>, extra_args: &[&str]) -> Vec<OsString> {
+fn macos_open_args(
+    path: Option<&Path>,
+    extra_args: &[&str],
+    open_directory: bool,
+) -> Vec<OsString> {
     let mut args = Vec::new();
 
     // Pass the notebook path as a document argument (before --args) so macOS
@@ -606,9 +610,18 @@ fn macos_open_args(path: Option<&Path>, extra_args: &[&str]) -> Vec<OsString> {
         args.push(p.as_os_str().to_os_string());
     }
 
-    if !extra_args.is_empty() {
+    if !extra_args.is_empty() || open_directory {
         args.push(OsString::from("--args"));
         args.extend(extra_args.iter().map(OsString::from));
+        if open_directory {
+            // macOS delivers the directory as a document event even on cold
+            // launch. Seed the requested window before runtime admission, then consume
+            // its matching initial document event without opening it twice.
+            args.push(OsString::from("--open-directory"));
+            if let Some(path) = path {
+                args.push(path.as_os_str().to_os_string());
+            }
+        }
     }
 
     args
@@ -676,7 +689,11 @@ fn open_notebook_installed_for(
                 cmd.arg("-n");
             }
             cmd.arg("-a").arg(app_name);
-            cmd.args(macos_open_args(path, extra_args));
+            cmd.args(macos_open_args(
+                path,
+                extra_args,
+                strict && path.is_some_and(Path::is_dir),
+            ));
             cmd.output().and_then(|output| {
                 if output.status.success() {
                     Ok(())
@@ -1979,7 +1996,7 @@ mod tests {
     #[test]
     fn test_macos_open_args_path_and_runtime() {
         let path = Path::new("/tmp/example.ipynb");
-        let args = macos_open_args(Some(path), &["--runtime", "python"]);
+        let args = macos_open_args(Some(path), &["--runtime", "python"], false);
 
         assert_eq!(
             args,
@@ -1995,14 +2012,31 @@ mod tests {
     #[test]
     fn test_macos_open_args_path_only() {
         let path = Path::new("/tmp/example.ipynb");
-        let args = macos_open_args(Some(path), &[]);
+        let args = macos_open_args(Some(path), &[], false);
 
         assert_eq!(args, vec![OsString::from("/tmp/example.ipynb")]);
     }
 
     #[test]
+    fn test_macos_directory_handoff_supports_cold_and_running_desktop() {
+        let path = Path::new("/tmp/my project");
+        let args = macos_open_args(Some(path), &["--runtime", "deno"], true);
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("/tmp/my project"),
+                OsString::from("--args"),
+                OsString::from("--runtime"),
+                OsString::from("deno"),
+                OsString::from("--open-directory"),
+                OsString::from("/tmp/my project"),
+            ]
+        );
+    }
+
+    #[test]
     fn test_macos_open_args_runtime_only() {
-        let args = macos_open_args(None, &["--runtime", "deno"]);
+        let args = macos_open_args(None, &["--runtime", "deno"], false);
 
         assert_eq!(
             args,

--- a/crates/runt/src/lib.rs
+++ b/crates/runt/src/lib.rs
@@ -633,7 +633,7 @@ mod path_shorthand_tests {
         ] {
             let cli = parse(&["nteract", path]).unwrap();
             assert!(
-                matches!(cli.command, Some(Commands::Open { path: Some(actual), runtime: None }) if actual == PathBuf::from(path))
+                matches!(cli.command, Some(Commands::Open { path: Some(actual), runtime: None }) if actual == Path::new(path))
             );
         }
         assert!(matches!(

--- a/crates/runt/src/lib.rs
+++ b/crates/runt/src/lib.rs
@@ -155,6 +155,13 @@ fn cli_command(entrypoint: EntryPoint) -> clap::Command {
             .name("nteract")
             .bin_name("nteract")
             .about("Open notebooks, manage runtimes and workstations, and serve MCP")
+            .subcommand_precedence_over_arg(true)
+            .arg(
+                clap::Arg::new("launch_path")
+                    .value_name("PATH")
+                    .value_parser(clap::value_parser!(PathBuf))
+                    .help("Open a notebook, or create an untitled notebook in a directory"),
+            )
             .mut_arg("channel", |arg| arg.hide(false))
             .mut_subcommand("nb", |command| {
                 command.about("Read, edit, and execute notebooks without the desktop app")
@@ -543,7 +550,7 @@ pub fn run(entrypoint: EntryPoint) -> Result<()> {
         route_channel(channel_from_args(std::env::args_os().skip(1))?)?;
     }
     let matches = cli_command(entrypoint).get_matches();
-    let cli = Cli::from_arg_matches(&matches)?;
+    let cli = cli_from_matches(entrypoint, &matches).unwrap_or_else(|error| error.exit());
     if entrypoint == EntryPoint::Runt && cli.channel.is_some() {
         anyhow::bail!("Select release channels with `nteract --channel stable|nightly`");
     }
@@ -567,7 +574,117 @@ pub fn run(entrypoint: EntryPoint) -> Result<()> {
     }
 }
 
+fn cli_from_matches(
+    entrypoint: EntryPoint,
+    matches: &clap::ArgMatches,
+) -> std::result::Result<Cli, clap::Error> {
+    let mut cli = Cli::from_arg_matches(matches)?;
+    if entrypoint == EntryPoint::Nteract {
+        if let Some(path) = matches.get_one::<PathBuf>("launch_path") {
+            if cli.command.is_some() {
+                return Err(cli_command(entrypoint).error(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    "Choose a command or a notebook path, not both",
+                ));
+            }
+            // Preserve useful typo errors for bare command-like words. Explicit
+            // paths and .ipynb names can name a new file; existing files without
+            // extensions remain valid. Subcommands always take precedence.
+            let explicit_path = path.is_absolute()
+                || path.components().count() > 1
+                || path.as_os_str().to_string_lossy().starts_with('.');
+            if !explicit_path
+                && !path.exists()
+                && path.extension() != Some(std::ffi::OsStr::new("ipynb"))
+                && notebook_id_from_uuid_arg(path).is_none()
+            {
+                return Err(cli_command(entrypoint)
+                    .error(clap::error::ErrorKind::InvalidSubcommand, format!("Unknown command or notebook path '{}'. Use an explicit path such as './{}', or 'nteract open <path>'.", path.display(), path.display())));
+            }
+            cli.command = Some(Commands::Open {
+                path: Some(path.clone()),
+                runtime: None,
+            });
+        }
+    }
+    Ok(cli)
+}
+
 const CHANNEL_DISPATCH_ENV: &str = "NTERACT_CLI_DISPATCH_CHANNEL";
+
+#[cfg(test)]
+mod path_shorthand_tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> std::result::Result<Cli, clap::Error> {
+        let matches = cli_command(EntryPoint::Nteract).try_get_matches_from(args)?;
+        cli_from_matches(EntryPoint::Nteract, &matches)
+    }
+
+    #[test]
+    fn paths_are_shorthand_for_open_and_commands_take_precedence() {
+        for path in [
+            ".",
+            "./project",
+            "./open",
+            "./nb",
+            "../analysis.ipynb",
+            "new.ipynb",
+        ] {
+            let cli = parse(&["nteract", path]).unwrap();
+            assert!(
+                matches!(cli.command, Some(Commands::Open { path: Some(actual), runtime: None }) if actual == PathBuf::from(path))
+            );
+        }
+        assert!(matches!(
+            parse(&["nteract", "open"]).unwrap().command,
+            Some(Commands::Open { path: None, .. })
+        ));
+        assert!(matches!(
+            parse(&["nteract", "nb", "tools"]).unwrap().command,
+            Some(Commands::Nb { .. })
+        ));
+        assert!(matches!(
+            parse(&["nteract", "doctor"]).unwrap().command,
+            Some(Commands::Doctor { .. })
+        ));
+        assert!(parse(&["nteract"]).unwrap().command.is_none());
+    }
+
+    #[test]
+    fn path_shorthand_preserves_channel_selection_and_explicit_open_runtime() {
+        let cli = parse(&["nteract", "--channel", "nightly", "."]).unwrap();
+        assert!(matches!(cli.channel, Some(CliChannel::Nightly)));
+        assert!(matches!(cli.command, Some(Commands::Open { .. })));
+        let cli = parse(&["nteract", "open", "./nb", "--runtime", "deno"]).unwrap();
+        assert!(
+            matches!(cli.command, Some(Commands::Open { runtime: Some(runtime), .. }) if runtime == "deno")
+        );
+    }
+
+    #[test]
+    fn path_shorthand_rejects_typos_and_mixed_commands_without_changing_runt() {
+        assert!(parse(&["nteract", "workstaiton"]).is_err());
+        assert!(parse(&["nteract", ".", "open"]).is_err());
+        assert!(cli_command(EntryPoint::Runt)
+            .try_get_matches_from(["runt", "."])
+            .is_err());
+    }
+
+    #[test]
+    fn directory_launch_preserves_explicit_location_and_spaces() {
+        let directory = tempfile::tempdir().unwrap();
+        let project = directory.path().join("project with spaces");
+        std::fs::create_dir(&project).unwrap();
+        let launch = open_notebook_launch_args(Some(project.clone()), None);
+        assert_eq!(launch.path, Some(project));
+        assert!(launch.extra_args.is_empty());
+        assert_eq!(
+            open_notebook_launch_args(Some(PathBuf::from(".")), None).path,
+            Some(std::env::current_dir().unwrap().join("."))
+        );
+    }
+}
 
 fn channel_from_args(args: impl IntoIterator<Item = OsString>) -> Result<Option<CliChannel>> {
     use clap::ValueEnum;
@@ -663,8 +780,8 @@ fn enable_virtual_terminal_processing() {}
 
 /// Open the notebook application with optional path and runtime arguments.
 ///
-/// The app automatically captures its working directory at startup for untitled
-/// notebooks, so we don't need to pass --cwd explicitly.
+/// Explicit paths are resolved against the invoking terminal's directory before
+/// handoff; a running Desktop process cannot inherit the caller's directory.
 async fn open_notebook_canonical(
     path: Option<PathBuf>,
     runtime: Option<String>,

--- a/crates/runt/tests/path_launch.rs
+++ b/crates/runt/tests/path_launch.rs
@@ -1,0 +1,86 @@
+#![cfg(unix)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn cli(root: &Path, invoking_directory: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_nteract-cli"));
+    command
+        .env_clear()
+        .env("HOME", root)
+        .env("USERPROFILE", root)
+        .env("XDG_CONFIG_HOME", root.join("config"))
+        .env("XDG_CACHE_HOME", root.join("cache"))
+        .env("XDG_DATA_HOME", root.join("data"))
+        .env("RUNTIMED_DEV", "1")
+        .env("RUNTIMED_WORKSPACE_PATH", root)
+        .env("CARGO_TARGET_DIR", root.join("target"))
+        .env("NTERACT_TEST_ARGS", root.join("arguments"))
+        .current_dir(invoking_directory);
+    command
+}
+
+#[test]
+fn path_launch_passes_the_invoking_directory_to_its_own_desktop() {
+    // macOS's default temporary directory leaves too little room for a Unix
+    // socket after adding the isolated runtime namespace.
+    let temp = tempfile::tempdir_in("/tmp").unwrap();
+    let root = temp.path();
+    let bin_dir = root.join("target/debug");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let desktop = bin_dir.join("notebook");
+    std::fs::write(
+        &desktop,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$NTERACT_TEST_ARGS\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&desktop, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::write(bin_dir.join(".notebook-bundled"), "").unwrap();
+
+    let invoking = root.join("terminal directory");
+    std::fs::create_dir_all(invoking.join("my project")).unwrap();
+    std::fs::create_dir_all(invoking.join("nb")).unwrap();
+    std::fs::write(invoking.join("open"), "{}").unwrap();
+    // getcwd resolves the temporary directory's /var symlink on macOS.
+    let invoking = invoking.canonicalize().unwrap();
+
+    for args in [
+        vec!["."],
+        vec!["./my project"],
+        vec!["./nb"],
+        vec!["./open"],
+        vec!["analysis.ipynb"],
+        vec!["open", "."],
+    ] {
+        let output = cli(root, &invoking).args(&args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected = format!("{}\n", invoking.join(args.last().unwrap()).display());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if std::fs::read_to_string(root.join("arguments"))
+                .ok()
+                .as_deref()
+                == Some(expected.as_str())
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "Desktop did not receive {expected:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        std::fs::remove_file(root.join("arguments")).unwrap();
+    }
+
+    let output = cli(root, &invoking).arg("workstaiton").output().unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!root.join("arguments").exists());
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Start here to understand a subsystem. This is not a complete inventory.
 | Product requirements | [`prd/notebook-identity-environment-surfaces.md`](prd/notebook-identity-environment-surfaces.md), [`prd/hosted-sharing-invites.md`](prd/hosted-sharing-invites.md) |
 | MCP, cloud embedding, and Automerge audit | [`audits/mcp-cloud-automerge-audit.md`](audits/mcp-cloud-automerge-audit.md) |
 | Evidence and measurements | [`audits/`](audits/), [`measurements/`](measurements/) |
-| CLI and installation | [`runbooks/cli.md`](runbooks/cli.md) |
+| CLI and installation | [`runbooks/cli.md`](runbooks/cli.md), [`plans/unified-cli-release.md`](plans/unified-cli-release.md) |
 | Operational setup | [`runbooks/macos-setup.md`](runbooks/macos-setup.md), [`runbooks/hosted-direct-oidc-demo-runbook.md`](runbooks/hosted-direct-oidc-demo-runbook.md) |
 
 For the architecture decision register's status vocabulary and maintenance

--- a/docs/plans/unified-cli-release.md
+++ b/docs/plans/unified-cli-release.md
@@ -1,0 +1,204 @@
+# Unified CLI release plan
+
+Status: proposed release sequence; no release or version bump is authorized by
+this document. Source and PR status checked on 2026-09-10.
+
+Ship the unified `nteract` CLI through Nightly first, qualify the actual installed
+artifacts, then promote that qualified source revision to Stable. Propose **2.8.0**
+as the next base version: this introduces a public command and installation
+contract while retaining the legacy commands. The checked-in base is currently
+2.7.6. Version choice remains a release-owner decision.
+
+## Scope and dependencies
+
+| Change | Release relationship |
+| --- | --- |
+| [Unified CLI #4231](https://github.com/nteract/nteract/pull/4231) | Merged; independently releasable. Introduces `nteract open`, notebook operations, supervised `nteract mcp`, workstation commands, and safe command installation. Its release does not depend on the path shorthand follow-up. |
+| Path and directory launch follow-up | Separate feature gate for directory semantics (including `nteract open <directory>`) and `nteract .`, `nteract <directory>`, and notebook paths without `open`. Include only after its own source and installed Desktop acceptance passes; otherwise release the unified CLI with explicit `nteract open <notebook.ipynb>`. |
+| [Runtime lock errors #4230](https://github.com/nteract/nteract/pull/4230) | Independent improvement, not a prerequisite established by current evidence. Open at this audit, head `e5f5188650c690625c66a0a4aa0d43e8cc24ea2c`. Its reported Python kernel-readiness failure still needs disposition. The change distinguishes lock contention from I/O errors; it does not solve Desktop's service-install race. Recheck status before selecting the release SHA. |
+| Atomic Desktop bootstrap | Separate service-lifecycle work. Desktop probes compatibility, but an endpoint appearing after the absence check can race with service installation. Do not describe this release as providing atomic, non-replacing Desktop startup. |
+
+The CLI contract and that known race are documented in the
+[CLI runbook](../runbooks/cli.md). Hosted MCP and workstation serving do not
+require the local notebook daemon service; they can still need the `runtimed`
+executable's agent entry points. Desktop and local notebook execution require a
+local runtime. Hosted examples require a configured deployment and credentials;
+this release does not announce a public hosted service.
+
+## User-facing command vocabulary
+
+Use **Install nteract CLI** for Desktop menu and rollout copy. The public command
+is `nteract`; retain the concrete daemon name when diagnosing the runtime rather
+than hiding it behind another new command name.
+
+| Intent | Public command | Preserved behavior |
+| --- | --- | --- |
+| Open Desktop | `nteract open <path>` | Explicit notebook handoff. The follow-up adds directory semantics and path-only invocation. |
+| Diagnose this installation | `nteract doctor`, `nteract doctor --json` | Alias for `nteract daemon doctor`; `--fix` remains an explicit repair action. |
+| Inspect/manage the runtime service | `nteract status`, `nteract daemon status`, `nteract daemon start`, `nteract daemon stop`, `nteract logs` | Installation-scoped runtime operations remain available. Add `--channel stable` or `--channel nightly` to select a specific installation. |
+| Operate on notebooks | `nteract notebooks`, `nteract nb tools`, `nteract nb call ...` | Uses the selected notebook runtime; discovery does not create a service. |
+| Offer a workstation | `nteract workstation connect`, `nteract workstation run`, `nteract workstation status` | Pairing and serving remain distinct from local daemon management. |
+| Serve MCP | `nteract mcp` | Canonical supervised entry point; existing `nteract-mcp` and `runt mcp` integrations remain supported. |
+
+## Publication contract
+
+The authoritative jobs are [release-common.yml](../../.github/workflows/release-common.yml),
+[release-nightly.yml](../../.github/workflows/release-nightly.yml), and
+[release-stable.yml](../../.github/workflows/release-stable.yml).
+
+Nightly runs daily at 09:00 UTC or by dispatch. Stable runs on `v*` tag pushes or
+by dispatch. Both call the same publishing workflow; they are not packaging-only
+dry runs. The workflow builds with `RUNT_BUILD_CHANNEL` and
+`NTERACT_BUILD_GIT_HASH` from the selected source revision. It computes a release
+version from `crates/runt/Cargo.toml`, the channel, and a UTC minute timestamp.
+Do not infer the source revision from the generated tag name: verify the tag's
+resolved commit against the run's `head_sha` and embedded build identity.
+
+| Surface | Expected artifact or behavior | Acceptance evidence |
+| --- | --- | --- |
+| Linux x64 | `nteract-cli-linux-x64` or `nteract-cli-nightly-linux-x64`; existing `runt`, `runtimed`, and `nteract-mcp` channel assets; `nteract-<channel>-linux-x64.AppImage` and updater signature | All names present; downloaded CLI reports expected version/channel/revision; installed backend is `<prefix>/bin/nteract-cli`. No DEB/RPM or Linux ARM64 release is implied. |
+| macOS arm64 and x64 | `nteract-<channel>-darwin-<arch>.dmg`, signed/notarized `.app.tar.gz`, updater signature; app includes `runt`, `runtimed`, `nteract-cli`, `nteract-mcp` | Validate app signature/notarization and all bundled executables after installation. Canonical CLI comes from the signed bundle; no standalone canonical macOS CLI asset is promised. Raw legacy CLI/daemon assets remain compatibility artifacts. |
+| Windows x64 | Signed `nteract-<channel>-windows-x64.exe` NSIS installer and updater signature; four bundled sidecars with `.exe` suffix | Native installation, first launch, menu installation, coexistence, upgrade, and uninstall tests. Canonical shim must invoke `nteract-cli.exe`, not Desktop's `notebook.exe`. No standalone canonical Windows CLI asset is promised. |
+| Shell installer | Release asset `install-linux-release`, despite its historical Linux-only name | Its stamped `DEFAULT_CHANNEL` and `DEFAULT_TAG` match that release. Install from that immutable asset; compare installed executables with its release's binaries. |
+| Updaters | Immutable release `latest.json` and the channel's `stable-latest` or `nightly-latest` manifest | Byte equality; platform URLs resolve to the intended immutable release; all signatures exist and installed updater succeeds. |
+| Python | Four `runtimed` wheels: macOS arm64/x64, Linux x64, Windows x64 | Wheel metadata and PyPI files match the intended stamp and platform matrix; isolated install, notebook execution, and shutdown pass. This workflow does not publish the separate Python `nteract` package. |
+| Agent plugins | Stable `plugins/nteract` or Nightly `plugins/nightly` in `nteract/agent-plugins`, with four platform MCP binaries and dispatch wrappers | Distribution commit records the same source SHA, correct channel configuration and manifest versions; actual MCP host starts the wrapper successfully. The other channel's subtree is preserved. |
+| Notebook UI archive | `nteract-<channel>-notebook-ui.tar.gz` and `.sha256` | Checksum verifies; archive belongs to the same release. Its presence does not establish hosted service availability. |
+
+The Python workflow uses the base version for Stable and **next-patch alpha** for
+Nightly. With the proposed 2.8.0 base, Desktop Nightly would be
+`2.8.0-nightly.<timestamp>`, Python Nightly `2.8.1a<timestamp>`, and Python Stable
+`2.8.0`. Preserve this existing policy unless a separate decision changes it;
+check wheel metadata rather than assuming identical full version strings.
+
+Publication is not atomic. `publish-plugin` depends on Desktop build jobs but
+does not wait for the release publication job. The latter publishes Python
+wheels before creating the GitHub Release and then updates the rolling updater
+manifest. A failed run can therefore already have changed plugins, PyPI, or
+GitHub assets. A green subset of jobs is not a completed release.
+
+## Installer and plugin migration
+
+The [shell installer](../../scripts/install-linux-release) is published by
+`release-common.yml`, which stamps its channel and exact tag. The separate
+[`install-sh` bootstrap](https://github.com/nteract/install-sh/blob/d6f4c79028ab9739e5658c0a589b3e5e298cba88/lib/script.js)
+already forwards all arguments. It normally fetches the **latest Stable
+installer** first, even when forwarded arguments request a Nightly tag. It can
+fall back to the main-branch installer on lookup failure or for older macOS
+installer support.
+
+Use the exact Nightly release's installer asset during qualification. An older
+Stable installer selected by `sh.nteract.io` may not support the new `--cli`
+behavior. After Stable publication, verify the public bootstrap resolves the
+new Stable asset and forwards `--cli` and custom paths correctly. Changing the
+bootstrap alone cannot supply the new binaries. Do not qualify from an
+unrecorded main-branch fallback.
+
+The older [install-nightly-release](../../scripts/install-nightly-release)
+still installs and starts a local daemon service and only downloads legacy
+commands. It is not the daemon-free CLI installer and is not the installer asset
+published by this workflow. Release instructions should use the published
+`install-linux-release` asset; retiring the older script is separate cleanup.
+
+The [plugin assembly script](../../scripts/assemble-plugin-dist.sh) ships
+`nteract-mcp` and platform wrappers, not a full CLI/runtime stack. The
+[legacy MCP entry point](../../crates/nteract-mcp/src/lib.rs) still locates
+`runt` or `runt-nightly` and launches `runt mcp`; existing
+[Claude configuration](../../plugins/nteract/.mcp.json) and
+[Codex configuration](../../plugins/nteract/.codex-mcp.json) keep that contract.
+Preserve those backends in installers and app bundles. A plugin-only machine
+without a discoverable legacy CLI is a negative test, not a supported
+self-contained runtime installation. Correct any generated plugin instructions
+that imply otherwise before promoting the release. Windows wrapper resolution
+must be tested in the actual supported MCP hosts, including their `.cmd`
+resolution; wrapper compilation alone cannot prove that behavior.
+
+| Migration scenario | Required result |
+| --- | --- |
+| Clean `--cli` / `--headless`, Linux and macOS | Public command and helpers installed; no local daemon service registered, repaired, started, or restarted. Existing runtime/service state unchanged. macOS may retain the complete signed bundle under the prefix. Help/discovery still leave the daemon absent. |
+| Desktop shell install versus `--no-start` | Default Desktop install may repair/install and start its service. `--no-start` still installs/repairs the service, so it is not equivalent to `--cli`. |
+| Stable then Nightly; Nightly then Stable; update either | First managed public `nteract` selection survives. `--default-cli` or Desktop's **Install nteract CLI** selects deliberately; `--channel stable` or `--channel nightly` resolves the registered installed backend. Missing channel fails without switching silently. |
+| Custom prefix/bin directory and unrelated PATH launcher | Channel records resolve the actual backend. Linux open uses that installation's AppImage or owned bundle launcher; an unrelated `nteract-desktop` is never executed. |
+| Pre-unified Linux `nteract` AppImage alias, then `--cli` | Exact owned alias migrates to canonical CLI while retaining access to the already-installed AppImage; no recursive CLI launch. Unknown app launchers remain unchanged. |
+| Current legacy `runt` link, then app relocation/update | Exact current target seeds ownership; a later recorded stale target repairs. Unknown, modified, unproven stale, regular-file, and broken-link aliases remain unchanged with actionable guidance. Only exact generated `nb` wrappers migrate. |
+| Existing `runt mcp`, `nteract-mcp`, and plugin registrations | Initialize, list tools, connect, execute/read a synced cell, reconnect, and exit retain their existing worker/supervisor semantics. No forced client configuration rewrite. |
+| Canonical `nteract mcp` | Supervisor stays on the selected installation, stdout remains protocol-only, target survives worker restart, and `--no-show` omits Desktop opening. Hosted connection does not start a local notebook daemon. |
+| Windows coexistence and uninstall | Shared selection and channel records match installed targets; preserve unrelated `.exe`/`.cmd` commands. Uninstalling one channel never deletes another's selected command. Test selected-channel removal and useful remaining-channel recovery separately. |
+| Runtime already running | Compatible runtime reused; incompatible, uncertain, or explicit unreachable endpoints cause useful errors without automatic repair. Record runtime PID/identity before and after. Explicit repair/updater transactions retain their documented behavior. |
+
+## Qualification and promotion gates
+
+1. **Select source and version.** Recheck the merged feature set, PR #4230 status,
+   and current version files. Decide whether shorthand is included. If 2.8.0 is
+   accepted, use the repository's coordinated version bump and commit it before
+   Nightly qualification. Review protocol/schema markers independently; command
+   naming alone does not require a wire or document-schema change. Capture the
+   exact candidate SHA and require CI on that SHA.
+2. **Pass source checks.** Run repository lint, CLI/parser and runtime/MCP tests,
+   Desktop installation/admission tests, release installer fixtures and
+   shellcheck, workflow validation, and Windows installer install/uninstall
+   compilation. Include shorthand path parsing and argument forwarding tests
+   only when that feature is included. Record failures and disposition; prior
+   PR results are not evidence for a later release revision.
+3. **Publish one Nightly candidate.** This is a real publication, including PyPI,
+   plugins, and `nightly-latest`. After release authorization, select the intended
+   ref explicitly and record the run ID, source SHA, generated tag, artifact
+   hashes, wheel versions, and plugin distribution commit. Wait for all required
+   jobs, including Fedora AppImage smoke and plugin publication.
+4. **Qualify installed artifacts.** Complete the artifact and migration matrices
+   above on supported platforms. Exercise the signed/notarized installed app,
+   not a dev build, on macOS; use the signed Windows installer and actual Linux
+   AppImage. Run a short cell and a roughly 30-second cell; require terminal
+   completion, visible output, and empty execution queues. Reopen saved content
+   and exercise MCP reconnect. Inspect active processes so an old app/runtime
+   cannot masquerade as the candidate.
+5. **Gate directory launch when included.** For `nteract open <directory>`,
+   `nteract .`, and `nteract <directory>`, test both an absent Desktop
+   process and an already-running one. Verify a notebook opens with the requested
+   working directory and runtime, not merely that a process exits successfully.
+   Include relative paths, paths with spaces, notebook files, same-named command
+   directories addressed with `./`, both channels, and a CLI launched outside
+   the target directory. Check existing windows remain attached to their correct
+   runtime. Run the absent-runtime case and record the known concurrent-start
+   race separately; a single successful launch does not resolve it.
+6. **Promote qualified source to Stable.** After acceptance, dispatch Stable from
+   the immutable qualified Nightly ref. This rebuilds and re-signs Stable; it
+   does not rename the Nightly artifacts. Verify the generated Stable tag resolves
+   to the same qualified source SHA. Any code or version-file change requires a
+   new qualified candidate rather than an untested promotion.
+7. **Verify Stable distribution and installed upgrade.** Check every surface in
+   the artifact table, including plugin publication, PyPI, rolling-manifest byte
+   equality, and the public bootstrap's actual installer URL. Upgrade an older
+   Stable app through its updater, repeat canonical command and directory-launch
+   acceptance, then execute a notebook cell. Publish release notes that distinguish
+   available commands, compatibility aliases, and remaining platform limitations.
+
+The release record should contain one row per acceptance scenario with platform,
+installer/tag, source SHA, app/CLI/runtime identity, expected result, observed
+result, and evidence. Until those rows exist, installed behavior is unverified.
+Shorthand failure may exclude the shorthand feature from a candidate; it does
+not retroactively make #4231 unmergeable. A failure in shared installation or
+runtime behavior must be assessed against the unified CLI itself.
+
+## Rollback and limits
+
+Record the previous channel manifest and plugin distribution revision before
+publication. If a candidate fails qualification, stop promotion and enumerate
+which surfaces already changed. Restore a prior channel manifest only through
+an explicit release-owner recovery action; it can stop advertising the candidate
+but does not downgrade apps that already installed it. A fixed newer release is
+the normal recovery for installed users. Preserve their notebooks, settings,
+workstation credentials, and unrelated command aliases.
+
+PyPI files cannot be replaced under previously used filenames. A bad release
+can be yanked with a reason, but already-installed or exactly pinned consumers
+are not rolled back; publish a corrected version. See
+[PyPI filename reuse](https://pypi.org/help/#file-name-reuse) and
+[yanking](https://docs.pypi.org/project-management/yanking/).
+Do not attempt recovery by reusing a version or moving a qualified immutable tag.
+
+Plugin distribution can be corrected with a new commit for the affected channel,
+but clients may retain cached binaries until refresh/restart. Updater manifests,
+GitHub assets, plugins, and PyPI need separate recovery verification. Repointing
+an owned public CLI to another installed channel is not a runtime/data rollback;
+do not delete runtime locks or services to bypass a compatibility problem.

--- a/docs/runbooks/cli.md
+++ b/docs/runbooks/cli.md
@@ -26,7 +26,7 @@ not on the current terminal's PATH, add it:
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-Desktop installation also bundles the CLI. Its Install Command menu can select
+Desktop installation also bundles the CLI. Its **Install nteract CLI** menu can select
 that installation. Existing unrelated commands are preserved rather than
 overwritten. The installer reports their path so you can resolve the conflict.
 
@@ -47,7 +47,14 @@ custom installation prefixes. Missing channels produce an installation error.
 ## Notebook and workstation commands
 
 ```sh
-# Open the Desktop app at a notebook
+# Create a fresh untitled Desktop notebook in this directory
+nteract .
+
+# Create a fresh untitled notebook in another project
+nteract ./project
+
+# Open a saved notebook (both forms are equivalent)
+nteract analysis.ipynb
 nteract open analysis.ipynb
 
 # Inspect local notebooks without creating a runtime as a side effect
@@ -64,6 +71,39 @@ nteract workstation run
 # Linux: keep the workstation available independently of this terminal
 nteract workstation service install --start
 ```
+
+A directory always requests a fresh untitled notebook with that directory as its
+working directory, including when Desktop is already running. It does not reopen
+a previous notebook or create an `Untitled.ipynb` file in the project. Save the
+notebook to choose its filename; normal recovery still protects untitled work.
+`nteract open .` uses the same directory behavior.
+
+Command names take precedence over shorthand paths. Use `nteract ./open` or
+`nteract ./nb` for paths with those names, or pass the path to `nteract open`.
+Notebook filenames and directory names are not restricted by the CLI's commands.
+Unknown bare words that do not name an existing path produce a command error;
+use an explicit path such as `./analysis` or an `.ipynb` filename to open a new file.
+
+## Runtime management and diagnostics
+
+The unified CLI keeps the runtime operations used for troubleshooting:
+
+```sh
+nteract doctor
+nteract status
+nteract daemon status
+nteract daemon logs -f
+nteract diagnostics
+
+# Explicitly inspect the Nightly installation
+nteract --channel nightly doctor
+```
+
+`nteract daemon --help` lists service lifecycle and maintenance operations.
+These commands describe the selected installation, even when notebook operations
+are sharing a compatible runtime from another installation.
+
+## Notebook operation behavior
 
 Notebook operations use the same implementation as MCP. Execution operates on
 synced cell IDs, preserving the document seen by other peers. `nb call --json`

--- a/docs/runbooks/cli.md
+++ b/docs/runbooks/cli.md
@@ -77,12 +77,16 @@ working directory, including when Desktop is already running. It does not reopen
 a previous notebook or create an `Untitled.ipynb` file in the project. Save the
 notebook to choose its filename; normal recovery still protects untitled work.
 `nteract open .` uses the same directory behavior.
+To select a runtime, use `nteract open . --runtime deno`. On macOS this explicit
+runtime choice starts a separate Desktop process so the option is honored even
+when Desktop is already running; ordinary directory opens use its default runtime.
 
 Command names take precedence over shorthand paths. Use `nteract ./open` or
 `nteract ./nb` for paths with those names, or pass the path to `nteract open`.
 Notebook filenames and directory names are not restricted by the CLI's commands.
 Unknown bare words that do not name an existing path produce a command error;
-use an explicit path such as `./analysis` or an `.ipynb` filename to open a new file.
+use an explicit path such as `./analysis` to disambiguate. Desktop reports file
+availability and notebook parsing errors.
 
 ## Runtime management and diagnostics
 


### PR DESCRIPTION
`nteract .` now requests a fresh untitled Desktop notebook rooted in the terminal's directory. Directory paths also work with explicit `nteract open`; notebook paths can omit `open`. Existing commands take precedence, with `./open` and `./nb` available as unambiguous paths.

Directory requests carry an absolute path through Desktop handoff. Cold macOS launches seed the requested startup window and consume its matching document event once; a running Desktop opens a fresh window without retargeting an existing notebook. An explicit runtime (`nteract open . --runtime deno`) starts a separate macOS Desktop instance so macOS cannot silently drop the option. Existing extensionless notebook files reach the normal daemon parser. Desktop menu and installation dialogs now say **Install nteract CLI**.

The CLI runbook documents these forms and the retained `daemon`, `doctor`, `status`, `logs`, and `diagnostics` operations. `docs/plans/unified-cli-release.md` provides a Nightly-first qualification and Stable promotion plan, including bootstrap behavior, migration scenarios, publication ordering, and rollback limits. No version bump or release is included. Follow-up to merged #4231, based directly on main.

Validation:

- `cargo test -p runt -p runt-workspace`: 98 passed, including isolated subprocess argument forwarding.
- `cargo test -p notebook`: 115 passed, including fresh directory requests, startup event handling, and Desktop CLI installation coverage.
- `cargo xtask lint --fix`: passed.
- `cargo clippy -p runt -p runt-workspace -p notebook --all-targets -- -D warnings`: passed.
- Independent correctness and operability reviews, plus a focused review of the explicit-runtime adjustment, returned no actionable findings. GitHub CI passed on `456b798f4ac270bbaf0bda241afcb92f933d4ea2`, including Linux Rust tests, Linux/Windows Clippy, JavaScript tests, docs, formatting, and NSIS checks.
- Native signed/installed Desktop launches have not been exercised here; cold/warm launch, cwd execution, channel coexistence, and platform acceptance remain explicit release gates. The existing Desktop service-install race is separate work.
