### PR TITLE
fix(cloud): handle WebSocket departures and page suspension

### DIFF
--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -78,6 +78,7 @@ export interface DurableObjectState {
   // text messages without waking the DO; fakes in tests need not implement
   // it (the room feature-detects before calling).
   setWebSocketAutoResponse?(pair: WebSocketRequestResponsePair): void;
+  getWebSocketAutoResponseTimestamp?(socket: CloudflareWebSocket): Date | null;
 }
 
 export interface WebSocketRequestResponsePair {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -38,6 +38,7 @@ import {
   type TypedFrame,
 } from "./protocol.ts";
 import { cloudLog, durationMs, errorMessage } from "./observability.ts";
+import { webSocketDisconnectFields, type WebSocketDisconnect } from "./websocket-lifecycle.ts";
 import { rewritePresenceIngress } from "./runtimed-wasm.ts";
 import {
   isMaterializedSyncFrame,
@@ -110,6 +111,7 @@ interface PeerCloseOptions {
   code?: number;
   reason?: string;
   suppressRuntimePeerWatch?: boolean;
+  observed?: WebSocketDisconnect;
 }
 
 interface PublishComputeSessionSummaryOptions {
@@ -735,12 +737,17 @@ export class NotebookRoom {
     await this.handleMessage(attachment.notebookId, peer, message);
   }
 
-  webSocketClose(socket: CloudflareWebSocket): void {
-    this.removeAttachedPeer(socket);
+  webSocketClose(
+    socket: CloudflareWebSocket,
+    code?: number,
+    reason?: string,
+    wasClean?: boolean,
+  ): void {
+    this.removeAttachedPeer(socket, { source: "websocket_close", code, reason, wasClean });
   }
 
-  webSocketError(socket: CloudflareWebSocket): void {
-    this.removeAttachedPeer(socket);
+  webSocketError(socket: CloudflareWebSocket, error?: unknown): void {
+    this.removeAttachedPeer(socket, { source: "websocket_error", error });
   }
 
   private async restoreHibernatedPeers(): Promise<void> {
@@ -887,11 +894,20 @@ export class NotebookRoom {
     peer.socket.addEventListener("message", (event) => {
       this.state.waitUntil(this.handleMessage(notebookId, peer, event.data));
     });
-    peer.socket.addEventListener("close", () => {
-      this.removePeer(notebookId, peer);
+    peer.socket.addEventListener("close", (event) => {
+      this.removePeer(notebookId, peer, {
+        observed: {
+          source: "websocket_close",
+          code: event.code,
+          reason: event.reason,
+          wasClean: event.wasClean,
+        },
+      });
     });
-    peer.socket.addEventListener("error", () => {
-      this.removePeer(notebookId, peer);
+    peer.socket.addEventListener("error", (event) => {
+      this.removePeer(notebookId, peer, {
+        observed: { source: "websocket_error", error: "error" in event ? event.error : undefined },
+      });
     });
   }
 
@@ -903,7 +919,7 @@ export class NotebookRoom {
     return this.peers.get(attachment.peerId);
   }
 
-  private removeAttachedPeer(socket: CloudflareWebSocket): void {
+  private removeAttachedPeer(socket: CloudflareWebSocket, observed: WebSocketDisconnect): void {
     const attachment = socketAttachment(socket);
     if (!attachment) {
       return;
@@ -914,7 +930,7 @@ export class NotebookRoom {
       return;
     }
 
-    this.removePeer(attachment.notebookId, peer);
+    this.removePeer(attachment.notebookId, peer, { observed });
   }
 
   private async handleMessage(
@@ -1019,6 +1035,9 @@ export class NotebookRoom {
     if (frame.type === FrameType.PRESENCE) {
       try {
         normalizedFrame = await rewritePresenceFrame(frame, peer);
+        // Normalization yields: close/error may already have announced this
+        // peer's departure. Do not resurrect their cursor with a late update.
+        if (this.peers.get(peer.id) !== peer) return;
       } catch (error) {
         this.rejectFrame(
           notebookId,
@@ -2351,6 +2370,16 @@ export class NotebookRoom {
     if (!this.peers.delete(peer.id)) {
       return;
     }
+    const disconnectFields = webSocketDisconnectFields(
+      this.state,
+      peer.socket,
+      closeOptions.observed ?? {
+        source: "room",
+        code: closeOptions.code,
+        reason: closeOptions.reason,
+      },
+      peer.connectedAt,
+    );
     this.rejectPendingRuntimePeerResponsesForPeer(
       notebookId,
       peer.id,
@@ -2369,6 +2398,7 @@ export class NotebookRoom {
     }
 
     cloudLog("info", "room.connection.closed", {
+      ...disconnectFields,
       notebook_id: notebookId,
       peer_id: peer.id,
       principal: peer.identity.principal,

--- a/apps/notebook-cloud/src/websocket-lifecycle.ts
+++ b/apps/notebook-cloud/src/websocket-lifecycle.ts
@@ -1,0 +1,45 @@
+import type { CloudflareWebSocket, DurableObjectState } from "./cloudflare-types.ts";
+import type { CloudLogFields } from "./observability.ts";
+import { errorMessage } from "./observability.ts";
+
+export type WebSocketDisconnect =
+  | { source: "websocket_close"; code?: number; reason?: string; wasClean?: boolean }
+  | { source: "websocket_error"; error?: unknown }
+  | { source: "room"; code?: number; reason?: string };
+
+/** Read runtime evidence before closing the socket. Never let diagnostics block cleanup. */
+export function webSocketDisconnectFields(
+  state: DurableObjectState,
+  socket: CloudflareWebSocket,
+  disconnect: WebSocketDisconnect,
+  connectedAt: string,
+): CloudLogFields {
+  let lastAutoResponseAt: string | null = null;
+  try {
+    lastAutoResponseAt = state.getWebSocketAutoResponseTimestamp?.(socket)?.toISOString() ?? null;
+  } catch {
+    // Some runtimes have already released the socket by the time close/error runs.
+  }
+  let closeError: string | undefined;
+  if (disconnect.source === "websocket_error" && disconnect.error !== undefined) {
+    try {
+      closeError = errorMessage(disconnect.error).slice(0, 512);
+    } catch {
+      closeError = "unprintable WebSocket error";
+    }
+  }
+  const startedAt = Date.parse(connectedAt);
+  return {
+    close_source: disconnect.source,
+    close_code: "code" in disconnect ? disconnect.code : undefined,
+    close_reason: "reason" in disconnect ? disconnect.reason?.slice(0, 256) : undefined,
+    close_was_clean: "wasClean" in disconnect ? disconnect.wasClean : undefined,
+    close_error: closeError,
+    connection_duration_ms: Number.isFinite(startedAt)
+      ? Math.max(0, Date.now() - startedAt)
+      : undefined,
+    auto_response_timestamp_supported:
+      typeof state.getWebSocketAutoResponseTimestamp === "function",
+    last_auto_response_at: lastAutoResponseAt,
+  };
+}

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -33,6 +33,8 @@ import {
   type PersistedCloudNotebookSeed,
 } from "../viewer/live-sync.ts";
 import { FrameType, LIVENESS_PING, LIVENESS_PONG } from "../src/protocol.ts";
+import { cloudPresenceFromControl } from "../viewer/live-presence.ts";
+import { RemotePresenceState } from "../../../src/components/editor/presence-state.ts";
 
 describe("cloud live sync", () => {
   it("accepts known connection scopes", () => {
@@ -956,6 +958,108 @@ describe("cloud persisted-seed handle resolution", () => {
 });
 
 describe("cloud transport reconnect loop", () => {
+  it("clears only the departed peer's cursors and selections on a room leave control", async () => {
+    const fake = installFakeWebSocket();
+    const state = new RemotePresenceState("local");
+    const transport = createTransport({
+      onControl: (message) => {
+        const presence = cloudPresenceFromControl(message);
+        if (presence) state.handlePresence(presence);
+      },
+    });
+    try {
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("local");
+      await transport.ready;
+      for (const peer_id of ["departing-tab", "remaining-tab"]) {
+        state.handlePresence({
+          type: "update",
+          peer_id,
+          channel: "cursor",
+          data: { cell_id: "cell", line: 1, column: 2 },
+        });
+        state.handlePresence({
+          type: "update",
+          peer_id,
+          channel: "selection",
+          data: { cell_id: "cell", anchor_line: 1, anchor_col: 0, head_line: 1, head_col: 2 },
+        });
+      }
+      assert.equal(state.presenceForCell("cell").cursors.length, 2);
+      assert.equal(state.presenceForCell("cell").selections.length, 2);
+      const leave = {
+        type: "cloud_peer_left",
+        notebook_id: "room",
+        peer_id: "departing-tab",
+        actor_label: "user:dev:alice/browser:tab",
+        room_peer_count: 2,
+        timestamp: new Date().toISOString(),
+      };
+      socket.control(leave);
+      socket.control(leave); // duplicate departure is harmless
+      await drainMicrotasks();
+      const remaining = state.presenceForCell("cell");
+      assert.deepEqual(
+        remaining.cursors.map((cursor) => cursor.peerId),
+        ["remaining-tab"],
+      );
+      assert.equal(remaining.selections.length, 1);
+    } finally {
+      transport.disconnect();
+      fake.restore();
+    }
+  });
+
+  for (const suspendEvent of ["visibilitychange", "pagehide", "freeze"]) {
+    it(`gives a fresh heartbeat deadline after ${suspendEvent} suspension`, async (t) => {
+      t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+      const fake = installFakeWebSocket();
+      const fakeWindow = installFakeWindow();
+      const originalDocument = (globalThis as { document?: unknown }).document;
+      const doc = Object.assign(new EventTarget(), { visibilityState: "visible" });
+      (globalThis as { document?: unknown }).document = doc;
+      const lost: Error[] = [];
+      const transport = createTransport({ onConnectionLost: (reason) => lost.push(reason) });
+      try {
+        const socket = await waitForSocket(0);
+        socket.open();
+        socket.ready("local");
+        await transport.ready;
+        t.mock.timers.tick(20_000); // deadline armed while visible
+        t.mock.timers.tick(9_000);
+        doc.visibilityState = "hidden";
+        if (suspendEvent === "pagehide") fakeWindow.dispatchEvent(new Event(suspendEvent));
+        else doc.dispatchEvent(new Event(suspendEvent));
+        t.mock.timers.tick(60_000);
+        assert.equal(lost.length, 0, "suspension cannot turn an old deadline into connection loss");
+        doc.visibilityState = "visible";
+        const before = socket.sentText.length;
+        if (suspendEvent === "pagehide") fakeWindow.dispatchEvent(new Event("pageshow"));
+        else
+          doc.dispatchEvent(new Event(suspendEvent === "freeze" ? "resume" : "visibilitychange"));
+        assert.equal(socket.sentText.length, before + 1, "resume probes immediately");
+        t.mock.timers.tick(9_999);
+        assert.equal(lost.length, 0);
+        socket.message(LIVENESS_PONG);
+        t.mock.timers.tick(1);
+        assert.equal(lost.length, 0, "queued reply keeps the resumed socket alive");
+        t.mock.timers.tick(10_000); // next periodic probe
+        t.mock.timers.tick(10_000);
+        assert.equal(lost.length, 1, "a silent visible socket still reconnects");
+        transport.disconnect();
+        const sent = socket.sentText.length;
+        doc.dispatchEvent(new Event("visibilitychange"));
+        fakeWindow.dispatchEvent(new Event("pageshow"));
+        assert.equal(socket.sentText.length, sent, "disposed transport does not probe");
+      } finally {
+        transport.disconnect();
+        (globalThis as { document?: unknown }).document = originalDocument;
+        fakeWindow.restore();
+        fake.restore();
+      }
+    });
+  }
   it("resolves the connect target per attempt (fresh auth + operator nonce)", async () => {
     const fake = installFakeWebSocket();
     const minted: string[] = [];
@@ -1520,11 +1624,13 @@ describe("cloud transport reconnect loop", () => {
     const fake = installFakeWebSocket();
     const visibility = { state: "hidden" };
     const originalDocument = (globalThis as { document?: unknown }).document;
-    (globalThis as { document?: unknown }).document = {
-      get visibilityState() {
+    const documentTarget = new EventTarget();
+    Object.defineProperty(documentTarget, "visibilityState", {
+      get() {
         return visibility.state;
       },
-    };
+    });
+    (globalThis as { document?: unknown }).document = documentTarget;
     try {
       const lost: Error[] = [];
       const transport = createTransport({

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -44,6 +44,129 @@ before(async () => {
 });
 
 describe("NotebookRoom presence rewrite", () => {
+  it("does not broadcast an in-flight cursor update after announcing the peer's departure", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    await state.drain();
+    const harness = roomHarness(room);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const observer = new FakeSocket();
+    const peer = {
+      id: "departing",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: new Date().toISOString(),
+      consecutiveRejectedFrames: 0,
+    };
+    harness.peers.set(peer.id, peer);
+    harness.peers.set("observer", {
+      ...peer,
+      id: "observer",
+      socket: observer.asCloudflareWebSocket(),
+    });
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    const frame = encodeTypedFrame(
+      FrameType.PRESENCE,
+      await encodePresenceFrame({
+        type: "update",
+        peer_id: peer.id,
+        channel: "cursor",
+        data: { cell_id: "cell", line: 1, column: 1 },
+      }),
+    );
+    const pending = harness.handleMessage("demo", peer, frame);
+    harness.removePeer("demo", peer);
+    await pending;
+    await state.drain();
+    const frames = observer.sent.map(splitTypedFrame);
+    assert.deepEqual(
+      frames.map((frame) => frame.type),
+      [FrameType.SESSION_CONTROL],
+    );
+    assert.equal(decodeJsonPayload<{ type: string }>(frames[0].payload).type, "cloud_peer_left");
+    assert.equal(socket.sent.length, 0, "a departed peer is not acknowledged after normalization");
+  });
+
+  for (const event of ["close", "error"] as const) {
+    it(`records ${event} evidence and broadcasts one departure for a hibernation socket`, async () => {
+      const state = hibernatedState([]);
+      const room = new NotebookRoom(state.state, {} as Env);
+      await state.drain();
+      const harness = roomHarness(room);
+      const socket = new FakeSocket();
+      const observer = new FakeSocket();
+      const identity = authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+      );
+      const connectedAt = new Date(Date.now() - 5_000).toISOString();
+      socket.serializeAttachment({
+        notebookId: "demo",
+        peerId: "departing",
+        identity,
+        connectedAt,
+      });
+      harness.peers.set("departing", {
+        id: "departing",
+        socket: socket.asCloudflareWebSocket(),
+        identity,
+        connectedAt,
+        consecutiveRejectedFrames: 0,
+      });
+      harness.peers.set("observer", {
+        id: "observer",
+        socket: observer.asCloudflareWebSocket(),
+        identity,
+        connectedAt,
+        consecutiveRejectedFrames: 0,
+      });
+      harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+      const heartbeatAt = new Date(Date.now() - 1_000);
+      state.state.getWebSocketAutoResponseTimestamp = (ws) => {
+        assert.equal(ws, socket.asCloudflareWebSocket());
+        assert.equal(socket.closed, false, "read runtime evidence before closing");
+        return heartbeatAt;
+      };
+      const logs: Record<string, unknown>[] = [];
+      const originalInfo = console.info;
+      console.info = (_prefix, record) => logs.push(record);
+      try {
+        if (event === "close")
+          room.webSocketClose(socket.asCloudflareWebSocket(), 1001, "going away", true);
+        else room.webSocketError(socket.asCloudflareWebSocket(), new Error("connection reset"));
+        room.webSocketClose(socket.asCloudflareWebSocket(), 1006, "", false);
+        await state.drain();
+      } finally {
+        console.info = originalInfo;
+      }
+      assert.equal(harness.peers.has("departing"), false);
+      assert.equal(harness.peers.has("observer"), true);
+      const closed = logs.filter((record) => record.event === "room.connection.closed");
+      assert.equal(closed.length, 1);
+      assert.equal(closed[0].close_source, `websocket_${event}`);
+      assert.equal(closed[0].last_auto_response_at, heartbeatAt.toISOString());
+      assert.equal(closed[0].auto_response_timestamp_supported, true);
+      if (event === "close") {
+        assert.equal(closed[0].close_code, 1001);
+        assert.equal(closed[0].close_reason, "going away");
+        assert.equal(closed[0].close_was_clean, true);
+      } else {
+        assert.equal(closed[0].close_error, "connection reset");
+        assert.equal(closed[0].close_was_clean, undefined);
+      }
+      const departures = observer.sent
+        .map(splitTypedFrame)
+        .filter((frame) => frame.type === FrameType.SESSION_CONTROL)
+        .map((frame) => decodeJsonPayload<{ type: string; peer_id: string }>(frame.payload))
+        .filter((control) => control.type === "cloud_peer_left");
+      assert.deepEqual(
+        departures.map((control) => control.peer_id),
+        ["departing"],
+      );
+    });
+  }
   it("builds room-ready rosters from current peers", () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const harness = roomHarness(room);

--- a/apps/notebook-cloud/test/websocket-lifecycle.test.ts
+++ b/apps/notebook-cloud/test/websocket-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { CloudflareWebSocket, DurableObjectState } from "../src/cloudflare-types.ts";
+import { webSocketDisconnectFields } from "../src/websocket-lifecycle.ts";
+
+describe("WebSocket disconnect diagnostics", () => {
+  const socket = {} as CloudflareWebSocket;
+  for (const capability of ["missing", "never", "released", "invalid"] as const) {
+    it(`keeps cleanup usable when heartbeat timestamps are ${capability}`, () => {
+      const state = {} as DurableObjectState;
+      if (capability !== "missing")
+        state.getWebSocketAutoResponseTimestamp = () => {
+          if (capability === "released") throw new Error("socket no longer registered");
+          return capability === "invalid" ? new Date(Number.NaN) : null;
+        };
+      const fields = webSocketDisconnectFields(
+        state,
+        socket,
+        { source: "room", code: 1008, reason: "access revoked" },
+        "invalid date",
+      );
+      assert.equal(fields.last_auto_response_at, null);
+      assert.equal(fields.auto_response_timestamp_supported, capability !== "missing");
+      assert.equal(fields.connection_duration_ms, undefined);
+      assert.equal(fields.close_source, "room");
+      assert.equal(fields.close_code, 1008);
+      assert.equal(fields.close_reason, "access revoked");
+      assert.equal(
+        fields.close_was_clean,
+        undefined,
+        "requested close is not an observed handshake",
+      );
+    });
+  }
+
+  it("bounds runtime error and peer-provided close text", () => {
+    const state = {} as DurableObjectState;
+    assert.equal(
+      String(
+        webSocketDisconnectFields(
+          state,
+          socket,
+          { source: "websocket_error", error: new Error("e".repeat(1000)) },
+          "",
+        ).close_error,
+      ).length,
+      512,
+    );
+    assert.equal(
+      String(
+        webSocketDisconnectFields(
+          state,
+          socket,
+          { source: "websocket_close", reason: "r".repeat(1000), wasClean: false },
+          "",
+        ).close_reason,
+      ).length,
+      256,
+    );
+  });
+
+  it("keeps cleanup usable for an error without a string representation", () => {
+    const fields = webSocketDisconnectFields(
+      {} as DurableObjectState,
+      socket,
+      { source: "websocket_error", error: Object.create(null) },
+      "",
+    );
+    assert.equal(fields.close_error, "unprintable WebSocket error");
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -40,7 +40,7 @@ import {
 } from "./collaborator-auth";
 import { useCloudAuthStore } from "./cloud-auth-context";
 import { materializeCloudNotebookView } from "./cloud-view-model";
-import { normalizeCloudPresencePayload } from "./live-presence";
+import { cloudPresenceFromControl, normalizeCloudPresencePayload } from "./live-presence";
 import {
   CloudConnectionStatusBridge,
   CloudRecoverableRejectionTracker,
@@ -1279,6 +1279,8 @@ export function useCloudViewerSession({
       },
       onControl: (message) => {
         if (disposed) return;
+        const presence = cloudPresenceFromControl(message);
+        if (presence) emitPresence(presence);
         if (
           message.type === "cloud_room_ready" ||
           message.type === "cloud_peer_joined" ||

--- a/apps/notebook-cloud/viewer/live-presence.ts
+++ b/apps/notebook-cloud/viewer/live-presence.ts
@@ -1,4 +1,11 @@
 import { cloudVisiblePeerLabel } from "./presence";
+import type { SessionControlMessage } from "../src/protocol";
+import type { PresenceLeft } from "@/components/editor/presence-state";
+
+/** Room membership is authoritative even when a departing browser cannot send presence. */
+export function cloudPresenceFromControl(message: SessionControlMessage): PresenceLeft | null {
+  return message.type === "cloud_peer_left" ? { type: "left", peer_id: message.peer_id } : null;
+}
 
 export function normalizeCloudPresencePayload(payload: unknown): unknown {
   if (!isRecord(payload)) return payload;

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -918,6 +918,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
   private livenessPingTimer: ReturnType<typeof setInterval> | null = null;
   private livenessPongTimer: ReturnType<typeof setTimeout> | null = null;
+  private pageSuspended = false;
   private manualDisconnect = false;
   private everReady = false;
   private readySettled = false;
@@ -982,6 +983,29 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.connectionLost(new Error("browser reported offline"), socket);
   };
 
+  private readonly handlePageSuspend = () => {
+    this.pageSuspended = true;
+    this.noteLivenessPong();
+  };
+
+  private readonly handlePageResume = () => {
+    this.pageSuspended = false;
+    this.handleVisibilityChange();
+  };
+
+  private readonly handleVisibilityChange = () => {
+    // A deadline from before suspension must not race a queued pong on resume.
+    this.noteLivenessPong();
+    if (
+      this.pageSuspended ||
+      (typeof document !== "undefined" && document.visibilityState === "hidden")
+    )
+      return;
+    if (this.manualDisconnect || this.livenessPingIntervalMs <= 0) return;
+    const socket = this.socket;
+    if (socket && this.connectionReady) this.sendLivenessPing(socket);
+  };
+
   constructor(options: CloudWebSocketTransportOptions) {
     this.options = options;
     this.reconnectBaseDelayMs = options.reconnectBaseDelayMs ?? RECONNECT_BASE_DELAY_MS;
@@ -1000,6 +1024,13 @@ export class CloudWebSocketTransport implements NotebookTransport {
     if (typeof window !== "undefined") {
       window.addEventListener("online", this.handleBrowserOnline);
       window.addEventListener("offline", this.handleBrowserOffline);
+      window.addEventListener("pagehide", this.handlePageSuspend);
+      window.addEventListener("pageshow", this.handlePageResume);
+    }
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this.handleVisibilityChange);
+      document.addEventListener("freeze", this.handlePageSuspend);
+      document.addEventListener("resume", this.handlePageResume);
     }
     void this.connect();
   }
@@ -1191,6 +1222,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 
   private sendLivenessPing(socket: WebSocket): void {
+    if (this.pageSuspended) return;
     if (socket.readyState !== WebSocket.OPEN) return; // close handler will recycle
     try {
       // Raw text send on purpose: the room's WebSocketRequestResponsePair
@@ -1213,12 +1245,17 @@ export class CloudWebSocketTransport implements NotebookTransport {
       // fire on resume BEFORE the queued pong MessageEvent dispatches,
       // declaring a healthy connection dead on every tab foreground. Send
       // the ping (it keeps intermediaries warm) but skip enforcement while
-      // hidden — the next visible-tab ping re-arms the deadline.
+      // hidden — returning to the visible tab probes with a fresh deadline.
       return;
     }
     this.livenessPongTimer = setTimeout(() => {
       this.livenessPongTimer = null;
       if (socket !== this.socket) return;
+      if (
+        this.pageSuspended ||
+        (typeof document !== "undefined" && document.visibilityState === "hidden")
+      )
+        return;
       // The link is zombie: readyState stays OPEN and sends buffer
       // silently, but the room's auto-response never made it back.
       this.connectionLost(
@@ -1371,6 +1408,13 @@ export class CloudWebSocketTransport implements NotebookTransport {
     if (typeof window !== "undefined") {
       window.removeEventListener("online", this.handleBrowserOnline);
       window.removeEventListener("offline", this.handleBrowserOffline);
+      window.removeEventListener("pagehide", this.handlePageSuspend);
+      window.removeEventListener("pageshow", this.handlePageResume);
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+      document.removeEventListener("freeze", this.handlePageSuspend);
+      document.removeEventListener("resume", this.handlePageResume);
     }
     this.teardownSocket();
     this.rejectPendingFrameAcks(new Error("cloud sync socket disconnected"));


### PR DESCRIPTION
Cloud viewers can keep a departed peer's cursor after the room removes their avatar, and a heartbeat deadline armed before a tab is suspended can expire on resume before a queued reply is processed. This follow-up to #4232 forwards room departures to the shared cursor state and gives returning tabs a fresh liveness probe. The room also drops cursor updates whose asynchronous normalization finishes after the peer leaves, preventing a late update from restoring a departed cursor.

Room disconnect logs now retain the event source, close code/reason/clean flag or runtime error, connection duration, and the last automatic heartbeat-response timestamp when supported. Server-requested closes remain distinguishable from observed close handshakes. The optional runtime API degrades safely when absent or when the socket has already been released.

Validation:

- 204 focused tests passed across transport, room, presence, and disconnect diagnostics; includes preserving another tab's cursors/selections, duplicate departures, a departure racing cursor normalization, visibility/pagehide/freeze recovery, and missing/throwing runtime APIs.
- Cloud typecheck, viewer build, and repository lint passed.
- GitHub CI passed at `609ccd603`: lint/format, shared UI artifact build, JavaScript tests/benchmarks, and CI health summary.
- Isolated local WebSocket probes using the diagnostic helper passed on celld 0.4.1 and Wrangler 4.94.0's local workerd. Both supply clean-close details and heartbeat timestamps. Abrupt TCP disconnects arrive as `webSocketError` in celld and unclean `webSocketClose(1006)` in workerd; both paths retain the evidence.
- Kilo panel completed: Claude Opus 4.8 correctness and Claude Sonnet 4.6 operability. No verified blockers; accepted a return-type nit and independently reproduced/fixed the late cursor update race. A focused Claude Sonnet 4.6 recheck of that final fix also found no actionable issues. All three reviews preserved source integrity; tests were executed separately by the primary agent.

No hosted deployment or live multi-browser notebook validation was performed. Browser suspension tests use deterministic events and timers; the local runtime probes test WebSocket lifecycle APIs, not a full notebook session.
