### PR TITLE
ci(windows): stage and verify the canonical CLI in smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,6 +13,11 @@ on:
         description: Optional release tag to run only the Windows app-launch smoke against.
         required: false
         type: string
+      windows_only:
+        description: Run only the Windows source-build smoke (ignored when release_tag is set).
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -135,7 +140,7 @@ jobs:
           }
 
           $appExe = Get-ChildItem -Path $installDir -Filter *.exe |
-            Where-Object { $_.Name -match '^nteract( Nightly)?\.exe$' } |
+            Where-Object { $_.Name -match '^(notebook|nteract( Nightly)?)\.exe$' } |
             Select-Object -First 1
           if (-not $appExe) {
             $appExe = Get-ChildItem -Path $installDir -Filter *.exe |
@@ -143,6 +148,7 @@ jobs:
                 $_.Name -notin @(
                   "runt.exe",
                   "runtimed.exe",
+                  "nteract-cli.exe",
                   "nteract-mcp.exe",
                   "uninstall.exe"
                 ) -and $_.Name -notmatch '^unins'
@@ -333,6 +339,7 @@ jobs:
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
           cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
+          cp target/release/nteract-cli.exe "crates/notebook/binaries/nteract-cli-$TARGET.exe"
           cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
 
       - name: Generate throwaway updater keypair
@@ -391,10 +398,21 @@ jobs:
           }
           Write-Host "Install dir contents:"
           Get-ChildItem -Path $installDir -Recurse | Select-Object FullName | Format-Table -AutoSize
+          foreach ($binary in @("runtimed", "runt", "nteract-cli", "nteract-mcp")) {
+            $installed = Join-Path $installDir "$binary.exe"
+            if (-not (Test-Path $installed -PathType Leaf)) {
+              throw "Installed sidecar missing: $installed"
+            }
+            $expectedHash = (Get-FileHash "target/release/$binary.exe" -Algorithm SHA256).Hash
+            if ((Get-FileHash $installed -Algorithm SHA256).Hash -ne $expectedHash) {
+              throw "Installed $binary.exe differs from the built sidecar"
+            }
+          }
           "INSTALL_DIR=$installDir" | Out-File -Append -FilePath $env:GITHUB_ENV
           "RUNT=$installDir\runt.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
           "RUNTIMED=$installDir\runtimed.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
           "MCP=$installDir\nteract-mcp.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
+          "NTERACT_CLI=$installDir\nteract-cli.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
 
           $bootstrapLog = Join-Path $env:LOCALAPPDATA "nteract\install-bootstrap.log"
           if (Test-Path $bootstrapLog) {
@@ -432,6 +450,14 @@ jobs:
           }
           Write-Host "$nbName resolved to $nbPath"
 
+          $canonical = Get-Command nteract -ErrorAction SilentlyContinue
+          $expectedShim = Join-Path (Split-Path -Parent $cmd.Source) "nteract.cmd"
+          if (-not $canonical -or $canonical.Source -ne $expectedShim) {
+            throw "Public nteract command must resolve to the installed shim: $expectedShim"
+          }
+          Write-Host "nteract resolved to $($canonical.Source)"
+          "NTERACT_CMD=$($canonical.Source)" | Out-File -Append -FilePath $env:GITHUB_ENV
+
       - name: runt --version
         shell: pwsh
         run: |
@@ -441,6 +467,33 @@ jobs:
           }
           & $env:RUNT --version
           & $env:RUNT_CMD --version
+
+      - name: Verify installed nteract CLI
+        shell: pwsh
+        run: |
+          $backendVersion = & $env:NTERACT_CLI --version
+          if ($LASTEXITCODE -ne 0) { throw "Installed nteract-cli.exe --version failed" }
+          $publicVersion = & $env:NTERACT_CMD --version
+          if ($LASTEXITCODE -ne 0) { throw "Installed nteract --version failed" }
+          if ($publicVersion -ne $backendVersion -or $publicVersion -notmatch '^nteract ') {
+            throw "Public nteract version does not match its installed backend: $publicVersion / $backendVersion"
+          }
+          Write-Host $publicVersion
+
+          $helpText = (& $env:NTERACT_CMD --help) -join "`n"
+          if ($LASTEXITCODE -ne 0) { throw "Installed nteract --help failed" }
+          foreach ($command in @("doctor", "daemon", "workstation", "mcp")) {
+            if ($helpText -notmatch "(?m)^\s+$command\s+") {
+              throw "Installed nteract help is missing $command"
+            }
+          }
+
+          $statusJson = & $env:NTERACT_CMD daemon status --json
+          if ($LASTEXITCODE -ne 0) { throw "Installed nteract daemon status failed" }
+          Write-Host $statusJson
+          if (($statusJson | ConvertFrom-Json).installed -ne $true) {
+            throw "Canonical CLI did not find the installed daemon service"
+          }
 
       - name: Verify installer bootstrap
         shell: pwsh
@@ -668,7 +721,7 @@ jobs:
     name: Linux (build + smoke)
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.event_name != 'release' && (github.event_name != 'workflow_dispatch' || inputs.release_tag == '')
+    if: github.event_name != 'release' && (github.event_name != 'workflow_dispatch' || (inputs.release_tag == '' && !inputs.windows_only))
     # Keep this native smoke off per-commit PR CI. It still runs after merge
     # and can be queued manually when a PR needs the extra signal.
     steps:


### PR DESCRIPTION
Windows Smoke failed to bundle the app after the canonical CLI was added because its sidecar staging omitted `nteract-cli.exe`, which Tauri now requires. Copy that binary alongside the existing sidecars, and prevent the published-app executable fallback from selecting the CLI as Desktop.

The source-build smoke now verifies that all four installed sidecars match the built binaries and checks the public `nteract` shim, version, command help, and daemon status. Existing `runt`, `nb`, and MCP execution checks remain. A default-off `windows_only` dispatch input allows focused Windows validation; main pushes still run both platforms and release-tag dispatches retain the installed-release launch check.

Evidence and validation:

- Original failure: [main Smoke run 34521297263](https://github.com/nteract/nteract/actions/runs/34521297263), missing the target-suffixed `nteract-cli` sidecar while bundling.
- `actionlint .github/workflows/smoke.yml`, `git diff --check`, and `cargo xtask lint --fix`: passed.
- Independent Kilo correctness and operability reviews completed; no actionable findings survived source verification.
- [Windows build/install/MCP Smoke run 34544952487](https://github.com/nteract/nteract/actions/runs/34544952487) passed on exact head `c36016b343e0bf224c7135f50406d3bf6e9c0f0f`: NSIS bundling, silent install, all four installed sidecar hashes, public `nteract` shim/version/help/daemon status, legacy CLI/bootstrap checks, and basic plus Polars notebook execution through legacy MCP. The installed CLI reported `nteract 2.7.6+c36016b`; both MCP passes completed successfully without pass retries.
- [PR Build run 34544955278](https://github.com/nteract/nteract/actions/runs/34544955278) passed on the same head, including browser E2E, Linux Rust tests, Linux/Windows Clippy, Python tests, Node bindings, WASM/Deno, JavaScript tests, UI build, lint, NSIS syntax, and final health summary.

This changes CI packaging and its assertions only. It does not publish a release or establish signed release, upgrade/coexistence, or Desktop path-launch acceptance.
