### PR TITLE
feat(comments): make discussions always available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -568,12 +568,14 @@ jobs:
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
 
       - name: Run browser E2E
+        id: browser_e2e
         run: pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1
         env:
           NTERACT_BROWSER_E2E_READY_TIMEOUT_MS: 900000
 
       - name: Upload Playwright report
-        if: failure()
+        # A successful retry must not discard the first attempt's failure trace.
+        if: ${{ !cancelled() && (steps.browser_e2e.outcome == 'success' || steps.browser_e2e.outcome == 'failure') }}
         uses: actions/upload-artifact@v7
         with:
           name: browser-e2e-playwright-report

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -6022,9 +6022,6 @@ async function viewer(
     hostCapabilities: {
       canManageSharing: true,
     },
-    featureFlags: {
-      enable_comments: true,
-    },
     initialCatalogAccess,
     session: session ? appSessionResponse(session) : null,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -770,6 +770,55 @@ describe("RoomMaterializer", () => {
     assert.deepEqual(await materializer.getCommentAuthorActorLabels(), [editorIdentity.actorLabel]);
   });
 
+  it("recovers comments after checkpoint and rejects viewer writes", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const editorIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+    );
+    const editorPeer = { id: "comments-editor", identity: editorIdentity };
+    const editor = NotebookHandle.create_bootstrap(editorIdentity.actorLabel);
+    editor.init_comments_sync_target("comments:demo");
+    await syncCommentsMaterializerWithClient(materializer, editorPeer, editor);
+    editor.create_comment_thread(
+      "thread-recovery",
+      "message-recovery",
+      { kind: "notebook" },
+      "Keep this discussion",
+      undefined,
+      "2026-09-11T00:00:00Z",
+    );
+    assert.equal(
+      (await applyCommentsClientChangesToMaterializer(materializer, editorPeer, editor)).changed,
+      true,
+    );
+    await materializer.checkpoint();
+
+    const reloaded = new RoomMaterializer("demo", state, {} as Env);
+    const viewerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=bob&operator=browser:b&scope=viewer"),
+    );
+    const viewerPeer = { id: "comments-viewer", identity: viewerIdentity };
+    const viewer = NotebookHandle.create_bootstrap(viewerIdentity.actorLabel);
+    viewer.init_comments_sync_target("comments:demo");
+    await syncCommentsMaterializerWithClient(reloaded, viewerPeer, viewer);
+    assert.deepEqual(await reloaded.getCommentAuthorActorLabels(), [editorIdentity.actorLabel]);
+    const projection = viewer.get_comments_projection();
+    assert.equal(projection.threads.length, 1);
+    assert.equal(projection.threads[0].messages[0].body, "Keep this discussion");
+    viewer.create_comment_thread(
+      "denied-thread",
+      "denied-message",
+      { kind: "notebook" },
+      "Viewer must not write",
+      undefined,
+      "2026-09-11T00:01:00Z",
+    );
+    const denied = await applyCommentsClientChangesToMaterializer(reloaded, viewerPeer, viewer);
+    assert.equal(denied.changed, false);
+    assert.deepEqual(await reloaded.getCommentAuthorActorLabels(), [editorIdentity.actorLabel]);
+  });
+
   it("ignores unversioned prototype checkpoints so published snapshots can hydrate rooms", async () => {
     const state = fakeState();
     const editorIdentity = authenticateDevRequest(
@@ -2156,7 +2205,17 @@ async function syncCommentsMaterializerWithClient(
   peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
   client: NotebookHandle,
 ): Promise<void> {
-  let result = await materializer.syncPeer(peer);
+  const initial = client.flush_comments_doc_sync();
+  const initialOutbound = initial
+    ? (
+        await materializer.receiveFrame(peer, {
+          type: FrameType.COMMENTS_DOC_SYNC,
+          payload: initial,
+        })
+      ).outbound
+    : [];
+  const hostSync = await materializer.syncPeer(peer);
+  let result = { ...hostSync, outbound: [...initialOutbound, ...hostSync.outbound] };
   for (let round = 0; round < 8; round += 1) {
     const replies = applyCommentsOutboundToClient(result.outbound, peer.id, client);
     if (replies.length === 0) {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1080,7 +1080,7 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     const html = await response.text();
     const config = notebookViewerConfig(html);
-    assert.equal(config.featureFlags?.enable_comments, true);
+    assert.equal(config.featureFlags?.enable_comments, undefined);
     assert.equal(config.session?.provider, "oidc");
     assert.equal(typeof config.session?.expires_at, "number");
     assert.equal(typeof config.session?.cache_key, "string");

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -63,7 +63,6 @@ function loadConfig(): CloudViewerConfig {
       canSubmitExecutionRequests: Boolean(parsed.hostCapabilities?.canSubmitExecutionRequests),
     },
     featureFlags: {
-      enable_comments: parsed.featureFlags?.enable_comments === true,
       disable_auto_format: parsed.featureFlags?.disable_auto_format === true,
     },
     initialCatalogAccess: normalizeInitialCatalogAccess(parsed.initialCatalogAccess),

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -139,7 +139,6 @@ export interface CloudViewerConfig {
     canSubmitExecutionRequests?: boolean;
   };
   featureFlags?: {
-    enable_comments?: boolean;
     disable_auto_format?: boolean;
   };
   initialCatalogAccess?: {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -299,7 +299,6 @@ export function NotebookViewer({
     CLOUD_VIEWER_COLOR_THEME_STORAGE_KEY,
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const commentsUiEnabled = config.featureFlags?.enable_comments === true;
   const { store: widgetStore } = useWidgetStoreRequired();
   // Selected interaction mode and the user's edit-access request are owned by the
   // access-request store; this component reads them through its domain hooks and
@@ -693,13 +692,9 @@ export function NotebookViewer({
     }
     openNotebookRailPanel("packages");
   }, [activeRailPanel, railCollapsed]);
-  const handleRailPanelChange = useCallback(
-    (panelId: NotebookRailPanelId) => {
-      if (!commentsUiEnabled && panelId === "comments") return;
-      setActiveNotebookRailPanel(panelId);
-    },
-    [commentsUiEnabled],
-  );
+  const handleRailPanelChange = useCallback((panelId: NotebookRailPanelId) => {
+    setActiveNotebookRailPanel(panelId);
+  }, []);
   const handleOpenMobileRail = useCallback(() => {
     setNotebookRailCollapsed(false);
   }, []);
@@ -1574,11 +1569,9 @@ export function NotebookViewer({
     [],
   );
   const renderedActiveRailPanel =
-    !commentsUiEnabled && activeRailPanel === "comments"
+    !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
       ? "outline"
-      : !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
-        ? "outline"
-        : activeRailPanel;
+      : activeRailPanel;
   const commentsPanelStatus = commentsProjection ? null : "Syncing comments...";
   const resolveSourceQuote = useCallback((anchor: SourceRangeCommentAnchor): string | null => {
     const cell = getCellById(anchor.cell_id);
@@ -1598,9 +1591,7 @@ export function NotebookViewer({
     return range ? sourcePointFromStringOffset(cell.source, range.from) : null;
   }, []);
   const pendingSourceCommentAnchor =
-    commentsUiEnabled && commentDraftTarget?.anchor.kind === "source_range"
-      ? commentDraftTarget.anchor
-      : null;
+    commentDraftTarget?.anchor.kind === "source_range" ? commentDraftTarget.anchor : null;
   const commentsPanel = (
     <NotebookCommentsPanel
       projection={commentsProjection}
@@ -1624,7 +1615,6 @@ export function NotebookViewer({
     />
   );
   const commentsUiSurface = resolveCommentsUiSurface({
-    commentsUiEnabled,
     canCreateComments: canWriteComments,
     commentsPanel,
     onCreateSourceComment: handleRequestSourceComment,
@@ -2019,7 +2009,7 @@ export function NotebookViewer({
                 onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
                 onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
                 onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
-                commentThreadsByCell={commentsUiEnabled ? sourceCommentThreadsByCell : undefined}
+                commentThreadsByCell={sourceCommentThreadsByCell}
                 pendingCommentAnchor={pendingSourceCommentAnchor}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
                 outputHostContext={outputHostContext}

--- a/apps/notebook/e2e/comments.spec.ts
+++ b/apps/notebook/e2e/comments.spec.ts
@@ -4,6 +4,7 @@ import {
   executeCell,
   waitForKernelStatus,
   waitForOutputContaining,
+  waitForNotebookSessionReady,
 } from "./helpers";
 import { McpPeer } from "./mcp-peer";
 
@@ -33,6 +34,9 @@ test("comments are always available and synchronize human and MCP replies across
     await reply.fill("Human reply first");
     await reply.press("ControlOrMeta+Enter");
     await expect(thread.getByText("Human reply first", { exact: true })).toBeVisible();
+    // Local rendering is optimistic. Establish that the MCP replica has seen
+    // the human reply before testing a causally ordered follow-up from that peer.
+    await expect.poll(() => peer.readCommentBodies(threadId)).toContain("Human reply first");
     await peer.replyComment(threadId, "MCP reply second");
     await expect(thread.getByText("MCP reply second", { exact: true })).toBeVisible();
     await expect(thread.locator("[data-comment-reply]")).toContainText([
@@ -52,6 +56,7 @@ test("comments are always available and synchronize human and MCP replies across
 
     await second.close();
     await page.reload();
+    await waitForNotebookSessionReady(page);
     await page.getByRole("button", { name: "Discussions", exact: true }).click();
     await expect(panel.getByText("MCP reply second", { exact: true })).toBeVisible();
     await expect(panel.getByText("Human document discussion", { exact: true })).toHaveCount(1);
@@ -90,6 +95,7 @@ test("source comments remain available after edits, moves, and cell deletion", a
     await peer.deleteCell(cellId);
     await expect(panel.getByText("Review selected value", { exact: true })).toBeVisible();
     await page.reload();
+    await waitForNotebookSessionReady(page);
     await page.getByRole("button", { name: "Discussions", exact: true }).click();
     await expect(panel.getByText("Review selected value", { exact: true })).toHaveCount(1);
   } finally {

--- a/apps/notebook/e2e/comments.spec.ts
+++ b/apps/notebook/e2e/comments.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+import {
+  openNotebookRoom,
+  executeCell,
+  waitForKernelStatus,
+  waitForOutputContaining,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test("comments are always available and synchronize human and MCP replies across reconnect", async ({
+  page,
+  context,
+}) => {
+  const notebookId = crypto.randomUUID();
+  await openNotebookRoom(page, notebookId);
+  await page.getByRole("button", { name: "Discussions", exact: true }).click();
+  const panel = page.getByTestId("notebook-comments-panel");
+  const composer = panel.getByRole("textbox", { name: "Add a comment on the document" });
+  await expect(composer).toBeEnabled();
+  await composer.fill("Human document discussion");
+  await composer.press("ControlOrMeta+Enter");
+  await expect(panel.getByText("Human document discussion", { exact: true })).toHaveCount(1);
+
+  const peer = await McpPeer.start();
+  try {
+    await peer.connectNotebook(notebookId);
+    const threadId = await peer.createComment("MCP discussion");
+    await expect(panel.getByText("MCP discussion", { exact: true })).toBeVisible();
+    const thread = panel.getByRole("listitem").filter({ hasText: "MCP discussion" });
+    await thread.getByRole("button", { name: /Reply to/ }).click();
+    const reply = thread.getByRole("textbox", { name: /Reply to/ });
+    await expect(reply).toBeFocused();
+    await reply.fill("Human reply first");
+    await reply.press("ControlOrMeta+Enter");
+    await expect(thread.getByText("Human reply first", { exact: true })).toBeVisible();
+    await peer.replyComment(threadId, "MCP reply second");
+    await expect(thread.getByText("MCP reply second", { exact: true })).toBeVisible();
+    await expect(thread.locator("[data-comment-reply]")).toContainText([
+      "Human reply first",
+      "MCP reply second",
+    ]);
+
+    const second = await context.newPage();
+    await openNotebookRoom(second, notebookId);
+    await second.getByRole("button", { name: "Discussions", exact: true }).click();
+    await expect(second.getByText("Human reply first", { exact: true })).toBeVisible();
+    await thread.getByRole("button", { name: /^Resolve / }).click();
+    await expect(panel.getByRole("button", { name: "Show resolved (1)" })).toBeVisible();
+    await panel.getByRole("button", { name: "Show resolved (1)" }).click();
+    await thread.getByRole("button", { name: /^Reopen / }).click();
+    await expect(thread.getByRole("button", { name: /^Resolve / })).toBeVisible();
+
+    await second.close();
+    await page.reload();
+    await page.getByRole("button", { name: "Discussions", exact: true }).click();
+    await expect(panel.getByText("MCP reply second", { exact: true })).toBeVisible();
+    await expect(panel.getByText("Human document discussion", { exact: true })).toHaveCount(1);
+    await expect(panel.getByText("Human reply first", { exact: true })).toHaveCount(1);
+    await page.screenshot({ path: "test-results/comments-wide.png", fullPage: true });
+    await page.setViewportSize({ width: 720, height: 900 });
+    await page.screenshot({ path: "test-results/comments-constrained.png", fullPage: true });
+  } finally {
+    await peer.close();
+  }
+});
+
+test("source comments remain available after edits, moves, and cell deletion", async ({ page }) => {
+  const notebookId = crypto.randomUUID();
+  await openNotebookRoom(page, notebookId);
+  const peer = await McpPeer.start();
+  try {
+    await peer.connectNotebook(notebookId);
+    const cellId = await peer.createCell("value = 42\nprint(value)");
+    const cell = page.getByRole("group", { name: "Cell 2", exact: true });
+    const editor = cell.getByRole("textbox");
+    await editor.click();
+    await editor.press("ControlOrMeta+Home");
+    await editor.press("Shift+End");
+    await editor.press("ControlOrMeta+Alt+m");
+    const panel = page.getByTestId("notebook-comments-panel");
+    const composer = panel.getByRole("textbox", { name: /New .* comment/ });
+    await expect(composer).toBeFocused();
+    await composer.fill("Review selected value");
+    await composer.press("ControlOrMeta+Enter");
+    await expect(panel.getByText("Review selected value", { exact: true })).toBeVisible();
+    await peer.setCell(cellId, "# inserted before selection\nvalue = 42\nprint(value)");
+    await expect(panel.getByTestId("comment-thread-source-quote")).toContainText("value = 42");
+    await peer.moveCell(cellId, null);
+    await expect(panel.getByText("Review selected value", { exact: true })).toHaveCount(1);
+    await peer.deleteCell(cellId);
+    await expect(panel.getByText("Review selected value", { exact: true })).toBeVisible();
+    await page.reload();
+    await page.getByRole("button", { name: "Discussions", exact: true }).click();
+    await expect(panel.getByText("Review selected value", { exact: true })).toHaveCount(1);
+  } finally {
+    await peer.close();
+  }
+});
+
+test("output comments remain in Discussions when a rerun replaces their output", async ({
+  page,
+}) => {
+  const notebookId = crypto.randomUUID();
+  await openNotebookRoom(page, notebookId);
+  await waitForKernelStatus(page, "idle", 120_000);
+  const peer = await McpPeer.start();
+  try {
+    await peer.connectNotebook(notebookId);
+    const cellId = await peer.createCell("print('original output')");
+    const cell = page.getByRole("group", { name: "Cell 2", exact: true });
+    await executeCell(cell);
+    await waitForOutputContaining(cell, "original output");
+    await cell.getByRole("button", { name: "Comment on outputs", exact: true }).click();
+    const panel = page.getByTestId("notebook-comments-panel");
+    const composer = panel.getByRole("textbox", { name: /New .* comment/ });
+    await composer.fill("Keep this output discussion");
+    await composer.press("ControlOrMeta+Enter");
+    await expect(panel.getByText("Keep this output discussion", { exact: true })).toBeVisible();
+    await peer.setCell(cellId, "print('replacement output')");
+    await executeCell(cell);
+    await waitForOutputContaining(cell, "replacement output");
+    await expect(panel.getByText("Keep this output discussion", { exact: true })).toHaveCount(1);
+    await expect(
+      panel.getByRole("button", { name: "Resolve Document comment 1", exact: true }),
+    ).toBeVisible();
+  } finally {
+    await peer.close();
+  }
+});

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -25,6 +25,11 @@ export interface ExecutionPerformanceSnapshot {
 
 export async function waitForNotebookReady(page: Page, path = "/") {
   await page.goto(path);
+  await waitForNotebookSessionReady(page);
+}
+
+/** Also used after reload, when the shell can render before its replica is ready. */
+export async function waitForNotebookSessionReady(page: Page) {
   await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
   // NotebookView marks sync complete once loading has finished without a load
   // error. Zero-cell notebooks are valid once the host has initialized them.

--- a/apps/notebook/e2e/mcp-peer.ts
+++ b/apps/notebook/e2e/mcp-peer.ts
@@ -73,7 +73,19 @@ export class McpPeer {
   }
 
   async connectNotebook(notebookId: string): Promise<unknown> {
-    return await this.callToolJson("connect_notebook", { notebook_id: notebookId });
+    // Connecting can return a readable projection before the replica can mutate.
+    // Reconnecting to the same active target samples its readiness without
+    // replacing the session. Never use a trial mutation as a readiness probe.
+    const deadline = Date.now() + 30_000;
+    let result: { capabilities?: { mutate?: boolean } };
+    do {
+      result = (await this.callToolJson("connect_notebook", {
+        notebook_id: notebookId,
+      })) as { capabilities?: { mutate?: boolean } };
+      if (result.capabilities?.mutate) return result;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } while (Date.now() < deadline);
+    throw new Error(`Notebook did not become ready for mutations: ${JSON.stringify(result)}`);
   }
 
   async createCell(source: string, cellType = "code"): Promise<string> {

--- a/apps/notebook/e2e/mcp-peer.ts
+++ b/apps/notebook/e2e/mcp-peer.ts
@@ -92,6 +92,28 @@ export class McpPeer {
     });
   }
 
+  async moveCell(cellId: string, afterCellId: string | null): Promise<unknown> {
+    return this.callToolText("move_cell", { cell_id: cellId, after_cell_id: afterCellId });
+  }
+
+  async deleteCell(cellId: string): Promise<unknown> {
+    return this.callToolText("delete_cell", { cell_id: cellId });
+  }
+
+  async createComment(body: string, cellId?: string): Promise<string> {
+    const text = await this.callToolText("create_comment", {
+      anchor: cellId ? { cell_id: cellId } : { notebook: true },
+      body,
+    });
+    const match = text.match(/Created comment thread:\s*([^\s]+)/);
+    if (!match) throw new Error(`create_comment did not return a thread id: ${text}`);
+    return match[1];
+  }
+
+  async replyComment(threadId: string, body: string): Promise<unknown> {
+    return await this.callToolText("reply_comment", { thread_id: threadId, body });
+  }
+
   async manageDependencies(dependencies: string[]): Promise<unknown> {
     return await this.callToolJson("manage_dependencies", {
       add: dependencies,

--- a/apps/notebook/e2e/mcp-peer.ts
+++ b/apps/notebook/e2e/mcp-peer.ts
@@ -28,6 +28,7 @@ export class McpPeer {
   private nextId = 1;
   private stdout = "";
   private stderr = "";
+  private notebookHandle: string | undefined;
 
   private constructor(child: ChildProcessWithoutNullStreams) {
     this.child = child;
@@ -77,12 +78,15 @@ export class McpPeer {
     // Reconnecting to the same active target samples its readiness without
     // replacing the session. Never use a trial mutation as a readiness probe.
     const deadline = Date.now() + 30_000;
-    let result: { capabilities?: { mutate?: boolean } };
+    let result: { notebook_handle?: string; capabilities?: { mutate?: boolean } };
     do {
       result = (await this.callToolJson("connect_notebook", {
         notebook_id: notebookId,
-      })) as { capabilities?: { mutate?: boolean } };
-      if (result.capabilities?.mutate) return result;
+      })) as { notebook_handle?: string; capabilities?: { mutate?: boolean } };
+      if (result.capabilities?.mutate) {
+        this.notebookHandle = result.notebook_handle;
+        return result;
+      }
       await new Promise((resolve) => setTimeout(resolve, 100));
     } while (Date.now() < deadline);
     throw new Error(`Notebook did not become ready for mutations: ${JSON.stringify(result)}`);
@@ -124,6 +128,21 @@ export class McpPeer {
 
   async replyComment(threadId: string, body: string): Promise<unknown> {
     return await this.callToolText("reply_comment", { thread_id: threadId, body });
+  }
+
+  async readCommentBodies(threadId: string): Promise<string[]> {
+    if (!this.notebookHandle) throw new Error("Connect a notebook before reading comments");
+    const result = (await this.request("resources/read", {
+      uri: `nteract://sessions/${this.notebookHandle}/comments`,
+    })) as { contents: Array<{ text: string }> };
+    const projection = JSON.parse(result.contents[0].text) as {
+      threads: Array<{ id: string; messages: Array<{ body: string }> }>;
+    };
+    return (
+      projection.threads
+        .find((thread) => thread.id === threadId)
+        ?.messages.map((message) => message.body) ?? []
+    );
   }
 
   async manageDependencies(dependencies: string[]): Promise<unknown> {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -345,7 +345,7 @@ function AppContent() {
   const daemonInfo = useDaemonInfo();
 
   // Apply theme to this window
-  const { defaultPythonEnv, featureFlags } = useSyncedTheme();
+  const { defaultPythonEnv } = useSyncedTheme();
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -346,7 +346,6 @@ function AppContent() {
 
   // Apply theme to this window
   const { defaultPythonEnv, featureFlags } = useSyncedTheme();
-  const commentsUiEnabled = featureFlags.enable_comments;
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());
@@ -1055,9 +1054,7 @@ function AppContent() {
   );
 
   const pendingSourceCommentAnchor =
-    commentsUiEnabled && commentDraftTarget?.anchor.kind === "source_range"
-      ? commentDraftTarget.anchor
-      : null;
+    commentDraftTarget?.anchor.kind === "source_range" ? commentDraftTarget.anchor : null;
   const commentsPanel = (
     <NotebookCommentsPanel
       projection={commentsProjection}
@@ -1081,7 +1078,6 @@ function AppContent() {
     />
   );
   const commentsUiSurface = resolveCommentsUiSurface({
-    commentsUiEnabled,
     canCreateComments: canMutateComments,
     commentsPanel,
     onCreateSourceComment: handleRequestSourceComment,
@@ -1384,17 +1380,12 @@ function AppContent() {
     return null;
   }, [envSource, envSyncState]);
 
-  const renderedActiveRailPanel =
-    !commentsUiEnabled && activeRailPanel === "comments" ? "outline" : activeRailPanel;
+  const renderedActiveRailPanel = activeRailPanel;
   const packagesRailOpen = !railCollapsed && renderedActiveRailPanel === "packages";
 
-  const handleRailPanelChange = useCallback(
-    (panelId: NotebookRailPanelId) => {
-      if (!commentsUiEnabled && panelId === "comments") return;
-      openNotebookRailPanel(panelId);
-    },
-    [commentsUiEnabled],
-  );
+  const handleRailPanelChange = useCallback((panelId: NotebookRailPanelId) => {
+    openNotebookRailPanel(panelId);
+  }, []);
 
   const handleTogglePackagesRail = useCallback(() => {
     if (!shellCapabilities.canViewPackages) {
@@ -2297,7 +2288,7 @@ function AppContent() {
                   onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
                   onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
                   onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
-                  commentThreadsByCell={commentsUiEnabled ? sourceCommentThreadsByCell : undefined}
+                  commentThreadsByCell={sourceCommentThreadsByCell}
                   pendingCommentAnchor={pendingSourceCommentAnchor}
                   markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
                 />

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -381,6 +381,7 @@ function AppContent() {
     clearOutputs,
     setCellType,
     save,
+    saveError,
     openNotebook,
     cloneNotebook,
 
@@ -1963,6 +1964,31 @@ function AppContent() {
           onRetry={reconnectRuntime}
           onRepair={host.daemon.repair ? repairRuntime : undefined}
         />
+        {saveError && (
+          <div
+            role="alert"
+            className="flex items-start justify-between gap-3 border-b border-destructive/30 bg-destructive/10 px-4 py-3 text-sm"
+          >
+            <div>
+              <p className="font-medium">Save did not finish</p>
+              <p>
+                Your notebook or discussions may not be fully saved. Keep this window open and
+                retry.
+              </p>
+              <details className="mt-1 text-xs">
+                <summary className="cursor-pointer">Error details</summary>
+                <p className="mt-1 break-all">{saveError}</p>
+              </details>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 font-medium underline"
+              onClick={() => void save()}
+            >
+              Retry save
+            </button>
+          </div>
+        )}
         <PoolErrorBanner
           uvError={poolUvError}
           condaError={poolCondaError}

--- a/apps/notebook/src/components/__tests__/comments-ui-gate.test.tsx
+++ b/apps/notebook/src/components/__tests__/comments-ui-gate.test.tsx
@@ -4,12 +4,11 @@ import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate
 import { NotebookPackagesPanel, NotebookRail } from "@/components/notebook-rail";
 
 describe("resolveCommentsUiSurface", () => {
-  it("passes the comments panel and callbacks when comments UI is enabled", () => {
+  it("passes the comments panel and callbacks for writers", () => {
     const onCreateSourceComment = vi.fn();
     const onCreateOutputComment = vi.fn();
     const onActivateCommentThread = vi.fn();
     const surface = resolveCommentsUiSurface({
-      commentsUiEnabled: true,
       canCreateComments: true,
       commentsPanel: "comments panel",
       onCreateSourceComment,
@@ -23,24 +22,17 @@ describe("resolveCommentsUiSurface", () => {
     expect(surface.onActivateCommentThread).toBe(onActivateCommentThread);
   });
 
-  it("suppresses the comments panel and every NotebookView callback when comments UI is disabled", () => {
+  it("always exposes Discussions in the rail", () => {
     const surface = resolveCommentsUiSurface({
-      commentsUiEnabled: false,
-      canCreateComments: true,
+      canCreateComments: false,
       commentsPanel: "comments panel",
       onCreateSourceComment: vi.fn(),
       onCreateOutputComment: vi.fn(),
       onActivateCommentThread: vi.fn(),
     });
-
-    expect(surface.commentsPanel).toBeUndefined();
-    expect(surface.onCreateSourceComment).toBeUndefined();
-    expect(surface.onCreateOutputComment).toBeUndefined();
-    expect(surface.onActivateCommentThread).toBeUndefined();
-
     render(
       <NotebookRail
-        activePanelId="outline"
+        activePanelId="comments"
         collapsed={false}
         outlineItems={[]}
         packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
@@ -49,14 +41,13 @@ describe("resolveCommentsUiSurface", () => {
         onCollapsedChange={vi.fn()}
       />,
     );
-    expect(screen.queryByRole("button", { name: "Discussions" })).not.toBeInTheDocument();
-    expect(screen.queryByText("comments panel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Discussions" })).toBeInTheDocument();
+    expect(screen.getByText("comments panel")).toBeInTheDocument();
   });
 
   it("keeps the panel and activation callback for read-only comments without create affordances", () => {
     const onActivateCommentThread = vi.fn();
     const surface = resolveCommentsUiSurface({
-      commentsUiEnabled: true,
       canCreateComments: false,
       commentsPanel: "comments panel",
       onCreateSourceComment: vi.fn(),

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -146,6 +146,9 @@ export function useNotebook() {
   const cellIds = useCellIds();
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const saveFeedbackGeneration = useRef(0);
+  const completedSaveFeedbackGeneration = useRef(0);
   const [canAcceptCellMutations, setCanAcceptCellMutations] = useState(false);
 
   const handleRef = useRef<NotebookHandle | null>(null);
@@ -624,9 +627,20 @@ export function useNotebook() {
     // it on save / save-as / untitled promotion. Reading it here avoids
     // a Tauri round-trip to the WindowNotebookRegistry.
     const hasPath = runtimePath != null;
-    await saveNotebook(host, flushSync, hasPath, {
+    const generation = ++saveFeedbackGeneration.current;
+    const saved = await saveNotebook(host, flushSync, hasPath, {
       hosted: hostedNotebookUrl !== null,
+      onError: (message) => {
+        if (generation >= completedSaveFeedbackGeneration.current) {
+          completedSaveFeedbackGeneration.current = generation;
+          setSaveError(message);
+        }
+      },
     });
+    if (saved && generation >= completedSaveFeedbackGeneration.current) {
+      completedSaveFeedbackGeneration.current = generation;
+      setSaveError(null);
+    }
   }, [host, flushSync, hostedNotebookUrl, runtimePath]);
 
   const openNotebook = useCallback(() => openNotebookFile(host), [host]);
@@ -697,6 +711,7 @@ export function useNotebook() {
     clearOutputs,
     setCellType,
     save,
+    saveError,
     openNotebook,
     cloneNotebook,
     loadError,

--- a/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
@@ -127,9 +127,35 @@ describe("saveNotebook", () => {
       reason: { type: "io", message: "disk full" },
     });
 
-    const result = await saveNotebook(stubHost, flushSync, true);
+    const onError = vi.fn();
+    const result = await saveNotebook(stubHost, flushSync, true, { onError });
 
     expect(result).toBe(false);
+    expect(onError).toHaveBeenCalledWith("disk full");
+  });
+
+  it("reports initial save binding failure and allows an already-current retry", async () => {
+    const onError = vi.fn();
+    mockSaveDialog.mockResolvedValueOnce("/tmp/saved.ipynb");
+    mockSaveAs.mockRejectedValueOnce(new Error("could not persist saved notebook discussion binding"));
+    await expect(saveNotebook(stubHost, flushSync, false, { onError })).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledWith("could not persist saved notebook discussion binding");
+    mockSendRequest.mockResolvedValueOnce({
+      result: "notebook_already_current", path: "/tmp/saved.ipynb",
+      exported_heads: ["abc123"], save_sequence: 2,
+    });
+    await expect(saveNotebook(stubHost, flushSync, true, { onError })).resolves.toBe(true);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed sync flush but stays quiet on dialog cancellation", async () => {
+    const onError = vi.fn();
+    await expect(saveNotebook(stubHost, async () => false, false, { onError })).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("synchronized"));
+    onError.mockClear();
+    mockSaveDialog.mockResolvedValueOnce(null);
+    await expect(saveNotebook(stubHost, flushSync, false, { onError })).resolves.toBe(false);
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("treats an already-current causal checkpoint as a successful save", async () => {
@@ -150,7 +176,9 @@ describe("saveNotebook", () => {
       reason: { type: "superseded", latest_sequence: 4 },
     });
 
-    await expect(saveNotebook(stubHost, flushSync, true)).resolves.toBe(false);
+    const onError = vi.fn();
+    await expect(saveNotebook(stubHost, flushSync, true, { onError })).resolves.toBe(false);
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("returns false on transport failure", async () => {

--- a/apps/notebook/src/lib/notebook-file-ops.ts
+++ b/apps/notebook/src/lib/notebook-file-ops.ts
@@ -32,11 +32,14 @@ export async function saveNotebook(
   host: NotebookHost,
   flushSync: () => Promise<boolean | void>,
   hasPath: boolean,
-  options: { hosted?: boolean } = {},
+  options: { hosted?: boolean; onError?: (message: string) => void } = {},
 ): Promise<boolean> {
   try {
     const flushed = await flushSync();
-    if (flushed === false) return false;
+    if (flushed === false) {
+      options.onError?.("Notebook changes could not be synchronized. Check the connection and retry.");
+      return false;
+    }
 
     // A daemon-mediated hosted room is already persisted by its cloud host.
     // Its daemon-local room is intentionally ephemeral, so `path == null`
@@ -48,6 +51,16 @@ export async function saveNotebook(
       const outcome = await client.saveNotebook({ formatCells: true });
       if (outcome.outcome === "blocked") {
         logger.error("[notebook-file-ops] Save blocked:", outcome.reason);
+        // A newer checkpoint superseding this request is not a save failure.
+        if (outcome.reason.type !== "superseded") {
+          options.onError?.(
+            "message" in outcome.reason
+              ? outcome.reason.message
+              : outcome.reason.type === "path_already_open"
+                ? "This file is already open in another notebook. Choose a different path."
+                : "The notebook could not be saved. Restart the application and retry.",
+          );
+        }
         return false;
       }
     } else {
@@ -63,6 +76,7 @@ export async function saveNotebook(
     return true;
   } catch (e) {
     logger.error("[notebook-file-ops] Save failed:", e);
+    options.onError?.(e instanceof Error ? e.message : String(e));
     return false;
   }
 }

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -329,8 +329,7 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub disable_nteract_launcher: bool,
 
-    /// Show the comments UI (panels and creation affordances). Comments sync stays
-    /// active regardless of this flag. Default off.
+    /// Legacy compatibility only. Commenting is always available; clients ignore this value.
     #[serde(default)]
     pub enable_comments: bool,
 

--- a/crates/runtimed/src/notebook_sync_server/comments_store.rs
+++ b/crates/runtimed/src/notebook_sync_server/comments_store.rs
@@ -96,7 +96,6 @@ impl CommentsSidecarStore {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn bind_doc_id_to_locator(
         &self,
         locator: &CommentsLocator,

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -158,6 +158,27 @@ impl NotebookFileBinding {
             .await;
     }
 
+    /// Keep the local discussion identity reachable through the saved path.
+    /// Called before acknowledging a file save, including retries after index IO errors.
+    pub(crate) fn persist_comments_binding(
+        room: &NotebookRoom,
+        canonical: &Path,
+    ) -> Result<(), String> {
+        let doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "missing comments document identity".to_string())?;
+        room.comments_store
+            .bind_doc_id_to_locator(
+                &comments_locator_for_room(room.id, Some(canonical)),
+                &doc_id,
+            )
+            .map_err(|error| {
+                format!("could not persist saved notebook discussion binding: {error:#}")
+            })
+    }
+
     pub async fn promote_after_save(room: &Arc<NotebookRoom>, canonical: PathBuf) {
         room.file_binding.set_bound_path(canonical.clone()).await;
         room.file_binding.mark_file_backed();

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6,6 +6,126 @@ use uuid::Uuid;
 
 const SCHEMA_SEED_ACTOR_LABEL: &str = "nteract:notebook-schema:v5";
 
+#[tokio::test]
+async fn comments_survive_initial_save_and_save_as_reopening() {
+    let tmp = tempfile::tempdir().unwrap();
+    let docs_dir = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+    let blobs = test_blob_store(&tmp);
+    let id = Uuid::new_v4();
+    let room = Arc::new(NotebookRoom::new_fresh(
+        id,
+        None,
+        &docs_dir,
+        blobs.clone(),
+        false,
+    ));
+    room.comments
+        .with_doc(|doc| {
+            doc.create_thread(
+                "thread",
+                "first",
+                &comments_doc::CommentAnchor::Notebook,
+                "Before initial save",
+                None,
+                "2026-09-11T00:00:00Z",
+            )?;
+            doc.reply(
+                "thread",
+                "reply",
+                "Reply in order",
+                Some("first"),
+                "2026-09-11T00:00:01Z",
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    room.comments_store.save_handle(&room.comments).unwrap();
+    let expected = room
+        .comments
+        .read(|doc| doc.read_projection(None).unwrap())
+        .unwrap();
+    let daemon = crate::daemon::Daemon::new_for_test(test_daemon_config(&tmp)).unwrap();
+
+    for name in ["initial.ipynb", "renamed.ipynb"] {
+        let path = tmp.path().join(name);
+        // A file checkpoint alone must not acknowledge success when its
+        // discussion locator cannot be persisted. A subsequent save can retry.
+        let index = room.comments_store.root().join("index.json");
+        let backup = index.with_extension("backup");
+        std::fs::rename(&index, &backup).unwrap();
+        std::fs::create_dir(&index).unwrap();
+        let blocked = crate::requests::save_notebook::handle(
+            &room,
+            &daemon,
+            false,
+            Some(path.to_string_lossy().into_owned()),
+        )
+        .await;
+        assert!(
+            matches!(
+                blocked,
+                crate::protocol::NotebookResponse::NotebookSaveBlocked {
+                    reason: notebook_protocol::protocol::SaveBlockedReason::Io { .. },
+                    ..
+                }
+            ),
+            "{blocked:?}"
+        );
+        std::fs::remove_dir(&index).unwrap();
+        std::fs::rename(&backup, &index).unwrap();
+        let response = crate::requests::save_notebook::handle(
+            &room,
+            &daemon,
+            false,
+            Some(path.to_string_lossy().into_owned()),
+        )
+        .await;
+        assert!(
+            matches!(
+                response,
+                crate::protocol::NotebookResponse::NotebookSaved { .. }
+                    | crate::protocol::NotebookResponse::NotebookAlreadyCurrent { .. }
+            ),
+            "{response:?}"
+        );
+        let canonical = std::fs::canonicalize(&path).unwrap();
+        // A new room loads only durable sidecar state, as after daemon restart.
+        let reopened =
+            NotebookRoom::new_fresh(id, Some(canonical), &docs_dir, blobs.clone(), false);
+        let actual = reopened
+            .comments
+            .read(|doc| doc.read_projection(None).unwrap())
+            .unwrap();
+        assert_eq!(
+            actual, expected,
+            "discussion identity and ordered content after {name}"
+        );
+    }
+    // A failed file write must leave every previous discussion association intact.
+    let index = room.comments_store.root().join("index.json");
+    let previous_index = std::fs::read(&index).unwrap();
+    let invalid_target = tmp.path().join("directory.ipynb");
+    std::fs::create_dir(&invalid_target).unwrap();
+    let blocked = crate::requests::save_notebook::handle(
+        &room,
+        &daemon,
+        false,
+        Some(invalid_target.to_string_lossy().into_owned()),
+    )
+    .await;
+    assert!(
+        matches!(
+            blocked,
+            crate::protocol::NotebookResponse::NotebookSaveBlocked { .. }
+        ),
+        "{blocked:?}"
+    );
+    assert_eq!(std::fs::read(index).unwrap(), previous_index);
+    room.file_binding.shutdown_notebook_watcher().await;
+    shutdown_autosave_debouncer(&room, "comments-test", std::time::Duration::from_secs(5)).await;
+}
+
 #[test]
 fn fallback_output_stamps_id_when_missing() {
     let raw = serde_json::json!({

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -296,6 +296,18 @@ async fn handle_with_intent(
         // If path didn't change, this is save-in-place: nothing else.
     }
 
+    // Comments remain the same room-owned document through promotion and Save As.
+    // Bind only after file checkpoint and promotion succeed, before acknowledging
+    // the save. On index IO failure the file remains bound, and saving again
+    // retries this step even when the notebook bytes are already current.
+    if let Err(message) = NotebookFileBinding::persist_comments_binding(room, &canonical) {
+        return NotebookResponse::NotebookSaveBlocked {
+            path: Some(written),
+            save_sequence: Some(checkpoint_sequence),
+            reason: notebook_protocol::protocol::SaveBlockedReason::Io { message },
+        };
+    }
+
     match save_outcome {
         FileSaveOutcome::Saved {
             exported_heads,

--- a/src/components/notebook/comments-ui-gate.ts
+++ b/src/components/notebook/comments-ui-gate.ts
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 export interface CommentsUiSurfaceOptions<SourceHandler, OutputHandler, ActivateHandler> {
-  commentsUiEnabled: boolean;
   canCreateComments: boolean;
   commentsPanel: ReactNode;
   onCreateSourceComment: SourceHandler;
@@ -17,7 +16,6 @@ export interface CommentsUiSurface<SourceHandler, OutputHandler, ActivateHandler
 }
 
 export function resolveCommentsUiSurface<SourceHandler, OutputHandler, ActivateHandler>({
-  commentsUiEnabled,
   canCreateComments,
   commentsPanel,
   onCreateSourceComment,
@@ -28,11 +26,10 @@ export function resolveCommentsUiSurface<SourceHandler, OutputHandler, ActivateH
   OutputHandler,
   ActivateHandler
 > {
-  const canShowCreateAffordances = commentsUiEnabled && canCreateComments;
   return {
-    commentsPanel: commentsUiEnabled ? commentsPanel : undefined,
-    onCreateSourceComment: canShowCreateAffordances ? onCreateSourceComment : undefined,
-    onCreateOutputComment: canShowCreateAffordances ? onCreateOutputComment : undefined,
-    onActivateCommentThread: commentsUiEnabled ? onActivateCommentThread : undefined,
+    commentsPanel,
+    onCreateSourceComment: canCreateComments ? onCreateSourceComment : undefined,
+    onCreateOutputComment: canCreateComments ? onCreateOutputComment : undefined,
+    onActivateCommentThread: onActivateCommentThread,
   };
 }

--- a/src/hooks/__tests__/useSyncedSettings.test.tsx
+++ b/src/hooks/__tests__/useSyncedSettings.test.tsx
@@ -5,7 +5,7 @@ import {
   getNotebookEditorSettingsSnapshot,
   setNotebookEditorSettings,
 } from "@/components/editor/editor-settings-store";
-import { useSyncedSettings, useSyncedTheme } from "../useSyncedSettings";
+import { FEATURE_FLAGS, useSyncedSettings, useSyncedTheme } from "../useSyncedSettings";
 
 const mocks = vi.hoisted(() => {
   const getSynced = vi.fn();
@@ -75,6 +75,18 @@ describe("useSyncedSettings", () => {
   afterEach(() => {
     localStorage.clear();
   });
+
+  it.each([false, true, undefined])(
+    "ignores legacy enable_comments=%s without rewriting old settings",
+    async (enable_comments) => {
+      mocks.getSynced.mockResolvedValue({ enable_comments, disable_auto_format: true });
+      const { result } = renderHook(() => useSyncedSettings());
+      await waitFor(() => expect(result.current.featureFlags.disable_auto_format).toBe(true));
+      expect(result.current.featureFlags).not.toHaveProperty("enable_comments");
+      expect(FEATURE_FLAGS.map((flag) => flag.id)).not.toContain("enable_comments");
+      expect(mocks.setSynced).not.toHaveBeenCalled();
+    },
+  );
 
   it("ignores initial host settings that resolve after unmount", async () => {
     const load = deferred<unknown>();

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -106,11 +106,6 @@ export const FEATURE_FLAG_METADATA = {
     label: "Use Legacy IPython Launcher",
     description: "Launch Python kernels with ipykernel_launcher instead of the nteract launcher.",
   },
-  enable_comments: {
-    label: "Enable Comments UI",
-    description:
-      "Show comment panels and creation affordances. Comments sync stays active either way.",
-  },
   disable_auto_format: {
     label: "Disable automatic formatting",
     description:
@@ -123,7 +118,6 @@ export type FeatureFlagValues = Record<FeatureFlagId, boolean>;
 
 const FEATURE_FLAG_DEFAULTS: FeatureFlagValues = {
   disable_nteract_launcher: false,
-  enable_comments: false,
   disable_auto_format: false,
 };
 


### PR DESCRIPTION
Make Discussions available on Desktop and cloud for every user, including users with persisted `enable_comments: false`. Remove the experimental toggle and cloud config gate while retaining legacy Rust setting compatibility and existing viewer/editor permissions.

Fix two blockers found during native QA. Initial Save and API Save As now bind the saved path to the existing discussion sidecar after the notebook checkpoint and promotion succeed. Reopening the file retains its discussions. If the index write fails, save reports failure and retries the binding even when notebook bytes are already current. Desktop shows a persistent save-error alert with details and Retry save; successful retry clears it.

Comments remain separate sidecars outside `.ipynb` exports. No automatic historical migration or merging is included. Recovery from the previous save bug requires proven notebook-to-original-sidecar provenance; a targeted recovery was verified on copies with both originals preserved.

### Validation

- 1,355 daemon unit tests passed (3 ignored), plus the final Save/Save As regression after its last extension: disk reopening, index failure/retry, ordered content retained, and failed notebook write leaves previous associations intact.
- 65 focused frontend tests, 194 comments/client/settings tests (1 ignored), 16 save-flow tests, 10 WASM commenting tests, 5 cloud commenting cases, and 2 Tokio lock-lint tests passed. Desktop/cloud typechecks, cloud viewer build, required lint, and actionlint passed.
- Native app and daemon at production commit `efde68371` retained discussions across full restart. Real index-write denial displayed the persistent error; restoring writes and clicking Retry save cleared it. Native initial Save was exercised; API Save As was tested through the daemon handler and disk reopening.
- Isolated cloud owner/editor/viewer UI passed collaboration, denied viewer controls, offline/reconnect, and reload. Three Chromium/dev-daemon journeys passed: human/MCP/two-client discussions, replies and resolve/reopen; source edits/moves/deletion; output replacement. After the final causal fixture correction, a fixed-count serial run passed 6/6 document/source journeys without retries, preserving actual two-client interactions.
- Kilo correctness (Claude Opus 4.8) and security (GPT-5.6-sol) reviews passed on the full production changes at `efde68371`, and both lenses separately passed the exact final test/CI delta to `b67603297`. No actionable findings survived independent source verification; all accepted review integrity checks passed. Final delta reviews were source-only because reviewer shell diagnostics were denied.
- Final head `b67603297cf470aa88661e762b8705ebbc0ffa5f`: [CI run 34619134800](https://github.com/nteract/nteract/actions/runs/34619134800) completed successfully. PR checks: 14 successful, 6 skipped, none pending or failed. Browser CI passed 37/37 in 5.7 minutes without retries/flaky tests; the successful job uploaded its Playwright report.

### Evidence boundaries

The first immediate MCP mutation was rejected before document/runtime readiness (`mutate=false`); the fixture now waits for mutation capability. Source readiness alone is insufficient.

The preceding CI run's source-comment reload assertion failed once and passed on retry. Its cause remains **unclassified**; the old successful-job artifact policy discarded the failed-attempt trace. Notebook/runtime readiness does not guarantee CommentsDoc hydration. Final fixtures wait for existing notebook/runtime readiness and retain independent discussion assertions with unchanged timeouts. CI now retains failed-attempt artifacts even when retries make the job green.

An earlier fixed-count parallel local run had 7 passes and 2 failures in 9 attempts. One exposed a test assumption: optimistic human reply display did not establish causal order at the MCP peer. The corrected fixture observes that reply through the MCP comments resource before appending the MCP reply, retaining content/order assertions. The other timed out during kernel startup before commenting behavior. Both failure traces were preserved; passing serial repetitions do not explain the original CI reload failure.

Seven snapshot-publication tests also fail with the base revision's test source (249/256 passed locally); they remain separate baseline failures. Local native/cloud QA does not qualify packaged installation, deployed cloud, or publication/revision recovery. Those remain release-owner gates.

Recommendation: go for this bounded commenting patch; keep draft for release-owner review. The earlier unclassified reload failure remains a residual risk despite the final clean run. This is not an unconditional 2.8 release qualification. No merge, release, version bump, or deployment performed.
