### PR TITLE
fix(cli): point user-facing hints at the nteract command

### DIFF
--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -166,7 +166,7 @@ RUNTIMED_SOCKET_PATH="$(./target/debug/runt daemon status --json | python3 -c 'i
 
 ## MCP Server
 
-The MCP server ships as `nteract mcp` (Rust; `runt mcp` remains a compatibility alias). Run via `cargo xtask run-mcp` for development.
+Use `nteract mcp` for the supervised MCP server. `runt mcp` remains available to run the worker directly. Run via `cargo xtask run-mcp` for development.
 
 **Advertised tools** (`all_tools()`): `list_active_notebooks`, `list_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`, `disconnect_notebook`, `create_cell`, `set_cell`, `delete_cell`, `move_cell`, `execute_cell`, `run_all_cells`, `get_results`, `interrupt_kernel`, `restart_kernel`, `manage_dependencies`, `replace_match`, `replace_regex`.
 

--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -166,7 +166,7 @@ RUNTIMED_SOCKET_PATH="$(./target/debug/runt daemon status --json | python3 -c 'i
 
 ## MCP Server
 
-The MCP server ships as `runt mcp` (Rust). Run via `cargo xtask run-mcp` for development.
+The MCP server ships as `nteract mcp` (Rust; `runt mcp` remains a compatibility alias). Run via `cargo xtask run-mcp` for development.
 
 **Advertised tools** (`all_tools()`): `list_active_notebooks`, `list_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`, `disconnect_notebook`, `create_cell`, `set_cell`, `delete_cell`, `move_cell`, `execute_cell`, `run_all_cells`, `get_results`, `interrupt_kernel`, `restart_kernel`, `manage_dependencies`, `replace_match`, `replace_regex`.
 
@@ -225,7 +225,7 @@ Each open notebook has a room (`NotebookRoom`), keyed by UUID. A `PathIndex` map
 
 ## Troubleshooting
 
-**Daemon lock held:** Inspect the selected endpoint with `runt daemon status` and check its `daemon.lock` with `lsof`. The OS releases the advisory lock when its owner exits; an existing file is not proof of a live owner. Do not delete the lock file to bypass contention, since replacing its inode can allow two owners. Filesystem failures are separate errors, and live socket metadata is the discovery source.
+**Daemon lock held:** Inspect the selected endpoint with `nteract daemon status` and check its `daemon.lock` with `lsof`. The OS releases the advisory lock when its owner exits; an existing file is not proof of a live owner. Do not delete the lock file to bypass contention, since replacing its inode can allow two owners. Filesystem failures are separate errors, and live socket metadata is the discovery source.
 
 **Pool not replenishing:** Verify `uv --version` and check `~/.cache/runt/envs/`.
 
@@ -235,7 +235,7 @@ Each open notebook has a room (`NotebookRoom`), keyed by UUID. A `PathIndex` map
 
 ## Shipped App / System Daemon
 
-Production daemon installs as a system service (macOS: launchd, Linux: systemd user). Manage with `runt daemon {status,stop,start,logs,uninstall}`.
+Production daemon installs as a system service (macOS: launchd, Linux: systemd user). Manage with `nteract daemon {status,stop,start,logs,uninstall}`.
 
 **Key paths (macOS):** Binary at `~/Library/Application Support/runt/bin/runtimed`, socket at `~/Library/Caches/runt/runtimed.sock`, logs at `~/Library/Caches/runt/runtimed.log`.
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -172,14 +172,14 @@ Other: `[data-cell-type="code"]`, `[data-cell-type="markdown"]`, `.cm-content[co
 
 ### Collecting
 
-Use `env -i` for system diagnostics to avoid dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) leaking through.
+Use `env -i` for system diagnostics to avoid dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) leaking through. `env -i` also clears `PATH`, so use the installed `nteract` link (`~/.local/bin` by default) and `--channel` to pick the installation.
 
 ```bash
 # Nightly (system)
-env -i HOME=$HOME /usr/local/bin/runt-nightly diagnostics
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly diagnostics
 
 # Stable (system)
-env -i HOME=$HOME /usr/local/bin/runt diagnostics
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel stable diagnostics
 
 # Dev daemon (no env -i needed)
 RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" ./target/debug/runt diagnostics
@@ -187,9 +187,9 @@ RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" ./target/debug/runt diagnostics
 
 Other system commands follow the same `env -i` pattern:
 ```bash
-env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status
-env -i HOME=$HOME /usr/local/bin/runt-nightly daemon logs -f
-env -i HOME=$HOME /usr/local/bin/runt ps
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly daemon status
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly daemon logs -f
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel stable ps
 ```
 
 Read files from tarball without extracting:

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -60,20 +60,20 @@ When falling back to manual commands, `cargo xtask dev-daemon`, `cargo xtask
 notebook`, and `cargo xtask run-mcp` derive the current git worktree and pass
 the dev env to subprocesses; direnv is not required for those xtask paths.
 
-## System daemon CLI (`runt` / `runt-nightly`)
+## System daemon CLI (`nteract --channel stable|nightly`)
 
 When running CLI commands against system-installed daemons from a dev environment, **always use `env -i`** to strip dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) that would otherwise redirect commands to the per-worktree dev daemon:
 
-**Important:** The repo's `bin/runt` (added to PATH by direnv) shadows `/usr/local/bin/runt` and always resolves to the dev build (nightly channel). When targeting system-installed daemons, use absolute paths:
+**Important:** `env -i` clears `PATH`, and the repo's `bin/runt` (added to PATH by direnv) shadows any installed legacy `runt` with the dev build. Invoke the installed `nteract` link by absolute path (`~/.local/bin` by default) and select the installation with `--channel`:
 
 ```bash
 # Nightly system daemon
-env -i HOME=$HOME /usr/local/bin/runt-nightly diagnostics
-env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly diagnostics
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly daemon status
 
 # Stable system daemon
-env -i HOME=$HOME /usr/local/bin/runt diagnostics
-env -i HOME=$HOME /usr/local/bin/runt daemon status
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel stable diagnostics
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel stable daemon status
 ```
 
 For the dev daemon, prefer `nteract-dev` tools or `cargo xtask` commands. If you
@@ -107,7 +107,7 @@ cat /proc/{PID}/environ | tr '\0' '\n' | grep RUNTIMED
 # Should return nothing: no RUNTIMED_DEV or RUNTIMED_WORKSPACE_PATH
 
 # 5. Verify nteract-nightly daemon socket (should be system socket)
-env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status --json | jq -r '.socket_path'
+env -i HOME=$HOME "$HOME/.local/bin/nteract" --channel nightly daemon status --json | jq -r '.socket_path'
 # Expected: ~/.cache/runt-nightly/runtimed.sock (NOT worktrees/)
 ```
 

--- a/apps/elements/components/workstation-management-example.tsx
+++ b/apps/elements/components/workstation-management-example.tsx
@@ -198,7 +198,7 @@ const pairingCode = "QNTR-0385-NM";
 function fixturePairingView(status: NotebookWorkstationPairingView["status"]) {
   return {
     code: pairingCode,
-    connectCommand: `runt workstation connect https://nteract.example --code ${pairingCode}`,
+    connectCommand: `nteract workstation connect https://nteract.example --code ${pairingCode}`,
     commands: [
       {
         id: "install",
@@ -209,7 +209,7 @@ function fixturePairingView(status: NotebookWorkstationPairingView["status"]) {
       {
         id: "connect",
         label: "Pair this workstation",
-        command: `runt workstation connect https://nteract.example --code ${pairingCode}`,
+        command: `nteract workstation connect https://nteract.example --code ${pairingCode}`,
       },
     ],
     expiresAt: new Date(FIXED_NOW + 9 * MINUTE_MS).toISOString(),

--- a/apps/notebook-cloud/test/cloud-workstations-store.test.ts
+++ b/apps/notebook-cloud/test/cloud-workstations-store.test.ts
@@ -729,7 +729,7 @@ describe("CloudWorkstationsStore pairing", () => {
     assert.equal(pairing?.code, "ABCD-EFGH");
     assert.equal(
       pairing?.connectCommand,
-      "runt workstation connect https://viewer.test --code ABCD-EFGH",
+      "nteract workstation connect https://viewer.test --code ABCD-EFGH",
     );
     assert.ok((pairing?.commands.length ?? 0) > 0);
 

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -354,7 +354,7 @@ describe("cloud workstations client", () => {
   it("builds the workstation pairing command from origin and code", () => {
     assert.equal(
       cloudWorkstationConnectCommand("https://preview.runt.run", "ABCD-EFGH-JKMN"),
-      "runt workstation connect https://preview.runt.run --code ABCD-EFGH-JKMN",
+      "nteract workstation connect https://preview.runt.run --code ABCD-EFGH-JKMN",
     );
   });
 
@@ -382,7 +382,7 @@ describe("cloud workstations client", () => {
         {
           id: "connect",
           label: "Pair this workstation",
-          command: "runt workstation connect https://preview.runt.run --code ABCD-EFGH-JKMN",
+          command: "nteract workstation connect https://preview.runt.run --code ABCD-EFGH-JKMN",
         },
         {
           id: "run",

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -147,15 +147,15 @@ describe("useCloudWorkstationManager pairing", () => {
     expect(pairing?.status).toBe("pending");
     expect(pairing?.code).toBe("ABCD-EFGH-JKMN");
     expect(pairing?.connectCommand).toBe(
-      `runt workstation connect ${window.location.origin} --code ABCD-EFGH-JKMN`,
+      `nteract workstation connect ${window.location.origin} --code ABCD-EFGH-JKMN`,
     );
     expect(pairing?.commands.map((command) => command.command)).toEqual([
       "sudo apt update && sudo apt install -y curl tmux",
       "curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless",
       'export PATH="$HOME/.local/bin:$PATH"',
-      `runt workstation connect ${window.location.origin} --code ABCD-EFGH-JKMN`,
-      "runt workstation service install --start",
-      "runt workstation run",
+      `nteract workstation connect ${window.location.origin} --code ABCD-EFGH-JKMN`,
+      "nteract workstation service install --start",
+      "nteract workstation run",
     ]);
     expect(pairing?.commands[0]?.optional).toBe(true);
     expect(pairing?.commands[2]?.optional).toBe(true);

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -243,8 +243,8 @@ export function cloudWorkstationPairingCommands(
       id: "path",
       label: "Use installed CLI in this shell",
       command: CLOUD_WORKSTATION_PATH_EXPORT_COMMAND,
-      // Only needed in the same shell you ran the installer in — a fresh
-      // terminal already has `nteract` on PATH.
+      // The installer links into ~/.local/bin and does not edit shell startup
+      // files, so this is needed whenever the shell cannot find `nteract`.
       optional: true,
     },
     {

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -212,15 +212,15 @@ export async function fetchCloudWorkstationPairingStatus(
 }
 
 export function cloudWorkstationConnectCommand(origin: string, code: string): string {
-  return `runt workstation connect ${origin} --code ${code}`;
+  return `nteract workstation connect ${origin} --code ${code}`;
 }
 
 export function cloudWorkstationRunCommand(): string {
-  return "runt workstation run";
+  return "nteract workstation run";
 }
 
 export function cloudWorkstationServiceInstallCommand(): string {
-  return "runt workstation service install --start";
+  return "nteract workstation service install --start";
 }
 
 export function cloudWorkstationPairingCommands(
@@ -244,7 +244,7 @@ export function cloudWorkstationPairingCommands(
       label: "Use installed CLI in this shell",
       command: CLOUD_WORKSTATION_PATH_EXPORT_COMMAND,
       // Only needed in the same shell you ran the installer in — a fresh
-      // terminal already has `runt` on PATH.
+      // terminal already has `nteract` on PATH.
       optional: true,
     },
     {

--- a/crates/notebook-protocol/src/connection/framing.rs
+++ b/crates/notebook-protocol/src/connection/framing.rs
@@ -57,7 +57,7 @@ pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Res
         let direction = if version > PROTOCOL_VERSION {
             "The daemon is newer than this client. Please update the CLI (or reinstall the app)."
         } else {
-            "The daemon is older than this client. Please update the daemon: runt daemon doctor --fix"
+            "The daemon is older than this client. Please update the daemon: nteract doctor --fix"
         };
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2142,7 +2142,7 @@ where
         error: error.clone(),
         guidance: format!(
             "Check daemon logs: {} daemon logs",
-            runt_workspace::cli_command_name()
+            runt_workspace::public_cli_invocation()
         ),
     });
     Err(error)
@@ -2649,7 +2649,7 @@ where
         error: error.clone(),
         guidance: format!(
             "Check daemon logs: {} daemon logs",
-            runt_workspace::cli_command_name()
+            runt_workspace::public_cli_invocation()
         ),
     });
     Err(error)

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -169,8 +169,30 @@ pub fn daemon_launchd_label() -> &'static str {
 }
 
 /// Channel-specific CLI command name.
+///
+/// This is the compatibility binary name (`runt` / `runt-nightly`) used for
+/// install paths and symlinks. For text that tells a user what to type, use
+/// [`public_cli_invocation`].
 pub fn cli_command_name() -> &'static str {
     cli_command_name_for(build_channel())
+}
+
+/// The public command for this installation, pinned to its channel:
+/// `nteract --channel stable` or `nteract --channel nightly`.
+///
+/// Use this in guidance strings ("Check daemon status with: ...") so that
+/// installation-scoped actions target the same channel that produced the
+/// message. `runt` and `runt-nightly` remain accepted aliases.
+pub fn public_cli_invocation_for(channel: BuildChannel) -> &'static str {
+    match channel {
+        BuildChannel::Stable => "nteract --channel stable",
+        BuildChannel::Nightly => "nteract --channel nightly",
+    }
+}
+
+/// See [`public_cli_invocation_for`].
+pub fn public_cli_invocation() -> &'static str {
+    public_cli_invocation_for(build_channel())
 }
 
 /// Channel-specific nteract-mcp binary base name (without extension).
@@ -264,7 +286,7 @@ pub fn daemon_unavailable_guidance() -> String {
     } else {
         format!(
             "Check daemon status with: {} daemon status",
-            cli_command_name()
+            public_cli_invocation()
         )
     }
 }

--- a/crates/runt/src/lib.rs
+++ b/crates/runt/src/lib.rs
@@ -145,6 +145,21 @@ impl EntryPoint {
     }
 }
 
+/// Command to show in hints for shared-runtime observation (`notebooks`,
+/// `ps`). An unscoped `nteract` discovers notebooks across channels, so the
+/// hint stays unscoped unless the user passed `--channel` explicitly;
+/// otherwise following it would show a different list than the command the
+/// user just ran.
+fn observation_command(options: &local_runtime::LocalRuntimeOptions) -> &'static str {
+    if options.enabled && options.explicit_channel {
+        EntryPoint::Nteract.action_command()
+    } else if options.enabled {
+        "nteract"
+    } else {
+        "runt"
+    }
+}
+
 fn cli_command(entrypoint: EntryPoint) -> clap::Command {
     let command = Cli::command();
     match entrypoint {
@@ -969,8 +984,9 @@ async fn async_main(
             pool_command(command).await?
         }
         Some(Commands::Rooms { json }) => {
+            let observe = observation_command(&local_runtime);
             eprintln!(
-                "Warning: '{command_name} rooms' is deprecated. Use '{command_name} notebooks' instead."
+                "Warning: '{observe} rooms' is deprecated. Use '{observe} notebooks' instead."
             );
             list_notebooks(json, local_runtime).await?
         }
@@ -5118,14 +5134,7 @@ async fn shutdown_notebook(
         }
         Ok(false) => {
             eprintln!("Notebook not found: {}", notebook_id);
-            // Keep shared runtime discovery for an unscoped notebook command.
-            let command = if options.enabled && options.explicit_channel {
-                EntryPoint::Nteract.action_command()
-            } else if options.enabled {
-                "nteract"
-            } else {
-                "runt"
-            };
+            let command = observation_command(&options);
             eprintln!("Use '{command} notebooks' to see open notebooks.");
             std::process::exit(1)
         }

--- a/crates/runt/src/lib.rs
+++ b/crates/runt/src/lib.rs
@@ -139,10 +139,7 @@ impl EntryPoint {
     /// observation hints preserve unscoped selection unless --channel was explicit.
     fn action_command(self) -> &'static str {
         match self {
-            Self::Nteract => match runt_workspace::build_channel() {
-                runt_workspace::BuildChannel::Stable => "nteract --channel stable",
-                runt_workspace::BuildChannel::Nightly => "nteract --channel nightly",
-            },
+            Self::Nteract => runt_workspace::public_cli_invocation(),
             Self::Runt => "runt",
         }
     }
@@ -966,11 +963,15 @@ async fn async_main(
         }
 
         Some(Commands::Pool { command }) => {
-            eprintln!("Warning: 'runt pool' is deprecated. Use 'runt daemon' instead.");
+            eprintln!(
+                "Warning: '{command_name} pool' is deprecated. Use '{command_name} daemon' instead."
+            );
             pool_command(command).await?
         }
         Some(Commands::Rooms { json }) => {
-            eprintln!("Warning: 'runt rooms' is deprecated. Use 'runt notebooks' instead.");
+            eprintln!(
+                "Warning: '{command_name} rooms' is deprecated. Use '{command_name} notebooks' instead."
+            );
             list_notebooks(json, local_runtime).await?
         }
 

--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -1,18 +1,19 @@
-//! `runt workstation` — pair this machine with a hosted nteract cloud and
+//! `nteract workstation` — pair this machine with a hosted nteract cloud and
 //! serve attach requests.
 //!
 //! The operator path (`docs/runbooks/remote-workstation.md`, ADR
 //! `docs/adr/hosted-credential-transport.md` Decision 9):
 //!
 //! 1. Mint a pairing code in the hosted workstation panel.
-//! 2. `runt workstation connect <url> --code XXXX-XXXX-XXXX` redeems it for a
+//! 2. `nteract workstation connect <url> --code XXXX-XXXX-XXXX` redeems it for a
 //!    long-lived workstation credential (`nwc_` token) and stores it at
 //!    [`runt_workspace::workstation_credentials_path`] (mode 0600).
-//! 3. `runt workstation run` launches the sibling `runtimed workstation-agent`
+//! 3. `nteract workstation run` launches the sibling `runtimed workstation-agent`
 //!    service loop with the credential in the environment (never argv).
 //!
-//! `runt workstation status` lists the workstations the credential can see.
-
+//! `nteract workstation status` lists the workstations the credential can see.
+//!
+//! `runt workstation ...` remains accepted as a compatibility alias.
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -116,12 +116,14 @@ impl PongInfo {
             )),
             Some(remote) => Err(format!(
                 "Daemon is running protocol version {remote}, but this CLI expects version {expected}. \
-                 Please update the daemon: runt daemon doctor --fix"
+                 Please update the daemon: {} doctor --fix",
+                runt_workspace::public_cli_invocation()
             )),
             None => {
                 log::warn!(
                     "[pool-client] Daemon did not report a protocol version — \
-                     it may be outdated. Consider updating: runt daemon doctor --fix"
+                     it may be outdated. Consider updating: {} doctor --fix",
+                    runt_workspace::public_cli_invocation()
                 );
                 Ok(())
             }

--- a/crates/runtimed-service/src/lib.rs
+++ b/crates/runtimed-service/src/lib.rs
@@ -242,7 +242,7 @@ fn linux_user_systemd_unavailable_message(detail: &str) -> String {
          The daemon service cannot be installed or started automatically here.\n\
          Use a normal login session with XDG_RUNTIME_DIR/DBus available, or ask an admin to enable lingering with `loginctl enable-linger $USER` if the daemon should stay available after logout.\n\
          For headless workstation sessions, use foreground mode: `{} workstation run`.",
-        runt_workspace::cli_command_name()
+        runt_workspace::public_cli_invocation()
     )
 }
 
@@ -1335,7 +1335,7 @@ mod tests {
             linux_user_systemd_unavailable_message("systemctl was not found on this host");
         let fallback = format!(
             "For headless workstation sessions, use foreground mode: `{} workstation run`.",
-            runt_workspace::cli_command_name()
+            runt_workspace::public_cli_invocation()
         );
 
         assert!(message.contains(

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -213,17 +213,17 @@ Install into workspace venv: `cd crates/runtimed-py && VIRTUAL_ENV=../../.venv m
 
 `Output.data` typing: binary MIME → `bytes`, JSON → `dict`, text → `str`. Binary images are raw bytes, not base64.
 
-Socket path: respects `RUNTIMED_SOCKET_PATH`. For worktree daemons, export the socket path from `runt daemon status --json`.
+Socket path: respects `RUNTIMED_SOCKET_PATH`. For worktree daemons, export the socket path from `nteract daemon status --json`.
 
 ## CLI commands
 
 ```bash
-runt daemon status          # Show service + pool statistics
-runt daemon start/stop      # Service lifecycle
-runt daemon logs -f         # Tail logs
-runt daemon ping            # Health check
-runt ps                     # List all kernels
-runt notebooks              # List open notebooks
+nteract daemon status          # Show service + pool statistics
+nteract daemon start/stop      # Service lifecycle
+nteract daemon logs -f         # Tail logs
+nteract daemon ping            # Health check
+nteract ps                     # List all kernels
+nteract notebooks              # List open notebooks
 ```
 
 ### Cloud workstation attach
@@ -245,7 +245,7 @@ The daemon installs as a system service at login:
 - **Linux**: systemd user service in `~/.config/systemd/user/`
 - **Windows**: Startup folder script
 
-Manage with `runt daemon start/stop/status/logs`. Cross-platform install/uninstall via `crates/runtimed-service/src/lib.rs`.
+Manage with `nteract daemon start/stop/status/logs`. Cross-platform install/uninstall via `crates/runtimed-service/src/lib.rs`.
 
 ## Troubleshooting
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -43,8 +43,10 @@ fn daemon_service_name() -> &'static str {
     runt_workspace::daemon_service_basename()
 }
 
+/// Public command to show in "use ... instead" hints, pinned to this build's
+/// channel. Every caller here is user-facing guidance, not a path.
 fn cli_command_name() -> &'static str {
-    runt_workspace::cli_command_name()
+    runt_workspace::public_cli_invocation()
 }
 
 #[derive(Subcommand, Debug)]

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -288,9 +288,9 @@ directory, and environment policy.
 
 ```bash
 nteract workstation status     # workstations the credential can see
-runt daemon status          # daemon state, pool sizes
-runt daemon logs -f         # tail the daemon log
-runt diagnostics            # bundle logs + system info into an archive
+nteract daemon status          # daemon state, pool sizes
+nteract daemon logs -f         # tail the daemon log
+nteract diagnostics            # bundle logs + system info into an archive
 journalctl --user -u nteract-workstation      # agent service logs
 ```
 

--- a/plugins/nightly/skills/repl/SKILL.md
+++ b/plugins/nightly/skills/repl/SKILL.md
@@ -33,7 +33,7 @@ Start a new Codex session after reinstalling; running sessions do not hot-load n
 If tools still don't appear after restarting Codex:
 
 - Confirm the nteract desktop app/daemon is running.
-- Run `runt doctor` to check the installation. (`runt-nightly` if this is the nightly release)
+- Run `nteract doctor` to check the installation (`nteract --channel nightly doctor` for the Nightly install).
 - Share any error messages from the session.
 
 ## Quick Start (direct pi tools)

--- a/plugins/nteract/pi/README.md
+++ b/plugins/nteract/pi/README.md
@@ -32,17 +32,17 @@ See [`packages/runtimed-node/README.md`](../../packages/runtimed-node/README.md)
 
 ### Inspecting and managing sessions
 
-The daemon is controlled by the `runt` CLI (installed with nteract). Use it to inspect active sessions, open notebooks in the desktop app, or troubleshoot:
+The daemon is controlled by the `nteract` CLI (installed with nteract). Use it to inspect active sessions, open notebooks in the desktop app, or troubleshoot:
 
 ```bash
 # List active Python sessions
-runt list
+nteract notebooks
 
-# Open a session in nteract Desktop
-runt show <notebook-id>
+# Open a notebook in nteract Desktop
+nteract open <path>
 
 # Check daemon status
-runt daemon status
+nteract daemon status
 ```
 
 ## Local development

--- a/plugins/nteract/pi/README.md
+++ b/plugins/nteract/pi/README.md
@@ -35,7 +35,7 @@ See [`packages/runtimed-node/README.md`](../../packages/runtimed-node/README.md)
 The daemon is controlled by the `nteract` CLI (installed with nteract). Use it to inspect active sessions, open notebooks in the desktop app, or troubleshoot:
 
 ```bash
-# List active Python sessions
+# List open notebooks and their kernel status
 nteract notebooks
 
 # Open a notebook in nteract Desktop

--- a/plugins/nteract/skills/repl/SKILL.md
+++ b/plugins/nteract/skills/repl/SKILL.md
@@ -33,7 +33,7 @@ Start a new Codex session after reinstalling; running sessions do not hot-load n
 If tools still don't appear after restarting Codex:
 
 - Confirm the nteract desktop app/daemon is running.
-- Run `runt doctor` to check the installation. (`runt-nightly` if this is the nightly release)
+- Run `nteract doctor` to check the installation (`nteract --channel nightly doctor` for the Nightly install).
 - Share any error messages from the session.
 
 ## Quick Start (direct pi tools)

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -12,7 +12,7 @@
 # installs the signed .app bundle (which carries the same sidecars in
 # Contents/MacOS) into ~/Applications and links the commands from there.
 # Desktop installs repair/install the per-user daemon service with
-# `runt daemon doctor --fix` (systemd on Linux, launchd on macOS) and start
+# `nteract daemon doctor --fix` (systemd on Linux, launchd on macOS) and start
 # it by default. CLI-only installs leave runtime services alone.
 
 set -euo pipefail
@@ -451,7 +451,7 @@ install_compatibility_link "$DAEMON_NAME" "$DAEMON_BIN"
 install_compatibility_link "$MCP_NAME" "$MCP_BIN"
 
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-  echo "Note: $BIN_DIR is not on PATH for this shell. Add it to use nteract/runt commands directly." >&2
+  echo "Note: $BIN_DIR is not on PATH for this shell. Add it to use the nteract command directly." >&2
 fi
 
 # Avoid accidentally installing a per-worktree dev daemon when the installer is
@@ -479,19 +479,21 @@ echo "CLI:      $GLOBAL_CLI_BIN"
 echo "Command:  $GLOBAL_CLI_LINK"
 echo "Daemon:   $DAEMON_BIN"
 echo "MCP:      $MCP_BIN"
+# Printed hints address the public command. When this install owns the shared
+# `nteract` link, scope it to this channel; otherwise point at the backend.
+CLI_INVOCATION="\"$GLOBAL_CLI_BIN\""
+if [[ "$managed_cli" == "1" ]]; then
+  CLI_INVOCATION="\"$GLOBAL_CLI_LINK\" --channel $CHANNEL"
+fi
 if [[ "$HEADLESS" == "1" ]]; then
   echo "CLI-only install: no daemon service was installed, repaired, or started."
 elif [[ "$NO_START" == "1" ]]; then
-  echo "Daemon was installed/repaired but not started (--no-start). Start with: \"$RUNT_BIN\" daemon start"
+  echo "Daemon was installed/repaired but not started (--no-start). Start with: $CLI_INVOCATION daemon start"
 else
   env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH PATH="$RUNT_DIR:$BIN_DIR:$PATH" \
     "$RUNT_BIN" daemon status || true
 fi
 if [[ "$HEADLESS" == "1" ]]; then
-  CLI_INVOCATION="\"$GLOBAL_CLI_BIN\""
-  if [[ "$managed_cli" == "1" ]]; then
-    CLI_INVOCATION="\"$GLOBAL_CLI_LINK\" --channel $CHANNEL"
-  fi
   echo
   echo "Headless workstation install. To offer this machine's compute to a hosted"
   echo "notebook, mint a pairing code from the notebook's workstation panel, then:"
@@ -505,6 +507,6 @@ if [[ "$HEADLESS" == "1" ]]; then
     echo "  $CLI_INVOCATION workstation run"
     echo "Persistent workstation service management starts with Linux user systemd."
   fi
-  echo "(Releases without '$CLI_NAME workstation' can use the cloud-runtime-agent flow"
+  echo "(Releases without 'nteract workstation' can use the cloud-runtime-agent flow"
   echo "in docs/runbooks/remote-workstation.md.)"
 fi

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -403,7 +403,7 @@ function additionalSetupHelpText(
   }
   if (ids.has("path")) {
     notes.push(
-      "Only needed in the same terminal you ran the install command in — a new terminal already has it on PATH.",
+      "If your shell can't find nteract, run this command to add it to PATH for the current session.",
     );
   }
   if (ids.has("foreground-run")) {

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -1009,7 +1009,7 @@ describe("NotebookWorkstationsPanel", () => {
     expect(
       additionalCommands.getByText(/Fresh Debian\/Ubuntu hosts may need curl and tmux/),
     ).toBeVisible();
-    expect(additionalCommands.getByText(/a new terminal already has it on PATH/)).toBeVisible();
+    expect(additionalCommands.getByText(/add it to PATH for the current session/)).toBeVisible();
     expect(additionalCommands.getByText(/foreground fallback in tmux/)).toBeVisible();
     expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
       /Waiting for this machine to connect/,

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -94,18 +94,18 @@ const cloudPairingCommands = [
   {
     id: "connect",
     label: "Pair this workstation",
-    command: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+    command: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
   },
   {
     id: "run",
     label: "Linux user systemd service",
-    command: "runt workstation service install --start",
+    command: "nteract workstation service install --start",
     recommended: true,
   },
   {
     id: "foreground-run",
     label: "macOS/non-systemd fallback",
-    command: "runt workstation run",
+    command: "nteract workstation run",
     optional: true,
   },
 ];
@@ -926,7 +926,7 @@ describe("NotebookWorkstationsPanel", () => {
         <WorkstationPairingDialog
           pairing={{
             code: "ABCD-EFGH-JKMN",
-            connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+            connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
             expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
             status: "pending",
             workstationName: null,
@@ -938,7 +938,7 @@ describe("NotebookWorkstationsPanel", () => {
           selection={selection}
           pairing={{
             code: "ABCD-EFGH-JKMN",
-            connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+            connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
             expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
             status: "pending",
             workstationName: null,
@@ -959,7 +959,7 @@ describe("NotebookWorkstationsPanel", () => {
       <WorkstationPairingDialog
         pairing={{
           code: "ABCD-EFGH-JKMN",
-          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
           commands: cloudPairingCommands,
           expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
           status: "pending",
@@ -984,8 +984,8 @@ describe("NotebookWorkstationsPanel", () => {
     const commands = screen.getAllByTestId("workstation-pairing-command");
     expect(commands.map((command) => command.textContent)).toEqual([
       "curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless",
-      "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
-      "runt workstation service install --start",
+      "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+      "nteract workstation service install --start",
     ]);
     expect(screen.getByText("(recommended)")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Show additional setup options" }));
@@ -1003,7 +1003,7 @@ describe("NotebookWorkstationsPanel", () => {
     ).toEqual([
       "sudo apt update && sudo apt install -y curl tmux",
       'export PATH="$HOME/.local/bin:$PATH"',
-      "runt workstation run",
+      "nteract workstation run",
     ]);
     // Each folded-away step explains why it's conditional, not a generic blurb.
     expect(
@@ -1030,8 +1030,8 @@ describe("NotebookWorkstationsPanel", () => {
     expect(writeText).toHaveBeenCalledWith(
       [
         "curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless",
-        "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
-        "runt workstation service install --start",
+        "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+        "nteract workstation service install --start",
       ].join("\n"),
     );
   });
@@ -1041,7 +1041,7 @@ describe("NotebookWorkstationsPanel", () => {
       <WorkstationPairingDialog
         pairing={{
           code: "ABCD-EFGH-JKMN",
-          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
           expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
           status: "pending",
           workstationName: null,
@@ -1054,14 +1054,14 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByText("ABCD-EFGH-JKMN")).toBeVisible();
     expect(
       screen.getAllByTestId("workstation-pairing-command").map((node) => node.textContent),
-    ).toEqual(["runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN"]);
+    ).toEqual(["nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN"]);
   });
 
   it("announces redemption and registration, and Done dismisses", () => {
     const dismissed: number[] = [];
     const pairingBase = {
       code: "ABCD-EFGH-JKMN",
-      connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+      connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
       commands: cloudPairingCommands,
       workstationName: null,
@@ -1094,7 +1094,7 @@ describe("NotebookWorkstationsPanel", () => {
       <WorkstationPairingDialog
         pairing={{
           code: "ABCD-EFGH-JKMN",
-          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          connectCommand: "nteract workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
           expiresAt: new Date(Date.now() - 1_000).toISOString(),
           status: "expired",
           workstationName: null,

--- a/src/components/widgets/AGENTS.md
+++ b/src/components/widgets/AGENTS.md
@@ -160,5 +160,5 @@ display(slider)
 The shared frontend logger in `src/lib/logger.ts` routes through the active host log sink. For comm-level tracing:
 
 ```bash
-runt daemon logs -f | grep -i comm
+nteract daemon logs -f | grep -i comm
 ```


### PR DESCRIPTION
Follow-up to #4231. Command examples shown to users now use `nteract`. Installation-specific recovery commands (`daemon status|logs|doctor`, `workstation run`, `runtimed install` output) keep their release channel via a new `runt_workspace::public_cli_invocation()` (`nteract --channel stable|nightly`). Shared-runtime observation hints (`notebooks`) stay unscoped unless the user passed `--channel`, since an unscoped `nteract` discovers notebooks across channels. Compatibility binaries (`runt`, `runt-nightly`, `runt mcp`, `nteract-mcp`) remain supported and unchanged.

Surfaces: the hosted workstation panel's generated pairing commands, the desktop daemon-failure banner, protocol-mismatch errors, the Linux user-systemd fallback, deprecation warnings, `install-linux-release` hints, the remote-workstation runbook, plugin READMEs and skills, and agent rules. The pairing panel's PATH note no longer promises a new terminal has `nteract` on PATH; the installer does not edit shell startup files.

Validation: `cargo test` for `runt-workspace`, `runtimed-service`, `runtimed-client`, `notebook-protocol`, `runt`; `cargo check -p runtimed -p notebook`; notebook-cloud node tests and vitest for the workstation panel; `test-install-release`, `shellcheck`, `cargo xtask lint --fix`.
